### PR TITLE
[F-012] Session orchestrator loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
  "chrono",
  "forge-core",
  "forge-ipc",
+ "forge-providers",
+ "futures",
  "serde_json",
  "tempfile",
  "tokio",

--- a/crates/forge-ipc/src/lib.rs
+++ b/crates/forge-ipc/src/lib.rs
@@ -17,6 +17,31 @@ pub enum IpcMessage {
     HelloAck(HelloAck),
     Subscribe(Subscribe),
     Event(IpcEvent),
+    SendUserMessage(SendUserMessage),
+    ToolCallApproved(ToolCallApproved),
+    ToolCallRejected(ToolCallRejected),
+}
+
+/// Client → session: send a user message to start a new turn.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SendUserMessage {
+    pub text: String,
+}
+
+/// Client → session: approve a pending tool call.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ToolCallApproved {
+    /// The ToolCallId to approve.
+    pub id: String,
+    /// Approval scope: "Once" | "ThisFile" | "ThisPattern" | "ThisTool".
+    pub scope: String,
+}
+
+/// Client → session: reject a pending tool call.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ToolCallRejected {
+    pub id: String,
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -1,8 +1,46 @@
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use forge_core::Result;
 use futures::stream::BoxStream;
 use serde::Deserialize;
+
+// ── Chat domain types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct ChatRequest {
+    pub system: Option<String>,
+    pub messages: Vec<ChatMessage>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatMessage {
+    pub role: ChatRole,
+    pub content: Vec<ChatBlock>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChatRole {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone)]
+pub enum ChatBlock {
+    Text(String),
+    ToolCall {
+        id: String,
+        name: String,
+        args: serde_json::Value,
+    },
+    ToolResult {
+        id: String,
+        result: serde_json::Value,
+    },
+}
+
+// ── Stream chunk ──────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChatChunk {
@@ -13,6 +51,18 @@ pub enum ChatChunk {
     },
     Done(String),
 }
