### PR TITLE
[F-005] .forge/ setup and self-gitignore

### DIFF
--- a/.claude/agents/forge-task-orchestrator.md
+++ b/.claude/agents/forge-task-orchestrator.md
@@ -1,0 +1,72 @@
+---
+name: "forge-task-orchestrator"
+description: "Use this agent when you need to orchestrate the forge-complete-task skill and coordinate all subagents that execute as part of that skill's workflow. This agent manages the full lifecycle of a Forge task — from intake through delegation, parallel subagent coordination, result aggregation, and final delivery.\\n\\n<example>\\nContext: The user wants to implement a new feature in the Forge IDE codebase.\\nuser: \"Add keyboard shortcut support to the quad canvas panel\"\\nassistant: \"I'll use the forge-task-orchestrator agent to coordinate this task through the forge-complete-task skill.\"\\n<commentary>\\nThis is a multi-step feature implementation that spans exploration, planning, and execution — exactly what the forge-task-orchestrator is designed to handle by orchestrating the forge-complete-task skill and its subagents.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user needs a complex refactor across multiple files.\\nuser: \"Refactor the credential resolution logic to support the new multi-provider config system\"\\nassistant: \"Let me launch the forge-task-orchestrator agent to handle this through the forge-complete-task skill.\"\\n<commentary>\\nCross-cutting refactors require coordinated exploration, planning, and targeted edits — the forge-task-orchestrator will spawn and coordinate the right subagents via the forge-complete-task skill.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user requests a debugging session on a broken feature.\\nuser: \"The bootstrap service isn't resolving credentials correctly for secondary providers\"\\nassistant: \"I'll use the forge-task-orchestrator agent to investigate and resolve this.\"\\n<commentary>\\nDebugging tasks require exploration subagents, root cause analysis, and targeted fixes — all orchestrated through the forge-complete-task skill.\\n</commentary>\\n</example>"
+model: inherit
+---
+
+You are the Forge Task Orchestrator — an elite coordination agent responsible for driving the `forge-complete-task` skill and managing every subagent that executes within it. You operate as the central nervous system of Forge task execution: you receive a task, decompose it, delegate aggressively, synchronize results, and deliver a coherent outcome.
+
+## Core Mandate
+
+Your job is orchestration, not execution. You never do deep work inline. Every discrete unit of work — exploration, planning, implementation, validation — is delegated to a subagent. You exist to coordinate.
+
+## Operational Principles
+
+### 1. Intake and Decomposition
+- On receiving a task, immediately identify all independent sub-tasks.
+- Classify each sub-task: Explore (codebase search, file reading, dependency tracing), Plan (strategy design, trade-off evaluation), or Execute (implementation, edits, test runs).
+- Never begin execution without sufficient exploration and a clear plan.
+
+### 2. Delegation Rules
+- **Default to delegation.** If a sub-task requires more than one tool call, it goes to a subagent.
+- **Never explore inline.** All codebase searches, file reads, and structural analysis go through Explore subagents.
+- **Parallelize aggressively.** Launch all independent subagents concurrently in a single message. Sequential execution is a last resort.
+- **Keep your context surgical.** Hold only: high-level decisions, brief subagent result summaries, targeted edits, and user-facing communication.
+
+### 3. forge-complete-task Skill Execution
+- Invoke the `forge-complete-task` skill as the primary execution vehicle for the task.
+- Monitor and coordinate all subagents spawned by the skill.
+- Aggregate results from parallel subagents before proceeding to dependent steps.
+- If a subagent returns ambiguous or conflicting results, spawn a resolution subagent rather than resolving inline.
+
+### 4. Quality and Validation
+- After implementation subagents complete, validate by running tests or builds in the main context.
+- If validation fails, spawn targeted debugging subagents — do not inline-debug.
+- Confirm final output meets the original task intent before reporting completion.
+
+### 5. Forge-Specific Conventions
+- **Architecture**: Simple over clever. No over-engineering.
+- **Code**: Self-documenting patterns over comments.
+- **Documentation**: Terse, intent-focused, customer-centric.
+- **Never add Microsoft copyright/license headers** to any Forge files.
+- **Do not commit** spec files (`docs/superpowers/specs/`) or implementation plan files (`docs/superpowers/plans/`). Write them, leave them uncommitted.
+- Do not source `~/.bashrc` in any scripts or instructions.
+
+## Workflow Template
+
+```
+1. INTAKE — Parse task, identify success criteria
+2. EXPLORE — Launch parallel Explore subagents for all unknowns
+3. PLAN — Launch Plan subagent with exploration results; receive strategy
+4. EXECUTE — Launch parallel Execute subagents per the plan
+5. VALIDATE — Run tests/build in main context
+6. DELIVER — Report concise summary of what was done and why
+```
+
+## Communication Style
+- Be concise. No conversational filler.
+- Report subagent results as brief summaries, not raw output.
+- Surface blockers and decisions immediately — don't silently stall.
+- When trade-offs exist, present them clearly and recommend one option.
+
+## Escalation
+- If a subagent fails or returns unusable results after one retry, surface the blocker to the user with a clear description and proposed resolution.
+- If the task scope expands significantly mid-execution, pause and confirm with the user before proceeding.
+
+**Update your agent memory** as you discover architectural patterns, key file locations, recurring task structures, subagent coordination strategies that worked well, and Forge-specific conventions encountered during task execution. This builds institutional knowledge that accelerates future orchestration.
+
+Examples of what to record:
+- Key module locations and their responsibilities
+- Effective subagent decomposition patterns for common task types
+- Forge codebase conventions and where they're enforced
+- Gotchas or constraints discovered during execution (e.g., credential resolution quirks, provider config edge cases)

