### PR TITLE
[F-010] Mock provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +188,16 @@ version = "0.1.0"
 [[package]]
 name = "forge-providers"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "forge-core",
+ "futures",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
 
 [[package]]
 name = "forge-session"
@@ -399,6 +430,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +481,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pin-project-lite"
@@ -519,6 +565,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/forge-providers/Cargo.toml
+++ b/crates/forge-providers/Cargo.toml
@@ -2,3 +2,17 @@
 name = "forge-providers"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+anyhow = "1"
+dirs = "6.0.0"
+forge-core = { path = "../forge-core" }
+futures = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["fs", "rt", "macros"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+futures = "0.3"

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -1,1 +1,70 @@
+use std::path::{Path, PathBuf};
 
+use forge_core::Result;
+use futures::stream::BoxStream;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChatChunk {
+    TextDelta(String),
+    ToolCall {
+        name: String,
+        args: serde_json::Value,
+    },
+    Done(String),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawChunk {
+    Delta { delta: String },
+    ToolCall { tool_call: RawToolCall },
+    Done { done: String },
+}
+
+#[derive(Deserialize)]
+struct RawToolCall {
+    name: String,
+    args: serde_json::Value,
+}
+
+pub struct MockProvider {
+    path: PathBuf,
+}
+
+impl MockProvider {
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    pub fn with_default_path() -> Self {
+        let path = dirs::config_dir()
+            .or_else(|| dirs::home_dir().map(|h| h.join(".config")))
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("forge/mock.json");
+        Self { path }
+    }
+
+    pub async fn stream(&self) -> Result<BoxStream<'static, ChatChunk>> {
+        let content = tokio::fs::read_to_string(&self.path).await?;
+        let chunks: Vec<ChatChunk> = content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|line| {
+                let raw: RawChunk = serde_json::from_str(line)?;
+                Ok(match raw {
+                    RawChunk::Delta { delta } => ChatChunk::TextDelta(delta),
+                    RawChunk::ToolCall { tool_call } => ChatChunk::ToolCall {
+                        name: tool_call.name,
+                        args: tool_call.args,
+                    },
+                    RawChunk::Done { done } => ChatChunk::Done(done),
+                })
+            })
+            .collect::<forge_core::Result<Vec<_>>>()?;
+
+        Ok(Box::pin(futures::stream::iter(chunks)))
+    }
+}

--- a/crates/forge-providers/tests/mock_provider.rs
+++ b/crates/forge-providers/tests/mock_provider.rs
@@ -1,0 +1,94 @@
+use forge_providers::{ChatChunk, MockProvider};
+use futures::StreamExt;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+#[tokio::test]
+async fn streams_delta_chunks() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(file, r#"{{"delta":"Hello "}}"#).unwrap();
+    writeln!(file, r#"{{"delta":"world"}}"#).unwrap();
+
+    let provider = MockProvider::new(file.path());
+    let chunks: Vec<ChatChunk> = provider.stream().await.unwrap().collect().await;
+
+    assert_eq!(chunks.len(), 2);
+    assert!(matches!(&chunks[0], ChatChunk::TextDelta(s) if s == "Hello "));
+    assert!(matches!(&chunks[1], ChatChunk::TextDelta(s) if s == "world"));
+}
+
+#[tokio::test]
+async fn streams_tool_call_chunks() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(
+        file,
+        r#"{{"tool_call":{{"name":"fs.read","args":{{"path":"README.md"}}}}}}"#
+    )
+    .unwrap();
+
+    let provider = MockProvider::new(file.path());
+    let chunks: Vec<ChatChunk> = provider.stream().await.unwrap().collect().await;
+
+    assert_eq!(chunks.len(), 1);
+    match &chunks[0] {
+        ChatChunk::ToolCall { name, args } => {
+            assert_eq!(name, "fs.read");
+            assert_eq!(args["path"], "README.md");
+        }
+        other => panic!("expected ToolCall, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn streams_done_chunk() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(file, r#"{{"done":"end_turn"}}"#).unwrap();
+
+    let provider = MockProvider::new(file.path());
+    let chunks: Vec<ChatChunk> = provider.stream().await.unwrap().collect().await;
+
+    assert_eq!(chunks.len(), 1);
+    assert!(matches!(&chunks[0], ChatChunk::Done(s) if s == "end_turn"));
+}
+
+#[tokio::test]
+async fn streams_full_scripted_turn() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(file, r#"{{"delta":"Hello "}}"#).unwrap();
+    writeln!(file, r#"{{"delta":"world"}}"#).unwrap();
+    writeln!(
+        file,
+        r#"{{"tool_call":{{"name":"fs.read","args":{{"path":"README.md"}}}}}}"#
+    )
+    .unwrap();
+    writeln!(file, r#"{{"done":"tool_use"}}"#).unwrap();
+
+    let provider = MockProvider::new(file.path());
+    let chunks: Vec<ChatChunk> = provider.stream().await.unwrap().collect().await;
+
+    assert_eq!(chunks.len(), 4);
+    assert!(matches!(&chunks[0], ChatChunk::TextDelta(_)));
+    assert!(matches!(&chunks[1], ChatChunk::TextDelta(_)));
+    assert!(matches!(&chunks[2], ChatChunk::ToolCall { .. }));
+    assert!(matches!(&chunks[3], ChatChunk::Done(_)));
+}
+
+#[tokio::test]
+async fn path_is_configurable() {
+    let dir = tempfile::tempdir().unwrap();
+    let custom_path = dir.path().join("my_script.json");
+    std::fs::write(&custom_path, "{\"delta\":\"hi\"}\n").unwrap();
+
+    let provider = MockProvider::new(&custom_path);
+    let chunks: Vec<ChatChunk> = provider.stream().await.unwrap().collect().await;
+
+    assert_eq!(chunks.len(), 1);
+    assert!(matches!(&chunks[0], ChatChunk::TextDelta(s) if s == "hi"));
+}
+
+#[tokio::test]
+async fn missing_file_returns_error() {
+    let provider = MockProvider::new("/nonexistent/path/mock.json");
+    let result = provider.stream().await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Closes forge-ide/forge#12

## Summary
- `ChatChunk` enum with `TextDelta`, `ToolCall`, and `Done` variants matching the NDJSON mock.json format
- `MockProvider::new(path)` accepts any configurable path
- `MockProvider::with_default_path()` resolves `~/.config/forge/mock.json` using platform-aware `dirs` crate
- `stream()` reads NDJSON file and returns `BoxStream<'static, ChatChunk>`
- 6 integration tests covering all chunk types, full scripted turns, configurable paths, and missing-file errors

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)