### PR TITLE
[F-033] Bug: emit SessionEnded after ephemeral turn completes

### DIFF
--- a/crates/forge-cli/src/main.rs
+++ b/crates/forge-cli/src/main.rs
@@ -228,6 +228,7 @@ async fn run_agent(name: &str, input_source: &str) -> Result<()> {
         .arg("--agent")
         .arg(name)
         .arg("--auto-approve-unsafe")
+        .arg("--ephemeral")
         .env("FORGE_SESSION_ID", session_id.to_string())
         .env("FORGE_SOCKET_PATH", sock.to_str().unwrap_or(""))
         .spawn()?;

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -29,3 +29,7 @@ tokio = { version = "1", features = ["rt", "macros", "time", "net", "process"] }
 [[test]]
 name = "headless_session_basic"
 path = "tests/headless_session/basic.rs"
+
+[[test]]
+name = "session_ended"
+path = "tests/session_ended.rs"

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let auto_approve = args.iter().any(|a| a == "--auto-approve-unsafe");
+    let ephemeral = args.iter().any(|a| a == "--ephemeral");
 
     // Allow the CLI to pre-assign the session ID and socket path so it can
     // print the path before forged starts and can track it for `session kill`.
@@ -32,9 +33,9 @@ async fn main() -> Result<()> {
             .join("events.jsonl");
         let session = Arc::new(Session::create(log_path).await?);
         let provider = Arc::new(MockProvider::from_responses(scripts)?);
-        serve_with_session(&socket_path, session, provider, auto_approve).await
+        serve_with_session(&socket_path, session, provider, auto_approve, ephemeral).await
     } else {
-        serve(&socket_path, auto_approve).await
+        serve(&socket_path, auto_approve, ephemeral).await
     }
 }
 

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -13,13 +13,13 @@ use crate::orchestrator::{run_turn, PendingApprovals};
 use crate::session::Session;
 
 /// Start a session server using the default `MockProvider`.
-pub async fn serve(path: &Path, auto_approve: bool) -> Result<()> {
+pub async fn serve(path: &Path, auto_approve: bool, ephemeral: bool) -> Result<()> {
     let log_path = std::env::temp_dir()
         .join(format!("forge-session-{}", SessionId::new()))
         .join("events.jsonl");
     let session = Arc::new(Session::create(log_path).await?);
     let provider = Arc::new(MockProvider::with_default_path());
-    serve_with_session(path, session, provider, auto_approve).await
+    serve_with_session(path, session, provider, auto_approve, ephemeral).await
 }
 
 /// Start a session server with an explicit provider.
@@ -28,6 +28,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
     session: Arc<Session>,
     provider: Arc<P>,
     auto_approve: bool,
+    ephemeral: bool,
 ) -> Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -36,12 +37,20 @@ pub async fn serve_with_session<P: Provider + 'static>(
         tokio::fs::remove_file(path).await?;
     }
     let listener = UnixListener::bind(path)?;
+
+    if ephemeral {
+        // Accept exactly one connection, serve it to completion, then exit.
+        let (stream, _) = listener.accept().await?;
+        return handle_connection(stream, session, provider, auto_approve, true).await;
+    }
+
     loop {
         let (stream, _) = listener.accept().await?;
         let session = Arc::clone(&session);
         let provider = Arc::clone(&provider);
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, session, provider, auto_approve).await {
+            if let Err(e) = handle_connection(stream, session, provider, auto_approve, false).await
+            {
                 eprintln!("connection error: {e}");
             }
         });
@@ -53,6 +62,7 @@ async fn handle_connection<P: Provider + 'static>(
     session: Arc<Session>,
     provider: Arc<P>,
     auto_approve: bool,
