### PR TITLE
[F-029] forge-fs write and edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,9 @@ dependencies = [
  "glob",
  "hex",
  "sha2",
+ "similar",
  "tempfile",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -385,6 +387,7 @@ dependencies = [
  "forge-providers",
  "futures",
  "serde_json",
+ "similar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -907,6 +910,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/crates/forge-fs/Cargo.toml
+++ b/crates/forge-fs/Cargo.toml
@@ -8,6 +8,9 @@ anyhow = "1"
 glob = "0.3"
 hex = "0.4"
 sha2 = "0.10"
+similar = "2"
+tempfile = "3"
+thiserror = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/forge-fs/src/lib.rs
+++ b/crates/forge-fs/src/lib.rs
@@ -1,7 +1,10 @@
 use anyhow::{bail, Context, Result};
 use glob::Pattern;
 use sha2::{Digest, Sha256};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+mod mutate;
+pub use mutate::{edit, edit_preview, write, write_preview, ApprovalPreview, FsError};
 
 /// Result of a successful `fs.read` operation.
 #[derive(Debug)]
@@ -19,7 +22,7 @@ pub fn read_file(path: &str, allowed_paths: &[String]) -> Result<ReadResult> {
     // Canonicalize first so `..` components can't bypass glob patterns.
     let canonical =
         std::fs::canonicalize(path).with_context(|| format!("cannot resolve path '{path}'"))?;
-    validate_path(&canonical, allowed_paths)?;
+    validate_against_globs(&canonical, allowed_paths)?;
     let raw = std::fs::read(&canonical)?;
     let bytes = raw.len();
     let content = String::from_utf8_lossy(&raw).into_owned();
@@ -31,7 +34,7 @@ pub fn read_file(path: &str, allowed_paths: &[String]) -> Result<ReadResult> {
     })
 }
 
-fn validate_path(path: &Path, allowed_paths: &[String]) -> Result<()> {
+fn validate_against_globs(path: &Path, allowed_paths: &[String]) -> Result<()> {
     for pattern in allowed_paths {
         if let Ok(pat) = Pattern::new(pattern) {
             if pat.matches_path(path) {
@@ -40,4 +43,58 @@ fn validate_path(path: &Path, allowed_paths: &[String]) -> Result<()> {
         }
     }
     bail!("path '{}' is not allowed by allowed_paths", path.display());
+}
+
+/// Shared helper: return the canonical form of `path` only if every component is
+/// symlink-free. Used by both write and edit to enforce symlink rejection even
+/// when the enclosing directory is allowed.
+pub(crate) fn canonicalize_no_symlink(path: &Path) -> std::result::Result<PathBuf, FsError> {
+    // Walk each ancestor; if any ancestor is a symlink, reject.
+    // The target itself may or may not exist yet (write creates it).
+    let mut cursor = PathBuf::new();
+    for comp in path.components() {
+        cursor.push(comp);
+        if let Ok(md) = std::fs::symlink_metadata(&cursor) {
+            if md.file_type().is_symlink() {
+                return Err(FsError::SymlinkDenied {
+                    path: path.to_path_buf(),
+                });
+            }
+        }
+    }
+    // Prefer canonicalizing the parent (always exists for write; target itself for edit).
+    // If canonicalize succeeds on the full path, use it; otherwise canonicalize parent and
+    // append the file name.
+    match std::fs::canonicalize(path) {
+        Ok(p) => Ok(p),
+        Err(_) => {
+            let parent = path.parent().ok_or_else(|| FsError::ParentMissing {
+                path: path.to_path_buf(),
+            })?;
+            let canonical_parent =
+                std::fs::canonicalize(parent).map_err(|_| FsError::ParentMissing {
+                    path: path.to_path_buf(),
+                })?;
+            let name = path.file_name().ok_or_else(|| FsError::ParentMissing {
+                path: path.to_path_buf(),
+            })?;
+            Ok(canonical_parent.join(name))
+        }
+    }
+}
+
+pub(crate) fn enforce_allowed(
+    path: &Path,
+    allowed_paths: &[String],
+) -> std::result::Result<(), FsError> {
+    for pattern in allowed_paths {
+        if let Ok(pat) = Pattern::new(pattern) {
+            if pat.matches_path(path) {
+                return Ok(());
+            }
+        }
+    }
+    Err(FsError::PathDenied {
+        path: path.to_path_buf(),
+    })
 }

--- a/crates/forge-fs/src/mutate.rs
+++ b/crates/forge-fs/src/mutate.rs
@@ -1,0 +1,312 @@
+//! `fs.write` and `fs.edit` — atomic path-validated file mutation with unified
+//! diff previews. Shared conventions:
+//!
+//! - Paths are canonicalized; symlinks anywhere in the path chain are rejected.
+//! - Writes refuse to create parent directories implicitly.
+//! - Edits require the target file to exist and apply a unified-diff patch.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use similar::TextDiff;
+
+use crate::{canonicalize_no_symlink, enforce_allowed};
+
+/// Error variants for mutation operations. Matches the DoD vocabulary.
+#[derive(Debug, thiserror::Error)]
+pub enum FsError {
+    #[error("path '{}' is not allowed by allowed_paths", path.display())]
+    PathDenied { path: PathBuf },
+    #[error("path '{}' traverses a symlink", path.display())]
+    SymlinkDenied { path: PathBuf },
+    #[error("parent directory of '{}' does not exist", path.display())]
+    ParentMissing { path: PathBuf },
+    #[error("target file '{}' does not exist", path.display())]
+    TargetMissing { path: PathBuf },
+    #[error("malformed unified-diff patch: {reason}")]
+    MalformedPatch { reason: String },
+    #[error("io error on '{}': {source}", path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Minimal approval preview payload for mutation ops. Renderable by the UI
+/// layer (F-027) without depending on this crate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApprovalPreview {
+    pub description: String,
+}
+
+/// Atomically write `content` to `path` after validating the path.
+///
+/// Steps: reject symlinks → canonicalize → enforce `allowed_paths` glob →
+/// refuse if the parent dir is missing → write `content` to a sibling
+/// `NamedTempFile` → `persist` (atomic rename on the same filesystem).
+pub fn write(path: &str, content: &str, allowed_paths: &[String]) -> Result<(), FsError> {
+    let input = Path::new(path);
+    let canonical = canonicalize_no_symlink(input)?;
+    enforce_allowed(&canonical, allowed_paths)?;
+
+    let parent = canonical.parent().ok_or_else(|| FsError::ParentMissing {
+        path: canonical.clone(),
+    })?;
+    if !parent.is_dir() {
+        return Err(FsError::ParentMissing {
+            path: canonical.clone(),
+        });
+    }
+
+    let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(|e| FsError::Io {
+        path: canonical.clone(),
+        source: e,
+    })?;
+    tmp.write_all(content.as_bytes()).map_err(|e| FsError::Io {
+        path: canonical.clone(),
+        source: e,
+    })?;
+    tmp.as_file_mut().sync_all().map_err(|e| FsError::Io {
+        path: canonical.clone(),
+        source: e,
+    })?;
+    tmp.persist(&canonical).map_err(|e| FsError::Io {
+        path: canonical.clone(),
+        source: e.error,
+    })?;
+    Ok(())
+}
+
+/// Apply a unified-diff `patch` to the file at `path` after validating the
+/// path. Writes atomically via [`write`]. Requires the target to exist.
+pub fn edit(path: &str, patch: &str, allowed_paths: &[String]) -> Result<(), FsError> {
+    let input = Path::new(path);
+    let canonical = canonicalize_no_symlink(input)?;
+    enforce_allowed(&canonical, allowed_paths)?;
+
+    if !canonical.is_file() {
+        return Err(FsError::TargetMissing {
+            path: canonical.clone(),
+        });
+    }
+
+    let original = std::fs::read_to_string(&canonical).map_err(|e| FsError::Io {
+        path: canonical.clone(),
+        source: e,
+    })?;
+    let updated = apply_unified_diff(&original, patch)?;
+
+    // Reuse atomic write (skipping re-canonicalization by round-tripping the string).
+    let canonical_str = canonical.to_str().ok_or_else(|| FsError::Io {
+        path: canonical.clone(),
+        source: std::io::Error::new(std::io::ErrorKind::InvalidData, "non-utf8 path"),
+    })?;
+    write(canonical_str, &updated, allowed_paths)
+}
+
+/// `ApprovalPreview` for a prospective write. Compares on-disk contents (or
+/// empty for new files) against the proposed content and returns a unified
+/// diff.
+pub fn write_preview(path: &str, content: &str) -> ApprovalPreview {
+    let old = std::fs::read_to_string(path).unwrap_or_default();
+    let diff = TextDiff::from_lines(old.as_str(), content);
+    let file_label = path;
+    let body = diff
+        .unified_diff()
+        .header(file_label, file_label)
+        .to_string();
+    ApprovalPreview {
+        description: format!("Write file {path} ({} bytes)\n{body}", content.len()),
+    }
+}
+
+/// `ApprovalPreview` for a prospective edit. The patch itself is the unified
+/// diff; we just echo it back with a header.
+pub fn edit_preview(path: &str, patch: &str) -> ApprovalPreview {
+    ApprovalPreview {
+        description: format!("Edit file {path}\n{patch}"),
+    }
+}
+
+/// Minimal unified-diff applier. Supports standard `@@ -a,b +c,d @@` hunks
+/// with `' '`, `'-'`, `'+'` line prefixes. Rejects anything else as
+/// [`FsError::MalformedPatch`].
+fn apply_unified_diff(original: &str, patch: &str) -> Result<String, FsError> {
+    let src_lines: Vec<&str> = split_preserving_newline(original);
+    let mut out: Vec<String> = Vec::with_capacity(src_lines.len());
+    let mut cursor = 0usize; // index into src_lines
+    let mut saw_hunk = false;
+    let mut lines = patch.lines().peekable();
+
+    while let Some(raw) = lines.next() {
+        if raw.starts_with("--- ") || raw.starts_with("+++ ") {
+            continue; // file headers are optional / ignored
+        }
+        if let Some(rest) = raw.strip_prefix("@@ ") {
+            saw_hunk = true;
+            let old_start = parse_hunk_old_start(rest)?;
+            // Copy lines from cursor up to hunk start (1-indexed → 0-indexed).
+            let target = old_start.saturating_sub(1);
+            if target < cursor || target > src_lines.len() {
+                return Err(FsError::MalformedPatch {
+                    reason: format!("hunk range out of bounds at line {old_start}"),
+                });
+            }
+            for l in &src_lines[cursor..target] {
+                out.push((*l).to_string());
+            }
+            cursor = target;
+
+            // Process hunk body.
+            while let Some(peek) = lines.peek() {
+                if peek.starts_with("@@ ") {
+                    break;
+                }
+                let body = lines.next().unwrap();
+                if let Some(ctx) = body.strip_prefix(' ') {
+                    let src = src_lines
+                        .get(cursor)
+                        .ok_or_else(|| FsError::MalformedPatch {
+                            reason: "context line past end of source".into(),
+                        })?;
+                    if src.trim_end_matches('\n') != ctx.trim_end_matches('\n') {
+                        return Err(FsError::MalformedPatch {
+                            reason: format!("context mismatch at line {}", cursor + 1),
+                        });
+                    }
+                    out.push((*src).to_string());
+                    cursor += 1;
+                } else if let Some(removed) = body.strip_prefix('-') {
+                    let src = src_lines
+                        .get(cursor)
+                        .ok_or_else(|| FsError::MalformedPatch {
+                            reason: "delete past end of source".into(),
+                        })?;
+                    if src.trim_end_matches('\n') != removed.trim_end_matches('\n') {
+                        return Err(FsError::MalformedPatch {
+                            reason: format!("delete mismatch at line {}", cursor + 1),
+                        });
+                    }
+                    cursor += 1;
+                } else if let Some(added) = body.strip_prefix('+') {
+                    // Preserve newline behavior: input lines are stored without
+                    // their trailing '\n' by split_preserving_newline; re-add
+                    // unless this was a "\ No newline at end of file" marker.
+                    out.push(format!("{added}\n"));
+                } else if body.starts_with("\\ ") {
+                    // "\ No newline at end of file" — strip trailing newline
+                    // from last emitted line if present.
+                    if let Some(last) = out.last_mut() {
+                        if last.ends_with('\n') {
+                            last.pop();
+                        }
+                    }
+                } else if body.is_empty() {
+                    // Some diff tools emit a bare empty line as a zero-width context line.
+                    let src = src_lines
+                        .get(cursor)
+                        .ok_or_else(|| FsError::MalformedPatch {
+                            reason: "empty context past end of source".into(),
+                        })?;
+                    if !src.trim_end_matches('\n').is_empty() {
+                        return Err(FsError::MalformedPatch {
+                            reason: format!("empty context mismatch at line {}", cursor + 1),
+                        });
+                    }
+                    out.push((*src).to_string());
+                    cursor += 1;
+                } else {
+                    return Err(FsError::MalformedPatch {
+                        reason: format!("unrecognized line prefix: {body:?}"),
+                    });
+                }
+            }
+        } else {
+            // Anything outside a recognized header before the first hunk is noise;
+            // anything after the first hunk without being captured is a format error.
+            if saw_hunk {
+                return Err(FsError::MalformedPatch {
+                    reason: format!("unexpected line outside hunk: {raw:?}"),
+                });
+            }
+        }
+    }
+
+    if !saw_hunk {
+        return Err(FsError::MalformedPatch {
+            reason: "no hunks found".into(),
+        });
+    }
+
+    // Append any source lines remaining after the last hunk.
+    for l in &src_lines[cursor..] {
+        out.push((*l).to_string());
+    }
+
+    Ok(out.concat())
+}
+
+/// Split `s` into lines while preserving the trailing newline on each line so
+/// concatenation round-trips exactly. A final line without a terminator yields
+/// a line without `'\n'`.
+fn split_preserving_newline(s: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let bytes = s.as_bytes();
+    let mut start = 0usize;
+    for (i, b) in bytes.iter().enumerate() {
+        if *b == b'\n' {
+            out.push(&s[start..=i]);
+            start = i + 1;
+        }
+    }
+    if start < bytes.len() {
+        out.push(&s[start..]);
+    }
+    out
+}
+
+fn parse_hunk_old_start(rest: &str) -> Result<usize, FsError> {
+    // rest begins like "-a,b +c,d @@ optional_trailing"
+    let minus = rest
+        .split_whitespace()
+        .find(|t| t.starts_with('-'))
+        .ok_or_else(|| FsError::MalformedPatch {
+            reason: format!("hunk header missing '-' range: {rest:?}"),
+        })?;
+    let spec = minus.trim_start_matches('-');
+    let (start_str, _count_str) = spec.split_once(',').unwrap_or((spec, "1"));
+    start_str
+        .parse::<usize>()
+        .map_err(|_| FsError::MalformedPatch {
+            reason: format!("hunk start not a number: {start_str:?}"),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_preserves_trailing_newlines() {
+        let lines = split_preserving_newline("a\nb\nc");
+        assert_eq!(lines, vec!["a\n", "b\n", "c"]);
+    }
+
+    #[test]
+    fn apply_unified_diff_edits_middle_line() {
+        let original = "alpha\nbeta\ngamma\n";
+        let updated = "alpha\nBETA\ngamma\n";
+        let patch = TextDiff::from_lines(original, updated)
+            .unified_diff()
+            .to_string();
+        let result = apply_unified_diff(original, &patch).unwrap();
+        assert_eq!(result, updated);
+    }
+
+    #[test]
+    fn apply_unified_diff_rejects_non_patch_input() {
+        let err = apply_unified_diff("a\n", "garbage\n").unwrap_err();
+        assert!(matches!(err, FsError::MalformedPatch { .. }));
+    }
+}

--- a/crates/forge-fs/tests/fs_edit.rs
+++ b/crates/forge-fs/tests/fs_edit.rs
@@ -1,0 +1,117 @@
+use forge_fs::{edit, edit_preview, FsError};
+use std::io::Write;
+use tempfile::tempdir;
+
+fn canonical_glob(dir: &std::path::Path) -> String {
+    let canonical = std::fs::canonicalize(dir).unwrap();
+    format!("{}/**", canonical.to_str().unwrap())
+}
+
+fn unified_diff(old: &str, new: &str) -> String {
+    similar::TextDiff::from_lines(old, new)
+        .unified_diff()
+        .to_string()
+}
+
+#[test]
+fn edit_applies_unified_diff_patch() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("src.txt");
+    let original = "alpha\nbeta\ngamma\n";
+    std::fs::write(&target, original).unwrap();
+    let allowed = vec![canonical_glob(dir.path())];
+    let updated = "alpha\nBETA\ngamma\n";
+    let patch = unified_diff(original, updated);
+
+    edit(target.to_str().unwrap(), &patch, &allowed).unwrap();
+
+    let body = std::fs::read_to_string(&target).unwrap();
+    assert_eq!(body, updated);
+}
+
+#[test]
+fn edit_rejects_malformed_patch() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("src.txt");
+    std::fs::write(&target, "alpha\nbeta\n").unwrap();
+    let allowed = vec![canonical_glob(dir.path())];
+    let bogus = "this is not a unified diff at all\n";
+
+    let err = edit(target.to_str().unwrap(), bogus, &allowed).unwrap_err();
+
+    assert!(
+        matches!(err, FsError::MalformedPatch { .. }),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn edit_rejects_path_outside_allowed_paths_with_path_denied() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("src.txt");
+    std::fs::write(&target, "a\n").unwrap();
+    let allowed = vec!["/nonexistent/allow/**".to_string()];
+    let patch = unified_diff("a\n", "b\n");
+
+    let err = edit(target.to_str().unwrap(), &patch, &allowed).unwrap_err();
+
+    assert!(matches!(err, FsError::PathDenied { .. }), "got: {err:?}");
+}
+
+#[test]
+fn edit_rejects_symlink_target() {
+    let dir = tempdir().unwrap();
+    let real = dir.path().join("real.txt");
+    std::fs::write(&real, "a\n").unwrap();
+    let link = dir.path().join("link.txt");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    #[cfg(not(unix))]
+    return;
+
+    let allowed = vec![canonical_glob(dir.path())];
+    let patch = unified_diff("a\n", "b\n");
+
+    let err = edit(link.to_str().unwrap(), &patch, &allowed).unwrap_err();
+
+    assert!(matches!(err, FsError::SymlinkDenied { .. }), "got: {err:?}");
+}
+
+#[test]
+fn edit_requires_target_file_to_exist() {
+    let dir = tempdir().unwrap();
+    let missing = dir.path().join("nope.txt");
+    let allowed = vec![canonical_glob(dir.path())];
+    let patch = unified_diff("a\n", "b\n");
+
+    let err = edit(missing.to_str().unwrap(), &patch, &allowed).unwrap_err();
+
+    assert!(matches!(err, FsError::TargetMissing { .. }), "got: {err:?}");
+}
+
+#[test]
+fn edit_preview_returns_unified_diff_description() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("src.txt");
+    let mut f = std::fs::File::create(&target).unwrap();
+    f.write_all(b"alpha\nbeta\ngamma\n").unwrap();
+    let patch = unified_diff("alpha\nbeta\ngamma\n", "alpha\nBETA\ngamma\n");
+
+    let preview = edit_preview(target.to_str().unwrap(), &patch);
+
+    assert!(
+        preview.description.contains("src.txt"),
+        "description missing path: {}",
+        preview.description
+    );
+    assert!(
+        preview.description.contains("-beta"),
+        "expected removed line: {}",
+        preview.description
+    );
+    assert!(
+        preview.description.contains("+BETA"),
+        "expected added line: {}",
+        preview.description
+    );
+}

--- a/crates/forge-fs/tests/fs_write.rs
+++ b/crates/forge-fs/tests/fs_write.rs
@@ -1,0 +1,115 @@
+use forge_fs::{write, write_preview, FsError};
+use std::io::Write;
+use tempfile::tempdir;
+
+fn canonical_glob(dir: &std::path::Path) -> String {
+    let canonical = std::fs::canonicalize(dir).unwrap();
+    format!("{}/**", canonical.to_str().unwrap())
+}
+
+#[test]
+fn write_creates_file_atomically_when_path_allowed() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("hello.txt");
+    let allowed = vec![canonical_glob(dir.path())];
+
+    write(target.to_str().unwrap(), "hello world", &allowed).unwrap();
+
+    let body = std::fs::read_to_string(&target).unwrap();
+    assert_eq!(body, "hello world");
+}
+
+#[test]
+fn write_overwrites_existing_file_atomically() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("exists.txt");
+    std::fs::write(&target, "old").unwrap();
+    let allowed = vec![canonical_glob(dir.path())];
+
+    write(target.to_str().unwrap(), "new", &allowed).unwrap();
+
+    let body = std::fs::read_to_string(&target).unwrap();
+    assert_eq!(body, "new");
+}
+
+#[test]
+fn write_rejects_path_outside_allowed_paths_with_path_denied() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("blocked.txt");
+    let allowed = vec!["/nonexistent/allow/**".to_string()];
+
+    let err = write(target.to_str().unwrap(), "nope", &allowed).unwrap_err();
+
+    assert!(matches!(err, FsError::PathDenied { .. }), "got: {err:?}");
+}
+
+#[test]
+fn write_rejects_symlink_parent() {
+    let dir = tempdir().unwrap();
+    let real = dir.path().join("real_dir");
+    std::fs::create_dir(&real).unwrap();
+    let link = dir.path().join("link_dir");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    #[cfg(not(unix))]
+    return;
+
+    let target = link.join("file.txt");
+    // allow the real directory; symlinked path must still be rejected
+    let allowed = vec![canonical_glob(dir.path())];
+
+    let err = write(target.to_str().unwrap(), "payload", &allowed).unwrap_err();
+
+    assert!(matches!(err, FsError::SymlinkDenied { .. }), "got: {err:?}");
+}
+
+#[test]
+fn write_refuses_to_create_parent_directories() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("missing_parent").join("file.txt");
+    let allowed = vec![canonical_glob(dir.path())];
+
+    let err = write(target.to_str().unwrap(), "x", &allowed).unwrap_err();
+
+    assert!(matches!(err, FsError::ParentMissing { .. }), "got: {err:?}");
+}
+
+#[test]
+fn write_preview_returns_unified_diff_for_new_file() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("new.txt");
+
+    let preview = write_preview(target.to_str().unwrap(), "line1\nline2\n");
+
+    assert!(
+        preview.description.contains("new.txt"),
+        "description missing path: {}",
+        preview.description
+    );
+    assert!(
+        preview.description.contains("+line1"),
+        "expected added line in diff: {}",
+        preview.description
+    );
+}
+
+#[test]
+fn write_preview_returns_unified_diff_for_overwrite() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("existing.txt");
+    let mut f = std::fs::File::create(&target).unwrap();
+    f.write_all(b"old_line\n").unwrap();
+
+    let preview = write_preview(target.to_str().unwrap(), "new_line\n");
+
+    assert!(
+        preview.description.contains("-old_line"),
+        "expected removed line: {}",
+        preview.description
+    );
+    assert!(
+        preview.description.contains("+new_line"),
+        "expected added line: {}",
+        preview.description
+    );
+}

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync"] }
 
 [dev-dependencies]
