### PR TITLE
[F-006] meta.toml and workspaces.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "ts-rs",
 ]
 
@@ -472,6 +473,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +561,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "ts-rs"
@@ -765,6 +816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/crates/forge-core/Cargo.toml
+++ b/crates/forge-core/Cargo.toml
@@ -12,6 +12,7 @@ ts-rs = { version = "10", features = ["serde-compat"] }
 rand = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["io-util", "fs", "time", "sync", "rt"] }
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -2,9 +2,11 @@ mod error;
 mod event;
 mod event_log;
 pub mod ids;
+pub mod meta;
 mod transcript;
 pub mod types;
 pub mod workspace;
+pub mod workspaces;
 
 pub use error::{ForgeError, Result};
 pub use event::{ApprovalPreview, ApprovalSource, ContextRef, EndReason, Event};

--- a/crates/forge-core/src/meta.rs
+++ b/crates/forge-core/src/meta.rs
@@ -1,0 +1,44 @@
+use crate::{
+    AgentId, ProviderId, Result, SessionId, SessionPersistence, SessionState, WorkspaceId,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionMeta {
+    pub id: SessionId,
+    pub workspace_id: WorkspaceId,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<AgentId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<ProviderId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub state: SessionState,
+    pub persistence: SessionPersistence,
+    pub started_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<DateTime<Utc>>,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+    pub cost_usd: f64,
+    pub pid: u32,
+    pub socket_path: PathBuf,
+}
+
+pub async fn write_meta(path: &Path, meta: &SessionMeta) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let contents = toml::to_string(meta).map_err(|e| anyhow::anyhow!(e))?;
+    tokio::fs::write(path, contents).await?;
+    Ok(())
+}
+
+pub async fn read_meta(path: &Path) -> Result<SessionMeta> {
+    let contents = tokio::fs::read_to_string(path).await?;
+    let meta = toml::from_str(&contents).map_err(|e| anyhow::anyhow!(e))?;
+    Ok(meta)
+}