+
+// ── Provider trait ────────────────────────────────────────────────────────────
+
+/// Streaming chat provider.
+pub trait Provider: Send + Sync {
+    fn chat(
+        &self,
+        req: ChatRequest,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send;
+}
+
+// ── NDJSON deserialization ────────────────────────────────────────────────────
 
 #[derive(Deserialize)]
 #[serde(untagged)]
@@ -28,14 +78,48 @@ struct RawToolCall {
     args: serde_json::Value,
 }
 
+fn parse_ndjson(content: &str) -> Result<Vec<ChatChunk>> {
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|line| {
+            let raw: RawChunk = serde_json::from_str(line)?;
+            Ok(match raw {
+                RawChunk::Delta { delta } => ChatChunk::TextDelta(delta),
+                RawChunk::ToolCall { tool_call } => ChatChunk::ToolCall {
+                    name: tool_call.name,
+                    args: tool_call.args,
+                },
+                RawChunk::Done { done } => ChatChunk::Done(done),
+            })
+        })
+        .collect()
+}
+
+// ── MockProvider ──────────────────────────────────────────────────────────────
+
+enum MockSource {
+    File(PathBuf),
+    Sequence {
+        scripts: Arc<Mutex<VecDeque<String>>>,
+        log: Arc<Mutex<Vec<ChatRequest>>>,
+    },
+}
+
+/// Scripted provider for testing.
+///
+/// Two construction modes:
+/// - `new(path)` — reads NDJSON from a file on every call
+/// - `from_responses(scripts)` — pops the next script per `chat()` call,
+///   and records every received `ChatRequest` (see `recorded_requests()`)
 pub struct MockProvider {
-    path: PathBuf,
+    source: MockSource,
 }
 
 impl MockProvider {
     pub fn new(path: impl AsRef<Path>) -> Self {
         Self {
-            path: path.as_ref().to_path_buf(),
+            source: MockSource::File(path.as_ref().to_path_buf()),
         }
     }
 
@@ -44,27 +128,63 @@ impl MockProvider {
             .or_else(|| dirs::home_dir().map(|h| h.join(".config")))
             .unwrap_or_else(|| PathBuf::from("/tmp"))
             .join("forge/mock.json");
-        Self { path }
+        Self::new(path)
     }
 
-    pub async fn stream(&self) -> Result<BoxStream<'static, ChatChunk>> {
-        let content = tokio::fs::read_to_string(&self.path).await?;
-        let chunks: Vec<ChatChunk> = content
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .map(|line| {
-                let raw: RawChunk = serde_json::from_str(line)?;
-                Ok(match raw {
-                    RawChunk::Delta { delta } => ChatChunk::TextDelta(delta),
-                    RawChunk::ToolCall { tool_call } => ChatChunk::ToolCall {
-                        name: tool_call.name,
-                        args: tool_call.args,
-                    },
-                    RawChunk::Done { done } => ChatChunk::Done(done),
-                })
-            })
-            .collect::<forge_core::Result<Vec<_>>>()?;
+    /// Construct from a sequence of NDJSON scripts, one per expected `chat()` call.
+    pub fn from_responses(scripts: Vec<String>) -> Result<Self> {
+        Ok(Self {
+            source: MockSource::Sequence {
+                scripts: Arc::new(Mutex::new(scripts.into_iter().collect())),
+                log: Arc::new(Mutex::new(Vec::new())),
+            },
+        })
+    }
 
-        Ok(Box::pin(futures::stream::iter(chunks)))
+    /// All `ChatRequest` values received in call order (sequence mode only).
+    pub fn recorded_requests(&self) -> Vec<ChatRequest> {
+        match &self.source {
+            MockSource::Sequence { log, .. } => log.lock().unwrap().clone(),
+            MockSource::File(_) => vec![],
+        }
+    }
+
+    /// Stream directly from file (legacy; ignores request content).
+    pub async fn stream(&self) -> Result<BoxStream<'static, ChatChunk>> {
+        match &self.source {
+            MockSource::File(path) => {
+                let content = tokio::fs::read_to_string(path).await?;
+                Ok(Box::pin(futures::stream::iter(parse_ndjson(&content)?)))
+            }
+            MockSource::Sequence { scripts, .. } => {
+                let script = scripts.lock().unwrap().pop_front().unwrap_or_default();
+                Ok(Box::pin(futures::stream::iter(parse_ndjson(&script)?)))
+            }
+        }
+    }
+}
+
+impl Provider for MockProvider {
+    fn chat(
+        &self,
+        req: ChatRequest,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        match &self.source {
+            MockSource::File(path) => {
+                let path = path.clone();
+                futures::future::Either::Left(async move {
+                    let content = tokio::fs::read_to_string(&path).await?;
+                    Ok(Box::pin(futures::stream::iter(parse_ndjson(&content)?))
+                        as BoxStream<'static, ChatChunk>)
+                })
+            }
+            MockSource::Sequence { scripts, log } => {
+                log.lock().unwrap().push(req);
+                let script = scripts.lock().unwrap().pop_front().unwrap_or_default();
+                let result: Result<BoxStream<'static, ChatChunk>> =
+                    parse_ndjson(&script).map(|c| Box::pin(futures::stream::iter(c)) as _);
+                futures::future::Either::Right(async move { result })
+            }
+        }
     }
 }

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -16,6 +16,8 @@ anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 forge-core = { path = "../forge-core" }
 forge-ipc = { path = "../forge-ipc" }
+forge-providers = { path = "../forge-providers" }
+futures = "0.3"
 serde_json = "1"
 tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync"] }
 

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod orchestrator;
 pub mod server;
 pub mod session;

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -1,0 +1,242 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::Result;
+use chrono::Utc;
+use forge_core::{
+    ids::{MessageId, ProviderId, ToolCallId},
+    ApprovalPreview, ApprovalScope, ApprovalSource, Event,
+};
+use forge_providers::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider};
+use futures::StreamExt;
+use tokio::sync::{oneshot, Mutex};
+
+use crate::session::Session;
+
+/// Pending tool call approvals: maps ToolCallId → sender for the approval result.
+pub type PendingApprovals = Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>;
+
+/// Run a complete turn for the given user text. Emits all session events for:
+/// UserMessage → AssistantMessage(open) → AssistantDelta* →
+/// [ToolCallStarted → ToolCallApprovalRequested → ToolCallApproved → ToolCallCompleted]* →
+/// AssistantMessage(finalised)
+///
+/// Tool calls block until the client sends `ToolCallApproved` / `ToolCallRejected`
+/// through `pending_approvals`.
+pub async fn run_turn<P: Provider>(
+    session: Arc<Session>,
+    provider: Arc<P>,
+    text: String,
+    pending_approvals: PendingApprovals,
+) -> Result<()> {
+    let msg_id = MessageId::new();
+
+    session
+        .emit(Event::UserMessage {
+            id: msg_id.clone(),
+            at: Utc::now(),
+            text: text.clone(),
+            context: vec![],
+            branch_parent: None,
+        })
+        .await?;
+
+    let initial_req = ChatRequest {
+        system: None,
+        messages: vec![ChatMessage {
+            role: ChatRole::User,
+            content: vec![ChatBlock::Text(text)],
+        }],
+    };
+
+    run_request_loop(session, provider, initial_req, msg_id, pending_approvals).await
+}
+
+/// Drives the provider request loop for one logical turn.
+/// On tool calls: waits for approval, executes stub, appends result to the
+/// next request, and continues until the provider returns `Done` with no
+/// pending tool calls.
+async fn run_request_loop<P: Provider>(
+    session: Arc<Session>,
+    provider: Arc<P>,
+    mut req: ChatRequest,
+    msg_id: MessageId,
+    pending_approvals: PendingApprovals,
+) -> Result<()> {
+    // Fixed provider/model identifiers for the mock provider.
+    let provider_id = ProviderId::new();
+    let model = "mock".to_string();
+
+    loop {
+        // Emit AssistantMessage(open) before any chunks arrive — ensures the
+        // event is present even when the first chunk is a tool call (not text).
+        session
+            .emit(Event::AssistantMessage {
+                id: msg_id.clone(),
+                provider: provider_id.clone(),
+                model: model.clone(),
+                at: Utc::now(),
+                stream_finalised: false,
+                text: String::new(),
+                branch_parent: None,
+                branch_variant_index: 0,
+            })
+            .await?;
+
+        let mut stream = provider.chat(req.clone()).await?;
+        let mut assistant_text = String::new();
+        // Separate accumulators for the assistant's tool-call blocks (added to the
+        // assistant message) and tool-result blocks (added to the next user message).
+        let mut tc_blocks: Vec<ChatBlock> = vec![];
+        let mut tr_blocks: Vec<ChatBlock> = vec![];
+        let mut had_tool_calls = false;
+
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                ChatChunk::TextDelta(delta) => {
+                    assistant_text.push_str(&delta);
+                    session
+                        .emit(Event::AssistantDelta {
+                            id: msg_id.clone(),
+                            at: Utc::now(),
+                            delta,
+                        })
+                        .await?;
+                }
+
+                ChatChunk::ToolCall { name, args } => {
+                    had_tool_calls = true;
+                    let call_id = ToolCallId::new();
+
+                    session
+                        .emit(Event::ToolCallStarted {
+                            id: call_id.clone(),
+                            msg: msg_id.clone(),
+                            tool: name.clone(),
+                            args: args.clone(),
+                            at: Utc::now(),
+                            parallel_group: None,
+                        })
+                        .await?;
+
+                    // Approval gate: register oneshot before emitting the event
+                    // so the connection handler can resolve it immediately on receipt.
+                    let (tx, rx) = oneshot::channel::<bool>();
+                    pending_approvals
+                        .lock()
+                        .await
+                        .insert(call_id.to_string(), tx);
+
+                    session
+                        .emit(Event::ToolCallApprovalRequested {
+                            id: call_id.clone(),
+                            preview: ApprovalPreview {
+                                description: format!("Run tool '{name}'?"),
+                            },
+                        })
+                        .await?;
+
+                    let approved = rx.await.unwrap_or(false);
+
+                    if !approved {
+                        session
+                            .emit(Event::ToolCallRejected {
+                                id: call_id,
+                                reason: Some("rejected by client".to_string()),
+                            })
+                            .await?;
+                        return Ok(());
+                    }
+
+                    session
+                        .emit(Event::ToolCallApproved {
+                            id: call_id.clone(),
+                            by: ApprovalSource::User,
+                            scope: ApprovalScope::Once,
+                            at: Utc::now(),
+                        })
+                        .await?;
+
+                    // Stub executor: returns a fixed result.
+                    let started = Instant::now();
+                    let result = serde_json::json!({ "content": "stub tool result" });
+                    let duration_ms = started.elapsed().as_millis() as u64;
+
+                    session
+                        .emit(Event::ToolCallCompleted {
+                            id: call_id.clone(),
+                            result: result.clone(),
+                            duration_ms,
+                            at: Utc::now(),
+                        })
+                        .await?;
+
+                    tc_blocks.push(ChatBlock::ToolCall {
+                        id: call_id.to_string(),
+                        name: name.clone(),
+                        args,
+                    });
+                    tr_blocks.push(ChatBlock::ToolResult {
+                        id: call_id.to_string(),
+                        result,
+                    });
+                }
+
+                ChatChunk::Done(_) => {
+                    // Always finalise the assistant message on Done, whether or not
+                    // tool calls occurred in this turn.
+                    session
+                        .emit(Event::AssistantMessage {
+                            id: msg_id.clone(),
+                            provider: provider_id.clone(),
+                            model: model.clone(),
+                            at: Utc::now(),
+                            stream_finalised: true,
+                            text: assistant_text.clone(),
+                            branch_parent: None,
+                            branch_variant_index: 0,
+                        })
+                        .await?;
+
+                    if !had_tool_calls {
+                        return Ok(());
+                    }
+                    // Tool calls happened — build continuation request and loop.
+                    break;
+                }
+            }
+        }
+
+        if !had_tool_calls {
+            // Stream ended without a Done chunk — finalise and complete.
+            session
+                .emit(Event::AssistantMessage {
+                    id: msg_id.clone(),
+                    provider: provider_id.clone(),
+                    model: model.clone(),
+                    at: Utc::now(),
+                    stream_finalised: true,
+                    text: assistant_text.clone(),
+                    branch_parent: None,
+                    branch_variant_index: 0,
+                })
+                .await?;
+            return Ok(());
+        }
+
+        // Build continuation: the assistant message includes the text + tool calls;
+        // the tool results are a new user message.
+        let mut assistant_content = vec![ChatBlock::Text(assistant_text)];
+        assistant_content.extend(tc_blocks);
+
+        req.messages.push(ChatMessage {
+            role: ChatRole::Assistant,
+            content: assistant_content,
+        });
+        req.messages.push(ChatMessage {
+            role: ChatRole::User,
+            content: tr_blocks,
+        });
+    }
+}

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -1,23 +1,33 @@
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Result;
 use forge_core::{read_since, SessionId};
 use forge_ipc::{HelloAck, IpcEvent, IpcMessage, PROTO_VERSION, SCHEMA_VERSION};