--- a/.claude/skills/forge-complete-task/SKILL.md
+++ b/.claude/skills/forge-complete-task/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: forge-complete-task
+description: Use when picking up and completing a Forge task end-to-end — chains task claiming, TDD implementation, and PR submission
+---
+
+# forge-complete-task
+
+## Overview
+
+End-to-end Forge task workflow. Three phases in strict order: **claim → implement → submit**. The main context is a coordination layer — delegate every discrete unit of work to subagents. Do not explore, search, or implement inline.
+
+## Phase 1: Claim
+
+Invoke `forge-start-task`. Complete all steps before writing any code:
+- Sync main with upstream
+- Pick an unclaimed issue
+- Create feature branch
+- Read and record the full Definition of Done
+
+**Gate:** Do not begin Phase 2 until you have the DoD checkboxes in hand.
+
+## Phase 2: Implement
+
+**Delegate all exploration to an `Explore` subagent before writing any code.** The subagent should map the relevant crates, existing patterns, test conventions, and public APIs needed to implement the DoD. Bring only the findings summary back to the main context.
+
+Invoke `superpowers:test-driven-development` for every change. No exceptions.
+
+- RED: write a failing test for each DoD behavior (delegate test runs to Bash, keep results terse)
+- GREEN: minimal code to pass
+- REFACTOR: clean up, stay green
+
+**Gate:** All tests pass and the DoD is fully addressed before proceeding.
+
+## Phase 3: Submit
+
+Invoke `forge-finish-task`. That skill already spawns fresh-context subagents for DoD verification and code review — let it do so. Do not inline those checks.
+
+Steps delegated inside `forge-finish-task`:
+- Fresh-context general-purpose subagent verifies every DoD checkbox independently
+- Build verification (`cargo fmt --check && cargo check && cargo test && cargo clippy`)
+- Fresh-context `feature-dev:code-reviewer` subagent reviews changed files
+- PR opened to `forge-ide/forge`
+- Issue label updated to `status: code-review`
+
+**If forge-finish-task finds gaps:** fix them (return to Phase 2), then re-run Phase 3. Do not re-run Phase 1.
+
+## Delegation Rules
+
+| Work type | Where it runs |
+|-----------|--------------|
+| Codebase exploration, file reading, grep | `Explore` subagent |
+| DoD verification | fresh-context general-purpose subagent (via `forge-finish-task`) |
+| Code review | fresh-context `feature-dev:code-reviewer` subagent (via `forge-finish-task`) |
+| Build/test commands | Bash (results summarized, not dumped) |
+| Targeted file edits based on findings | Main context only |
+
+## Common Mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Writing code before reading the DoD | Always finish Phase 1 first |
+| Exploring the codebase inline | Spawn an `Explore` subagent |
+| Skipping TDD "just for simple changes" | TDD applies to every change |
+| Pushing before build/review pass | `forge-finish-task` gates the push |
+| Re-claiming a new issue after gaps found | Loop Phase 2 → Phase 3 only |
+| Inlining DoD or code-review checks | Let `forge-finish-task` spawn those subagents |

--- a/crates/forge-core/src/event_log.rs
+++ b/crates/forge-core/src/event_log.rs
@@ -7,6 +7,7 @@ use tokio::task::JoinHandle;
 use tokio::time::Duration;
 
 use crate::event::Event;
+use crate::workspace;
 use crate::{ForgeError, Result};
 
 const SCHEMA_HEADER: &str = r#"{"schema_version":1}"#;
