### PR TITLE
[F-009] Subscribe + Event replay

### DIFF
--- a/crates/forge-core/src/event_log.rs
+++ b/crates/forge-core/src/event_log.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufWriter};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
@@ -100,6 +100,37 @@ impl EventLog {
         self.flush_task.abort();
         self.flush().await
     }
+}
+
+/// Reads events from the log at `path` that have sequence number greater than `since`.
+///
+/// Events are 1-indexed: the first event in the file is seq 1. Sending `since: 0`
+/// returns all events; `since: N` returns events N+1 onward.
+pub async fn read_since(path: &Path, since: u64) -> Result<Vec<(u64, Event)>> {
+    let file = tokio::fs::File::open(path).await?;
+    let mut lines = BufReader::new(file).lines();
+
+    let header = lines
+        .next_line()
+        .await?
+        .ok_or_else(|| ForgeError::Other(anyhow::anyhow!("event log is empty")))?;
+    if header != SCHEMA_HEADER {
+        return Err(ForgeError::Other(anyhow::anyhow!(
+            "schema header mismatch: expected {SCHEMA_HEADER:?}, got {header:?}"
+        )));
+    }
+
+    let mut events = Vec::new();
+    let mut seq = 0u64;
+    while let Some(line) = lines.next_line().await? {
+        seq += 1;
+        if seq > since {
+            let event: Event = serde_json::from_str(&line)
+                .map_err(|e| ForgeError::Other(anyhow::anyhow!("bad event at seq {seq}: {e}")))?;
+            events.push((seq, event));
+        }
+    }
+    Ok(events)
 }
 
 /// Returns the workspace root if `path` is nested under a `.forge` directory.

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -10,7 +10,7 @@ pub mod workspaces;
 
 pub use error::{ForgeError, Result};
 pub use event::{ApprovalPreview, ApprovalSource, ContextRef, EndReason, Event};
-pub use event_log::EventLog;
+pub use event_log::{read_since, EventLog};
 pub use ids::{
     AgentId, AgentInstanceId, MessageId, ProviderId, SessionId, ToolCallId, WorkspaceId,
 };

