### PR TITLE
[F-004] JSONL event log persistence with schema header

### DIFF
--- a/.claude/skills/forge-finish-task/SKILL.md
+++ b/.claude/skills/forge-finish-task/SKILL.md
@@ -39,7 +39,7 @@ Prompt template:
   If any item is NOT FOUND, stop and report — do not guess.
 ```
 
-**If any item comes back NOT FOUND:** implement the missing items, then spawn a fresh-context DoD subagent and repeat this step. Loop until every checkbox comes back VERIFIED. Each iteration must use a new subagent with no memory of prior runs.
+**If any item comes back NOT FOUND:** implement the missing items, re-run the build verification from step 3, then spawn a fresh-context DoD subagent and repeat this step. Loop until every checkbox comes back VERIFIED. Each iteration must use a new subagent with no memory of prior runs.
 
 3. **Verify the build**
 
@@ -70,7 +70,7 @@ Prompt template:
   4. Report only HIGH-confidence findings. Skip style nitpicks.
 ```
 
-**If the reviewer raises any HIGH-confidence finding:** fix all findings, then spawn a fresh-context code-reviewer subagent and repeat this step. Loop until the reviewer reports no HIGH-confidence findings. Each iteration must use a new subagent with no memory of prior runs. Do not push code with known issues.
+**If the reviewer raises any HIGH-confidence finding:** fix all findings, re-run the build verification from step 3, then spawn a fresh-context code-reviewer subagent and repeat this step. Loop until the reviewer reports no HIGH-confidence findings. Each iteration must use a new subagent with no memory of prior runs. Do not push code with known issues.
 
 5. **Create and push the feature branch**
 

--- a/.claude/skills/forge-finish-task/SKILL.md
+++ b/.claude/skills/forge-finish-task/SKILL.md
@@ -44,7 +44,7 @@ Prompt template:
 3. **Verify the build**
 
 ```bash
-cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings
+cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings
 ```
 
 All must pass before continuing.

--- a/.claude/skills/forge-finish-task/SKILL.md
+++ b/.claude/skills/forge-finish-task/SKILL.md
@@ -11,15 +11,37 @@ When implementation is done, verify every DoD checkbox, push the feature branch,
 
 ## Steps
 
-1. **View the issue's Definition of Done**
+1. **Read the Definition of Done**
 
 ```bash
 gh issue view <number> --repo forge-ide/forge
 ```
 
-Work through every unchecked `- [ ]` item. Do not proceed until all are satisfied.
+Extract every `- [ ]` item. You will verify each one in the next step.
 
-2. **Verify the build**
+2. **Verify each DoD item via a fresh-context subagent**
+
+Spawn a general-purpose subagent. Give it the DoD checkboxes and nothing else — no implementation context, no file names, no hints. It must find evidence independently.
+
+```
+Prompt template:
+  Verify the following Definition of Done checkboxes for forge repo at /home/jeroche/repos/github/jeff-roche/forge.
+  For each item, find concrete code evidence (grep result, file read, or test run).
+  Do NOT accept "it compiles" as evidence for a specific item — find the actual symbol, method, or file.
+
+  Definition of Done:
+  <paste DoD checkboxes>
+
+  For each checkbox report:
+  - VERIFIED: <what you found and where>
+  - NOT FOUND: <what is missing>
+
+  If any item is NOT FOUND, stop and report — do not guess.
+```
+
+**If any item comes back NOT FOUND:** implement the missing items, then spawn a fresh-context DoD subagent and repeat this step. Loop until every checkbox comes back VERIFIED. Each iteration must use a new subagent with no memory of prior runs.
+
+3. **Verify the build**
 
 ```bash
 cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings
@@ -27,7 +49,30 @@ cargo check --workspace && cargo test --workspace && cargo clippy --all-targets 
 
 All must pass before continuing.
 
-3. **Create and push the feature branch**
+4. **Code review with a fresh-context subagent**
+
+Spawn a `feature-dev:code-reviewer` subagent. Give it the issue number, the DoD, and the list of changed files — nothing else. It must derive its own understanding from the code.
+
+```
+Prompt template:
+  Review the implementation for forge-ide/forge issue #<N>: "<issue title>"
+
+  Definition of Done:
+  <paste DoD checkboxes>
+
+  Changed files (git diff --name-only upstream/main):
+  <paste list>
+
+  Verify:
+  1. Every DoD item is fully implemented — not just structurally present but behaviorally correct.
+  2. No regressions in existing tests or public APIs.
+  3. Rust-specific issues: missing derives, incorrect serde attributes, unused imports, clippy violations.
+  4. Report only HIGH-confidence findings. Skip style nitpicks.
+```
+
+**If the reviewer raises any HIGH-confidence finding:** fix all findings, then spawn a fresh-context code-reviewer subagent and repeat this step. Loop until the reviewer reports no HIGH-confidence findings. Each iteration must use a new subagent with no memory of prior runs. Do not push code with known issues.
+
+5. **Create and push the feature branch**
 
 If not already on a feature branch, create one now:
 
@@ -44,7 +89,7 @@ Commit all changes, then push to `origin` (your fork):
 git push -u origin <branch-name>
 ```
 
