### PR TITLE
[F-016] Integration test: full headless turn

### DIFF
--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -24,4 +24,8 @@ tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", 
 
 [dev-dependencies]
 tempfile = "3"
-tokio = { version = "1", features = ["rt", "macros", "time", "net"] }
+tokio = { version = "1", features = ["rt", "macros", "time", "net", "process"] }
+
+[[test]]
+name = "headless_session_basic"
+path = "tests/headless_session/basic.rs"

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -1,6 +1,11 @@
 use anyhow::Result;
-use forge_session::server::serve;
+use forge_providers::MockProvider;
+use forge_session::{
+    server::{serve, serve_with_session},
+    session::Session,
+};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -15,7 +20,22 @@ async fn main() -> Result<()> {
         .map(PathBuf::from)
         .unwrap_or_else(|_| resolve_socket_path(&session_id));
     eprintln!("forged: listening on {}", socket_path.display());
-    serve(&socket_path, auto_approve).await
+
+    // FORGE_MOCK_SEQUENCE_FILE points to a JSON array of NDJSON scripts.
+    // Each element is used in order as the response for successive provider calls.
+    // Used by integration tests to inject scripted multi-turn responses.
+    if let Ok(seq_file) = std::env::var("FORGE_MOCK_SEQUENCE_FILE") {
+        let content = tokio::fs::read_to_string(&seq_file).await?;
+        let scripts: Vec<String> = serde_json::from_str(&content)?;
+        let log_path = std::env::temp_dir()
+            .join(format!("forge-session-{session_id}"))
+            .join("events.jsonl");
+        let session = Arc::new(Session::create(log_path).await?);
+        let provider = Arc::new(MockProvider::from_responses(scripts)?);
+        serve_with_session(&socket_path, session, provider, auto_approve).await
+    } else {
+        serve(&socket_path, auto_approve).await
+    }
 }
 
 fn resolve_socket_path(session_id: &str) -> PathBuf {

--- a/crates/forge-session/tests/headless_session/basic.rs
+++ b/crates/forge-session/tests/headless_session/basic.rs
@@ -1,0 +1,237 @@
+//! Integration test: full headless turn via UDS.
+//!
+//! Spawns `forged`, connects via Unix domain socket, sends a `SendUserMessage`,
+//! and asserts the complete event sequence including a tool call auto-approved
+//! by the server.
+
+use forge_core::{ApprovalSource, Event};
+use forge_ipc::{
+    ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, PROTO_VERSION,
+};
+use std::process::Stdio;
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+const FORGED: &str = env!("CARGO_BIN_EXE_forged");
+
+async fn connect_with_retry(path: &std::path::Path) -> UnixStream {
+    for _ in 0..50 {
+        if let Ok(s) = UnixStream::connect(path).await {
+            return s;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("forged did not create socket in time")
+}
+
+fn extract_event(msg: &IpcMessage) -> Option<Event> {
+    if let IpcMessage::Event(IpcEvent { event, .. }) = msg {
+        Some(
+            serde_json::from_value::<Event>(event.clone())
+                .expect("forged emitted an unrecognized event variant"),
+        )
+    } else {
+        None
+    }
+}
+
+/// Spawn `forged`, perform a full turn with a tool call, assert the event sequence.
+///
+/// Expected sequence (with `--auto-approve-unsafe`):
+///   UserMessage
+///   AssistantMessage(open)
+///   AssistantDelta("I will read the file.")
+///   ToolCallStarted { tool: "fs.read" }
+///   ToolCallApproved { by: Auto }
+///   ToolCallCompleted
+///   AssistantMessage(final)
+///   AssistantMessage(open)    ← continuation turn
+///   AssistantDelta("Done reading.")
+///   AssistantMessage(final)
+#[tokio::test]
+async fn full_headless_turn_emits_correct_event_sequence() {
+    let dir = TempDir::new().unwrap();
+
+    // File for fs.read to read during the turn
+    let readable_file = dir.path().join("readable.txt");
+    std::fs::write(&readable_file, "hello world\n").unwrap();
+
+    // Build two NDJSON scripts: initial turn with tool call, then continuation
+    let script1 = format!(
+        "{}\n{}\n{}",
+        serde_json::json!({"delta": "I will read the file."}),
+        serde_json::json!({"tool_call": {"name": "fs.read", "args": {"path": readable_file.to_str().unwrap()}}}),
+        serde_json::json!({"done": "tool_use"}),
+    );
+    let script2 = format!(
+        "{}\n{}",
+        serde_json::json!({"delta": "Done reading."}),
+        serde_json::json!({"done": "end_turn"}),
+    );
+
+    let mock_path = dir.path().join("mock.json");
+    std::fs::write(
+        &mock_path,
+        serde_json::to_string(&vec![script1, script2]).unwrap(),
+    )
+    .unwrap();
+
+    let sock_path = dir.path().join("session.sock");
+
+    let mut child = tokio::process::Command::new(FORGED)
+        .arg("--auto-approve-unsafe")
+        .env("FORGE_SESSION_ID", "headless-test-001")
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .env("FORGE_MOCK_SEQUENCE_FILE", &mock_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to spawn forged");
+
+    let mut stream = connect_with_retry(&sock_path).await;
+
+    // Handshake
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "test".into(),
+                pid: std::process::id(),
+                user: "tester".into(),
+            },
+        }),
+    )
+    .await
+    .unwrap();
+
+    let ack = forge_ipc::read_frame(&mut stream).await.unwrap();
+    assert!(
+        matches!(ack, IpcMessage::HelloAck(_)),
+        "expected HelloAck, got {ack:?}"
+    );
+
+    // Subscribe from the beginning
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+
+    // Send user message to start the turn
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "please read the file".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Collect events until two AssistantMessage(final) events arrive
+    let mut events: Vec<Event> = Vec::new();
+    let mut final_count = 0;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+
+    loop {
+        let frame = tokio::time::timeout_at(deadline, forge_ipc::read_frame(&mut stream))
+            .await
+            .expect("timed out waiting for events from forged")
+            .unwrap();
+
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+
+        if matches!(
+            event,
+            Event::AssistantMessage {
+                stream_finalised: true,
+                ..
+            }
+        ) {
+            final_count += 1;
+        }
+        events.push(event);
+        if final_count >= 2 {
+            break;
+        }
+    }
+
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+
+    // --- Assertions ---
+
+    let kinds: Vec<&str> = events
+        .iter()
+        .map(|e| match e {
+            Event::UserMessage { .. } => "UserMessage",
+            Event::AssistantMessage {
+                stream_finalised: false,
+                ..
+            } => "AssistantMessage(open)",
+            Event::AssistantMessage {
+                stream_finalised: true,
+                ..
+            } => "AssistantMessage(final)",
+            Event::AssistantDelta { .. } => "AssistantDelta",
+            Event::ToolCallStarted { .. } => "ToolCallStarted",
+            Event::ToolCallApprovalRequested { .. } => "ToolCallApprovalRequested",
+            Event::ToolCallApproved { .. } => "ToolCallApproved",
+            Event::ToolCallCompleted { .. } => "ToolCallCompleted",
+            _ => "Other",
+        })
+        .collect();
+
+    assert_eq!(
+        kinds,
+        vec![
+            "UserMessage",
+            "AssistantMessage(open)",
+            "AssistantDelta",
+            "ToolCallStarted",
+            "ToolCallApproved",
+            "ToolCallCompleted",
+            "AssistantMessage(final)",
+            "AssistantMessage(open)",
+            "AssistantDelta",
+            "AssistantMessage(final)",
+        ],
+        "event sequence mismatch: got {kinds:?}"
+    );
+
+    let deltas: Vec<&str> = events
+        .iter()
+        .filter_map(|e| {
+            if let Event::AssistantDelta { delta, .. } = e {
+                Some(delta.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(
+        deltas,
+        vec!["I will read the file.", "Done reading."],
+        "delta text mismatch"
+    );
+
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::ToolCallStarted { tool, .. } if tool == "fs.read")),
+        "expected ToolCallStarted for fs.read"
+    );
+
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            Event::ToolCallApproved {
+                by: ApprovalSource::Auto,
+                ..
+            }
+        )),
+        "expected ToolCallApproved with by=Auto"
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#18

## Summary
- Adds `tests/headless_session/basic.rs` integration test that spawns the real `forged` binary
- Connects via UDS, performs handshake + subscribe, sends `SendUserMessage`
- Uses `MockProvider` with a scripted `mock.json` (JSON array of NDJSON scripts) injected via `FORGE_MOCK_SEQUENCE_FILE` env var
- Asserts the complete 10-event sequence: `UserMessage → AssistantMessage(open) → AssistantDelta → ToolCallStarted → ToolCallApproved(Auto) → ToolCallCompleted → AssistantMessage(final) → AssistantMessage(open) → AssistantDelta → AssistantMessage(final)`
- Adds `FORGE_MOCK_SEQUENCE_FILE` support to `forged` main for scripted multi-turn provider injection

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)