--- a/crates/forge-ipc/src/lib.rs
+++ b/crates/forge-ipc/src/lib.rs
@@ -15,6 +15,19 @@ const MAX_FRAME_SIZE: usize = 4 * 1024 * 1024;
 pub enum IpcMessage {
     Hello(Hello),
     HelloAck(HelloAck),
+    Subscribe(Subscribe),
+    Event(IpcEvent),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Subscribe {
+    pub since: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IpcEvent {
+    pub seq: u64,
+    pub event: serde_json::Value,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod server;
+pub mod session;

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -1,9 +1,23 @@
-use anyhow::Result;
-use forge_ipc::{HelloAck, IpcMessage, PROTO_VERSION, SCHEMA_VERSION};
 use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use forge_core::{read_since, SessionId};
+use forge_ipc::{HelloAck, IpcEvent, IpcMessage, PROTO_VERSION, SCHEMA_VERSION};
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::broadcast;
+
+use crate::session::Session;
 
 pub async fn serve(path: &Path) -> Result<()> {
+    let log_path = std::env::temp_dir()
+        .join(format!("forge-session-{}", SessionId::new()))
+        .join("events.jsonl");
+    let session = Arc::new(Session::create(log_path).await?);
+    serve_with_session(path, session).await
+}
+
+pub async fn serve_with_session(path: &Path, session: Arc<Session>) -> Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
@@ -13,34 +27,71 @@ pub async fn serve(path: &Path) -> Result<()> {
     let listener = UnixListener::bind(path)?;
     loop {
         let (stream, _) = listener.accept().await?;
+        let session = Arc::clone(&session);
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream).await {
+            if let Err(e) = handle_connection(stream, session).await {
                 eprintln!("connection error: {e}");
             }
         });
     }
 }
 
-async fn handle_connection(mut stream: UnixStream) -> Result<()> {
+async fn handle_connection(mut stream: UnixStream, session: Arc<Session>) -> Result<()> {
     let msg = forge_ipc::read_frame(&mut stream).await?;
-
     let IpcMessage::Hello(hello) = msg else {
         anyhow::bail!("expected Hello, got unexpected message type");
     };
-
     if hello.proto != PROTO_VERSION {
         anyhow::bail!("unsupported protocol version: {}", hello.proto);
     }
 
-    let session_id = forge_core::SessionId::new();
+    let session_id = SessionId::new();
     let ack = IpcMessage::HelloAck(HelloAck {
         session_id: session_id.to_string(),
         workspace: String::new(),
         started_at: chrono::Utc::now().to_rfc3339(),
-        event_seq: 0,
+        event_seq: session.current_seq().await,
         schema_version: SCHEMA_VERSION,
     });
-
     forge_ipc::write_frame(&mut stream, &ack).await?;
+
+    let msg = forge_ipc::read_frame(&mut stream).await?;
+    let IpcMessage::Subscribe(sub) = msg else {
+        anyhow::bail!("expected Subscribe after HelloAck");
+    };
+
+    // Subscribe to live broadcast BEFORE reading history to avoid missing events.
+    let mut live_rx = session.event_tx.subscribe();
+
+    let history = read_since(&session.log_path, sub.since).await?;
+    let mut last_sent = sub.since;
+    for (seq, event) in history {
+        let frame = IpcMessage::Event(IpcEvent {
+            seq,
+            event: serde_json::to_value(&event)?,
+        });
+        forge_ipc::write_frame(&mut stream, &frame).await?;
+        last_sent = seq;
+    }
+
+    loop {
+        match live_rx.recv().await {
+            Ok((seq, event)) if seq > last_sent => {
+                let frame = IpcMessage::Event(IpcEvent {
+                    seq,
+                    event: serde_json::to_value(&event)?,
+                });
+                forge_ipc::write_frame(&mut stream, &frame).await?;
+                last_sent = seq;
+            }
+            Ok(_) => {}
+            Err(broadcast::error::RecvError::Closed) => break,
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                eprintln!("subscriber dropped {n} events; closing connection");
+                break;
+            }
+        }
+    }
+
     Ok(())
 }

--- a/crates/forge-session/src/session.rs
+++ b/crates/forge-session/src/session.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use forge_core::{Event, EventLog};
+use tokio::sync::{broadcast, Mutex};
+
+pub struct Session {
+    pub log_path: PathBuf,
+    pub event_tx: broadcast::Sender<(u64, Event)>,
+    log: Arc<Mutex<EventLog>>,
+    seq: Arc<Mutex<u64>>,
+}
+
+impl Session {
+    pub async fn create(log_path: PathBuf) -> anyhow::Result<Self> {
+        if let Some(parent) = log_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let log = EventLog::create(&log_path)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
+        let (tx, _) = broadcast::channel(1024);
+        Ok(Self {
+            log_path,
+            event_tx: tx,
+            log: Arc::new(Mutex::new(log)),
+            seq: Arc::new(Mutex::new(0)),
+        })
+    }
+
+    pub async fn emit(&self, event: Event) -> anyhow::Result<()> {
+        let mut seq = self.seq.lock().await;
+        *seq += 1;
+        let seq_num = *seq;
+
+        let mut log = self.log.lock().await;
+        log.append(&event).await.map_err(|e| anyhow::anyhow!(e))?;
+        log.flush().await.map_err(|e| anyhow::anyhow!(e))?;
+        drop(log);
+        drop(seq);
+
+        let _ = self.event_tx.send((seq_num, event));
+        Ok(())
+    }
+
+    pub async fn current_seq(&self) -> u64 {
+        *self.seq.lock().await
+    }
+}

--- a/crates/forge-session/tests/subscribe_replay.rs
+++ b/crates/forge-session/tests/subscribe_replay.rs
@@ -1,0 +1,102 @@
+use forge_core::{types::SessionPersistence, Event};
+use forge_ipc::{ClientInfo, Hello, IpcEvent, IpcMessage, Subscribe, PROTO_VERSION};
+use forge_session::{server::serve_with_session, session::Session};
+use std::{path::PathBuf, sync::Arc};
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+fn session_started_event() -> Event {
+    Event::SessionStarted {
+        at: chrono::Utc::now(),
+        workspace: PathBuf::from("/tmp/ws"),
+        agent: None,
+        persistence: SessionPersistence::Ephemeral,
+    }
+}
+
+async fn connect_with_retry(path: &PathBuf) -> UnixStream {
+    for _ in 0..20 {
+        match UnixStream::connect(path).await {
+            Ok(s) => return s,
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+        }
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("server did not start in time")
+}
+
+async fn do_handshake(stream: &mut UnixStream) -> u64 {
+    let hello = IpcMessage::Hello(Hello {
+        proto: PROTO_VERSION,
+        client: ClientInfo {
+            kind: "test".into(),
+            pid: std::process::id(),
+            user: "tester".into(),
+        },
+    });
+    forge_ipc::write_frame(stream, &hello).await.unwrap();
+    let response = forge_ipc::read_frame(stream).await.unwrap();
+    let IpcMessage::HelloAck(ack) = response else {
+        panic!("expected HelloAck, got {:?}", response);
+    };
+    ack.event_seq
+}
+
+#[tokio::test]
+async fn subscribe_mid_stream_receives_historical_then_live_events() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("test.sock");
+
+    // Create session and pre-write 3 events (seq 1, 2, 3)
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    session.emit(session_started_event()).await.unwrap(); // seq 1
+    session.emit(session_started_event()).await.unwrap(); // seq 2
+    session.emit(session_started_event()).await.unwrap(); // seq 3
+
+    // Start server
+    let server_session = Arc::clone(&session);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(&server_sock, server_session)
+            .await
+            .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+
+    // Handshake — event_seq should reflect 3 written events
+    let event_seq = do_handshake(&mut stream).await;
+    assert_eq!(
+        event_seq, 3,
+        "HelloAck.event_seq should equal number of written events"
+    );
+
+    // Subscribe since: 1 — want events at seq 2 and 3 (historical), then live
+    let sub = IpcMessage::Subscribe(Subscribe { since: 1 });
+    forge_ipc::write_frame(&mut stream, &sub).await.unwrap();
+
+    // Read 2 historical events
+    let frame2 = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let IpcMessage::Event(IpcEvent { seq: s2, .. }) = frame2 else {
+        panic!("expected Event frame, got {:?}", frame2);
+    };
+    assert_eq!(s2, 2, "first historical event should be seq 2");
+
+    let frame3 = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let IpcMessage::Event(IpcEvent { seq: s3, .. }) = frame3 else {
+        panic!("expected Event frame, got {:?}", frame3);
+    };
+    assert_eq!(s3, 3, "second historical event should be seq 3");
+
+    // Emit a live event (seq 4)
+    session.emit(session_started_event()).await.unwrap();
+
+    // Client should receive it
+    let frame4 = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let IpcMessage::Event(IpcEvent { seq: s4, .. }) = frame4 else {
+        panic!("expected live Event frame, got {:?}", frame4);
+    };
+    assert_eq!(s4, 4, "live event should be seq 4");
+}


### PR DESCRIPTION
Closes forge-ide/forge#11

## Summary
- Added `Subscribe { since }` and `IpcEvent { seq, event }` variants to `IpcMessage` in `forge-ipc`
- Added `read_since(path, since)` to `forge-core` — reads all JSONL events with seq > `since`
- Added `Session` struct to `forge-session` — holds the event log and a broadcast channel for live events
- Extended session handler: after HelloAck, accepts Subscribe, replays history, then tails live events; lagged subscribers close cleanly
- Integration test verifies mid-stream subscription receives historical events (seq 2, 3) then a live event (seq 4)

## Test plan
- `cargo test --workspace` passes (47 tests across all crates)
- `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)