+    ephemeral: bool,
 ) -> Result<()> {
     // ── Handshake ──────────────────────────────────────────────────────────────
     let msg = forge_ipc::read_frame(&mut stream).await?;
@@ -118,12 +128,16 @@ async fn handle_connection<P: Provider + 'static>(
             result = live_rx.recv() => {
                 match result {
                     Ok((seq, event)) if seq > last_sent => {
+                        let is_session_ended = matches!(event, forge_core::Event::SessionEnded { .. });
                         let frame = IpcMessage::Event(IpcEvent {
                             seq,
                             event: serde_json::to_value(&event)?,
                         });
                         forge_ipc::write_frame(&mut writer, &frame).await?;
                         last_sent = seq;
+                        if is_session_ended {
+                            break;
+                        }
                     }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Closed) => break,
@@ -145,8 +159,22 @@ async fn handle_connection<P: Provider + 'static>(
                             // TODO(F-013): thread AgentDef.allowed_paths once agent
                             // context is passed through the server connection.
                             // Using ["**"] (allow all) until then.
-                            if let Err(e) = run_turn(session, provider, m.text, approvals, vec!["**".to_string()], auto_approve).await {
+                            let result = run_turn(Arc::clone(&session), provider, m.text, approvals, vec!["**".to_string()], auto_approve).await;
+                            if let Err(e) = &result {
                                 eprintln!("turn error: {e}");
+                            }
+                            if ephemeral {
+                                let reason = match result {
+                                    Ok(()) => forge_core::EndReason::Completed,
+                                    Err(e) => forge_core::EndReason::Error(e.to_string()),
+                                };
+                                if let Err(e) = session.emit(forge_core::Event::SessionEnded {
+                                    at: chrono::Utc::now(),
+                                    reason,
+                                    archived: false,
+                                }).await {
+                                    eprintln!("failed to emit SessionEnded: {e}");
+                                }
                             }
                         });
                     }

--- a/crates/forge-session/tests/fs_read_tool.rs
+++ b/crates/forge-session/tests/fs_read_tool.rs
@@ -77,7 +77,7 @@ async fn fs_read_tool_returns_content_bytes_sha256() {
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, server_provider, false)
+        serve_with_session(&server_sock, server_session, server_provider, false, false)
             .await
             .unwrap();
     });

--- a/crates/forge-session/tests/handshake.rs
+++ b/crates/forge-session/tests/handshake.rs
@@ -23,7 +23,7 @@ async fn handshake_succeeds_with_valid_proto() {
 
     let server_path = path.clone();
     tokio::spawn(async move {
-        serve(&server_path, false).await.unwrap();
+        serve(&server_path, false, false).await.unwrap();
     });
 
     let mut stream = connect_with_retry(&path).await;
@@ -53,7 +53,7 @@ async fn unknown_proto_rejected() {
 
     let server_path = path.clone();
     tokio::spawn(async move {
-        serve(&server_path, false).await.unwrap();
+        serve(&server_path, false, false).await.unwrap();
     });
 
     let mut stream = connect_with_retry(&path).await;
@@ -82,7 +82,7 @@ async fn garbage_frame_rejected() {
 
     let server_path = path.clone();
     tokio::spawn(async move {
-        serve(&server_path, false).await.unwrap();
+        serve(&server_path, false, false).await.unwrap();
     });
 
     let mut stream = connect_with_retry(&path).await;

--- a/crates/forge-session/tests/orchestrator.rs
+++ b/crates/forge-session/tests/orchestrator.rs
@@ -90,7 +90,7 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, server_provider, false)
+        serve_with_session(&server_sock, server_session, server_provider, false, false)
             .await
             .unwrap();
     });
@@ -242,7 +242,7 @@ async fn approval_gate_fires_and_blocks_until_client_approves() {
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, server_provider, false)
+        serve_with_session(&server_sock, server_session, server_provider, false, false)
             .await
             .unwrap();
     });
@@ -323,7 +323,7 @@ async fn auto_approve_skips_approval_gate_and_emits_auto_approved() {
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, server_provider, true)
+        serve_with_session(&server_sock, server_session, server_provider, true, false)
             .await
             .unwrap();
     });
@@ -444,7 +444,7 @@ async fn tool_result_fed_back_to_provider_in_continuation() {
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, server_provider, false)
+        serve_with_session(&server_sock, server_session, server_provider, false, false)
             .await
             .unwrap();
     });