+use forge_providers::{MockProvider, Provider};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Mutex};
 
+use crate::orchestrator::{run_turn, PendingApprovals};
 use crate::session::Session;
 
+/// Start a session server using the default `MockProvider`.
 pub async fn serve(path: &Path) -> Result<()> {
     let log_path = std::env::temp_dir()
         .join(format!("forge-session-{}", SessionId::new()))
         .join("events.jsonl");
     let session = Arc::new(Session::create(log_path).await?);
-    serve_with_session(path, session).await
+    let provider = Arc::new(MockProvider::with_default_path());
+    serve_with_session(path, session, provider).await
 }
 
-pub async fn serve_with_session(path: &Path, session: Arc<Session>) -> Result<()> {
+/// Start a session server with an explicit provider.
+pub async fn serve_with_session<P: Provider + 'static>(
+    path: &Path,
+    session: Arc<Session>,
+    provider: Arc<P>,
+) -> Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
@@ -28,15 +38,21 @@ pub async fn serve_with_session(path: &Path, session: Arc<Session>) -> Result<()
     loop {
         let (stream, _) = listener.accept().await?;
         let session = Arc::clone(&session);
+        let provider = Arc::clone(&provider);
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, session).await {
+            if let Err(e) = handle_connection(stream, session, provider).await {
                 eprintln!("connection error: {e}");
             }
         });
     }
 }
 
