### PR TITLE
[F-011] Agent definition loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +150,12 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "forge-agents"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gray_matter",
+ "serde",
+ "tempfile",
+]
 
 [[package]]
 name = "forge-cli"
@@ -333,6 +354,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gray_matter"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3563a3eb8bacf11a0a6d93de7885f2cca224dddff0114e4eb8053ca0f1918acd"
+dependencies = [
+ "serde",
+ "thiserror",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +378,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -1120,6 +1161,17 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/crates/forge-agents/Cargo.toml
+++ b/crates/forge-agents/Cargo.toml
@@ -2,3 +2,11 @@
 name = "forge-agents"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+anyhow = "1"
+gray_matter = "0.3"
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/forge-agents/src/lib.rs
+++ b/crates/forge-agents/src/lib.rs
@@ -1,1 +1,118 @@
+use anyhow::{bail, Context, Result};
+use gray_matter::{engine::YAML, Matter, ParsedEntity};
+use serde::Deserialize;
+use std::{fs, path::Path};
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentDef {
+    pub name: String,
+    pub description: Option<String>,
+    pub body: String,
+}
+
+#[derive(Deserialize, Default)]
+struct Frontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    isolation: Option<String>,
+}
+
+fn parse_agent_file(path: &Path) -> Result<AgentDef> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+
+    let matter = Matter::<YAML>::new();
+    let parsed: ParsedEntity<Frontmatter> = matter
+        .parse(&raw)
+        .with_context(|| format!("parsing frontmatter in {}", path.display()))?;
+
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    match parsed.data {
+        Some(fm) => {
+            if fm.isolation.as_deref() == Some("trusted") {
+                bail!(
+                    "isolation: trusted is not allowed for user-defined agents ({})",
+                    path.display()
+                );
+            }
+            Ok(AgentDef {
+                name: fm.name.unwrap_or(stem),
+                description: fm.description,
+                body: parsed.content,
+            })
+        }
+        None => Ok(AgentDef {
+            name: stem,
+            description: None,
+            body: parsed.content,
+        }),
+    }
+}
+
+fn load_from_dir(dir: &Path) -> Result<Vec<AgentDef>> {
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut paths: Vec<_> = fs::read_dir(dir)?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
+        .collect();
+    paths.sort();
+    paths.iter().map(|p| parse_agent_file(p)).collect()
+}
+
+pub fn load_workspace_agents(workspace_root: &Path) -> Result<Vec<AgentDef>> {
+    load_from_dir(&workspace_root.join(".agents"))
+}
+
+pub fn load_user_agents(user_home: &Path) -> Result<Vec<AgentDef>> {
+    load_from_dir(&user_home.join(".agents"))
+}
+
+pub fn load_agents(workspace_root: &Path, user_home: &Path) -> Result<Vec<AgentDef>> {
+    let workspace = load_workspace_agents(workspace_root)?;
+    let mut merged = load_user_agents(user_home)?;
+
+    for ws_agent in workspace {
+        match merged.iter().position(|a| a.name == ws_agent.name) {
+            Some(pos) => merged[pos] = ws_agent,
+            None => merged.push(ws_agent),
+        }
+    }
+    Ok(merged)
+}
+
+pub fn load_agents_md(workspace_root: &Path) -> Result<Option<String>> {
+    let path = workspace_root.join("AGENTS.md");
+    if path.exists() {
+        Ok(Some(fs::read_to_string(path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub struct AgentLoader {
+    agents: Vec<AgentDef>,
+    agents_md: Option<String>,
+}
+
+impl AgentLoader {
+    pub fn load(workspace_root: &Path, user_home: &Path) -> Result<Self> {
+        Ok(Self {
+            agents: load_agents(workspace_root, user_home)?,
+            agents_md: load_agents_md(workspace_root)?,
+        })
+    }
+
+    pub fn agents(&self) -> &[AgentDef] {
+        &self.agents
+    }
+
+    pub fn agents_md(&self) -> Option<&str> {
+        self.agents_md.as_deref()
+    }
+}

--- a/crates/forge-agents/tests/agent_loader.rs
+++ b/crates/forge-agents/tests/agent_loader.rs
@@ -1,0 +1,195 @@
+use forge_agents::{load_agents, load_agents_md, load_workspace_agents, AgentDef, AgentLoader};
+use std::fs;
+use tempfile::tempdir;
+
+fn write_agent(dir: &std::path::Path, filename: &str, content: &str) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(dir.join(filename), content).unwrap();
+}
+
+#[test]
+fn parses_agent_with_yaml_frontmatter() {
+    let workspace = tempdir().unwrap();
+    let agents_dir = workspace.path().join(".agents");
+    write_agent(
+        &agents_dir,
+        "helper.md",
+        "---\nname: helper\ndescription: A helpful agent\n---\n\nDoes helpful things.",
+    );
+
+    let agents = load_workspace_agents(workspace.path()).unwrap();
+
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].name, "helper");
+    assert_eq!(agents[0].description.as_deref(), Some("A helpful agent"));
+    assert!(agents[0].body.contains("Does helpful things."));
+}
+
+#[test]
+fn uses_filename_stem_as_name_when_no_frontmatter() {
+    let workspace = tempdir().unwrap();
+    let agents_dir = workspace.path().join(".agents");
+    write_agent(&agents_dir, "default.md", "# Default Agent\n\nDoes stuff.");
+
+    let agents = load_workspace_agents(workspace.path()).unwrap();
+
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].name, "default");
+    assert!(agents[0].body.contains("Does stuff."));
+}
+
+#[test]
+fn rejects_isolation_trusted_for_user_defined_agents() {
+    let workspace = tempdir().unwrap();
+    let agents_dir = workspace.path().join(".agents");
+    write_agent(
+        &agents_dir,
+        "evil.md",
+        "---\nname: evil\nisolation: trusted\n---\n\nDo bad things.",
+    );
+
+    let result = load_workspace_agents(workspace.path());
+
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("trusted"),
+        "error should mention trusted: {msg}"
+    );
+}
+
+#[test]
+fn workspace_agent_wins_on_name_collision() {
+    let workspace = tempdir().unwrap();
+    let user_agents_dir = tempdir().unwrap();
+
+    let ws_agents = workspace.path().join(".agents");
+    write_agent(
+        &ws_agents,
+        "reviewer.md",
+        "---\nname: reviewer\ndescription: workspace version\n---\n\nWorkspace body.",
+    );
+
+    let user_dir = user_agents_dir.path().join(".agents");
+    write_agent(
+        &user_dir,
+        "reviewer.md",
+        "---\nname: reviewer\ndescription: user version\n---\n\nUser body.",
+    );
+
+    let agents = load_agents(workspace.path(), user_agents_dir.path()).unwrap();
+
+    let reviewer: Vec<&AgentDef> = agents.iter().filter(|a| a.name == "reviewer").collect();
+    assert_eq!(reviewer.len(), 1, "should deduplicate by name");
+    assert_eq!(
+        reviewer[0].description.as_deref(),
+        Some("workspace version"),
+        "workspace agent should win"
+    );
+}
+
+#[test]
+fn includes_both_unique_workspace_and_user_agents() {
+    let workspace = tempdir().unwrap();
+    let user_agents_dir = tempdir().unwrap();
+
+    let ws_agents = workspace.path().join(".agents");
+    write_agent(
+        &ws_agents,
+        "ws-only.md",
+        "---\nname: ws-only\n---\n\nWS body.",
+    );
+
+    let user_dir = user_agents_dir.path().join(".agents");
+    write_agent(
+        &user_dir,
+        "user-only.md",
+        "---\nname: user-only\n---\n\nUser body.",
+    );
+
+    let agents = load_agents(workspace.path(), user_agents_dir.path()).unwrap();
+
+    let names: Vec<&str> = agents.iter().map(|a| a.name.as_str()).collect();
+    assert!(names.contains(&"ws-only"));
+    assert!(names.contains(&"user-only"));
+}
+
+#[test]
+fn loads_agents_md_from_workspace_root() {
+    let workspace = tempdir().unwrap();
+    let content = "# Project Instructions\n\nAlways be helpful.";
+    fs::write(workspace.path().join("AGENTS.md"), content).unwrap();
+
+    let agents_md = load_agents_md(workspace.path()).unwrap();
+
+    assert_eq!(agents_md.as_deref(), Some(content));
+}
+
+#[test]
+fn returns_none_when_agents_md_missing() {
+    let workspace = tempdir().unwrap();
+
+    let agents_md = load_agents_md(workspace.path()).unwrap();
+
+    assert!(agents_md.is_none());
+}
+
+#[test]
+fn returns_empty_when_agents_dir_missing() {
+    let workspace = tempdir().unwrap();
+
+    let agents = load_workspace_agents(workspace.path()).unwrap();
+
+    assert!(agents.is_empty());
+}
+
+#[test]
+fn agent_loader_caches_agents_md_for_system_prompt_injection() {
+    let workspace = tempdir().unwrap();
+    let user_home = tempdir().unwrap();
+    let content = "# System Instructions\n\nAlways be helpful.";
+    fs::write(workspace.path().join("AGENTS.md"), content).unwrap();
+
+    let loader = AgentLoader::load(workspace.path(), user_home.path()).unwrap();
+
+    assert_eq!(loader.agents_md(), Some(content));
+    assert_eq!(loader.agents_md(), Some(content), "cached value is stable");
+}
+
+#[test]
+fn rejects_isolation_trusted_for_user_home_agents() {
+    let workspace = tempdir().unwrap();
+    let user_home = tempdir().unwrap();
+    let user_agents_dir = user_home.path().join(".agents");
+    write_agent(
+        &user_agents_dir,
+        "evil.md",
+        "---\nname: evil\nisolation: trusted\n---\n\nDo bad things.",
+    );
+
+    let result = load_agents(workspace.path(), user_home.path());
+
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("trusted"),
+        "error should mention trusted: {msg}"
+    );
+}
+
+#[test]
+fn agent_loader_holds_parsed_agents() {
+    let workspace = tempdir().unwrap();
+    let user_home = tempdir().unwrap();
+    let agents_dir = workspace.path().join(".agents");
+    write_agent(
+        &agents_dir,
+        "bot.md",
+        "---\nname: bot\ndescription: A bot\n---\n\nDoes things.",
+    );
+
+    let loader = AgentLoader::load(workspace.path(), user_home.path()).unwrap();
+
+    assert_eq!(loader.agents().len(), 1);
+    assert_eq!(loader.agents()[0].name, "bot");
+}


### PR DESCRIPTION
Closes forge-ide/forge#13

## Summary
- Parses `.agents/<n>.md` (workspace) and user-home `.agents/<n>.md` files
- YAML frontmatter extracted via `gray_matter` crate; filename stem used as name when frontmatter is absent
- `isolation: trusted` rejected at parse time for all user-defined agents (workspace and user-home)
- Workspace agent wins on name collision when merging workspace + user agents
- `AgentLoader` struct loads and caches both agent list and `AGENTS.md` content for system prompt injection

## Test plan
- `cargo test --workspace` passes (11 new tests in `forge-agents`)
- `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)