--- a/crates/forge-session/tests/session_ended.rs
+++ b/crates/forge-session/tests/session_ended.rs
@@ -1,0 +1,148 @@
+//! Integration tests: SessionEnded emission for ephemeral sessions.
+//!
+//! Verifies that forged emits `SessionEnded { reason: Completed }` after a
+//! single-turn ephemeral session and that the process exits cleanly.
+
+use forge_core::{EndReason, Event};
+use forge_ipc::{
+    ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, PROTO_VERSION,
+};
+use std::process::Stdio;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+const FORGED: &str = env!("CARGO_BIN_EXE_forged");
+
+async fn connect_with_retry(path: &std::path::Path) -> UnixStream {
+    for _ in 0..50 {
+        if let Ok(s) = UnixStream::connect(path).await {
+            return s;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("forged did not create socket in time")
+}
+
+fn extract_event(msg: &IpcMessage) -> Option<Event> {
+    if let IpcMessage::Event(IpcEvent { event, .. }) = msg {
+        Some(
+            serde_json::from_value::<Event>(event.clone())
+                .expect("forged emitted an unrecognized event variant"),
+        )
+    } else {
+        None
+    }
+}
+
+/// Ephemeral session: `SessionEnded { reason: Completed }` must be the last
+/// event and forged must exit with code 0.
+#[tokio::test]
+async fn ephemeral_session_emits_session_ended_with_completed_reason() {
+    let dir = TempDir::new().unwrap();
+
+    let script = format!(
+        "{}\n{}",
+        serde_json::json!({"delta": "Hello."}),
+        serde_json::json!({"done": "end_turn"}),
+    );
+    let mock_path = dir.path().join("mock.json");
+    std::fs::write(&mock_path, serde_json::to_string(&vec![script]).unwrap()).unwrap();
+
+    let sock_path = dir.path().join("session.sock");
+
+    let mut child = tokio::process::Command::new(FORGED)
+        .arg("--ephemeral")
+        .env("FORGE_SESSION_ID", "ephemeral-ended-test")
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .env("FORGE_MOCK_SEQUENCE_FILE", &mock_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to spawn forged");
+
+    let mut stream = connect_with_retry(&sock_path).await;
+
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "test".into(),
+                pid: std::process::id(),
+                user: "tester".into(),
+            },
+        }),
+    )
+    .await
+    .unwrap();
+
+    let ack = forge_ipc::read_frame(&mut stream).await.unwrap();
+    assert!(
+        matches!(ack, IpcMessage::HelloAck(_)),
+        "expected HelloAck, got {ack:?}"
+    );
+
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "say hello".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Collect all events until SessionEnded or timeout.
+    let mut events: Vec<Event> = Vec::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+
+    loop {
+        let frame = tokio::time::timeout_at(deadline, forge_ipc::read_frame(&mut stream))
+            .await
+            .expect("timed out waiting for SessionEnded from forged");
+
+        match frame {
+            Ok(msg) => {
+                if let Some(event) = extract_event(&msg) {
+                    let is_ended = matches!(event, Event::SessionEnded { .. });
+                    events.push(event);
+                    if is_ended {
+                        break;
+                    }
+                }
+            }
+            // Connection closed without SessionEnded — test will fail on assert below.
+            Err(_) => break,
+        }
+    }
+
+    let last = events.last().expect("no events received");
+    assert!(
+        matches!(
+            last,
+            Event::SessionEnded {
+                reason: EndReason::Completed,
+                archived: false,
+                ..
+            }
+        ),
+        "last event was not SessionEnded{{Completed}}: {last:?}"
+    );
+
+    // forged must exit cleanly after the ephemeral session ends.
+    let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+        .await
+        .expect("forged did not exit within 5s after SessionEnded")
+        .expect("child.wait() failed");
+    assert!(
+        status.success(),
+        "forged exited with non-zero: {:?}",
+        status.code()
+    );
+}

--- a/crates/forge-session/tests/subscribe_replay.rs
+++ b/crates/forge-session/tests/subscribe_replay.rs
@@ -61,7 +61,7 @@ async fn subscribe_mid_stream_receives_historical_then_live_events() {
     let server_sock = sock_path.clone();
     let provider = Arc::new(MockProvider::with_default_path());
     tokio::spawn(async move {
-        serve_with_session(&server_sock, server_session, provider, false)
+        serve_with_session(&server_sock, server_session, provider, false, false)
             .await
             .unwrap();
     });


### PR DESCRIPTION
Closes forge-ide/forge#52

## Summary
- Adds `--ephemeral` flag to `forged`: accepts one connection, runs a single turn, emits `SessionEnded { reason: Completed }`, then exits cleanly
- `forge run agent` passes `--ephemeral` so it no longer hangs waiting for a session that never ends
- On turn error, emits `SessionEnded { reason: Error(...) }` so the CLI exits non-zero
- Existing persistent sessions unchanged (`ephemeral: false` preserves the accept-loop behavior)
- Integration test (`tests/session_ended.rs`) verifies `SessionEnded` is the last event and `forged` exits 0

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)