### PR TITLE
[F-014] Approval flow (sprint-minimum)

### DIFF
--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -4,10 +4,13 @@ use std::path::PathBuf;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let auto_approve = args.iter().any(|a| a == "--auto-approve-unsafe");
+
     let session_id = forge_core::SessionId::new();
     let socket_path = resolve_socket_path(&session_id.to_string());
     eprintln!("forged: listening on {}", socket_path.display());
-    serve(&socket_path).await
+    serve(&socket_path, auto_approve).await
 }
 
 fn resolve_socket_path(session_id: &str) -> PathBuf {

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -33,6 +33,7 @@ pub async fn run_turn<P: Provider>(
     text: String,
     pending_approvals: PendingApprovals,
     allowed_paths: Vec<String>,
+    auto_approve: bool,
 ) -> Result<()> {
     let msg_id = MessageId::new();
 
@@ -61,6 +62,7 @@ pub async fn run_turn<P: Provider>(
         msg_id,
         pending_approvals,
         allowed_paths,
+        auto_approve,
     )
     .await
 }
@@ -76,6 +78,7 @@ async fn run_request_loop<P: Provider>(
     msg_id: MessageId,
     pending_approvals: PendingApprovals,
     allowed_paths: Vec<String>,
+    auto_approve: bool,
 ) -> Result<()> {
     // Fixed provider/model identifiers for the mock provider.
     let provider_id = ProviderId::new();
@@ -133,43 +136,69 @@ async fn run_request_loop<P: Provider>(
                         })
                         .await?;
 
-                    // Approval gate: register oneshot before emitting the event
-                    // so the connection handler can resolve it immediately on receipt.
-                    let (tx, rx) = oneshot::channel::<bool>();
-                    pending_approvals
-                        .lock()
-                        .await
-                        .insert(call_id.to_string(), tx);
-
-                    session
-                        .emit(Event::ToolCallApprovalRequested {
-                            id: call_id.clone(),
-                            preview: ApprovalPreview {
-                                description: format!("Run tool '{name}'?"),
-                            },
-                        })
-                        .await?;
-
-                    let approved = rx.await.unwrap_or(false);
-
-                    if !approved {
+                    if auto_approve {
+                        // --auto-approve-unsafe: skip the approval gate entirely.
                         session
-                            .emit(Event::ToolCallRejected {
-                                id: call_id,
-                                reason: Some("rejected by client".to_string()),
+                            .emit(Event::ToolCallApproved {
+                                id: call_id.clone(),
+                                by: ApprovalSource::Auto,
+                                scope: ApprovalScope::Once,
+                                at: Utc::now(),
                             })
                             .await?;
-                        return Ok(());
-                    }
+                    } else {
+                        // Approval gate: register oneshot before emitting the event
+                        // so the connection handler can resolve it immediately on receipt.
+                        let (tx, rx) = oneshot::channel::<bool>();
+                        pending_approvals
+                            .lock()
+                            .await
+                            .insert(call_id.to_string(), tx);
 
-                    session
-                        .emit(Event::ToolCallApproved {
-                            id: call_id.clone(),
-                            by: ApprovalSource::User,
-                            scope: ApprovalScope::Once,
-                            at: Utc::now(),
-                        })
-                        .await?;
+                        session
+                            .emit(Event::ToolCallApprovalRequested {
+                                id: call_id.clone(),
+                                preview: ApprovalPreview {
+                                    description: format!("Run tool '{name}'?"),
+                                },
+                            })
+                            .await?;
+
+                        let approved = rx.await.unwrap_or(false);
+
+                        if !approved {
+                            session
+                                .emit(Event::ToolCallRejected {
+                                    id: call_id,
+                                    reason: Some("rejected by client".to_string()),
+                                })
+                                .await?;
+                            // Finalise the open AssistantMessage so the session log
+                            // is never left with a dangling un-finalised message.
+                            session
+                                .emit(Event::AssistantMessage {
+                                    id: msg_id.clone(),
+                                    provider: provider_id.clone(),
+                                    model: model.clone(),
+                                    at: Utc::now(),
+                                    stream_finalised: true,
+                                    text: assistant_text.clone(),
+                                    branch_parent: None,
+                                    branch_variant_index: 0,
+                                })
+                                .await?;
+                            return Ok(());
+                        }
+
+                        session
+                            .emit(Event::ToolCallApproved {
+                                id: call_id.clone(),
+                                by: ApprovalSource::User,
+                                scope: ApprovalScope::Once,
+                                at: Utc::now(),
+                            })
+                            .await?;
+                    }
 
                     // Execute the tool.
                     let started = Instant::now();

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -13,13 +13,13 @@ use crate::orchestrator::{run_turn, PendingApprovals};
 use crate::session::Session;
 
 /// Start a session server using the default `MockProvider`.
-pub async fn serve(path: &Path) -> Result<()> {
+pub async fn serve(path: &Path, auto_approve: bool) -> Result<()> {
     let log_path = std::env::temp_dir()
         .join(format!("forge-session-{}", SessionId::new()))
         .join("events.jsonl");
     let session = Arc::new(Session::create(log_path).await?);
     let provider = Arc::new(MockProvider::with_default_path());
-    serve_with_session(path, session, provider).await
+    serve_with_session(path, session, provider, auto_approve).await
 }
 
 /// Start a session server with an explicit provider.
@@ -27,6 +27,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
     path: &Path,
     session: Arc<Session>,
     provider: Arc<P>,
+    auto_approve: bool,
 ) -> Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -40,7 +41,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
         let session = Arc::clone(&session);
         let provider = Arc::clone(&provider);
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, session, provider).await {
+            if let Err(e) = handle_connection(stream, session, provider, auto_approve).await {
                 eprintln!("connection error: {e}");
             }
         });
@@ -51,6 +52,7 @@ async fn handle_connection<P: Provider + 'static>(
     mut stream: UnixStream,
     session: Arc<Session>,
     provider: Arc<P>,
+    auto_approve: bool,
 ) -> Result<()> {
     // ── Handshake ──────────────────────────────────────────────────────────────
     let msg = forge_ipc::read_frame(&mut stream).await?;
@@ -143,7 +145,7 @@ async fn handle_connection<P: Provider + 'static>(
                             // TODO(F-013): thread AgentDef.allowed_paths once agent
                             // context is passed through the server connection.
                             // Using ["**"] (allow all) until then.
-                            if let Err(e) = run_turn(session, provider, m.text, approvals, vec!["**".to_string()]).await {
+                            if let Err(e) = run_turn(session, provider, m.text, approvals, vec!["**".to_string()], auto_approve).await {
                                 eprintln!("turn error: {e}");
                             }
                         });

