### PR TITLE
[F-015] forge-cli binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +135,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation-sys"
@@ -198,6 +294,18 @@ dependencies = [
 [[package]]
 name = "forge-cli"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "forge-core",
+ "forge-ipc",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
 
 [[package]]
 name = "forge-core"
@@ -507,6 +615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +706,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -784,6 +904,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +928,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -862,6 +998,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",
@@ -972,6 +1109,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -3,6 +3,25 @@ name = "forge-cli"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+name = "forge_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "forge"
 path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+forge-core = { path = "../forge-core" }
+forge-ipc = { path = "../forge-ipc" }
+libc = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "process", "io-std", "fs", "io-util"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "macros", "time", "net"] }

--- a/crates/forge-cli/src/display.rs
+++ b/crates/forge-cli/src/display.rs
@@ -1,0 +1,156 @@
+use forge_core::{EndReason, Event};
+
+/// Format a single session event as a human-readable string for stdout.
+/// Returns `None` for events that should be suppressed (e.g. deltas, usage ticks).
+pub fn format_event(event: &Event) -> Option<String> {
+    match event {
+        Event::UserMessage { text, .. } => Some(format!("» {text}")),
+        Event::AssistantMessage {
+            text,
+            model,
+            stream_finalised,
+            ..
+        } => {
+            if *stream_finalised {
+                Some(format!("[{model}] {text}"))
+            } else {
+                None
+            }
+        }
+        Event::AssistantDelta { delta, .. } => {
+            if delta.is_empty() {
+                None
+            } else {
+                Some(delta.clone())
+            }
+        }
+        Event::ToolCallStarted { tool, args, .. } => {
+            let args_str = serde_json::to_string(args).unwrap_or_default();
+            Some(format!("  ⚙ {tool}({args_str})"))
+        }
+        Event::ToolCallCompleted { duration_ms, .. } => Some(format!("  ✓ done ({duration_ms}ms)")),
+        Event::ToolCallApprovalRequested { preview, .. } => {
+            Some(format!("  ? approval needed: {}", preview.description))
+        }
+        Event::SessionStarted { workspace, .. } => {
+            Some(format!("session started in {}", workspace.display()))
+        }
+        Event::SessionEnded { reason, .. } => match reason {
+            EndReason::Completed => Some("session ended: completed".into()),
+            EndReason::UserExit => Some("session ended: user exit".into()),
+            EndReason::Error(msg) => Some(format!("session ended: error — {msg}")),
+        },
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use forge_core::types::SessionPersistence;
+    use forge_core::{EndReason, Event, MessageId, ProviderId, ToolCallId};
+    use std::path::PathBuf;
+
+    fn ts() -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc::now()
+    }
+
+    #[test]
+    fn format_user_message_includes_text() {
+        let e = Event::UserMessage {
+            id: MessageId::new(),
+            at: ts(),
+            text: "hello world".into(),
+            context: vec![],
+            branch_parent: None,
+        };
+        let s = format_event(&e).expect("should produce output");
+        assert!(s.contains("hello world"), "got: {s}");
+    }
+
+    #[test]
+    fn format_assistant_message_finalised_includes_text_and_model() {
+        let e = Event::AssistantMessage {
+            id: MessageId::new(),
+            provider: ProviderId::new(),
+            model: "claude-opus-4".into(),
+            at: ts(),
+            stream_finalised: true,
+            text: "I can help with that".into(),
+            branch_parent: None,
+            branch_variant_index: 0,
+        };
+        let s = format_event(&e).expect("should produce output");
+        assert!(s.contains("I can help with that"), "got: {s}");
+        assert!(s.contains("claude-opus-4"), "got: {s}");
+    }
+
+    #[test]
+    fn format_assistant_message_not_finalised_is_suppressed() {
+        let e = Event::AssistantMessage {
+            id: MessageId::new(),
+            provider: ProviderId::new(),
+            model: "claude-opus-4".into(),
+            at: ts(),
+            stream_finalised: false,
+            text: "partial...".into(),
+            branch_parent: None,
+            branch_variant_index: 0,
+        };
+        assert!(
+            format_event(&e).is_none(),
+            "non-finalised should be suppressed"
+        );
+    }
+
+    #[test]
+    fn format_tool_call_started_includes_tool_name() {
+        let e = Event::ToolCallStarted {
+            id: ToolCallId::new(),
+            msg: MessageId::new(),
+            tool: "fs.read".into(),
+            args: serde_json::json!({"path": "/tmp/test.txt"}),
+            at: ts(),
+            parallel_group: None,
+        };
+        let s = format_event(&e).expect("should produce output");
+        assert!(s.contains("fs.read"), "got: {s}");
+    }
+
+    #[test]
+    fn format_session_ended_completed() {
+        let e = Event::SessionEnded {
+            at: ts(),
+            reason: EndReason::Completed,
+            archived: false,
+        };
+        let s = format_event(&e).expect("should produce output");
+        assert!(
+            s.to_lowercase().contains("completed") || s.to_lowercase().contains("ended"),
+            "got: {s}"
+        );
+    }
+
+    #[test]
+    fn format_session_ended_error_includes_message() {
+        let e = Event::SessionEnded {
+            at: ts(),
+            reason: EndReason::Error("provider timeout".into()),
+            archived: false,
+        };
+        let s = format_event(&e).expect("should produce output");
+        assert!(s.contains("provider timeout"), "got: {s}");
+    }
+
+    #[test]
+    fn format_session_started_includes_workspace() {
+        let e = Event::SessionStarted {
+            at: ts(),
+            workspace: PathBuf::from("/home/user/myproject"),
+            agent: None,
+            persistence: SessionPersistence::Persist,
+        };
+        let s = format_event(&e).expect("should produce output");
+        assert!(s.contains("myproject"), "got: {s}");
+    }
+}