+similar = "2"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros", "time", "net", "process"] }
 

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -13,7 +13,7 @@ use futures::StreamExt;
 use tokio::sync::{oneshot, Mutex};
 
 use crate::session::Session;
-use crate::tools::{FsReadTool, ToolCtx, ToolDispatcher, ToolError};
+use crate::tools::{FsEditTool, FsReadTool, FsWriteTool, ToolCtx, ToolDispatcher, ToolError};
 
 /// Pending tool call approvals: maps ToolCallId → sender for the approval result.
 pub type PendingApprovals = Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>;
@@ -58,6 +58,12 @@ pub async fn run_turn<P: Provider>(
     dispatcher
         .register(Box::new(FsReadTool))
         .expect("fs.read must register on a fresh dispatcher");
+    dispatcher
+        .register(Box::new(FsWriteTool))
+        .expect("fs.write must register on a fresh dispatcher");
+    dispatcher
+        .register(Box::new(FsEditTool))
+        .expect("fs.edit must register on a fresh dispatcher");
     let ctx = ToolCtx { allowed_paths };
 
     run_request_loop(

--- a/crates/forge-session/src/tools/fs_edit.rs
+++ b/crates/forge-session/src/tools/fs_edit.rs
@@ -1,0 +1,32 @@
+//! `fs.edit` tool: applies a unified-diff patch via [`forge_fs::edit`] and
+//! returns `{ ok: true }` or `{ error }`. Preview delegates to
+//! [`forge_fs::edit_preview`].
+
+use super::{Tool, ToolCtx};
+use forge_core::ApprovalPreview;
+
+pub struct FsEditTool;
+
+impl Tool for FsEditTool {
+    fn name(&self) -> &str {
+        "fs.edit"
+    }
+
+    fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
+        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let patch = args.get("patch").and_then(|v| v.as_str()).unwrap_or("");
+        let fs_preview = forge_fs::edit_preview(path, patch);
+        ApprovalPreview {
+            description: fs_preview.description,
+        }
+    }
+
+    fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
+        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let patch = args.get("patch").and_then(|v| v.as_str()).unwrap_or("");
+        match forge_fs::edit(path, patch, &ctx.allowed_paths) {
+            Ok(()) => serde_json::json!({ "ok": true }),
+            Err(e) => serde_json::json!({ "error": e.to_string() }),
+        }
+    }
+}