-4. **Open a PR to upstream**
+6. **Open a PR to upstream**
 
 ```bash
 gh pr create \
@@ -67,13 +112,13 @@ EOF
 )"
 ```
 
-5. **Update the issue label**
+7. **Update the issue label**
 
 ```bash
 gh issue edit <number> --remove-label "status: in-progress" --add-label "status: code-review" --repo forge-ide/forge
 ```
 
-6. **Confirm**
+8. **Confirm**
 
 ```bash
 gh issue view <number> --repo forge-ide/forge --json state,labels --jq '{state,labels: .labels | map(.name)}'
@@ -99,3 +144,5 @@ Expected: `"state": "OPEN"` with `status: code-review` label.
 - Pushing to `upstream` instead of `origin` — always push to your fork (`origin`)
 - Skipping `cargo clippy` — CI enforces `-D warnings`
 - Using the GitHub issue number in the branch name instead of the F-number from the title
+- Checking a DoD box without verifying the code — a passing test or a `pub use` in `lib.rs` is evidence; memory is not
+- Assuming a prior issue is fully implemented without running the verification grep — always confirm types/methods exist before marking dependents as unblocked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +130,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tokio",
  "ts-rs",
 ]
 
@@ -316,6 +323,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -511,6 +524,28 @@ name = "thiserror-impl"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/forge-core/Cargo.toml
+++ b/crates/forge-core/Cargo.toml
@@ -11,6 +11,8 @@ serde_json = "1"
 ts-rs = { version = "10", features = ["serde-compat"] }
 rand = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1", features = ["io-util", "fs", "time", "sync", "rt"] }
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["rt", "macros", "time"] }

--- a/crates/forge-core/src/event_log.rs
+++ b/crates/forge-core/src/event_log.rs
@@ -73,7 +73,10 @@ impl EventLog {
                 }
             })
         };
-        Self { writer: shared, flush_task: flush_handle }
+        Self {
+            writer: shared,
+            flush_task: flush_handle,
+        }
     }
 
     pub async fn append(&mut self, event: &Event) -> Result<()> {

--- a/crates/forge-core/src/event_log.rs
+++ b/crates/forge-core/src/event_log.rs
@@ -1,0 +1,102 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufWriter};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time::Duration;
+
+use crate::event::Event;
+use crate::{ForgeError, Result};
+
+const SCHEMA_HEADER: &str = r#"{"schema_version":1}"#;
+const FLUSH_INTERVAL: Duration = Duration::from_millis(50);
+
+pub struct EventLog {
+    writer: Arc<Mutex<BufWriter<tokio::fs::File>>>,
+    flush_task: JoinHandle<()>,
+}
+
+impl EventLog {
+    pub async fn create(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(path)
+            .await?;
+        let mut writer = BufWriter::new(file);
+        writer.write_all(SCHEMA_HEADER.as_bytes()).await?;
+        writer.write_all(b"\n").await?;
+        writer.flush().await?;
+        Ok(Self::with_writer(writer))
+    }
+
+    pub async fn open(path: &Path) -> Result<Self> {
+        let mut file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .await?;
+
+        // Validate schema header using a single file handle to avoid TOCTOU.
+        let expected = format!("{SCHEMA_HEADER}\n");
+        let mut buf = vec![0u8; expected.len()];
+        file.read_exact(&mut buf).await.map_err(|_| {
+            ForgeError::Other(anyhow::anyhow!(
+                "events.jsonl too short or missing schema header"
+            ))
+        })?;
+        if buf != expected.as_bytes() {
+            return Err(ForgeError::Other(anyhow::anyhow!(
+                "events.jsonl schema header mismatch: expected {SCHEMA_HEADER:?}"
+            )));
+        }
+
+        // Seek to end on the same handle before wrapping in BufWriter.
+        file.seek(std::io::SeekFrom::End(0)).await?;
+        Ok(Self::with_writer(BufWriter::new(file)))
+    }
+
+    fn with_writer(writer: BufWriter<tokio::fs::File>) -> Self {
+        let shared = Arc::new(Mutex::new(writer));
+        let flush_handle = {
+            let shared = Arc::clone(&shared);
+            tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(FLUSH_INTERVAL);
+                loop {
+                    ticker.tick().await;
+                    let _ = shared.lock().await.flush().await;
+                }
+            })
+        };
+        Self { writer: shared, flush_task: flush_handle }
+    }
+
+    pub async fn append(&mut self, event: &Event) -> Result<()> {
+        let line = serde_json::to_string(event)?;
+        let mut w = self.writer.lock().await;
+        w.write_all(line.as_bytes()).await?;
+        w.write_all(b"\n").await?;
+        Ok(())
+    }
+
+    pub async fn flush(&mut self) -> Result<()> {
+        self.writer.lock().await.flush().await?;
+        Ok(())
+    }
+
+    pub async fn close(mut self) -> Result<()> {
+        self.flush_task.abort();
+        self.flush().await
+    }
+}
+
+impl Drop for EventLog {
+    fn drop(&mut self) {
+        self.flush_task.abort();
+    }
+}

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -7,9 +7,9 @@ pub mod types;
 
 pub use error::{ForgeError, Result};
 pub use event::{ApprovalPreview, ApprovalSource, ContextRef, EndReason, Event};
+pub use event_log::EventLog;
 pub use ids::{
     AgentId, AgentInstanceId, MessageId, ProviderId, SessionId, ToolCallId, WorkspaceId,
 };
-pub use event_log::EventLog;
 pub use transcript::Transcript;
 pub use types::{ApprovalScope, CompactTrigger, RosterScope, SessionPersistence, SessionState};

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -1,5 +1,6 @@
 mod error;
 mod event;
+mod event_log;
 pub mod ids;
 mod transcript;
 pub mod types;
@@ -9,5 +10,6 @@ pub use event::{ApprovalPreview, ApprovalSource, ContextRef, EndReason, Event};
 pub use ids::{
     AgentId, AgentInstanceId, MessageId, ProviderId, SessionId, ToolCallId, WorkspaceId,
 };
+pub use event_log::EventLog;
 pub use transcript::Transcript;
 pub use types::{ApprovalScope, CompactTrigger, RosterScope, SessionPersistence, SessionState};

--- a/crates/forge-core/tests/event_log_persistence.rs
+++ b/crates/forge-core/tests/event_log_persistence.rs
@@ -1,0 +1,134 @@
+use forge_core::{EventLog, SessionId};
+use std::io::{BufRead, BufReader};
+use tempfile::TempDir;
+
+fn session_path(dir: &TempDir, id: &SessionId) -> std::path::PathBuf {
+    dir.path().join(".forge").join("sessions").join(id.to_string()).join("events.jsonl")
+}
+
+#[tokio::test]
+async fn creates_file_with_schema_header() {
+    let dir = TempDir::new().unwrap();
+    let id = SessionId::new();
+    let path = session_path(&dir, &id);
+
+    let _log = EventLog::create(&path).await.unwrap();
+
+    let file = std::fs::File::open(&path).unwrap();
+    let mut lines = BufReader::new(file).lines();
+    let first = lines.next().expect("file should have at least one line").unwrap();
+    assert_eq!(first, r#"{"schema_version":1}"#);
+}
+
+#[tokio::test]
+async fn creates_parent_directories() {
+    let dir = TempDir::new().unwrap();
+    let id = SessionId::new();
+    let path = session_path(&dir, &id);
+
+    EventLog::create(&path).await.unwrap();
+
+    assert!(path.exists());
+}
+
+#[tokio::test]
+async fn open_rejects_file_missing_schema_header() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("events.jsonl");
+    std::fs::write(&path, b"not a schema header\n").unwrap();
+
+    let result = EventLog::open(&path).await;
+
+    assert!(result.is_err(), "open should reject file without schema header");
+}
+
+#[tokio::test]
+async fn open_rejects_empty_file() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("events.jsonl");
+    std::fs::write(&path, b"").unwrap();
+
+    let result = EventLog::open(&path).await;
+
+    assert!(result.is_err(), "open should reject empty file");
+}
+
+#[tokio::test]
+async fn open_accepts_file_with_valid_schema_header() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("events.jsonl");
+
+    let _log = EventLog::create(&path).await.unwrap();
+    drop(_log);
+
+    EventLog::open(&path).await.expect("open should succeed on a freshly created file");
+}
+
+#[tokio::test]
+async fn appended_events_appear_after_header() {
+    use forge_core::{Event, MessageId};
+    use chrono::Utc;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("events.jsonl");
+    let mut log = EventLog::create(&path).await.unwrap();
+
+    let event = Event::AssistantDelta {
+        id: MessageId::new(),
+        at: Utc::now(),
+        delta: "hello".to_string(),
+    };
+    log.append(&event).await.unwrap();
+    log.flush().await.unwrap();
+
+    let file = std::fs::File::open(&path).unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+
+    assert_eq!(lines[0], r#"{"schema_version":1}"#);
+    assert_eq!(lines.len(), 2, "header + one event");
+    let _: Event = serde_json::from_str(&lines[1]).expect("second line should be valid event JSON");
+}
+
+#[tokio::test]
+async fn background_task_flushes_after_50ms_without_further_appends() {
+    use forge_core::{Event, MessageId};
+    use chrono::Utc;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("events.jsonl");
+    let mut log = EventLog::create(&path).await.unwrap();
+
+    let event = Event::AssistantDelta {
+        id: MessageId::new(),
+        at: Utc::now(),
+        delta: "persisted".to_string(),
+    };
+    log.append(&event).await.unwrap();
+
+    // No further appends — background flush task should flush within 50ms.
+    tokio::time::sleep(tokio::time::Duration::from_millis(75)).await;
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(content.contains("persisted"), "background flush should write to disk within 75ms");
+}
+
+#[tokio::test]
+async fn close_flushes_final_buffered_event() {
+    use forge_core::{Event, MessageId};
+    use chrono::Utc;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("events.jsonl");
+    let mut log = EventLog::create(&path).await.unwrap();
+
+    let event = Event::AssistantDelta {
+        id: MessageId::new(),
+        at: Utc::now(),
+        delta: "final".to_string(),
+    };
+    log.append(&event).await.unwrap();
+    log.close().await.unwrap();
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(content.contains("final"), "close() must flush the final buffered event");
+}

--- a/crates/forge-core/tests/event_log_persistence.rs
+++ b/crates/forge-core/tests/event_log_persistence.rs
@@ -3,7 +3,11 @@ use std::io::{BufRead, BufReader};
 use tempfile::TempDir;
 
 fn session_path(dir: &TempDir, id: &SessionId) -> std::path::PathBuf {
-    dir.path().join(".forge").join("sessions").join(id.to_string()).join("events.jsonl")
+    dir.path()
+        .join(".forge")
+        .join("sessions")
+        .join(id.to_string())
+        .join("events.jsonl")
 }
 
 #[tokio::test]
@@ -16,7 +20,10 @@ async fn creates_file_with_schema_header() {
 
     let file = std::fs::File::open(&path).unwrap();
     let mut lines = BufReader::new(file).lines();
-    let first = lines.next().expect("file should have at least one line").unwrap();
+    let first = lines
+        .next()
+        .expect("file should have at least one line")
+        .unwrap();
     assert_eq!(first, r#"{"schema_version":1}"#);
 }
 
@@ -39,7 +46,10 @@ async fn open_rejects_file_missing_schema_header() {
 
     let result = EventLog::open(&path).await;
 
-    assert!(result.is_err(), "open should reject file without schema header");
+    assert!(
+        result.is_err(),
+        "open should reject file without schema header"
+    );
 }
 
 #[tokio::test]
@@ -61,13 +71,15 @@ async fn open_accepts_file_with_valid_schema_header() {
     let _log = EventLog::create(&path).await.unwrap();
     drop(_log);
 
-    EventLog::open(&path).await.expect("open should succeed on a freshly created file");
+    EventLog::open(&path)
+        .await
+        .expect("open should succeed on a freshly created file");
 }
 
 #[tokio::test]
 async fn appended_events_appear_after_header() {
-    use forge_core::{Event, MessageId};
     use chrono::Utc;
+    use forge_core::{Event, MessageId};
 
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("events.jsonl");
@@ -91,8 +103,8 @@ async fn appended_events_appear_after_header() {
 
 #[tokio::test]
 async fn background_task_flushes_after_50ms_without_further_appends() {
-    use forge_core::{Event, MessageId};
     use chrono::Utc;
+    use forge_core::{Event, MessageId};
 
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("events.jsonl");
@@ -109,13 +121,16 @@ async fn background_task_flushes_after_50ms_without_further_appends() {
     tokio::time::sleep(tokio::time::Duration::from_millis(75)).await;
 
     let content = std::fs::read_to_string(&path).unwrap();
-    assert!(content.contains("persisted"), "background flush should write to disk within 75ms");
+    assert!(
+        content.contains("persisted"),
+        "background flush should write to disk within 75ms"
+    );
 }
 
 #[tokio::test]
 async fn close_flushes_final_buffered_event() {
-    use forge_core::{Event, MessageId};
     use chrono::Utc;
+    use forge_core::{Event, MessageId};
 
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("events.jsonl");
@@ -130,5 +145,8 @@ async fn close_flushes_final_buffered_event() {
     log.close().await.unwrap();
 
     let content = std::fs::read_to_string(&path).unwrap();
-    assert!(content.contains("final"), "close() must flush the final buffered event");
+    assert!(
+        content.contains("final"),
+        "close() must flush the final buffered event"
+    );
 }


### PR DESCRIPTION
Closes forge-ide/forge#6

## Summary
- Adds `EventLog` to `forge-core` for append-only `.forge/sessions/<id>/events.jsonl` persistence
- First line of every file is always `{"schema_version":1}`; `open()` rejects files where it is absent or malformed
- `open()` validates the header on a single file handle (no TOCTOU double-open)
- Background tokio task flushes `BufWriter` every 50ms; `close()` performs a final flush on shutdown
- 8 integration tests covering create, open, reject, append, background flush, and close-flush

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)