### PR TITLE
[F-028] Tool dispatcher in forge-session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "ts-rs",
@@ -386,6 +386,7 @@ dependencies = [
  "futures",
  "serde_json",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -532,7 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3563a3eb8bacf11a0a6d93de7885f2cca224dddff0114e4eb8053ca0f1918acd"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "yaml-rust2",
 ]
 
@@ -800,7 +801,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -964,11 +965,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1069,7 +1090,7 @@ version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
  "ts-rs-macros",
 ]
 

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -20,6 +20,7 @@ forge-ipc = { path = "../forge-ipc" }
 forge-providers = { path = "../forge-providers" }
 futures = "0.3"
 serde_json = "1"
+thiserror = "1"
 tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync"] }
 
 [dev-dependencies]

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod orchestrator;
 pub mod server;
 pub mod session;
+pub mod tools;

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -2,19 +2,18 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use forge_fs::read_file;
-
 use anyhow::Result;
 use chrono::Utc;
 use forge_core::{
     ids::{MessageId, ProviderId, ToolCallId},
-    ApprovalPreview, ApprovalScope, ApprovalSource, Event,
+    ApprovalScope, ApprovalSource, Event,
 };
 use forge_providers::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider};
 use futures::StreamExt;
 use tokio::sync::{oneshot, Mutex};
 
 use crate::session::Session;
+use crate::tools::{FsReadTool, ToolCtx, ToolDispatcher, ToolError};
 
 /// Pending tool call approvals: maps ToolCallId → sender for the approval result.
 pub type PendingApprovals = Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>;
@@ -55,13 +54,20 @@ pub async fn run_turn<P: Provider>(
         }],
     };
 
+    let mut dispatcher = ToolDispatcher::new();
+    dispatcher
+        .register(Box::new(FsReadTool))
+        .expect("fs.read must register on a fresh dispatcher");
+    let ctx = ToolCtx { allowed_paths };
+
     run_request_loop(
         session,
         provider,
         initial_req,
         msg_id,
         pending_approvals,
-        allowed_paths,
+        &dispatcher,
+        &ctx,
         auto_approve,
     )
     .await
@@ -71,13 +77,15 @@ pub async fn run_turn<P: Provider>(
 /// On tool calls: waits for approval, executes stub, appends result to the
 /// next request, and continues until the provider returns `Done` with no
 /// pending tool calls.
+#[allow(clippy::too_many_arguments)]
 async fn run_request_loop<P: Provider>(
     session: Arc<Session>,
     provider: Arc<P>,
     mut req: ChatRequest,
     msg_id: MessageId,
     pending_approvals: PendingApprovals,
-    allowed_paths: Vec<String>,
+    dispatcher: &ToolDispatcher,
+    ctx: &ToolCtx,
     auto_approve: bool,
 ) -> Result<()> {
     // Fixed provider/model identifiers for the mock provider.
@@ -136,73 +144,76 @@ async fn run_request_loop<P: Provider>(
                         })
                         .await?;
 
-                    if auto_approve {
-                        // --auto-approve-unsafe: skip the approval gate entirely.
-                        session
-                            .emit(Event::ToolCallApproved {
-                                id: call_id.clone(),
-                                by: ApprovalSource::Auto,
-                                scope: ApprovalScope::Once,
-                                at: Utc::now(),
-                            })
-                            .await?;
-                    } else {
-                        // Approval gate: register oneshot before emitting the event
-                        // so the connection handler can resolve it immediately on receipt.
-                        let (tx, rx) = oneshot::channel::<bool>();
-                        pending_approvals
-                            .lock()
-                            .await
-                            .insert(call_id.to_string(), tx);
-
-                        session
-                            .emit(Event::ToolCallApprovalRequested {
-                                id: call_id.clone(),
-                                preview: ApprovalPreview {
-                                    description: format!("Run tool '{name}'?"),
-                                },
-                            })
-                            .await?;
-
-                        let approved = rx.await.unwrap_or(false);
-
-                        if !approved {
-                            session
-                                .emit(Event::ToolCallRejected {
-                                    id: call_id,
-                                    reason: Some("rejected by client".to_string()),
-                                })
-                                .await?;
-                            // Finalise the open AssistantMessage so the session log
-                            // is never left with a dangling un-finalised message.
-                            session
-                                .emit(Event::AssistantMessage {
-                                    id: msg_id.clone(),
-                                    provider: provider_id.clone(),
-                                    model: model.clone(),
-                                    at: Utc::now(),
-                                    stream_finalised: true,
-                                    text: assistant_text.clone(),
-                                    branch_parent: None,
-                                    branch_variant_index: 0,
-                                })
-                                .await?;
-                            return Ok(());
-                        }
-
-                        session
-                            .emit(Event::ToolCallApproved {
-                                id: call_id.clone(),
-                                by: ApprovalSource::User,
-                                scope: ApprovalScope::Once,
-                                at: Utc::now(),
-                            })
-                            .await?;
-                    }
-
-                    // Execute the tool.
                     let started = Instant::now();
-                    let result = dispatch_tool(&name, &args, &allowed_paths);
+                    let tool = dispatcher.get(&name);
+
+                    let result = match tool {
+                        Ok(tool) => {
+                            if auto_approve {
+                                session
+                                    .emit(Event::ToolCallApproved {
+                                        id: call_id.clone(),
+                                        by: ApprovalSource::Auto,
+                                        scope: ApprovalScope::Once,
+                                        at: Utc::now(),
+                                    })
+                                    .await?;
+                            } else {
+                                let (tx, rx) = oneshot::channel::<bool>();
+                                pending_approvals
+                                    .lock()
+                                    .await
+                                    .insert(call_id.to_string(), tx);
+
+                                session
+                                    .emit(Event::ToolCallApprovalRequested {
+                                        id: call_id.clone(),
+                                        preview: tool.approval_preview(&args),
+                                    })
+                                    .await?;
+
+                                let approved = rx.await.unwrap_or(false);
+
+                                if !approved {
+                                    session
+                                        .emit(Event::ToolCallRejected {
+                                            id: call_id,
+                                            reason: Some("rejected by client".to_string()),
+                                        })
+                                        .await?;
+                                    session
+                                        .emit(Event::AssistantMessage {
+                                            id: msg_id.clone(),
+                                            provider: provider_id.clone(),
+                                            model: model.clone(),
+                                            at: Utc::now(),
+                                            stream_finalised: true,
+                                            text: assistant_text.clone(),
+                                            branch_parent: None,
+                                            branch_variant_index: 0,
+                                        })
+                                        .await?;
+                                    return Ok(());
+                                }
+
+                                session
+                                    .emit(Event::ToolCallApproved {
+                                        id: call_id.clone(),
+                                        by: ApprovalSource::User,
+                                        scope: ApprovalScope::Once,
+                                        at: Utc::now(),
+                                    })
+                                    .await?;
+                            }
+
+                            tool.invoke(&args, ctx)
+                        }
+                        Err(ToolError::UnknownTool(n)) => {
+                            serde_json::json!({ "error": format!("unknown tool '{n}'") })
+                        }
+                        Err(e) => serde_json::json!({ "error": e.to_string() }),
+                    };
+
                     let duration_ms = started.elapsed().as_millis() as u64;
 
                     session
@@ -280,26 +291,5 @@ async fn run_request_loop<P: Provider>(
             role: ChatRole::User,
             content: tr_blocks,
         });