--- a/crates/forge-cli/src/ipc.rs
+++ b/crates/forge-cli/src/ipc.rs
@@ -1,0 +1,1 @@
+// IPC helpers — currently thin wrappers; logic lives in forge-ipc's FramedStream.

--- a/crates/forge-cli/src/lib.rs
+++ b/crates/forge-cli/src/lib.rs
@@ -1,0 +1,79 @@
+pub mod display;
+pub mod socket;
+
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(name = "forge", about = "Forge IDE command-line interface")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Manage forge sessions.
+    Session {
+        #[command(subcommand)]
+        cmd: SessionCommands,
+    },
+    /// One-shot ephemeral agent run.
+    Run {
+        #[command(subcommand)]
+        cmd: RunCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SessionCommands {
+    /// Start a new session.
+    New {
+        #[command(subcommand)]
+        kind: SessionNewKind,
+    },
+    /// List known sessions and their state.
+    List,
+    /// Stream events from a session to stdout.
+    Tail {
+        /// Session ID to tail.
+        id: String,
+    },
+    /// Send SIGTERM to a session process.
+    Kill {
+        /// Session ID to kill.
+        id: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SessionNewKind {
+    /// Start an agent session.
+    Agent {
+        /// Agent name (must exist in .agents/).
+        name: String,
+        /// Workspace root directory.
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+    },
+    /// Start a bare provider session.
+    Provider {
+        /// Provider spec string.
+        spec: String,
+        /// Workspace root directory.
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RunCommands {
+    /// Run an agent with a single input message and exit.
+    Agent {
+        /// Agent name.
+        name: String,
+        /// Input source: "-" reads from stdin, otherwise a file path.
+        #[arg(long, default_value = "-")]
+        input: String,
+    },
+}

--- a/crates/forge-cli/src/main.rs
+++ b/crates/forge-cli/src/main.rs
@@ -1,1 +1,332 @@
-fn main() {}
+use anyhow::Result;
+use clap::Parser;
+use forge_cli::{Cli, Commands, RunCommands, SessionCommands, SessionNewKind};
+use std::path::PathBuf;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Session { cmd } => match cmd {
+            SessionCommands::New { kind } => session_new(kind).await,
+            SessionCommands::List => session_list().await,
+            SessionCommands::Tail { id } => session_tail(&id).await,
+            SessionCommands::Kill { id } => session_kill(&id).await,
+        },
+        Commands::Run { cmd } => match cmd {
+            RunCommands::Agent { name, input } => run_agent(&name, &input).await,
+        },
+    }
+}
+
+async fn session_new(kind: SessionNewKind) -> Result<()> {
+    let workspace = match &kind {
+        SessionNewKind::Agent { workspace, .. } | SessionNewKind::Provider { workspace, .. } => {
+            workspace
+                .clone()
+                .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
+        }
+    };
+
+    let session_id = forge_core::SessionId::new();
+    let sock = forge_cli::socket::socket_path(&session_id.to_string());
+    let pid_file = forge_cli::socket::pid_path(&session_id.to_string());
+
+    if let Some(parent) = sock.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let forged = find_forged_binary()?;
+    let mut cmd = std::process::Command::new(&forged);
+    cmd.env("FORGE_SESSION_ID", session_id.to_string())
+        .env("FORGE_SOCKET_PATH", sock.to_str().unwrap_or(""))
+        .env("FORGE_WORKSPACE", workspace.to_str().unwrap_or(""));
+
+    match &kind {
+        SessionNewKind::Agent { name, .. } => {
+            cmd.arg("--agent").arg(name);
+        }
+        SessionNewKind::Provider { spec, .. } => {
+            cmd.arg("--provider").arg(spec);
+        }
+    }
+
+    // Spawn forged as a detached process. Using std::process::Command means
+    // the child is not killed when this handle is dropped; forged lives on
+    // independently and is adopted by init once `forge` exits.
+    let child = cmd.spawn()?;
+    let pid = child.id();
+    // Explicitly leak the handle — we want forged to run independently.
+    std::mem::forget(child);
+
+    tokio::fs::write(&pid_file, pid.to_string()).await?;
+
+    // Wait for socket to appear.
+    wait_for_socket(&sock).await?;
+
+    println!("session {} started at {}", session_id, sock.display());
+    Ok(())
+}
+
+async fn session_list() -> Result<()> {
+    use forge_ipc::{ClientInfo, FramedStream, Hello, IpcMessage, PROTO_VERSION};
+    use tokio::net::UnixStream;
+
+    let dir = forge_cli::socket::sessions_socket_dir();
+    let mut read_dir = match tokio::fs::read_dir(&dir).await {
+        Ok(d) => d,
+        Err(_) => {
+            println!("no active sessions");
+            return Ok(());
+        }
+    };
+
+    let mut found = false;
+    while let Some(entry) = read_dir.next_entry().await? {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("sock") {
+            continue;
+        }
+        let id = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        match UnixStream::connect(&path).await {
+            Ok(stream) => {
+                let mut framed = FramedStream::new(stream);
+                let hello = IpcMessage::Hello(Hello {
+                    proto: PROTO_VERSION,
+                    client: ClientInfo {
+                        kind: "forge-cli".into(),
+                        pid: std::process::id(),
+                        user: whoami(),
+                    },
+                });
+                if framed.send(&hello).await.is_ok() {
+                    if let Ok(Some(IpcMessage::HelloAck(ack))) = framed.recv().await {
+                        println!(
+                            "{id}  active  workspace={}  started={}",
+                            ack.workspace, ack.started_at
+                        );
+                        found = true;
+                    }
+                }
+            }
+            Err(_) => {
+                println!("{id}  stale");
+                found = true;
+            }
+        }
+    }
+
+    if !found {
+        println!("no active sessions");
+    }
+    Ok(())
+}
+
+async fn session_tail(id: &str) -> Result<()> {
+    use forge_core::Event;
+    use forge_ipc::{ClientInfo, FramedStream, Hello, IpcMessage, Subscribe, PROTO_VERSION};
+    use tokio::net::UnixStream;
+
+    let sock = forge_cli::socket::socket_path(id);
+    let stream = UnixStream::connect(&sock)
+        .await
+        .map_err(|e| anyhow::anyhow!("cannot connect to session {id}: {e}"))?;
+
+    let mut framed = FramedStream::new(stream);
+
+    framed
+        .send(&IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "forge-cli".into(),
+                pid: std::process::id(),
+                user: whoami(),
+            },
+        }))
+        .await?;
+    let _ack: IpcMessage = framed
+        .recv()
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("server closed connection during handshake"))?;
+
+    framed
+        .send(&IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await?;
+
+    loop {
+        match framed.recv::<IpcMessage>().await? {
+            Some(IpcMessage::Event(ipc_event)) => {
+                if let Ok(event) = serde_json::from_value::<Event>(ipc_event.event) {
+                    if let Some(line) = forge_cli::display::format_event(&event) {
+                        println!("{line}");
+                    }
+                    if matches!(event, Event::SessionEnded { .. }) {
+                        break;
+                    }
+                }
+            }
+            None => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+async fn session_kill(id: &str) -> Result<()> {
+    let pid_file = forge_cli::socket::pid_path(id);
+    let raw = tokio::fs::read_to_string(&pid_file)
+        .await
+        .map_err(|_| anyhow::anyhow!("no pid file for session {id} — is it running?"))?;
+    let pid: libc::pid_t = raw
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid pid file for session {id}"))?;
+
+    // SAFETY: pid comes from a file we wrote; SIGTERM is a valid signal number.
+    let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        anyhow::bail!("kill({pid}, SIGTERM) failed: {err}");
+    }
+
+    let _ = tokio::fs::remove_file(&pid_file).await;
+    println!("sent SIGTERM to session {id} (pid {pid})");
+    Ok(())
+}
+
+async fn run_agent(name: &str, input_source: &str) -> Result<()> {
+    use forge_core::Event;
+    use forge_ipc::{
+        ClientInfo, FramedStream, Hello, IpcMessage, SendUserMessage, Subscribe, PROTO_VERSION,
+    };
+    use tokio::net::UnixStream;
+
+    let text = if input_source == "-" {
+        use tokio::io::AsyncReadExt;
+        let mut buf = String::new();
+        tokio::io::stdin().read_to_string(&mut buf).await?;
+        buf
+    } else {
+        tokio::fs::read_to_string(input_source).await?
+    };
+
+    let session_id = forge_core::SessionId::new();
+    let sock = forge_cli::socket::socket_path(&session_id.to_string());
+    let pid_file = forge_cli::socket::pid_path(&session_id.to_string());
+
+    if let Some(parent) = sock.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let forged = find_forged_binary()?;
+    let mut child = tokio::process::Command::new(&forged)
+        .arg("--agent")
+        .arg(name)
+        .arg("--auto-approve-unsafe")
+        .env("FORGE_SESSION_ID", session_id.to_string())
+        .env("FORGE_SOCKET_PATH", sock.to_str().unwrap_or(""))
+        .spawn()?;
+
+    let pid = child.id().unwrap_or(0);
+    tokio::fs::write(&pid_file, pid.to_string()).await?;
+
+    wait_for_socket(&sock).await?;
+
+    let stream = UnixStream::connect(&sock).await?;
+    let mut framed = FramedStream::new(stream);
+
+    framed
+        .send(&IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "forge-cli".into(),
+                pid: std::process::id(),
+                user: whoami(),
+            },
+        }))
+        .await?;
+    framed
+        .recv::<IpcMessage>()
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("handshake failed"))?;
+
+    framed
+        .send(&IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await?;
+    framed
+        .send(&IpcMessage::SendUserMessage(SendUserMessage { text }))
+        .await?;
+
+    // Stream events until the session ends.
+    let mut event_exit_code = 0i32;
+    loop {
+        match framed.recv::<IpcMessage>().await? {
+            Some(IpcMessage::Event(ipc_event)) => {
+                if let Ok(event) = serde_json::from_value::<Event>(ipc_event.event) {
+                    if let Some(line) = forge_cli::display::format_event(&event) {
+                        println!("{line}");
+                    }
+                    if let Event::SessionEnded { reason, .. } = &event {
+                        if matches!(reason, forge_core::EndReason::Error(_)) {
+                            event_exit_code = 1;
+                        }
+                        break;
+                    }
+                }
+            }
+            None => break,
+            _ => {}
+        }
+    }
+
+    // Await the forged process; prefer its OS exit code, fall back to event-derived code.
+    let _ = tokio::fs::remove_file(&pid_file).await;
+    let process_exit_code = child
+        .wait()
+        .await
+        .ok()
+        .and_then(|s| s.code())
+        .unwrap_or(event_exit_code);
+    let exit_code = if process_exit_code != 0 {
+        process_exit_code
+    } else {
+        event_exit_code
+    };
+
+    std::process::exit(exit_code);
+}
+
+/// Locate the `forged` binary relative to the current executable, then fall back to PATH.
+fn find_forged_binary() -> Result<PathBuf> {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join("forged");
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+    }
+    Ok(PathBuf::from("forged"))
+}
+
+/// Wait until a Unix socket file appears (max 5 seconds, polling every 50ms).
+async fn wait_for_socket(path: &std::path::Path) -> Result<()> {
+    for _ in 0..100 {
+        if path.exists() {
+            return Ok(());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    anyhow::bail!("timed out waiting for socket at {}", path.display())
+}
+
+fn whoami() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "unknown".into())
+}

