### PR TITLE
[F-031] Session archive on end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "forge-ipc",
  "forge-providers",
  "futures",
+ "libc",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -19,6 +19,7 @@ forge-fs = { path = "../forge-fs" }
 forge-ipc = { path = "../forge-ipc" }
 forge-providers = { path = "../forge-providers" }
 futures = "0.3"
+libc = "0.2"
 serde_json = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync"] }
@@ -34,3 +35,11 @@ path = "tests/headless_session/basic.rs"
 [[test]]
 name = "session_ended"
 path = "tests/session_ended.rs"
+
+[[test]]
+name = "archive"
+path = "tests/archive.rs"
+
+[[test]]
+name = "archive_shutdown"
+path = "tests/archive_shutdown.rs"

--- a/crates/forge-session/src/archive.rs
+++ b/crates/forge-session/src/archive.rs
@@ -1,0 +1,129 @@
+use std::future::Future;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use forge_core::{
+    meta::{read_meta, write_meta},
+    SessionPersistence, SessionState,
+};
+
+pub async fn archive_or_purge(
+    session_dir: &Path,
+    persistence: SessionPersistence,
+    socket_path: &Path,
+) -> Result<()> {
+    match persistence {
+        SessionPersistence::Ephemeral => {
+            if session_dir.exists() {
+                tokio::fs::remove_dir_all(session_dir).await?;
+            }
+        }
+        SessionPersistence::Persist => {
+            let archived_dir = archived_destination(session_dir)?;
+            if let Some(parent) = archived_dir.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+            move_dir(session_dir, &archived_dir).await?;
+            update_meta_to_archived(&archived_dir.join("meta.toml")).await?;
+        }
+    }
+
+    remove_socket(socket_path).await?;
+    Ok(())
+}
+
+fn archived_destination(session_dir: &Path) -> Result<PathBuf> {
+    let id = session_dir.file_name().ok_or_else(|| {
+        anyhow!(
+            "session_dir has no final component: {}",
+            session_dir.display()
+        )
+    })?;
+    let parent = session_dir
+        .parent()
+        .ok_or_else(|| anyhow!("session_dir has no parent: {}", session_dir.display()))?;
+    Ok(parent.join("archived").join(id))
+}
+
+async fn move_dir(src: &Path, dst: &Path) -> Result<()> {
+    move_dir_with_rename(src, dst, |s, d| std::fs::rename(s, d)).await
+}
+
+async fn move_dir_with_rename<F>(src: &Path, dst: &Path, rename: F) -> Result<()>
+where
+    F: FnOnce(&Path, &Path) -> io::Result<()>,
+{
+    match rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) if is_cross_device(&e) => {
+            copy_dir_all(src, dst).await?;
+            tokio::fs::remove_dir_all(src).await?;
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn is_cross_device(err: &io::Error) -> bool {
+    err.raw_os_error() == Some(libc::EXDEV)
+}
+
+async fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
+    copy_dir_all_boxed(src.to_path_buf(), dst.to_path_buf()).await
+}
+
+fn copy_dir_all_boxed(
+    src: PathBuf,
+    dst: PathBuf,
+) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
+    Box::pin(async move {
+        tokio::fs::create_dir_all(&dst).await?;
+        let mut entries = tokio::fs::read_dir(&src).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let file_type = entry.file_type().await?;
+            let src_path = entry.path();
+            let dst_path = dst.join(entry.file_name());
+            if file_type.is_dir() {
+                copy_dir_all_boxed(src_path, dst_path).await?;
+            } else {
+                tokio::fs::copy(&src_path, &dst_path).await?;
+            }
+        }
+        Ok(())
+    })
+}
+
+async fn update_meta_to_archived(meta_path: &Path) -> Result<()> {
+    if !meta_path.exists() {
+        return Ok(());
+    }
+    let mut meta = read_meta(meta_path).await?;
+    meta.state = SessionState::Archived;
+    meta.ended_at = Some(Utc::now());
+    write_meta(meta_path, &meta).await?;
+    Ok(())
+}
+
+async fn remove_socket(socket_path: &Path) -> Result<()> {
+    match tokio::fs::remove_file(socket_path).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[doc(hidden)]
+pub async fn copy_dir_all_for_test(src: &Path, dst: &Path) -> Result<()> {
+    copy_dir_all(src, dst).await
+}
+
+#[doc(hidden)]
+pub async fn move_dir_with_rename_for_test<F>(src: &Path, dst: &Path, rename: F) -> Result<()>
+where
+    F: FnOnce(&Path, &Path) -> io::Result<()>,
+{
+    move_dir_with_rename(src, dst, rename).await
+}

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod archive;
 pub mod orchestrator;
 pub mod server;
 pub mod session;

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -3,12 +3,13 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
-use forge_core::{read_since, SessionId};
+use forge_core::{read_since, SessionId, SessionPersistence};
 use forge_ipc::{HelloAck, IpcEvent, IpcMessage, PROTO_VERSION, SCHEMA_VERSION};
 use forge_providers::{MockProvider, Provider};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{broadcast, Mutex};
 
+use crate::archive::archive_or_purge;
 use crate::orchestrator::{run_turn, PendingApprovals};
 use crate::session::Session;
 
@@ -69,6 +70,8 @@ pub async fn serve_with_session<P: Provider + 'static>(
     );
     let session_id = Arc::new(session_id.unwrap_or_else(|| SessionId::new().to_string()));
 