-    }
-}
-
-fn dispatch_tool(
-    name: &str,
-    args: &serde_json::Value,
-    allowed_paths: &[String],
-) -> serde_json::Value {
-    match name {
-        "fs.read" => {
-            let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
-            match read_file(path, allowed_paths) {
-                Ok(r) => serde_json::json!({
-                    "content": r.content,
-                    "bytes": r.bytes,
-                    "sha256": r.sha256,
-                }),
-                Err(e) => serde_json::json!({ "error": e.to_string() }),
-            }
-        }
-        _ => serde_json::json!({ "content": "stub tool result" }),
     }
 }

--- a/crates/forge-session/src/tools/fs_read.rs
+++ b/crates/forge-session/src/tools/fs_read.rs
@@ -1,0 +1,32 @@
+//! `fs.read` tool: reads a file via [`forge_fs::read_file`] and returns
+//! `{ content, bytes, sha256 }` or `{ error }`.
+
+use super::{Tool, ToolCtx};
+use forge_core::ApprovalPreview;
+
+pub struct FsReadTool;
+
+impl Tool for FsReadTool {
+    fn name(&self) -> &str {
+        "fs.read"
+    }
+
+    fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
+        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        ApprovalPreview {
+            description: format!("Read file '{path}'"),
+        }
+    }
+
+    fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
+        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        match forge_fs::read_file(path, &ctx.allowed_paths) {
+            Ok(r) => serde_json::json!({
+                "content": r.content,
+                "bytes": r.bytes,
+                "sha256": r.sha256,
+            }),
+            Err(e) => serde_json::json!({ "error": e.to_string() }),
+        }
+    }
+}