--- a/crates/forge-session/src/tools/fs_write.rs
+++ b/crates/forge-session/src/tools/fs_write.rs
@@ -1,0 +1,32 @@
+//! `fs.write` tool: writes a file via [`forge_fs::write`] and returns
+//! `{ ok: true }` or `{ error }`. Preview delegates to
+//! [`forge_fs::write_preview`].
+
+use super::{Tool, ToolCtx};
+use forge_core::ApprovalPreview;
+
+pub struct FsWriteTool;
+
+impl Tool for FsWriteTool {
+    fn name(&self) -> &str {
+        "fs.write"
+    }
+
+    fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
+        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let content = args.get("content").and_then(|v| v.as_str()).unwrap_or("");
+        let fs_preview = forge_fs::write_preview(path, content);
+        ApprovalPreview {
+            description: fs_preview.description,
+        }
+    }
+
+    fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
+        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let content = args.get("content").and_then(|v| v.as_str()).unwrap_or("");
+        match forge_fs::write(path, content, &ctx.allowed_paths) {
+            Ok(()) => serde_json::json!({ "ok": true }),
+            Err(e) => serde_json::json!({ "error": e.to_string() }),
+        }
+    }
+}

--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -2,9 +2,13 @@
 
 use forge_core::ApprovalPreview;
 