+    let socket_path = Arc::new(path.to_path_buf());
+
     if ephemeral {
         // Accept exactly one connection, serve it to completion, then exit.
         let (stream, _) = listener.accept().await?;
@@ -80,6 +83,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
             true,
             workspace,
             session_id,
+            socket_path,
         )
         .await;
     }
@@ -90,6 +94,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
         let provider = Arc::clone(&provider);
         let workspace = Arc::clone(&workspace);
         let session_id = Arc::clone(&session_id);
+        let socket_path = Arc::clone(&socket_path);
         tokio::spawn(async move {
             if let Err(e) = handle_connection(
                 stream,
@@ -99,6 +104,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
                 false,
                 workspace,
                 session_id,
+                socket_path,
             )
             .await
             {
@@ -108,6 +114,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_connection<P: Provider + 'static>(
     mut stream: UnixStream,
     session: Arc<Session>,
@@ -116,6 +123,7 @@ async fn handle_connection<P: Provider + 'static>(
     ephemeral: bool,
     workspace: Arc<String>,
     session_id: Arc<String>,
+    socket_path: Arc<PathBuf>,
 ) -> Result<()> {
     // ── Handshake ──────────────────────────────────────────────────────────────
     let msg = forge_ipc::read_frame(&mut stream).await?;
@@ -246,6 +254,16 @@ async fn handle_connection<P: Provider + 'static>(
                     Some(_) => {} // ignore other messages
                     None => break,
                 }
+            }
+        }
+    }
+
+    if ephemeral {
+        if let Some(session_dir) = session.log_path.parent() {
+            if let Err(e) =
+                archive_or_purge(session_dir, SessionPersistence::Ephemeral, &socket_path).await
+            {
+                eprintln!("archive_or_purge failed: {e}");
             }
         }
     }