--- a/crates/forge-cli/src/socket.rs
+++ b/crates/forge-cli/src/socket.rs
@@ -1,0 +1,72 @@
+use std::path::PathBuf;
+
+/// Resolve the Unix socket path for a session, using the same logic as `forged`.
+pub fn socket_path(session_id: &str) -> PathBuf {
+    let base = std::env::var("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let uid = std::env::var("UID").unwrap_or_else(|_| "0".to_string());
+            PathBuf::from(format!("/tmp/forge-{uid}"))
+        });
+    base.join("forge/sessions")
+        .join(format!("{session_id}.sock"))
+}
+
+/// Return the directory containing all session sockets.
+pub fn sessions_socket_dir() -> PathBuf {
+    let base = std::env::var("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let uid = std::env::var("UID").unwrap_or_else(|_| "0".to_string());
+            PathBuf::from(format!("/tmp/forge-{uid}"))
+        });
+    base.join("forge/sessions")
+}
+
+/// Resolve the PID file path for a session.
+pub fn pid_path(session_id: &str) -> PathBuf {
+    socket_path(session_id).with_extension("pid")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_path_uses_xdg_runtime_dir() {
+        // Temporarily set XDG_RUNTIME_DIR to a known value.
+        // Use a fixed path so the test is deterministic.
+        // We can't really set env vars safely in parallel tests, so just verify
+        // the path structure with the fallback UID approach.
+        let path = socket_path("deadbeefcafebabe");
+        let path_str = path.to_string_lossy();
+        assert!(
+            path_str.contains("forge/sessions"),
+            "expected forge/sessions in path: {path_str}"
+        );
+        assert!(
+            path_str.ends_with("deadbeefcafebabe.sock"),
+            "expected .sock extension: {path_str}"
+        );
+    }
+
+    #[test]
+    fn pid_path_has_pid_extension() {
+        let path = pid_path("abc123");
+        assert!(
+            path.to_string_lossy().ends_with("abc123.pid"),
+            "expected .pid extension: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn sessions_socket_dir_contains_forge_sessions() {
+        let dir = sessions_socket_dir();
+        assert!(
+            dir.to_string_lossy().contains("forge/sessions"),
+            "got: {}",
+            dir.display()
+        );
+    }
+}

--- a/crates/forge-cli/tests/cli_args.rs
+++ b/crates/forge-cli/tests/cli_args.rs
@@ -1,0 +1,150 @@
+/// Integration tests for CLI argument parsing.
+/// These import the production `Cli` struct directly so any structural change
+/// to the real command hierarchy will break these tests.
+use clap::Parser;
+use forge_cli::{Cli, Commands, RunCommands, SessionCommands, SessionNewKind};
+use std::path::PathBuf;
+
+#[test]
+fn parse_session_new_agent_with_workspace() {
+    let cli = Cli::try_parse_from([
+        "forge",
+        "session",
+        "new",
+        "agent",
+        "code-review",
+        "--workspace",
+        "/tmp/myproject",
+    ])
+    .expect("should parse");
+    let Commands::Session {
+        cmd:
+            SessionCommands::New {
+                kind: SessionNewKind::Agent { name, workspace },
+            },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(name, "code-review");
+    assert_eq!(workspace, Some(PathBuf::from("/tmp/myproject")));
+}
+
+#[test]
+fn parse_session_new_agent_without_workspace() {
+    let cli =
+        Cli::try_parse_from(["forge", "session", "new", "agent", "helper"]).expect("should parse");
+    let Commands::Session {
+        cmd:
+            SessionCommands::New {
+                kind: SessionNewKind::Agent { name, workspace },
+            },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(name, "helper");
+    assert!(workspace.is_none());
+}
+
+#[test]
+fn parse_session_new_provider() {
+    let cli = Cli::try_parse_from([
+        "forge",
+        "session",
+        "new",
+        "provider",
+        "anthropic/claude-opus-4",
+        "--workspace",
+        "/home/user/proj",
+    ])
+    .expect("should parse");
+    let Commands::Session {
+        cmd:
+            SessionCommands::New {
+                kind: SessionNewKind::Provider { spec, workspace },
+            },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(spec, "anthropic/claude-opus-4");
+    assert_eq!(workspace, Some(PathBuf::from("/home/user/proj")));
+}
+
+#[test]
+fn parse_session_list() {
+    let cli = Cli::try_parse_from(["forge", "session", "list"]).expect("should parse");
+    assert!(matches!(
+        cli.command,
+        Commands::Session {
+            cmd: SessionCommands::List
+        }
+    ));
+}
+
+#[test]
+fn parse_session_tail() {
+    let cli =
+        Cli::try_parse_from(["forge", "session", "tail", "abc123def456"]).expect("should parse");
+    let Commands::Session {
+        cmd: SessionCommands::Tail { id },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(id, "abc123def456");
+}
+
+#[test]
+fn parse_session_kill() {
+    let cli = Cli::try_parse_from(["forge", "session", "kill", "deadbeefcafe0000"])
+        .expect("should parse");
+    let Commands::Session {
+        cmd: SessionCommands::Kill { id },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(id, "deadbeefcafe0000");
+}
+
+#[test]
+fn parse_run_agent_with_default_input() {
+    let cli = Cli::try_parse_from(["forge", "run", "agent", "code-review"]).expect("should parse");
+    let Commands::Run {
+        cmd: RunCommands::Agent { name, input },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(name, "code-review");
+    assert_eq!(input, "-");
+}
+
+#[test]
+fn parse_run_agent_with_file_input() {
+    let cli = Cli::try_parse_from([
+        "forge",
+        "run",
+        "agent",
+        "helper",
+        "--input",
+        "/tmp/prompt.txt",
+    ])
+    .expect("should parse");
+    let Commands::Run {
+        cmd: RunCommands::Agent { name, input },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(name, "helper");
+    assert_eq!(input, "/tmp/prompt.txt");
+}
+
+#[test]
+fn unknown_command_returns_error() {
+    let result = Cli::try_parse_from(["forge", "bogus"]);
+    assert!(result.is_err(), "bogus command should fail to parse");
+}

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -7,8 +7,13 @@ async fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let auto_approve = args.iter().any(|a| a == "--auto-approve-unsafe");
 
-    let session_id = forge_core::SessionId::new();
-    let socket_path = resolve_socket_path(&session_id.to_string());
+    // Allow the CLI to pre-assign the session ID and socket path so it can
+    // print the path before forged starts and can track it for `session kill`.
+    let session_id = std::env::var("FORGE_SESSION_ID")
+        .unwrap_or_else(|_| forge_core::SessionId::new().to_string());
+    let socket_path = std::env::var("FORGE_SOCKET_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| resolve_socket_path(&session_id));
     eprintln!("forged: listening on {}", socket_path.display());
     serve(&socket_path, auto_approve).await
 }


### PR DESCRIPTION
Closes forge-ide/forge#17

## Summary
- All 6 commands implemented with `clap`: `session new agent`, `session new provider`, `session list`, `session tail`, `session kill`, `run agent`
- `forge session new` pre-assigns session ID + socket path via env vars, spawns `forged` as detached process, waits for socket, then prints `session <id> started at <sock>`
- `forge session list` enumerates `*.sock` files and pings each via IPC Hello/HelloAck for live state
- `forge session tail` subscribes from seq 0 and pretty-prints events (user messages, assistant replies, tool calls, session lifecycle)
- `forge session kill` reads stored PID file and sends SIGTERM via `libc::kill` syscall
- `forge run agent` spawns ephemeral session, sends stdin as message, streams until `SessionEnded`, exits with session's exit code
- `forged` updated to accept `FORGE_SESSION_ID`/`FORGE_SOCKET_PATH` env vars for CLI-assigned sessions

## Test plan
- `cargo test --workspace` passes (19 new tests in forge-cli)
- `cargo clippy --all-targets -- -D warnings` passes
- Integration tests import from production `forge_cli` lib target (no mirrored structs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)