### PR TITLE
docs(roadmap): mark Phase 0 complete

### DIFF
--- a/docs/build/roadmap.md
+++ b/docs/build/roadmap.md
@@ -8,7 +8,7 @@
 
 The sequencing that builds toward v1.0. Milestones are outcome-based.
 
-### Phase 0 — Foundations (weeks 1–2)
+### Phase 0 — Foundations (weeks 1–2) ✅ Complete
 **Outcome.** A new user can run `forge session new` and get a working session process with IPC.
 - Repo scaffold, workspace, CI, rustfmt/clippy baselines
 - `forge-core`, `forge-ipc` skeletons with `ts-rs` working


### PR DESCRIPTION
## Summary
- Mark Phase 0 as complete in `docs/build/roadmap.md`
- Phase 0 milestone closed upstream with all 21 issues shipped (F-000–F-017 plus post-sprint fixes F-033–F-035)
- Tag `phase-0` pushed to upstream on the Phase 0 foundation commit

## Test plan
- [x] Roadmap renders correctly with status marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)