--- a/crates/forge-session/tests/archive.rs
+++ b/crates/forge-session/tests/archive.rs
@@ -1,0 +1,189 @@
+use chrono::Utc;
+use forge_core::meta::{read_meta, write_meta, SessionMeta};
+use forge_core::{SessionId, SessionPersistence, SessionState, WorkspaceId};
+use forge_session::archive::archive_or_purge;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn make_meta(socket: PathBuf) -> SessionMeta {
+    SessionMeta {
+        id: SessionId::new(),
+        workspace_id: WorkspaceId::new(),
+        name: "test-session".to_string(),
+        agent: None,
+        provider_id: None,
+        model: None,
+        state: SessionState::Active,
+        persistence: SessionPersistence::Persist,
+        started_at: Utc::now(),
+        ended_at: None,
+        tokens_in: 0,
+        tokens_out: 0,
+        cost_usd: 0.0,
+        pid: 1234,
+        socket_path: socket,
+    }
+}
+
+async fn seed_persist_session(session_dir: &Path, socket_path: &Path) {
+    std::fs::create_dir_all(session_dir).unwrap();
+    std::fs::write(session_dir.join("events.jsonl"), "{}\n").unwrap();
+    let meta = make_meta(socket_path.to_path_buf());
+    write_meta(&session_dir.join("meta.toml"), &meta)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn ephemeral_removes_session_dir_and_socket() {
+    let tmp = TempDir::new().unwrap();
+    let session_dir = tmp.path().join("sessions").join("abc123");
+    std::fs::create_dir_all(&session_dir).unwrap();
+    std::fs::write(session_dir.join("events.jsonl"), "{}\n").unwrap();
+
+    let sock_dir = tmp.path().join("run");
+    std::fs::create_dir_all(&sock_dir).unwrap();
+    let socket_path = sock_dir.join("abc123.sock");
+    std::fs::write(&socket_path, "").unwrap();
+
+    archive_or_purge(&session_dir, SessionPersistence::Ephemeral, &socket_path)
+        .await
+        .unwrap();
+
+    assert!(!session_dir.exists(), "session dir must be removed");
+    assert!(!socket_path.exists(), "socket must be removed");
+}
+
+#[tokio::test]
+async fn persist_moves_to_archived_and_updates_meta() {
+    let tmp = TempDir::new().unwrap();
+    let sessions_root = tmp.path().join("sessions");
+    let session_id = "persist123";
+    let session_dir = sessions_root.join(session_id);
+
+    let sock_dir = tmp.path().join("run");
+    std::fs::create_dir_all(&sock_dir).unwrap();
+    let socket_path = sock_dir.join(format!("{session_id}.sock"));
+    std::fs::write(&socket_path, "").unwrap();
+
+    seed_persist_session(&session_dir, &socket_path).await;
+
+    archive_or_purge(&session_dir, SessionPersistence::Persist, &socket_path)
+        .await
+        .unwrap();
+
+    let archived_dir = sessions_root.join("archived").join(session_id);
+    assert!(!session_dir.exists(), "original session dir must be gone");
+    assert!(archived_dir.exists(), "archived dir must exist");
+    assert!(
+        archived_dir.join("events.jsonl").exists(),
+        "event log must be moved"
+    );
+    assert!(!socket_path.exists(), "socket must be removed");
+
+    let meta = read_meta(&archived_dir.join("meta.toml")).await.unwrap();
+    assert_eq!(meta.state, SessionState::Archived);
+    assert!(meta.ended_at.is_some(), "ended_at must be set");
+}
+
+#[tokio::test]
+async fn missing_socket_is_tolerated_on_ephemeral() {
+    let tmp = TempDir::new().unwrap();
+    let session_dir = tmp.path().join("sessions").join("abc");
+    std::fs::create_dir_all(&session_dir).unwrap();
+
+    let socket_path = tmp.path().join("run").join("abc.sock");
+    assert!(!socket_path.exists());
+
+    archive_or_purge(&session_dir, SessionPersistence::Ephemeral, &socket_path)
+        .await
+        .expect("must tolerate missing socket");
+    assert!(!session_dir.exists());
+}
+
+#[tokio::test]
+async fn missing_socket_is_tolerated_on_persist() {
+    let tmp = TempDir::new().unwrap();
+    let sessions_root = tmp.path().join("sessions");
+    let session_id = "no-sock";
+    let session_dir = sessions_root.join(session_id);
+
+    let socket_path = tmp.path().join("run").join(format!("{session_id}.sock"));
+    seed_persist_session(&session_dir, &socket_path).await;
+    assert!(!socket_path.exists());
+
+    archive_or_purge(&session_dir, SessionPersistence::Persist, &socket_path)
+        .await
+        .expect("must tolerate missing socket");
+
+    assert!(sessions_root.join("archived").join(session_id).exists());
+}
+
+#[tokio::test]
+async fn copy_dir_all_fallback_preserves_tree() {
+    use forge_session::archive::copy_dir_all_for_test;
+
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir_all(src.join("nested")).unwrap();
+    std::fs::write(src.join("top.txt"), "one").unwrap();
+    std::fs::write(src.join("nested").join("inner.txt"), "two").unwrap();
+
+    copy_dir_all_for_test(&src, &dst).await.unwrap();
+
+    assert_eq!(std::fs::read_to_string(dst.join("top.txt")).unwrap(), "one");
+    assert_eq!(
+        std::fs::read_to_string(dst.join("nested").join("inner.txt")).unwrap(),
+        "two"
+    );
+}
+
+#[tokio::test]
+async fn move_dir_falls_back_when_rename_crosses_devices() {
+    use forge_session::archive::move_dir_with_rename_for_test;
+
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir_all(src.join("nested")).unwrap();
+    std::fs::write(src.join("a.txt"), "a").unwrap();
+    std::fs::write(src.join("nested").join("b.txt"), "b").unwrap();
+
+    // Force rename to fail with EXDEV (simulated cross-device).
+    let exdev = std::io::Error::from_raw_os_error(libc::EXDEV);
+    move_dir_with_rename_for_test(&src, &dst, move |_, _| Err(exdev))
+        .await
+        .unwrap();
+
+    assert!(!src.exists(), "src must be removed after fallback");
+    assert_eq!(std::fs::read_to_string(dst.join("a.txt")).unwrap(), "a");
+    assert_eq!(
+        std::fs::read_to_string(dst.join("nested").join("b.txt")).unwrap(),
+        "b"
+    );
+}
+
+#[tokio::test]
+async fn persist_tolerates_missing_meta_toml() {
+    let tmp = TempDir::new().unwrap();
+    let sessions_root = tmp.path().join("sessions");
+    let session_id = "no-meta";
+    let session_dir = sessions_root.join(session_id);
+    std::fs::create_dir_all(&session_dir).unwrap();
+    std::fs::write(session_dir.join("events.jsonl"), "{}\n").unwrap();
+    // deliberately no meta.toml
+
+    let socket_path = tmp.path().join("run").join(format!("{session_id}.sock"));
+    std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+    std::fs::write(&socket_path, "").unwrap();
+
+    archive_or_purge(&session_dir, SessionPersistence::Persist, &socket_path)
+        .await
+        .expect("must tolerate missing meta.toml");
+
+    let archived_dir = sessions_root.join("archived").join(session_id);
+    assert!(archived_dir.exists());
+    assert!(!archived_dir.join("meta.toml").exists());
+    assert!(!socket_path.exists());
+}

--- a/crates/forge-session/tests/archive_shutdown.rs
+++ b/crates/forge-session/tests/archive_shutdown.rs
@@ -1,0 +1,135 @@
+//! Integration test: orchestrator shutdown wires `archive_or_purge`.
+//!
+//! Spawns `forged --ephemeral` with an explicit workspace, drives a single
+//! turn, waits for `SessionEnded`, and asserts the session directory and
+//! socket are removed.
+
+use forge_core::Event;
+use forge_ipc::{
+    ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, PROTO_VERSION,
+};
+use std::process::Stdio;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+const FORGED: &str = env!("CARGO_BIN_EXE_forged");
+
+async fn connect_with_retry(path: &std::path::Path) -> UnixStream {
+    for _ in 0..50 {
+        if let Ok(s) = UnixStream::connect(path).await {
+            return s;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("forged did not create socket in time")
+}
+
+fn extract_event(msg: &IpcMessage) -> Option<Event> {
+    if let IpcMessage::Event(IpcEvent { event, .. }) = msg {
+        Some(serde_json::from_value::<Event>(event.clone()).unwrap())
+    } else {
+        None
+    }
+}
+
+#[tokio::test]
+async fn ephemeral_shutdown_removes_session_dir_and_socket() {
+    let dir = TempDir::new().unwrap();
+    let workspace = dir.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let script = format!(
+        "{}\n{}",
+        serde_json::json!({"delta": "Hello."}),
+        serde_json::json!({"done": "end_turn"}),
+    );
+    let mock_path = dir.path().join("mock.json");
+    std::fs::write(&mock_path, serde_json::to_string(&vec![script]).unwrap()).unwrap();
+
+    let session_id = "archive-shutdown-test";
+    let sock_path = dir.path().join("session.sock");
+    let session_dir = workspace.join(".forge").join("sessions").join(session_id);
+
+    let mut child = tokio::process::Command::new(FORGED)
+        .arg("--ephemeral")
+        .env("FORGE_SESSION_ID", session_id)
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .env("FORGE_WORKSPACE", &workspace)
+        .env("FORGE_MOCK_SEQUENCE_FILE", &mock_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to spawn forged");
+
+    let mut stream = connect_with_retry(&sock_path).await;
+
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "test".into(),
+                pid: std::process::id(),
+                user: "tester".into(),
+            },
+        }),
+    )
+    .await
+    .unwrap();
+
+    let _ack = forge_ipc::read_frame(&mut stream).await.unwrap();
+
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "hi".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let frame = tokio::time::timeout_at(deadline, forge_ipc::read_frame(&mut stream))
+            .await
+            .expect("timed out waiting for SessionEnded");
+        match frame {
+            Ok(msg) => {
+                if let Some(event) = extract_event(&msg) {
+                    if matches!(event, Event::SessionEnded { .. }) {
+                        break;
+                    }
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+        .await
+        .expect("forged did not exit after SessionEnded")
+        .expect("child.wait() failed");
+    assert!(
+        status.success(),
+        "forged exited non-zero: {:?}",
+        status.code()
+    );
+
+    assert!(
+        !session_dir.exists(),
+        "ephemeral session dir must be purged on shutdown: {}",
+        session_dir.display()
+    );
+    assert!(
+        !sock_path.exists(),
+        "socket must be removed on shutdown: {}",
+        sock_path.display()
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#49

## Summary
- Adds `forge_session::archive::archive_or_purge(session_dir, persistence, socket_path)` implementing the terminal state transition from `docs/architecture/persistence.md` §7.5.
- **Persist**: atomic rename `<session_dir>` → `<parent>/archived/<id>/`, with copy+delete fallback on `EXDEV` (cross-device). Rewrites `meta.toml` with `state = "archived"` and `ended_at = <RFC 3339>`.
- **Ephemeral**: recursively removes the session directory.
- Both branches remove the UDS socket (missing socket is tolerated).
- Orchestrator `server::handle_connection` calls `archive_or_purge` after the `SessionEnded` event has been emitted (and flushed to the event log by `Session::emit`) on the ephemeral shutdown path.
- Reactivation of archived sessions (§7.6) is intentionally out of scope.

## Notes for reviewers
- Socket path threaded through `serve_with_session` → `handle_connection` via `Arc<PathBuf>`.
- Cross-device fallback detected via `raw_os_error() == Some(libc::EXDEV)` (stable; avoids the unstable `ErrorKind::CrossesDevices`).
- Test seams `copy_dir_all_for_test` and `move_dir_with_rename_for_test` are `#[doc(hidden)] pub` to enable unit testing the EXDEV fallback without relying on an actual cross-device mount.
- F-030 (Process isolation) will also touch the orchestrator shutdown path; changes here are kept minimal (single call site) to ease that rebase.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (7 archive unit tests + 1 end-to-end integration test covering ephemeral shutdown purging both session dir and socket)
- `cargo clippy --all-targets -- -D warnings` passes

Unit tests with `tempdir` cover all DoD-specified scenarios:
- `ephemeral_removes_session_dir_and_socket`
- `persist_moves_to_archived_and_updates_meta`
- `missing_socket_is_tolerated_on_ephemeral`
- `missing_socket_is_tolerated_on_persist`
- `copy_dir_all_fallback_preserves_tree`
- `move_dir_falls_back_when_rename_crosses_devices` (forces EXDEV via injected closure)
- `persist_tolerates_missing_meta_toml`

Integration test `archive_shutdown::ephemeral_shutdown_removes_session_dir_and_socket` spawns `forged --ephemeral` with an explicit workspace, drives a single turn, and asserts the session directory and socket are gone after `SessionEnded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)