--- a/crates/forge-core/src/workspaces.rs
+++ b/crates/forge-core/src/workspaces.rs
@@ -1,0 +1,37 @@
+use crate::{Result, WorkspaceId};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkspaceEntry {
+    pub id: WorkspaceId,
+    pub path: PathBuf,
+    pub name: String,
+    pub last_opened: DateTime<Utc>,
+    pub pinned: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct WorkspacesFile {
+    #[serde(default)]
+    workspaces: Vec<WorkspaceEntry>,
+}
+
+pub async fn write_workspaces(path: &Path, entries: &[WorkspaceEntry]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let file = WorkspacesFile {
+        workspaces: entries.to_vec(),
+    };
+    let contents = toml::to_string(&file).map_err(|e| anyhow::anyhow!(e))?;
+    tokio::fs::write(path, contents).await?;
+    Ok(())
+}
+
+pub async fn read_workspaces(path: &Path) -> Result<Vec<WorkspaceEntry>> {
+    let contents = tokio::fs::read_to_string(path).await?;
+    let file: WorkspacesFile = toml::from_str(&contents).map_err(|e| anyhow::anyhow!(e))?;
+    Ok(file.workspaces)
+}

--- a/crates/forge-core/tests/meta_toml.rs
+++ b/crates/forge-core/tests/meta_toml.rs
@@ -1,0 +1,131 @@
+use chrono::Utc;
+use forge_core::{
+    meta::{read_meta, write_meta, SessionMeta},
+    AgentId, ProviderId, SessionId, SessionPersistence, SessionState, WorkspaceId,
+};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn meta_toml_round_trip_full() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("meta.toml");
+
+    let started = Utc::now().with_nanosecond(0).unwrap();
+    let ended = Utc::now().with_nanosecond(0).unwrap();
+
+    let meta = SessionMeta {
+        id: SessionId::new(),
+        workspace_id: WorkspaceId::new(),
+        name: "refactor-payment-service".to_string(),
+        agent: Some(AgentId::new()),
+        provider_id: None,
+        model: None,
+        state: SessionState::Active,
+        persistence: SessionPersistence::Persist,
+        started_at: started,
+        ended_at: Some(ended),
+        tokens_in: 48200,
+        tokens_out: 12100,
+        cost_usd: 0.23,
+        pid: 48211,
+        socket_path: PathBuf::from("/tmp/forge-1000/sessions/a3f1b2c4.sock"),
+    };
+
+    write_meta(&path, &meta).await.unwrap();
+    let loaded = read_meta(&path).await.unwrap();
+
+    assert_eq!(meta.id, loaded.id);
+    assert_eq!(meta.workspace_id, loaded.workspace_id);
+    assert_eq!(meta.name, loaded.name);
+    assert_eq!(meta.agent, loaded.agent);
+    assert_eq!(meta.provider_id, loaded.provider_id);
+    assert_eq!(meta.model, loaded.model);
+    assert_eq!(meta.state, loaded.state);
+    assert_eq!(meta.persistence, loaded.persistence);
+    assert_eq!(meta.started_at, loaded.started_at);
+    assert_eq!(meta.ended_at, loaded.ended_at);
+    assert_eq!(meta.tokens_in, loaded.tokens_in);
+    assert_eq!(meta.tokens_out, loaded.tokens_out);
+    assert_eq!(meta.cost_usd, loaded.cost_usd);
+    assert_eq!(meta.pid, loaded.pid);
+    assert_eq!(meta.socket_path, loaded.socket_path);
+}
+
+#[tokio::test]
+async fn meta_toml_round_trip_bare_provider() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("meta.toml");
+
+    let meta = SessionMeta {
+        id: SessionId::new(),
+        workspace_id: WorkspaceId::new(),
+        name: "bare-session".to_string(),
+        agent: None,
+        provider_id: Some(ProviderId::new()),
+        model: Some("sonnet-4.5".to_string()),
+        state: SessionState::Ended,
+        persistence: SessionPersistence::Ephemeral,
+        started_at: Utc::now().with_nanosecond(0).unwrap(),
+        ended_at: None,
+        tokens_in: 100,
+        tokens_out: 50,
+        cost_usd: 0.01,
+        pid: 99999,
+        socket_path: PathBuf::from("/tmp/forge-1000/sessions/bare.sock"),
+    };
+
+    write_meta(&path, &meta).await.unwrap();
+    let loaded = read_meta(&path).await.unwrap();
+
+    assert_eq!(meta.agent, loaded.agent);
+    assert_eq!(meta.provider_id, loaded.provider_id);
+    assert_eq!(meta.model, loaded.model);
+    assert_eq!(meta.state, loaded.state);
+    assert_eq!(meta.persistence, loaded.persistence);
+    assert_eq!(meta.ended_at, loaded.ended_at);
+}
+
+#[tokio::test]
+async fn meta_toml_creates_parent_dirs() {
+    let dir = TempDir::new().unwrap();
+    let path = dir
+        .path()
+        .join(".forge")
+        .join("sessions")
+        .join("abc123")
+        .join("meta.toml");
+
+    let meta = SessionMeta {
+        id: SessionId::new(),
+        workspace_id: WorkspaceId::new(),
+        name: "test".to_string(),
+        agent: None,
+        provider_id: None,
+        model: None,
+        state: SessionState::Active,
+        persistence: SessionPersistence::Persist,
+        started_at: Utc::now().with_nanosecond(0).unwrap(),
+        ended_at: None,
+        tokens_in: 0,
+        tokens_out: 0,
+        cost_usd: 0.0,
+        pid: 1,
+        socket_path: PathBuf::from("/tmp/test.sock"),
+    };
+
+    write_meta(&path, &meta).await.unwrap();
+    assert!(path.exists());
+}
+
+trait WithNanosecond {
+    fn with_nanosecond(self, ns: u32) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+impl WithNanosecond for chrono::DateTime<chrono::Utc> {
+    fn with_nanosecond(self, ns: u32) -> Option<Self> {
+        chrono::Timelike::with_nanosecond(&self, ns)
+    }
+}

--- a/crates/forge-core/tests/workspaces_toml.rs
+++ b/crates/forge-core/tests/workspaces_toml.rs
@@ -1,0 +1,99 @@
+use chrono::Utc;
+use forge_core::{
+    workspaces::{read_workspaces, write_workspaces, WorkspaceEntry},
+    WorkspaceId,
+};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn workspaces_toml_round_trip_single() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("workspaces.toml");
+
+    let entries = vec![WorkspaceEntry {
+        id: WorkspaceId::new(),
+        path: PathBuf::from("/home/alice/code/acme-api"),
+        name: "acme-api".to_string(),
+        last_opened: Utc::now().with_nanosecond(0).unwrap(),
+        pinned: false,
+    }];
+
+    write_workspaces(&path, &entries).await.unwrap();
+    let loaded = read_workspaces(&path).await.unwrap();
+
+    assert_eq!(entries.len(), loaded.len());
+    assert_eq!(entries[0].id, loaded[0].id);
+    assert_eq!(entries[0].path, loaded[0].path);
+    assert_eq!(entries[0].name, loaded[0].name);
+    assert_eq!(entries[0].last_opened, loaded[0].last_opened);
+    assert_eq!(entries[0].pinned, loaded[0].pinned);
+}
+
+#[tokio::test]
+async fn workspaces_toml_round_trip_multiple() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("workspaces.toml");
+
+    let entries = vec![
+        WorkspaceEntry {
+            id: WorkspaceId::new(),
+            path: PathBuf::from("/home/alice/code/acme-api"),
+            name: "acme-api".to_string(),
+            last_opened: Utc::now().with_nanosecond(0).unwrap(),
+            pinned: true,
+        },
+        WorkspaceEntry {
+            id: WorkspaceId::new(),
+            path: PathBuf::from("/home/alice/code/docs-v2"),
+            name: "docs-v2".to_string(),
+            last_opened: Utc::now().with_nanosecond(0).unwrap(),
+            pinned: false,
+        },
+    ];
+
+    write_workspaces(&path, &entries).await.unwrap();
+    let loaded = read_workspaces(&path).await.unwrap();
+
+    assert_eq!(2, loaded.len());
+    assert_eq!(entries[0].name, loaded[0].name);
+    assert_eq!(entries[1].name, loaded[1].name);
+    assert_eq!(entries[0].pinned, loaded[0].pinned);
+    assert_eq!(entries[1].pinned, loaded[1].pinned);
+}
+
+#[tokio::test]
+async fn workspaces_toml_creates_parent_dirs() {
+    let dir = TempDir::new().unwrap();
+    let path = dir
+        .path()
+        .join(".config")
+        .join("forge")
+        .join("workspaces.toml");
+
+    write_workspaces(&path, &[]).await.unwrap();
+    assert!(path.exists());
+}
+
+#[tokio::test]
+async fn workspaces_toml_empty_list() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("workspaces.toml");
+
+    write_workspaces(&path, &[]).await.unwrap();
+    let loaded = read_workspaces(&path).await.unwrap();
+
+    assert!(loaded.is_empty());
+}
+
+trait WithNanosecond {
+    fn with_nanosecond(self, ns: u32) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+impl WithNanosecond for chrono::DateTime<chrono::Utc> {
+    fn with_nanosecond(self, ns: u32) -> Option<Self> {
+        chrono::Timelike::with_nanosecond(&self, ns)
+    }
+}


### PR DESCRIPTION
Closes forge-ide/forge#8

## Summary
- `SessionMeta` struct with all §7.3 fields (id, workspace_id, name, agent, provider_id, model, state, persistence, started_at, ended_at, tokens_in, tokens_out, cost_usd, pid, socket_path) + `write_meta`/`read_meta` async fns
- `WorkspaceEntry` struct with all §7.2 fields (id, path, name, last_opened, pinned) + `write_workspaces`/`read_workspaces` async fns using `[[workspaces]]` array-of-tables format
- Parent directories created automatically on write
- 7 round-trip integration tests covering full/bare-provider sessions, multiple entries, empty list, and nested path creation

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)