+pub mod fs_edit;
 pub mod fs_read;
+pub mod fs_write;
 
+pub use fs_edit::FsEditTool;
 pub use fs_read::FsReadTool;
+pub use fs_write::FsWriteTool;
 
 pub struct ToolCtx {
     pub allowed_paths: Vec<String>,
@@ -128,6 +132,71 @@ mod tests {
         let d = ToolDispatcher::new();
         let err = d.dispatch("nope", &json!({}), &empty_ctx()).unwrap_err();
         assert_eq!(err, ToolError::UnknownTool("nope".to_string()));
+    }
+
+    #[test]
+    fn fs_write_dispatch_writes_file_and_previews_diff() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("out.txt");
+        let canonical_parent = std::fs::canonicalize(dir.path()).unwrap();
+        let allowed = format!("{}/**", canonical_parent.to_str().unwrap());
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(FsWriteTool)).unwrap();
+
+        let ctx = ToolCtx {
+            allowed_paths: vec![allowed],
+        };
+        let result = d
+            .dispatch(
+                "fs.write",
+                &json!({"path": target.to_str().unwrap(), "content": "hi"}),
+                &ctx,
+            )
+            .unwrap();
+        assert_eq!(result["ok"].as_bool(), Some(true));
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "hi");
+
+        let preview = d
+            .get("fs.write")
+            .unwrap()
+            .approval_preview(&json!({"path": target.to_str().unwrap(), "content": "hi"}));
+        assert!(preview.description.contains("Write file"));
+    }
+
+    #[test]
+    fn fs_edit_dispatch_applies_patch_and_previews_diff() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("src.txt");
+        std::fs::write(&target, "alpha\nbeta\n").unwrap();
+        let canonical_parent = std::fs::canonicalize(dir.path()).unwrap();
+        let allowed = format!("{}/**", canonical_parent.to_str().unwrap());
+
+        let patch = similar::TextDiff::from_lines("alpha\nbeta\n", "alpha\nBETA\n")
+            .unified_diff()
+            .to_string();
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(FsEditTool)).unwrap();
+
+        let ctx = ToolCtx {
+            allowed_paths: vec![allowed],
+        };
+        let result = d
+            .dispatch(
+                "fs.edit",
+                &json!({"path": target.to_str().unwrap(), "patch": patch}),
+                &ctx,
+            )
+            .unwrap();
+        assert_eq!(result["ok"].as_bool(), Some(true));
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "alpha\nBETA\n");
+
+        let preview = d
+            .get("fs.edit")
+            .unwrap()
+            .approval_preview(&json!({"path": target.to_str().unwrap(), "patch": patch}));
+        assert!(preview.description.contains("Edit file"));
     }
 
     #[test]


### PR DESCRIPTION
Closes forge-ide/forge#47

## Summary
- `forge_fs::write(path, content, allowed_paths)` — atomic write via sibling `NamedTempFile` + `persist` after path validation
- `forge_fs::edit(path, patch, allowed_paths)` — applies a unified-diff patch (using `similar` for diff generation, minimal in-crate applier for hunk parsing)
- Both reject paths outside `allowed_paths` with `FsError::PathDenied`, reject symlinks anywhere in the path chain with `FsError::SymlinkDenied`, and reject `..` escapes via canonicalization
- `forge_fs::write_preview` / `forge_fs::edit_preview` return `ApprovalPreview` with unified-diff text
- `FsWriteTool` / `FsEditTool` register with the F-028 `ToolDispatcher` in `orchestrator::run_turn`
- `write` refuses to create parent directories implicitly (`FsError::ParentMissing`); `edit` requires the target to exist (`FsError::TargetMissing`)

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` passes
- Unit tests cover: successful write, overwrite, disallowed path, symlink rejection, parent-missing, patch apply, malformed patch rejection, target-missing, preview output format, dispatcher-level wiring for both tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)