--- a/crates/forge-session/tests/fs_read_tool.rs
+++ b/crates/forge-session/tests/fs_read_tool.rs
@@ -77,7 +77,7 @@ async fn fs_read_tool_returns_content_bytes_sha256() {
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, server_provider)
+        serve_with_session(&server_sock, server_session, server_provider, false)
             .await
             .unwrap();
     });

--- a/crates/forge-session/tests/handshake.rs
+++ b/crates/forge-session/tests/handshake.rs
@@ -23,7 +23,7 @@ async fn handshake_succeeds_with_valid_proto() {
 
     let server_path = path.clone();
     tokio::spawn(async move {
-        serve(&server_path).await.unwrap();
+        serve(&server_path, false).await.unwrap();
     });
 
     let mut stream = connect_with_retry(&path).await;
@@ -53,7 +53,7 @@ async fn unknown_proto_rejected() {
 
     let server_path = path.clone();
     tokio::spawn(async move {
-        serve(&server_path).await.unwrap();
+        serve(&server_path, false).await.unwrap();
     });
 
     let mut stream = connect_with_retry(&path).await;
@@ -82,7 +82,7 @@ async fn garbage_frame_rejected() {
 
     let server_path = path.clone();
     tokio::spawn(async move {
-        serve(&server_path).await.unwrap();
+        serve(&server_path, false).await.unwrap();
     });
 
     let mut stream = connect_with_retry(&path).await;

--- a/crates/forge-session/tests/orchestrator.rs
+++ b/crates/forge-session/tests/orchestrator.rs
@@ -90,7 +90,7 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, server_provider)
+        serve_with_session(&server_sock, server_session, server_provider, false)
             .await
             .unwrap();
     });
@@ -242,7 +242,7 @@ async fn approval_gate_fires_and_blocks_until_client_approves() {
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, server_provider)
+        serve_with_session(&server_sock, server_session, server_provider, false)
             .await
             .unwrap();
     });
@@ -302,6 +302,127 @@ async fn approval_gate_fires_and_blocks_until_client_approves() {
     assert!(saw_completed, "expected ToolCallCompleted after approval");
 }
 