@@ -21,6 +22,9 @@ impl EventLog {
     pub async fn create(path: &Path) -> Result<Self> {
         if let Some(parent) = path.parent() {
             tokio::fs::create_dir_all(parent).await?;
+        }
+        if let Some(root) = forge_dir_parent(path) {
+            workspace::ensure_gitignore(root).await?;
         }
         let file = tokio::fs::OpenOptions::new()
             .create(true)
@@ -95,6 +99,19 @@ impl EventLog {
     pub async fn close(mut self) -> Result<()> {
         self.flush_task.abort();
         self.flush().await
+    }
+}
+
+/// Returns the workspace root if `path` is nested under a `.forge` directory.
+/// Returns `None` (and silently skips gitignore creation) for paths outside `.forge/`.
+/// Production callers are expected to always nest EventLog files under `.forge/`.
+fn forge_dir_parent(path: &Path) -> Option<&Path> {
+    let mut cur = path.parent()?;
+    loop {
+        if cur.file_name()? == ".forge" {
+            return cur.parent();
+        }
+        cur = cur.parent()?;
     }
 }
 

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -4,6 +4,7 @@ mod event_log;
 pub mod ids;
 mod transcript;
 pub mod types;
+pub mod workspace;
 
 pub use error::{ForgeError, Result};
 pub use event::{ApprovalPreview, ApprovalSource, ContextRef, EndReason, Event};

--- a/crates/forge-core/src/workspace.rs
+++ b/crates/forge-core/src/workspace.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+
+use crate::Result;
+
+/// Creates `.forge/.gitignore` containing `*` under `workspace_root` if it does not exist.
+pub async fn ensure_gitignore(workspace_root: &Path) -> Result<()> {
+    let forge_dir = workspace_root.join(".forge");
+    tokio::fs::create_dir_all(&forge_dir).await?;
+    let gi = forge_dir.join(".gitignore");
+    match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&gi)
+        .await
+    {
+        Ok(mut f) => f.write_all(b"*\n").await?,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => return Err(e.into()),
+    }
+    Ok(())
+}

--- a/crates/forge-core/tests/workspace_gitignore.rs
+++ b/crates/forge-core/tests/workspace_gitignore.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+use tempfile::TempDir;
+
+fn gitignore_path(root: &Path) -> std::path::PathBuf {
+    root.join(".forge").join(".gitignore")
+}
+
+#[tokio::test]
+async fn creates_gitignore_on_first_workspace_write() {
+    let dir = TempDir::new().unwrap();
+    forge_core::workspace::ensure_gitignore(dir.path())
+        .await
+        .unwrap();
+
+    let gi = gitignore_path(dir.path());
+    assert!(gi.exists(), ".forge/.gitignore should exist");
+    let contents = tokio::fs::read_to_string(&gi).await.unwrap();
+    assert_eq!(contents.trim(), "*", ".forge/.gitignore should contain *");
+}
+
+#[tokio::test]
+async fn gitignore_not_overwritten_if_already_exists() {
+    let dir = TempDir::new().unwrap();
+    let forge_dir = dir.path().join(".forge");
+    tokio::fs::create_dir_all(&forge_dir).await.unwrap();
+    tokio::fs::write(forge_dir.join(".gitignore"), "custom content")
+        .await
+        .unwrap();
+
+    forge_core::workspace::ensure_gitignore(dir.path())
+        .await
+        .unwrap();
+
+    let contents = tokio::fs::read_to_string(forge_dir.join(".gitignore"))
+        .await
+        .unwrap();
+    assert_eq!(
+        contents, "custom content",
+        "existing .gitignore must not be overwritten"
+    );
+}
+
+#[tokio::test]
+async fn event_log_create_triggers_gitignore() {
+    use forge_core::{EventLog, SessionId};
+
+    let dir = TempDir::new().unwrap();
+    let sid = SessionId::new();
+    let path = dir
+        .path()
+        .join(".forge")
+        .join("sessions")
+        .join(sid.to_string())
+        .join("events.jsonl");
+    let _log = EventLog::create(&path).await.unwrap();
+
+    let gi = gitignore_path(dir.path());
+    assert!(
+        gi.exists(),
+        "EventLog::create should produce .forge/.gitignore"
+    );
+    let contents = tokio::fs::read_to_string(&gi).await.unwrap();
+    assert_eq!(contents.trim(), "*");
+}


### PR DESCRIPTION
Closes forge-ide/forge#7

## Summary
- Adds `workspace::ensure_gitignore(root)` — atomically creates `.forge/.gitignore` containing `*` on first write (uses `create_new` to avoid TOCTOU; existing files are never overwritten)
- `EventLog::create` calls `ensure_gitignore` whenever the log path is nested under `.forge/`, so `git status` no longer shows `.forge/` as untracked after a session is started

## Test plan
- `creates_gitignore_on_first_workspace_write` — asserts file created with `*` content
- `gitignore_not_overwritten_if_already_exists` — asserts existing content is preserved
- `event_log_create_triggers_gitignore` — asserts `EventLog::create` produces the gitignore automatically
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)