--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -1,0 +1,154 @@
+//! Tool dispatch: name → handler routing for orchestrator tool calls.
+
+use forge_core::ApprovalPreview;
+
+pub mod fs_read;
+
+pub use fs_read::FsReadTool;
+
+pub struct ToolCtx {
+    pub allowed_paths: Vec<String>,
+}
+
+pub trait Tool: Send + Sync {
+    fn name(&self) -> &str;
+    fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview;
+    fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value;
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum ToolError {
+    #[error("tool '{0}' is already registered")]
+    DuplicateName(String),
+    #[error("unknown tool '{0}'")]
+    UnknownTool(String),
+}
+
+#[derive(Default)]
+pub struct ToolDispatcher {
+    tools: std::collections::HashMap<String, Box<dyn Tool>>,
+}
+
+impl ToolDispatcher {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, tool: Box<dyn Tool>) -> Result<(), ToolError> {
+        let name = tool.name().to_string();
+        if self.tools.contains_key(&name) {
+            return Err(ToolError::DuplicateName(name));
+        }
+        self.tools.insert(name, tool);
+        Ok(())
+    }
+
+    pub fn get(&self, name: &str) -> Result<&dyn Tool, ToolError> {
+        self.tools
+            .get(name)
+            .map(|b| b.as_ref())
+            .ok_or_else(|| ToolError::UnknownTool(name.to_string()))
+    }
+
+    pub fn dispatch(
+        &self,
+        name: &str,
+        args: &serde_json::Value,
+        ctx: &ToolCtx,
+    ) -> Result<serde_json::Value, ToolError> {
+        Ok(self.get(name)?.invoke(args, ctx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    struct StubTool {
+        name: &'static str,
+        response: serde_json::Value,
+    }
+
+    impl Tool for StubTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn approval_preview(&self, _args: &serde_json::Value) -> ApprovalPreview {
+            ApprovalPreview {
+                description: format!("stub: {}", self.name),
+            }
+        }
+        fn invoke(&self, _args: &serde_json::Value, _ctx: &ToolCtx) -> serde_json::Value {
+            self.response.clone()
+        }
+    }
+
+    fn empty_ctx() -> ToolCtx {
+        ToolCtx {
+            allowed_paths: vec![],
+        }
+    }
+
+    #[test]
+    fn register_and_dispatch_returns_tool_result() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(StubTool {
+            name: "noop",
+            response: json!({"ok": true}),
+        }))
+        .unwrap();
+
+        let result = d.dispatch("noop", &json!({}), &empty_ctx()).unwrap();
+        assert_eq!(result, json!({"ok": true}));
+    }
+
+    #[test]
+    fn duplicate_registration_returns_error() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(StubTool {
+            name: "noop",
+            response: json!({}),
+        }))
+        .unwrap();
+
+        let err = d
+            .register(Box::new(StubTool {
+                name: "noop",
+                response: json!({}),
+            }))
+            .unwrap_err();
+        assert_eq!(err, ToolError::DuplicateName("noop".to_string()));
+    }
+
+    #[test]
+    fn dispatch_unknown_tool_returns_error() {
+        let d = ToolDispatcher::new();
+        let err = d.dispatch("nope", &json!({}), &empty_ctx()).unwrap_err();
+        assert_eq!(err, ToolError::UnknownTool("nope".to_string()));
+    }
+
+    #[test]
+    fn fs_read_dispatch_returns_content_bytes_sha256() {
+        let mut file = NamedTempFile::new().unwrap();
+        let body = "hello dispatcher";
+        file.write_all(body.as_bytes()).unwrap();
+        let path = file.path().to_str().unwrap().to_string();
+        let canonical = std::fs::canonicalize(&path).unwrap();
+        let allowed = canonical.to_str().unwrap().to_string();
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(FsReadTool)).unwrap();
+
+        let ctx = ToolCtx {
+            allowed_paths: vec![allowed],
+        };
+        let result = d.dispatch("fs.read", &json!({"path": path}), &ctx).unwrap();
+
+        assert_eq!(result["content"].as_str().unwrap(), body);
+        assert_eq!(result["bytes"].as_u64().unwrap(), body.len() as u64);
+        assert_eq!(result["sha256"].as_str().unwrap().len(), 64);
+    }
+}


### PR DESCRIPTION
Closes forge-ide/forge#46

## Summary

Introduces a generic `ToolDispatcher` in `crates/forge-session/src/tools/` that routes `ToolCall` events to named handlers instead of the previous hard-wired `fs.read` branch in the orchestrator loop.

- `Tool` trait (`name`, `approval_preview`, `invoke`) — per-tool approval previews and execution live on the implementation, not the orchestrator
- `ToolDispatcher::register(Box<dyn Tool>)` — duplicate names return `ToolError::DuplicateName`
- `ToolDispatcher::dispatch(name, args, ctx)` — unknown names return `ToolError::UnknownTool`
- `ToolCtx { allowed_paths }` — extensible context passed to tool invocations
- `fs.read` re-homed from `orchestrator::dispatch_tool` to `tools::fs_read::FsReadTool`, still delegating to `forge_fs::read_file`
- `orchestrator.rs` builds the dispatcher once per turn, resolves tool by name before the approval gate, sources the `ApprovalPreview` from the trait, and invokes through the dispatcher

Wave-2 tools (F-029 fs.write/fs.edit, F-030/F-031) can now register themselves without touching the orchestrator.

## Test plan

- `cargo test --workspace` — all green, including 4 new unit tests in `forge_session::tools::tests` (register+dispatch, duplicate-name, unknown-tool, fs.read happy path via dispatcher)
- Existing orchestrator integration tests (`tests/orchestrator.rs`, `tests/fs_read_tool.rs`) pass unchanged, proving observable event-stream behavior is identical for known tools
- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean

## Notes

- Approval preview for `fs.read` changed from `"Run tool 'fs.read'?"` to `"Read file '<path>'"`. No existing test asserts on description content.
- Unknown-tool result changed from `{"content": "stub tool result"}` to `{"error": "unknown tool '<n>'"}`. Closer to intended error semantics; no caller depended on the old stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)