+/// With --auto-approve-unsafe, tool calls proceed without client approval.
+/// ToolCallApproved { by: Auto } must be emitted; ToolCallApprovalRequested must not.
+#[tokio::test]
+async fn auto_approve_skips_approval_gate_and_emits_auto_approved() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("auto_approve.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(
+        MockProvider::from_responses(vec![
+            SCRIPT_INITIAL.to_string(),
+            SCRIPT_CONTINUATION.to_string(),
+        ])
+        .unwrap(),
+    );
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(&server_sock, server_session, server_provider, true)
+            .await
+            .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "hello".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Collect events until the turn completes (two finalised AssistantMessages).
+    // No client approval is sent — the session must complete without it.
+    let mut events: Vec<Event> = Vec::new();
+    let mut final_count = 0;
+    let (reader, _writer) = stream.into_split();
+    // Use a timeout so the test fails fast if the session blocks waiting for approval.
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut reader = reader;
+
+    loop {
+        let frame = tokio::time::timeout_at(deadline, forge_ipc::read_frame(&mut reader))
+            .await
+            .expect("timed out — session may be blocked waiting for approval")
+            .unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if matches!(
+            event,
+            Event::AssistantMessage {
+                stream_finalised: true,
+                ..
+            }
+        ) {
+            final_count += 1;
+        }
+        events.push(event);
+        if final_count >= 2 {
+            break;
+        }
+    }
+
+    let kinds: Vec<&str> = events
+        .iter()
+        .map(|e| match e {
+            Event::UserMessage { .. } => "UserMessage",
+            Event::AssistantMessage {
+                stream_finalised: false,
+                ..
+            } => "AssistantMessage(open)",
+            Event::AssistantMessage {
+                stream_finalised: true,
+                ..
+            } => "AssistantMessage(final)",
+            Event::AssistantDelta { .. } => "AssistantDelta",
+            Event::ToolCallStarted { .. } => "ToolCallStarted",
+            Event::ToolCallApprovalRequested { .. } => "ToolCallApprovalRequested",
+            Event::ToolCallApproved { .. } => "ToolCallApproved",
+            Event::ToolCallCompleted { .. } => "ToolCallCompleted",
+            _ => "Other",
+        })
+        .collect();
+
+    // ToolCallApprovalRequested must NOT appear; ToolCallApproved must appear.
+    assert!(
+        !kinds.contains(&"ToolCallApprovalRequested"),
+        "auto-approve must not emit ToolCallApprovalRequested; got: {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&"ToolCallApproved"),
+        "auto-approve must emit ToolCallApproved; got: {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&"ToolCallCompleted"),
+        "auto-approve must emit ToolCallCompleted; got: {kinds:?}"
+    );
+
+    // Verify ToolCallApproved carries ApprovalSource::Auto.
+    use forge_core::ApprovalSource;
+    let auto_approved = events.iter().any(|e| {
+        matches!(
+            e,
+            Event::ToolCallApproved {
+                by: ApprovalSource::Auto,
+                ..
+            }
+        )
+    });
+    assert!(auto_approved, "ToolCallApproved must have by=Auto");
+}
+
 /// Verify tool result is included in the next ChatRequest to the provider.
 /// Proven by: the continuation response arrives (provider was called a second time).
 #[tokio::test]
@@ -323,7 +444,7 @@ async fn tool_result_fed_back_to_provider_in_continuation() {
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, server_provider)
+        serve_with_session(&server_sock, server_session, server_provider, false)
             .await
             .unwrap();
     });

--- a/crates/forge-session/tests/subscribe_replay.rs
+++ b/crates/forge-session/tests/subscribe_replay.rs
@@ -61,7 +61,7 @@ async fn subscribe_mid_stream_receives_historical_then_live_events() {
     let server_sock = sock_path.clone();
     let provider = Arc::new(MockProvider::with_default_path());
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, provider)
+        serve_with_session(&server_sock, server_session, provider, false)
             .await
             .unwrap();
     });


### PR DESCRIPTION
Closes forge-ide/forge#16

## Summary
- Thread `auto_approve: bool` through `serve` → `handle_connection` → `run_turn` → `run_request_loop`
- With `--auto-approve-unsafe`: skip approval gate, emit `ToolCallApproved { by: Auto }` immediately
- Without the flag: emit `ToolCallApprovalRequested` and block until client sends `ToolCallApproved` / `ToolCallRejected`
- Fix rejection path to emit a finalised `AssistantMessage` before returning (prevents dangling un-finalised messages in the session log)

## Test plan
- `cargo test --workspace` passes (65 tests)
- `cargo clippy --all-targets -- -D warnings` passes
- New test `auto_approve_skips_approval_gate_and_emits_auto_approved` verifies: no `ToolCallApprovalRequested`, `ToolCallApproved { by: Auto }` present, turn completes without client sending approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)