### PR TITLE
[F-008] Length-prefixed JSON framing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,12 @@ name = "forge-ipc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
+ "futures",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -185,6 +188,94 @@ version = "0.1.0"
 [[package]]
 name = "forge-term"
 version = "0.1.0"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -514,6 +605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +697,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/forge-ipc/Cargo.toml
+++ b/crates/forge-ipc/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+bytes = "1"
+futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["io-util"] }
+tokio = { version = "1", features = ["io-util", "net"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }

--- a/crates/forge-ipc/src/lib.rs
+++ b/crates/forge-ipc/src/lib.rs
@@ -1,6 +1,10 @@
 use anyhow::bail;
-use serde::{Deserialize, Serialize};
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::UnixStream;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
 pub const PROTO_VERSION: u32 = 1;
 pub const SCHEMA_VERSION: u32 = 1;
@@ -57,4 +61,89 @@ pub async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> anyhow::Result<
     reader.read_exact(&mut buf).await?;
     let msg = serde_json::from_slice(&buf)?;
     Ok(msg)
+}
+
+pub struct FramedStream {
+    inner: Framed<UnixStream, LengthDelimitedCodec>,
+}
+
+impl FramedStream {
+    pub fn new(stream: UnixStream) -> Self {
+        let codec = LengthDelimitedCodec::builder()
+            .max_frame_length(MAX_FRAME_SIZE)
+            .new_codec();
+        Self {
+            inner: Framed::new(stream, codec),
+        }
+    }
+
+    pub async fn send<T: Serialize>(&mut self, msg: &T) -> anyhow::Result<()> {
+        let bytes = Bytes::from(serde_json::to_vec(msg)?);
+        self.inner.send(bytes).await?;
+        Ok(())
+    }
+
+    pub async fn recv<T: DeserializeOwned>(&mut self) -> anyhow::Result<Option<T>> {
+        match self.inner.next().await {
+            Some(Ok(bytes)) => Ok(Some(serde_json::from_slice(&bytes)?)),
+            Some(Err(e)) => Err(e.into()),
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hello_msg() -> IpcMessage {
+        IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "test".to_string(),
+                pid: 1234,
+                user: "alice".to_string(),
+            },
+        })
+    }
+
+    fn hello_ack_msg() -> IpcMessage {
+        IpcMessage::HelloAck(HelloAck {
+            session_id: "sess-abc".to_string(),
+            workspace: "/tmp/ws".to_string(),
+            started_at: "2024-01-01T00:00:00Z".to_string(),
+            event_seq: 7,
+            schema_version: SCHEMA_VERSION,
+        })
+    }
+
+    #[tokio::test]
+    async fn framed_stream_round_trips_hello() {
+        let (a, b) = UnixStream::pair().unwrap();
+        let mut sender = FramedStream::new(a);
+        let mut receiver = FramedStream::new(b);
+
+        let sent = hello_msg();
+        sender.send(&sent).await.unwrap();
+        let got: IpcMessage = receiver.recv().await.unwrap().unwrap();
+
+        let sent_json = serde_json::to_string(&sent).unwrap();
+        let got_json = serde_json::to_string(&got).unwrap();
+        assert_eq!(sent_json, got_json);
+    }
+
+    #[tokio::test]
+    async fn framed_stream_round_trips_hello_ack() {
+        let (a, b) = UnixStream::pair().unwrap();
+        let mut sender = FramedStream::new(a);
+        let mut receiver = FramedStream::new(b);
+
+        let sent = hello_ack_msg();
+        sender.send(&sent).await.unwrap();
+        let got: IpcMessage = receiver.recv().await.unwrap().unwrap();
+
+        let sent_json = serde_json::to_string(&sent).unwrap();
+        let got_json = serde_json::to_string(&got).unwrap();
+        assert_eq!(sent_json, got_json);
+    }
 }


### PR DESCRIPTION
Closes forge-ide/forge#10

## Summary
- Added `FramedStream` to `forge-ipc` wrapping `tokio::net::UnixStream` via `Framed<_, LengthDelimitedCodec>`
- Generic `send<T: Serialize>` / `recv<T: DeserializeOwned>` methods serialize/deserialize via `serde_json`
- 4 MiB max frame limit preserved from existing constants
- Added `tokio-util`, `bytes`, and `futures` dependencies

## Test plan
- `cargo test -p forge-ipc` — 2 tests pass (Hello and HelloAck round-trip)
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)