-async fn handle_connection(mut stream: UnixStream, session: Arc<Session>) -> Result<()> {
+async fn handle_connection<P: Provider + 'static>(
+    mut stream: UnixStream,
+    session: Arc<Session>,
+    provider: Arc<P>,
+) -> Result<()> {
+    // ── Handshake ──────────────────────────────────────────────────────────────
     let msg = forge_ipc::read_frame(&mut stream).await?;
     let IpcMessage::Hello(hello) = msg else {
         anyhow::bail!("expected Hello, got unexpected message type");
@@ -45,9 +61,8 @@ async fn handle_connection(mut stream: UnixStream, session: Arc<Session>) -> Res
         anyhow::bail!("unsupported protocol version: {}", hello.proto);
     }
 
-    let session_id = SessionId::new();
     let ack = IpcMessage::HelloAck(HelloAck {
-        session_id: session_id.to_string(),
+        session_id: SessionId::new().to_string(),
         workspace: String::new(),
         started_at: chrono::Utc::now().to_rfc3339(),
         event_seq: session.current_seq().await,
@@ -55,6 +70,7 @@ async fn handle_connection(mut stream: UnixStream, session: Arc<Session>) -> Res
     });
     forge_ipc::write_frame(&mut stream, &ack).await?;
 
+    // ── Subscribe + history replay ─────────────────────────────────────────────
     let msg = forge_ipc::read_frame(&mut stream).await?;
     let IpcMessage::Subscribe(sub) = msg else {
         anyhow::bail!("expected Subscribe after HelloAck");
@@ -65,30 +81,88 @@ async fn handle_connection(mut stream: UnixStream, session: Arc<Session>) -> Res
 
     let history = read_since(&session.log_path, sub.since).await?;
     let mut last_sent = sub.since;
+
+    // Split stream so we can read and write concurrently.
+    let (mut reader, mut writer) = stream.into_split();
+
     for (seq, event) in history {
         let frame = IpcMessage::Event(IpcEvent {
             seq,
             event: serde_json::to_value(&event)?,
         });
-        forge_ipc::write_frame(&mut stream, &frame).await?;
+        forge_ipc::write_frame(&mut writer, &frame).await?;
         last_sent = seq;
     }
 
-    loop {
-        match live_rx.recv().await {
-            Ok((seq, event)) if seq > last_sent => {
-                let frame = IpcMessage::Event(IpcEvent {
-                    seq,
-                    event: serde_json::to_value(&event)?,
-                });
-                forge_ipc::write_frame(&mut stream, &frame).await?;
-                last_sent = seq;
-            }
-            Ok(_) => {}
-            Err(broadcast::error::RecvError::Closed) => break,
-            Err(broadcast::error::RecvError::Lagged(n)) => {
-                eprintln!("subscriber dropped {n} events; closing connection");
+    // ── Bidirectional loop ─────────────────────────────────────────────────────
+    // Pending tool call approvals shared between this loop and spawned turn tasks.
+    let pending_approvals: PendingApprovals = Arc::new(Mutex::new(HashMap::new()));
+
+    // Channel for commands arriving from the client reader.
+    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<IpcMessage>(32);
+
+    // Spawn a task that forwards client frames onto the command channel.
+    tokio::spawn(async move {
+        while let Ok(msg) = forge_ipc::read_frame(&mut reader).await {
+            if cmd_tx.send(msg).await.is_err() {
                 break;
+            }
+        }
+    });
+
+    loop {
+        tokio::select! {
+            // Live events → forward to client.
+            result = live_rx.recv() => {
+                match result {
+                    Ok((seq, event)) if seq > last_sent => {
+                        let frame = IpcMessage::Event(IpcEvent {
+                            seq,
+                            event: serde_json::to_value(&event)?,
+                        });
+                        forge_ipc::write_frame(&mut writer, &frame).await?;
+                        last_sent = seq;
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        eprintln!("subscriber dropped {n} events; closing connection");
+                        break;
+                    }
+                }
+            }
+
+            // Commands from client → dispatch.
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    Some(IpcMessage::SendUserMessage(m)) => {
+                        let session = Arc::clone(&session);
+                        let provider = Arc::clone(&provider);
+                        let approvals = Arc::clone(&pending_approvals);
+                        tokio::spawn(async move {
+                            if let Err(e) = run_turn(session, provider, m.text, approvals).await {
+                                eprintln!("turn error: {e}");
+                            }
+                        });
+                    }
+
+                    Some(IpcMessage::ToolCallApproved(a)) => {
+                        let mut map = pending_approvals.lock().await;
+                        if let Some(tx) = map.remove(&a.id) {
+                            let _ = tx.send(true);
+                        }
+                    }
+
+                    Some(IpcMessage::ToolCallRejected(r)) => {
+                        let mut map = pending_approvals.lock().await;
+                        if let Some(tx) = map.remove(&r.id) {
+                            let _ = tx.send(false);
+                        }
+                    }
+
+                    Some(_) => {} // ignore other messages
+                    None => break,
+                }
             }
         }
     }

--- a/crates/forge-session/tests/orchestrator.rs
+++ b/crates/forge-session/tests/orchestrator.rs
@@ -1,0 +1,415 @@
+use forge_core::Event;
+use forge_ipc::{
+    ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, ToolCallApproved,
+    PROTO_VERSION,
+};
+use forge_providers::{ChatBlock, MockProvider};
+use forge_session::{server::serve_with_session, session::Session};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+// Script 1: provider returns a text delta, then a tool call, then Done("tool_use")
+const SCRIPT_INITIAL: &str = r#"{"delta":"Hi there. "}
+{"tool_call":{"name":"fs.read","args":{"path":"readme.txt"}}}
+{"done":"tool_use"}
+"#;
+
+// Script 2: provider receives tool result, returns continuation text, then Done("end_turn")
+const SCRIPT_CONTINUATION: &str = r#"{"delta":"Here is the file content."}
+{"done":"end_turn"}
+"#;
+
+async fn connect_with_retry(path: &std::path::PathBuf) -> UnixStream {
+    for _ in 0..20 {
+        match UnixStream::connect(path).await {
+            Ok(s) => return s,
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+        }
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("server did not start in time")
+}
+
+async fn do_handshake(stream: &mut UnixStream) {
+    let hello = IpcMessage::Hello(Hello {
+        proto: PROTO_VERSION,
+        client: ClientInfo {
+            kind: "test".into(),
+            pid: std::process::id(),
+            user: "tester".into(),
+        },
+    });
+    forge_ipc::write_frame(stream, &hello).await.unwrap();
+    let response = forge_ipc::read_frame(stream).await.unwrap();
+    assert!(
+        matches!(response, IpcMessage::HelloAck(_)),
+        "expected HelloAck"
+    );
+}
+
+fn extract_event(msg: &IpcMessage) -> Option<Event> {
+    if let IpcMessage::Event(IpcEvent { event, .. }) = msg {
+        serde_json::from_value::<Event>(event.clone()).ok()
+    } else {
+        None
+    }
+}
+
+/// Full turn with tool call: verifies correct event sequence end-to-end.
+///
+/// Expected sequence:
+///   UserMessage
+///   AssistantMessage { stream_finalised: false }   ← opened before first chunk
+///   AssistantDelta("Hi there. ")
+///   ToolCallStarted { tool: "fs.read" }
+///   ToolCallApprovalRequested   ← approval gate fires for non-whitelisted tool
+///   ToolCallApproved            ← logged after client approves
+///   ToolCallCompleted
+///   AssistantMessage { stream_finalised: true }    ← finalised when Done("tool_use") arrives
+///   AssistantMessage { stream_finalised: false }   ← continuation turn opens
+///   AssistantDelta("Here is the file content.")
+///   AssistantMessage { stream_finalised: true }    ← continuation finalised
+#[tokio::test]
+async fn full_turn_with_tool_call_emits_correct_event_sequence() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("test.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(
+        MockProvider::from_responses(vec![
+            SCRIPT_INITIAL.to_string(),
+            SCRIPT_CONTINUATION.to_string(),
+        ])
+        .unwrap(),
+    );
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(&server_sock, server_session, server_provider)
+            .await
+            .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+
+    let sub = IpcMessage::Subscribe(Subscribe { since: 0 });
+    forge_ipc::write_frame(&mut stream, &sub).await.unwrap();
+
+    let send = IpcMessage::SendUserMessage(SendUserMessage {
+        text: "hello".to_string(),
+    });
+    forge_ipc::write_frame(&mut stream, &send).await.unwrap();
+
+    // Collect events; when we see ToolCallApprovalRequested, send approval back.
+    // The full turn produces two AssistantMessage(final) events: one when the
+    // initial stream ends with Done("tool_use"), and one when the continuation ends.
+    let (mut reader, mut writer) = stream.into_split();
+    let mut events: Vec<Event> = Vec::new();
+    let mut final_count = 0;
+
+    loop {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+
+        // Auto-approve tool calls during the test
+        if let Event::ToolCallApprovalRequested { ref id, .. } = event {
+            let approval = IpcMessage::ToolCallApproved(ToolCallApproved {
+                id: id.to_string(),
+                scope: "Once".to_string(),
+            });
+            forge_ipc::write_frame(&mut writer, &approval)
+                .await
+                .unwrap();
+        }
+
+        if matches!(
+            event,
+            Event::AssistantMessage {
+                stream_finalised: true,
+                ..
+            }
+        ) {
+            final_count += 1;
+        }
+        events.push(event);
+        // Two scripts → two provider calls → two finalised messages.
+        if final_count >= 2 {
+            break;
+        }
+    }
+
+    // Assert the event sequence
+    let kinds: Vec<&str> = events
+        .iter()
+        .map(|e| match e {
+            Event::UserMessage { .. } => "UserMessage",
+            Event::AssistantMessage {
+                stream_finalised: false,
+                ..
+            } => "AssistantMessage(open)",
+            Event::AssistantMessage {
+                stream_finalised: true,
+                ..
+            } => "AssistantMessage(final)",
+            Event::AssistantDelta { .. } => "AssistantDelta",
+            Event::ToolCallStarted { .. } => "ToolCallStarted",
+            Event::ToolCallApprovalRequested { .. } => "ToolCallApprovalRequested",
+            Event::ToolCallApproved { .. } => "ToolCallApproved",
+            Event::ToolCallCompleted { .. } => "ToolCallCompleted",
+            _ => "Other",
+        })
+        .collect();
+
+    assert_eq!(
+        kinds,
+        vec![
+            "UserMessage",
+            "AssistantMessage(open)", // opened before first chunk
+            "AssistantDelta",
+            "ToolCallStarted",
+            "ToolCallApprovalRequested",
+            "ToolCallApproved",
+            "ToolCallCompleted",
+            "AssistantMessage(final)", // finalised when Done("tool_use") arrives
+            "AssistantMessage(open)",  // continuation turn opens
+            "AssistantDelta",
+            "AssistantMessage(final)", // continuation turn finalised
+        ],
+        "event sequence mismatch: got {kinds:?}"
+    );
+
+    // Verify text delta content
+    let deltas: Vec<&str> = events
+        .iter()
+        .filter_map(|e| {
+            if let Event::AssistantDelta { delta, .. } = e {
+                Some(delta.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(deltas, vec!["Hi there. ", "Here is the file content."]);
+
+    // Verify tool call details
+    let tool_name = events.iter().find_map(|e| {
+        if let Event::ToolCallStarted { tool, .. } = e {
+            Some(tool.as_str())
+        } else {
+            None
+        }
+    });
+    assert_eq!(tool_name, Some("fs.read"));
+
+    // Verify tool result was fed back: the second provider call happened
+    // (proven by receiving continuation events after ToolCallCompleted)
+    let continuation_delta_idx = events
+        .iter()
+        .enumerate()
+        .filter_map(|(i, e)| matches!(e, Event::AssistantDelta { .. }).then_some(i))
+        .nth(1); // second delta
+    let tool_completed_idx = events
+        .iter()
+        .position(|e| matches!(e, Event::ToolCallCompleted { .. }));
+    assert!(
+        continuation_delta_idx > tool_completed_idx,
+        "continuation delta must follow tool completion"
+    );
+}
+
+/// Verify approval gate fires for non-whitelisted tools (and NOT for the turn to continue
+/// without approval being sent — i.e., the orchestrator pauses until client responds).
+#[tokio::test]
+async fn approval_gate_fires_and_blocks_until_client_approves() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("test2.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    // Single-script provider: tool call only (no continuation needed for this test)
+    let provider =
+        Arc::new(MockProvider::from_responses(vec![SCRIPT_INITIAL.to_string()]).unwrap());
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(&server_sock, server_session, server_provider)
+            .await
+            .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "hi".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    let (mut reader, mut writer) = stream.into_split();
+
+    // Read events until ToolCallApprovalRequested is received
+    let mut saw_approval_requested = false;
+    let mut tool_call_id = String::new();
+    for _ in 0..10 {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        if let Some(Event::ToolCallApprovalRequested { id, .. }) = extract_event(&frame) {
+            saw_approval_requested = true;
+            tool_call_id = id.to_string();
+            break;
+        }
+    }
+    assert!(
+        saw_approval_requested,
+        "expected ToolCallApprovalRequested to be emitted"
+    );
+
+    // Now send approval
+    forge_ipc::write_frame(
+        &mut writer,
+        &IpcMessage::ToolCallApproved(ToolCallApproved {
+            id: tool_call_id,
+            scope: "Once".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Verify ToolCallCompleted arrives after approval
+    let mut saw_completed = false;
+    for _ in 0..10 {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        if let Some(Event::ToolCallCompleted { .. }) = extract_event(&frame) {
+            saw_completed = true;
+            break;
+        }
+    }
+    assert!(saw_completed, "expected ToolCallCompleted after approval");
+}
+
+/// Verify tool result is included in the next ChatRequest to the provider.
+/// Proven by: the continuation response arrives (provider was called a second time).
+#[tokio::test]
+async fn tool_result_fed_back_to_provider_in_continuation() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("test3.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(
+        MockProvider::from_responses(vec![
+            SCRIPT_INITIAL.to_string(),
+            SCRIPT_CONTINUATION.to_string(),
+        ])
+        .unwrap(),
+    );
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(&server_sock, server_session, server_provider)
+            .await
+            .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "hello".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    let (mut reader, mut writer) = stream.into_split();
+    let mut events: Vec<Event> = Vec::new();
+    let mut final_count = 0;
+
+    loop {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::ToolCallApprovalRequested { ref id, .. } = event {
+            forge_ipc::write_frame(
+                &mut writer,
+                &IpcMessage::ToolCallApproved(ToolCallApproved {
+                    id: id.to_string(),
+                    scope: "Once".to_string(),
+                }),
+            )
+            .await
+            .unwrap();
+        }
+        if matches!(
+            event,
+            Event::AssistantMessage {
+                stream_finalised: true,
+                ..
+            }
+        ) {
+            final_count += 1;
+        }
+        events.push(event);
+        // Two scripts → two provider calls → two finalised messages.
+        if final_count >= 2 {
+            break;
+        }
+    }
+
+    // The second AssistantDelta ("Here is the file content.") proves the provider
+    // was called a second time — i.e., tool result was fed back.
+    let continuation_text = events.iter().find_map(|e| {
+        if let Event::AssistantDelta { delta, .. } = e {
+            if delta.contains("file content") {
+                Some(delta.as_str())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    });
+    assert_eq!(
+        continuation_text,
+        Some("Here is the file content."),
+        "continuation response from second provider call not received"
+    );
+
+    // Check that the second ChatRequest included a ToolResult block.
+    // We verify this indirectly: MockProvider::from_responses() tracks requests;
+    // assert the second request contains a ToolResult block.
+    let requests = provider.recorded_requests();
+    assert_eq!(requests.len(), 2, "provider should have been called twice");
+    let second_req = &requests[1];
+    let has_tool_result = second_req.messages.iter().any(|m| {
+        m.content
+            .iter()
+            .any(|b| matches!(b, ChatBlock::ToolResult { .. }))
+    });
+    assert!(
+        has_tool_result,
+        "second ChatRequest should contain a ToolResult block"
+    );
+}

--- a/crates/forge-session/tests/subscribe_replay.rs
+++ b/crates/forge-session/tests/subscribe_replay.rs
@@ -1,5 +1,6 @@
 use forge_core::{types::SessionPersistence, Event};
 use forge_ipc::{ClientInfo, Hello, IpcEvent, IpcMessage, Subscribe, PROTO_VERSION};
+use forge_providers::MockProvider;
 use forge_session::{server::serve_with_session, session::Session};
 use std::{path::PathBuf, sync::Arc};
 use tempfile::TempDir;
@@ -55,11 +56,12 @@ async fn subscribe_mid_stream_receives_historical_then_live_events() {
     session.emit(session_started_event()).await.unwrap(); // seq 2
     session.emit(session_started_event()).await.unwrap(); // seq 3
 
-    // Start server
+    // Start server (provider unused in this test)
     let server_session = Arc::clone(&session);
     let server_sock = sock_path.clone();
+    let provider = Arc::new(MockProvider::with_default_path());
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session)
+        serve_with_session(&server_sock, server_session, provider)
             .await
             .unwrap();
     });


### PR DESCRIPTION
Closes forge-ide/forge#14

## Summary
- Adds `SendUserMessage`, `ToolCallApproved`, `ToolCallRejected` to the IPC protocol so clients can drive turns and approve tool calls
- Defines `ChatRequest`, `Provider` trait, and `ChatBlock` types in `forge-providers`; extends `MockProvider` with sequence-mode and request recording for test assertions
- Implements the full turn lifecycle in `forge-session`: bidirectional connection handler (concurrent event streaming + command dispatch via `tokio::select!`), `run_turn` / `run_request_loop` orchestrator that emits the correct event sequence including the tool call approval gate and continuation request with tool results

## Event sequence per turn
```
UserMessage → AssistantMessage(open) → AssistantDelta* →
[ToolCallStarted → ToolCallApprovalRequested → ToolCallApproved → ToolCallCompleted]* →
AssistantMessage(final)
```

## Test plan
- `cargo test --workspace` passes (3 new integration tests in `tests/orchestrator.rs`)
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)