### PR TITLE
[F-020] Tauri<->session IPC bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,12 +1078,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "forge-core",
+ "forge-ipc",
  "forge-providers",
+ "forge-session",
  "png",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
  "tokio",
  "wiremock",
 ]

--- a/crates/forge-shell/Cargo.toml
+++ b/crates/forge-shell/Cargo.toml
@@ -19,14 +19,18 @@ tauri-build = { version = "2", features = [], optional = true }
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+forge-ipc = { path = "../forge-ipc" }
 forge-providers = { path = "../forge-providers" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", optional = true }
-tokio = { version = "1", features = ["sync", "time", "rt", "macros"] }
+tokio = { version = "1", features = ["net", "io-util", "sync", "time", "rt", "rt-multi-thread", "macros"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
+forge-core = { path = "../forge-core" }
+forge-session = { path = "../forge-session" }
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "net", "time"] }
 wiremock = "0.6"
 
 [features]
@@ -36,3 +40,7 @@ wiremock = "0.6"
 # host without WebKitGTK installed.
 default = ["webview"]
 webview = ["dep:tauri", "dep:tauri-build", "dep:png"]
+# Opt-in feature that activates Tauri's `test` helpers so integration tests
+# can use `tauri::test::mock_builder`. Implies `webview`. Not on by default
+# so production builds don't pull test scaffolding.
+webview-test = ["webview", "tauri?/test"]

--- a/crates/forge-shell/src-tauri/capabilities/default.json
+++ b/crates/forge-shell/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capability for the Dashboard and Session windows. Grants Tauri's built-in core APIs only; feature-specific capabilities land with their owning tasks (F-020+).",
+  "description": "Default capability for the Dashboard and Session windows. Grants Tauri's built-in core APIs. App-local commands (F-020 session bridge etc.) do not require capability entries — Tauri only gates plugin commands.",
   "windows": ["dashboard", "session-*"],
   "permissions": ["core:default"]
 }

--- a/crates/forge-shell/src/bridge.rs
+++ b/crates/forge-shell/src/bridge.rs
@@ -1,0 +1,248 @@
+//! Tauri ↔ session UDS bridge.
+//!
+//! The Tauri commands in [`crate::ipc`] are thin wrappers over this module.
+//! This split keeps the bridge logic testable without a live Tauri runtime:
+//! tests spawn a real `forge-session` daemon, drive the bridge via
+//! [`SessionBridge`], and capture forwarded events through a generic
+//! [`EventSink`].
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+use forge_ipc::{
+    read_frame, write_frame, ClientInfo, Hello, HelloAck, IpcMessage, SendUserMessage, Subscribe,
+    ToolCallApproved, ToolCallRejected, PROTO_VERSION,
+};
+use serde::Serialize;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::UnixStream;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+/// Payload emitted to the webview for every session event forwarded by the
+/// background reader task. The `event` value is the daemon's `Event` JSON
+/// pass-through (see `forge-core::Event`).
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionEventPayload {
+    pub session_id: String,
+    pub seq: u64,
+    pub event: serde_json::Value,
+}
+
+/// Sink for forwarded session events. In production the Tauri command layer
+/// implements this by calling `AppHandle::emit("session:event", payload)`;
+/// tests use an in-memory channel to assert end-to-end delivery.
+pub trait EventSink: Send + Sync + 'static {
+    fn emit(&self, payload: SessionEventPayload);
+}
+
+/// A single open session connection: a writer half used for send/approve/reject
+/// plus an optional background reader task that pumps events into the sink.
+struct Connection {
+    writer: Arc<Mutex<OwnedWriteHalf>>,
+    reader: Option<OwnedReadHalf>,
+    reader_task: Option<JoinHandle<()>>,
+}
+
+/// Session-id keyed registry of active bridge connections.
+#[derive(Clone, Default)]
+pub struct SessionConnections {
+    inner: Arc<Mutex<HashMap<String, Connection>>>,
+}
+
+impl SessionConnections {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn len(&self) -> usize {
+        self.inner.lock().await.len()
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.inner.lock().await.is_empty()
+    }
+
+    pub async fn contains(&self, session_id: &str) -> bool {
+        self.inner.lock().await.contains_key(session_id)
+    }
+}
+
+/// Resolve the default socket path for a session id, following the same
+/// rules as `forge-session::main`. Exposed so the Tauri command layer and
+/// tests agree on the convention.
+pub fn default_socket_path(session_id: &str) -> PathBuf {
+    let base = std::env::var("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let uid = std::env::var("UID").unwrap_or_else(|_| "0".to_string());
+            PathBuf::from(format!("/tmp/forge-{uid}"))
+        });
+    base.join("forge/sessions")
+        .join(format!("{session_id}.sock"))
+}
+
+/// Top-level bridge operations invoked by Tauri commands. Keyed on
+/// [`SessionConnections`]; safe to clone and share across command handlers.
+#[derive(Clone)]
+pub struct SessionBridge {
+    connections: SessionConnections,
+}
+
+impl SessionBridge {
+    pub fn new(connections: SessionConnections) -> Self {
+        Self { connections }
+    }
+
+    pub fn connections(&self) -> &SessionConnections {
+        &self.connections
+    }
+
+    /// Open (or reuse) a UDS connection for `session_id` and perform the
+    /// framed `Hello`/`HelloAck` handshake. Returns the daemon's ack.
+    ///
+    /// If `socket_path` is `None`, [`default_socket_path`] is used.
+    pub async fn hello(&self, session_id: &str, socket_path: Option<&Path>) -> Result<HelloAck> {
+        {
+            let map = self.connections.inner.lock().await;
+            if map.contains_key(session_id) {
+                return Err(anyhow!(
+                    "session_hello: already connected to session {session_id}"
+                ));
+            }
+        }
+
+        let path: PathBuf = socket_path
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| default_socket_path(session_id));
+        let stream = UnixStream::connect(&path)
+            .await
+            .with_context(|| format!("connect UDS {}", path.display()))?;
+        let (mut reader, mut writer) = stream.into_split();
+
+        let hello = IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "shell".to_string(),
+                pid: std::process::id(),
+                user: std::env::var("USER").unwrap_or_else(|_| "forge".to_string()),
+            },
+        });
+        write_frame(&mut writer, &hello).await?;
+
+        let ack = read_frame(&mut reader)
+            .await
+            .context("read HelloAck frame")?;
+        let IpcMessage::HelloAck(ack) = ack else {
+            return Err(anyhow!("expected HelloAck, got unexpected frame"));
+        };
+
+        let conn = Connection {
+            writer: Arc::new(Mutex::new(writer)),
+            reader: Some(reader),
+            reader_task: None,
+        };
+        self.connections
+            .inner
+            .lock()
+            .await
+            .insert(session_id.to_string(), conn);
+
+        Ok(ack)
+    }
+
+    /// Send `Subscribe { since }` to the daemon and spawn a background task
+    /// that reads event frames and delivers them to `sink`. Idempotent per
+    /// connection: a second call is a no-op (task already running).
+    pub async fn subscribe(
+        &self,
+        session_id: &str,
+        since: u64,
+        sink: Arc<dyn EventSink>,
+    ) -> Result<()> {
+        let mut map = self.connections.inner.lock().await;
+        let conn = map
+            .get_mut(session_id)
+            .ok_or_else(|| anyhow!("session_subscribe: no active connection for {session_id}"))?;
+
+        if conn.reader_task.is_some() {
+            return Ok(());
+        }
+
+        let sub = IpcMessage::Subscribe(Subscribe { since });
+        {
+            let mut writer = conn.writer.lock().await;
+            write_frame(&mut *writer, &sub).await?;
+        }
+
+        let reader = conn
+            .reader
+            .take()
+            .ok_or_else(|| anyhow!("session_subscribe: reader already consumed"))?;
+        let session_id_owned = session_id.to_string();
+        let task = tokio::spawn(async move {
+            pump_events(reader, session_id_owned, sink).await;
+        });
+        conn.reader_task = Some(task);
+
+        Ok(())
+    }
+
+    pub async fn send_message(&self, session_id: &str, text: String) -> Result<()> {
+        let writer = self.writer_for(session_id).await?;
+        let mut writer = writer.lock().await;
+        let frame = IpcMessage::SendUserMessage(SendUserMessage { text });
+        write_frame(&mut *writer, &frame).await
+    }
+
+    pub async fn approve_tool(&self, session_id: &str, id: String, scope: String) -> Result<()> {
+        let writer = self.writer_for(session_id).await?;
+        let mut writer = writer.lock().await;
+        let frame = IpcMessage::ToolCallApproved(ToolCallApproved { id, scope });
+        write_frame(&mut *writer, &frame).await
+    }
+
+    pub async fn reject_tool(
+        &self,
+        session_id: &str,
+        id: String,
+        reason: Option<String>,
+    ) -> Result<()> {
+        let writer = self.writer_for(session_id).await?;
+        let mut writer = writer.lock().await;
+        let frame = IpcMessage::ToolCallRejected(ToolCallRejected { id, reason });
+        write_frame(&mut *writer, &frame).await
+    }
+
+    async fn writer_for(&self, session_id: &str) -> Result<Arc<Mutex<OwnedWriteHalf>>> {
+        let map = self.connections.inner.lock().await;
+        let conn = map
+            .get(session_id)
+            .ok_or_else(|| anyhow!("no active connection for session {session_id}"))?;
+        Ok(Arc::clone(&conn.writer))
+    }
+}
+
+async fn pump_events(mut reader: OwnedReadHalf, session_id: String, sink: Arc<dyn EventSink>) {
+    loop {
+        match read_frame(&mut reader).await {
+            Ok(IpcMessage::Event(event)) => {
+                sink.emit(SessionEventPayload {
+                    session_id: session_id.clone(),
+                    seq: event.seq,
+                    event: event.event,
+                });
+            }
+            Ok(_) => {
+                // Non-event frames (e.g. late HelloAck) are ignored; only
+                // session events flow to the webview.
+            }
+            Err(_) => {
+                // Peer closed or unrecoverable framing error. Task exits.
+                break;
+            }
+        }
+    }
+}

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -1,0 +1,131 @@
+//! Tauri command surface for the session IPC bridge.
+//!
+//! Every command is a thin wrapper over [`crate::bridge::SessionBridge`],
+//! plus an [`EventSink`] implementation that forwards payloads to the
+//! webview via `AppHandle::emit("session:event", …)`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use forge_ipc::HelloAck;
+use tauri::{AppHandle, Emitter, Manager, Runtime, State};
+
+use crate::bridge::{EventSink, SessionBridge, SessionConnections, SessionEventPayload};
+
+/// Tauri-managed bridge state. One per App; commands resolve it via
+/// `State<BridgeState>`.
+pub struct BridgeState {
+    pub bridge: SessionBridge,
+}
+
+impl BridgeState {
+    pub fn new(connections: SessionConnections) -> Self {
+        Self {
+            bridge: SessionBridge::new(connections),
+        }
+    }
+}
+
+/// Event sink that forwards session events to the webview under the
+/// `session:event` event name.
+struct AppHandleSink<R: Runtime> {
+    app: AppHandle<R>,
+}
+
+impl<R: Runtime> EventSink for AppHandleSink<R> {
+    fn emit(&self, payload: SessionEventPayload) {
+        if let Err(e) = self.app.emit("session:event", payload) {
+            eprintln!("session:event emit failed: {e}");
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn session_hello(
+    session_id: String,
+    socket_path: Option<String>,
+    state: State<'_, BridgeState>,
+) -> Result<HelloAck, String> {
+    let socket_path = socket_path.as_deref().map(PathBuf::from);
+    state
+        .bridge
+        .hello(&session_id, socket_path.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn session_subscribe<R: Runtime>(
+    session_id: String,
+    since: Option<u64>,
+    app: AppHandle<R>,
+    state: State<'_, BridgeState>,
+) -> Result<(), String> {
+    let sink: Arc<dyn EventSink> = Arc::new(AppHandleSink { app });
+    state
+        .bridge
+        .subscribe(&session_id, since.unwrap_or(0), sink)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn session_send_message(
+    session_id: String,
+    text: String,
+    state: State<'_, BridgeState>,
+) -> Result<(), String> {
+    state
+        .bridge
+        .send_message(&session_id, text)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn session_approve_tool(
+    session_id: String,
+    tool_call_id: String,
+    scope: String,
+    state: State<'_, BridgeState>,
+) -> Result<(), String> {
+    state
+        .bridge
+        .approve_tool(&session_id, tool_call_id, scope)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn session_reject_tool(
+    session_id: String,
+    tool_call_id: String,
+    reason: Option<String>,
+    state: State<'_, BridgeState>,
+) -> Result<(), String> {
+    state
+        .bridge
+        .reject_tool(&session_id, tool_call_id, reason)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Returns a fully-wired invoke handler registering all five session bridge
+/// commands. Called from `window_manager::run` when building the Tauri app.
+pub fn build_invoke_handler<R: Runtime>() -> Box<dyn Fn(tauri::ipc::Invoke<R>) -> bool + Send + Sync>
+{
+    Box::new(tauri::generate_handler![
+        session_hello,
+        session_subscribe,
+        session_send_message,
+        session_approve_tool,
+        session_reject_tool,
+    ])
+}
+
+/// Attach the `BridgeState` to an app builder. Used by `window_manager::run`.
+pub fn manage_bridge<R: Runtime>(app: &AppHandle<R>) {
+    if app.try_state::<BridgeState>().is_none() {
+        app.manage(BridgeState::new(SessionConnections::new()));
+    }
+}

--- a/crates/forge-shell/src/lib.rs
+++ b/crates/forge-shell/src/lib.rs
@@ -10,8 +10,11 @@
 //! that `window_spec` can be unit-tested on hosts without WebKitGTK via
 //! `cargo test -p forge-shell --no-default-features`.
 
+pub mod bridge;
 pub mod dashboard;
 pub mod window_spec;
 
+#[cfg(feature = "webview")]
+pub mod ipc;
 #[cfg(feature = "webview")]
 pub mod window_manager;

--- a/crates/forge-shell/src/window_manager.rs
+++ b/crates/forge-shell/src/window_manager.rs
@@ -58,13 +58,21 @@ impl<R: Runtime> WindowManager<R> {
     }
 }
 
-/// Entry point invoked from `main`. Builds the Tauri app and opens the
-/// Dashboard on setup.
+/// Entry point invoked from `main`. Builds the Tauri app, registers the
+/// session IPC bridge + dashboard commands, and opens the Dashboard on setup.
 pub fn run() -> Result<()> {
     tauri::Builder::default()
         .manage(ProviderStatusCache::new(CACHE_TTL))
-        .invoke_handler(tauri::generate_handler![dashboard::provider_status])
+        .invoke_handler(tauri::generate_handler![
+            dashboard::provider_status,
+            crate::ipc::session_hello,
+            crate::ipc::session_subscribe,
+            crate::ipc::session_send_message,
+            crate::ipc::session_approve_tool,
+            crate::ipc::session_reject_tool,
+        ])
         .setup(|app| {
+            crate::ipc::manage_bridge(&app.handle().clone());
             let manager = WindowManager::new(app.handle().clone());
             manager.open_dashboard()?;
             Ok(())

--- a/crates/forge-shell/tests/bridge_e2e.rs
+++ b/crates/forge-shell/tests/bridge_e2e.rs
@@ -1,0 +1,168 @@
+//! End-to-end bridge tests: spawn a real `forge-session` daemon, drive it
+//! through [`SessionBridge`], and assert the full command + event flow.
+//!
+//! These tests satisfy the integration requirement in F-020's DoD: the
+//! webview → Tauri command → UDS → daemon path is exercised with the real
+//! session server. A capturing [`EventSink`] stands in for the Tauri
+//! `AppHandle::emit` call; the Tauri command wrappers in [`forge_shell::ipc`]
+//! delegate to the same bridge code tested here.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use forge_core::Event;
+use forge_providers::MockProvider;
+use forge_session::server::serve_with_session;
+use forge_session::session::Session;
+use forge_shell::bridge::{EventSink, SessionBridge, SessionConnections, SessionEventPayload};
+use tempfile::TempDir;
+use tokio::sync::mpsc;
+
+/// Test sink that forwards every emitted payload through an mpsc channel so
+/// the test can await delivery with a timeout.
+struct ChannelSink {
+    tx: mpsc::UnboundedSender<SessionEventPayload>,
+}
+
+impl EventSink for ChannelSink {
+    fn emit(&self, payload: SessionEventPayload) {
+        let _ = self.tx.send(payload);
+    }
+}
+
+async fn spawn_daemon(path: &Path, session_id: &str) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(MockProvider::with_default_path());
+    let sock = path.to_path_buf();
+    let sid = session_id.to_string();
+    tokio::spawn(async move {
+        serve_with_session(&sock, session, provider, true, false, None, Some(sid))
+            .await
+            .unwrap();
+    });
+    // Wait for the server to bind its socket.
+    for _ in 0..50 {
+        if path.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    dir
+}
+
+#[tokio::test]
+async fn hello_handshake_against_real_daemon() {
+    let sock_dir = TempDir::new().unwrap();
+    let sock = sock_dir.path().join("hello.sock");
+    let _daemon = spawn_daemon(&sock, "fixed-id").await;
+
+    let bridge = SessionBridge::new(SessionConnections::new());
+    let ack = bridge
+        .hello("fixed-id", Some(&sock))
+        .await
+        .expect("hello succeeds");
+
+    assert_eq!(ack.session_id, "fixed-id");
+    assert_eq!(ack.schema_version, 1);
+    assert_eq!(bridge.connections().len().await, 1);
+    assert!(bridge.connections().contains("fixed-id").await);
+}
+
+#[tokio::test]
+async fn send_message_forwards_events_end_to_end() {
+    let sock_dir = TempDir::new().unwrap();
+    let sock = sock_dir.path().join("send.sock");
+    let _daemon = spawn_daemon(&sock, "send-session").await;
+
+    let bridge = SessionBridge::new(SessionConnections::new());
+    bridge
+        .hello("send-session", Some(&sock))
+        .await
+        .expect("hello");
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let sink = Arc::new(ChannelSink { tx });
+    bridge
+        .subscribe("send-session", 0, sink)
+        .await
+        .expect("subscribe");
+
+    bridge
+        .send_message("send-session", "hello world".to_string())
+        .await
+        .expect("send_message");
+
+    // Drain events until we see a UserMessageAdded whose text matches.
+    let mut saw_user_message = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline - tokio::time::Instant::now();
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Some(payload)) => {
+                assert_eq!(payload.session_id, "send-session");
+                let event: Event = serde_json::from_value(payload.event).unwrap();
+                if let Event::UserMessage { text, .. } = event {
+                    assert_eq!(text, "hello world");
+                    saw_user_message = true;
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    assert!(saw_user_message, "expected UserMessageAdded event");
+}
+
+#[tokio::test]
+async fn approve_tool_proxies_to_daemon() {
+    // Without a tool call in flight, approve is a no-op on the daemon side
+    // (the pending-approvals map has no entry). We assert the frame is
+    // written without error — i.e. the bridge routes the command through
+    // the same writer it uses for send_message.
+    let sock_dir = TempDir::new().unwrap();
+    let sock = sock_dir.path().join("approve.sock");
+    let _daemon = spawn_daemon(&sock, "approve-session").await;
+
+    let bridge = SessionBridge::new(SessionConnections::new());
+    bridge
+        .hello("approve-session", Some(&sock))
+        .await
+        .expect("hello");
+
+    let (tx, _rx) = mpsc::unbounded_channel();
+    bridge
+        .subscribe("approve-session", 0, Arc::new(ChannelSink { tx }))
+        .await
+        .expect("subscribe");
+
+    bridge
+        .approve_tool("approve-session", "call-123".into(), "Once".into())
+        .await
+        .expect("approve_tool writes frame");
+
+    bridge
+        .reject_tool("approve-session", "call-456".into(), Some("nope".into()))
+        .await
+        .expect("reject_tool writes frame");
+}
+
+#[tokio::test]
+async fn hello_twice_for_same_session_is_rejected() {
+    let sock_dir = TempDir::new().unwrap();
+    let sock = sock_dir.path().join("dup.sock");
+    let _daemon = spawn_daemon(&sock, "dup-session").await;
+
+    let bridge = SessionBridge::new(SessionConnections::new());
+    bridge
+        .hello("dup-session", Some(&sock))
+        .await
+        .expect("first hello");
+    let err = bridge
+        .hello("dup-session", Some(&sock))
+        .await
+        .expect_err("second hello must be rejected");
+    assert!(err.to_string().contains("already connected"));
+}

--- a/crates/forge-shell/tests/bridge_registry.rs
+++ b/crates/forge-shell/tests/bridge_registry.rs
@@ -1,0 +1,11 @@
+//! RED 1: Bridge connection registry starts empty and tracks connections
+//! by `session_id`. This is the foundation on top of which the Tauri
+//! commands dispatch.
+
+use forge_shell::bridge::SessionConnections;
+
+#[tokio::test]
+async fn new_registry_is_empty() {
+    let connections = SessionConnections::new();
+    assert_eq!(connections.len().await, 0);
+}

--- a/crates/forge-shell/tests/ipc_commands.rs
+++ b/crates/forge-shell/tests/ipc_commands.rs
@@ -1,0 +1,96 @@
+//! RED 3: The Tauri `ipc` module must expose the five commands required by
+//! F-020 and register them with `tauri::generate_handler!` without errors.
+//!
+//! These tests run under the `webview` feature so they can invoke real
+//! Tauri machinery via `tauri::test::mock_builder`.
+
+#![cfg(feature = "webview-test")]
+
+use std::sync::Arc;
+
+use forge_providers::MockProvider;
+use forge_session::server::serve_with_session;
+use forge_session::session::Session;
+use forge_shell::bridge::SessionConnections;
+use forge_shell::ipc::{build_invoke_handler, BridgeState};
+use tauri::test::{mock_builder, mock_context, noop_assets, INVOKE_KEY};
+use tauri::Manager;
+use tempfile::TempDir;
+
+fn make_app() -> tauri::App<tauri::test::MockRuntime> {
+    mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app")
+}
+
+#[test]
+fn invoke_handler_builds_without_error() {
+    let app = make_app();
+    // Attach fresh bridge state so commands have something to resolve against.
+    app.manage(BridgeState::new(SessionConnections::new()));
+    // Nothing else — this test just proves `build_invoke_handler()` and the
+    // five `#[tauri::command]` handlers compile and register together.
+    drop(app);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_hello_command_round_trips_via_tauri_invoke() {
+    let sock_dir = TempDir::new().unwrap();
+    let sock = sock_dir.path().join("tauri-hello.sock");
+
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(MockProvider::with_default_path());
+    let server_sock = sock.clone();
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            session,
+            provider,
+            true,
+            false,
+            None,
+            Some("tauri-hello".to_string()),
+        )
+        .await
+        .unwrap();
+    });
+    for _ in 0..50 {
+        if sock.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+
+    let window =
+        tauri::WebviewWindowBuilder::new(&app, "main", tauri::WebviewUrl::App("index.html".into()))
+            .build()
+            .expect("mock window");
+
+    let payload = serde_json::json!({
+        "sessionId": "tauri-hello",
+        "socketPath": sock.to_string_lossy(),
+    });
+    let res = tauri::test::get_ipc_response(
+        &window,
+        tauri::webview::InvokeRequest {
+            cmd: "session_hello".into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+
+    let value = res.expect("session_hello returns HelloAck JSON");
+    let obj = value.deserialize::<serde_json::Value>().unwrap();
+    assert_eq!(obj["session_id"], "tauri-hello");
+    assert_eq!(obj["schema_version"], 1);
+}

--- a/web/packages/app/package.json
+++ b/web/packages/app/package.json
@@ -14,6 +14,7 @@
     "@forge/design": "workspace:*",
     "@forge/ipc": "workspace:*",
     "@solidjs/router": "^0.15.1",
+    "@tauri-apps/api": "^2.1.1",
     "solid-js": "^1.9.3"
   },
   "devDependencies": {

--- a/web/packages/app/src/ipc/session.test.ts
+++ b/web/packages/app/src/ipc/session.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeMock, listenMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  listenMock: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: listenMock,
+}));
+
+import {
+  sessionHello,
+  sessionSubscribe,
+  sessionSendMessage,
+  sessionApproveTool,
+  sessionRejectTool,
+  onSessionEvent,
+  SESSION_EVENT,
+} from './session';
+
+describe('session ipc wrappers', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    listenMock.mockReset();
+  });
+
+  it('sessionHello invokes `session_hello` with sessionId + socketPath', async () => {
+    invokeMock.mockResolvedValue({
+      session_id: 'abc',
+      workspace: '/ws',
+      started_at: '2026-04-15T14:22:00Z',
+      event_seq: 0,
+      schema_version: 1,
+    });
+
+    const ack = await sessionHello('abc', '/tmp/forge.sock');
+
+    expect(invokeMock).toHaveBeenCalledWith('session_hello', {
+      sessionId: 'abc',
+      socketPath: '/tmp/forge.sock',
+    });
+    expect(ack.session_id).toBe('abc');
+  });
+
+  it('sessionHello omits socketPath when unspecified', async () => {
+    invokeMock.mockResolvedValue({
+      session_id: 'abc',
+      workspace: '',
+      started_at: '',
+      event_seq: 0,
+      schema_version: 1,
+    });
+
+    await sessionHello('abc');
+
+    expect(invokeMock).toHaveBeenCalledWith('session_hello', {
+      sessionId: 'abc',
+      socketPath: undefined,
+    });
+  });
+
+  it('sessionSubscribe invokes `session_subscribe` with since', async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await sessionSubscribe('abc', 42);
+
+    expect(invokeMock).toHaveBeenCalledWith('session_subscribe', {
+      sessionId: 'abc',
+      since: 42,
+    });
+  });
+
+  it('sessionSendMessage invokes `session_send_message`', async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await sessionSendMessage('abc', 'hello');
+
+    expect(invokeMock).toHaveBeenCalledWith('session_send_message', {
+      sessionId: 'abc',
+      text: 'hello',
+    });
+  });
+
+  it('sessionApproveTool invokes `session_approve_tool` with scope', async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await sessionApproveTool('abc', 'call-1', 'Once');
+
+    expect(invokeMock).toHaveBeenCalledWith('session_approve_tool', {
+      sessionId: 'abc',
+      toolCallId: 'call-1',
+      scope: 'Once',
+    });
+  });
+
+  it('sessionRejectTool invokes `session_reject_tool` with optional reason', async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await sessionRejectTool('abc', 'call-1');
+    expect(invokeMock).toHaveBeenLastCalledWith('session_reject_tool', {
+      sessionId: 'abc',
+      toolCallId: 'call-1',
+      reason: undefined,
+    });
+
+    await sessionRejectTool('abc', 'call-2', 'nope');
+    expect(invokeMock).toHaveBeenLastCalledWith('session_reject_tool', {
+      sessionId: 'abc',
+      toolCallId: 'call-2',
+      reason: 'nope',
+    });
+  });
+
+  it('onSessionEvent subscribes to session:event with callback receiving payload', async () => {
+    const unlisten = vi.fn();
+    listenMock.mockResolvedValue(unlisten);
+
+    const handler = vi.fn();
+    const off = await onSessionEvent(handler);
+
+    expect(listenMock).toHaveBeenCalledWith(SESSION_EVENT, expect.any(Function));
+    expect(SESSION_EVENT).toBe('session:event');
+
+    // Simulate Tauri emitting an event by calling the bound listener.
+    const listener = listenMock.mock.calls[0]![1] as (
+      event: { payload: unknown },
+    ) => void;
+    const payload = { session_id: 'abc', seq: 1, event: { kind: 'AssistantDelta' } };
+    listener({ payload });
+
+    expect(handler).toHaveBeenCalledWith(payload);
+    expect(off).toBe(unlisten);
+  });
+});

--- a/web/packages/app/src/ipc/session.ts
+++ b/web/packages/app/src/ipc/session.ts
@@ -1,0 +1,73 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import type { SessionId, ToolCallId, ApprovalScope } from '@forge/ipc';
+
+export const SESSION_EVENT = 'session:event';
+
+/** Mirror of `forge_ipc::HelloAck`. */
+export interface HelloAck {
+  session_id: string;
+  workspace: string;
+  started_at: string;
+  event_seq: number;
+  schema_version: number;
+}
+
+/** Payload emitted by the shell's bridge reader task. */
+export interface SessionEventPayload {
+  session_id: SessionId;
+  seq: number;
+  event: unknown;
+}
+
+export async function sessionHello(
+  sessionId: SessionId,
+  socketPath?: string,
+): Promise<HelloAck> {
+  return invoke<HelloAck>('session_hello', {
+    sessionId,
+    socketPath,
+  });
+}
+
+export async function sessionSubscribe(
+  sessionId: SessionId,
+  since = 0,
+): Promise<void> {
+  await invoke('session_subscribe', { sessionId, since });
+}
+
+export async function sessionSendMessage(
+  sessionId: SessionId,
+  text: string,
+): Promise<void> {
+  await invoke('session_send_message', { sessionId, text });
+}
+
+export async function sessionApproveTool(
+  sessionId: SessionId,
+  toolCallId: ToolCallId,
+  scope: ApprovalScope,
+): Promise<void> {
+  await invoke('session_approve_tool', { sessionId, toolCallId, scope });
+}
+
+export async function sessionRejectTool(
+  sessionId: SessionId,
+  toolCallId: ToolCallId,
+  reason?: string,
+): Promise<void> {
+  await invoke('session_reject_tool', { sessionId, toolCallId, reason });
+}
+
+/**
+ * Subscribe to session events from the shell. Returns an unlisten handle.
+ * The callback receives the payload unwrapped from Tauri's event envelope.
+ */
+export async function onSessionEvent(
+  handler: (payload: SessionEventPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<SessionEventPayload>(SESSION_EVENT, (event) => {
+    handler(event.payload);
+  });
+}

--- a/web/packages/app/src/stores/session.event.test.ts
+++ b/web/packages/app/src/stores/session.event.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { listenMock, unlistenMock } = vi.hoisted(() => ({
+  listenMock: vi.fn(),
+  unlistenMock: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: listenMock,
+}));
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+import type { SessionId } from '@forge/ipc';
+import {
+  sessionEvents,
+  initSessionEventPump,
+  resetSessionEventStore,
+} from './session';
+
+describe('session event pump', () => {
+  beforeEach(() => {
+    listenMock.mockReset();
+    unlistenMock.mockReset();
+    resetSessionEventStore();
+  });
+
+  it('records the latest seq and event payload per session', async () => {
+    listenMock.mockResolvedValue(unlistenMock);
+
+    const off = await initSessionEventPump();
+    expect(listenMock).toHaveBeenCalledWith(
+      'session:event',
+      expect.any(Function),
+    );
+
+    const listener = listenMock.mock.calls[0]![1] as (event: {
+      payload: unknown;
+    }) => void;
+
+    const sid = 'session-1' as SessionId;
+    listener({
+      payload: {
+        session_id: sid,
+        seq: 1,
+        event: { kind: 'UserMessage', text: 'hi' },
+      },
+    });
+    listener({
+      payload: {
+        session_id: sid,
+        seq: 2,
+        event: { kind: 'AssistantDelta', delta: 'yo' },
+      },
+    });
+
+    const slot = sessionEvents[sid];
+    expect(slot).toBeDefined();
+    expect(slot!.lastSeq).toBe(2);
+    expect(slot!.lastEvent).toEqual({
+      kind: 'AssistantDelta',
+      delta: 'yo',
+    });
+
+    // Handle returned by initSessionEventPump is the unlisten callback.
+    expect(off).toBe(unlistenMock);
+  });
+});

--- a/web/packages/app/src/stores/session.ts
+++ b/web/packages/app/src/stores/session.ts
@@ -1,6 +1,11 @@
 import { createSignal } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import type { SessionId, SessionState } from '@forge/ipc';
+import {
+  onSessionEvent,
+  type SessionEventPayload,
+} from '../ipc/session';
+import type { UnlistenFn } from '@tauri-apps/api/event';
 
 export interface SessionSummary {
   id: SessionId;
@@ -10,3 +15,36 @@ export interface SessionSummary {
 export const [activeSessionId, setActiveSessionId] = createSignal<SessionId | null>(null);
 
 export const [sessions, setSessions] = createStore<Record<SessionId, SessionSummary>>({});
+
+/**
+ * Per-session view of the most recent event received from the shell bridge.
+ * Components that need fine-grained state (messages, tool calls, etc.) will
+ * derive from this or dispatch to richer stores. For F-020 the pump's job is
+ * simply to prove event delivery works end-to-end.
+ */
+export interface SessionEventSlot {
+  lastSeq: number;
+  lastEvent: unknown;
+}
+
+export const [sessionEvents, setSessionEvents] = createStore<
+  Record<SessionId, SessionEventSlot>
+>({});
+
+/**
+ * Subscribe the store to the `session:event` Tauri event. Returns the
+ * unlisten handle so the caller (app bootstrap) can tear it down on unmount.
+ */
+export async function initSessionEventPump(): Promise<UnlistenFn> {
+  return onSessionEvent((payload: SessionEventPayload) => {
+    setSessionEvents(payload.session_id, {
+      lastSeq: payload.seq,
+      lastEvent: payload.event,
+    });
+  });
+}
+
+/** Test helper — clears the event slots store between tests. */
+export function resetSessionEventStore(): void {
+  setSessionEvents({});
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@solidjs/router':
         specifier: ^0.15.1
         version: 0.15.4(solid-js@1.9.12)
+      '@tauri-apps/api':
+        specifier: ^2.1.1
+        version: 2.10.1
       solid-js:
         specifier: ^1.9.3
         version: 1.9.12
@@ -626,6 +629,9 @@ packages:
     peerDependenciesMeta:
       '@solidjs/router':
         optional: true
+
+  '@tauri-apps/api@2.10.1':
+    resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1717,6 +1723,8 @@ snapshots:
       solid-js: 1.9.12
     optionalDependencies:
       '@solidjs/router': 0.15.4(solid-js@1.9.12)
+
+  '@tauri-apps/api@2.10.1': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
Closes forge-ide/forge#38

## Summary

Bridge the Tauri webview to `forge-session` UDS sockets so the Solid app can drive a session and consume its event stream without speaking raw framing.

- Five `#[tauri::command]` handlers in `forge-shell/src/ipc.rs`: `session_hello`, `session_subscribe`, `session_send_message`, `session_approve_tool`, `session_reject_tool`
- Core bridge logic in `forge-shell/src/bridge.rs` owns a `SessionConnections` registry keyed by `session_id`; each connection holds one UDS writer, does the `Hello`/`HelloAck` handshake, and (on subscribe) spawns a background task that pumps `IpcMessage::Event` frames into an `EventSink`
- Production `EventSink` emits `session:event` via `AppHandle::emit`; tests use an in-memory channel sink
- Typed TS wrappers in `web/packages/app/src/ipc/session.ts` (camelCase kwargs → Tauri commands), plus `onSessionEvent` for the event pump
- `stores/session.ts` gains `initSessionEventPump()` + a per-session `sessionEvents` store recording the latest `seq` and `event`
- Split bridge logic from Tauri command surface so integration tests can exercise the full handshake + event forwarding path against a real `forge-session` daemon without a webview runtime

## Test plan

- `cargo test --workspace` — all green, including 4 new end-to-end tests in `crates/forge-shell/tests/bridge_e2e.rs` that spawn a real `forge_session::server::serve_with_session` and assert events flow
- `cargo test -p forge-shell --features webview-test` — includes a Tauri `mock_builder` + `get_ipc_response` round-trip proving `session_hello` invokes end-to-end through the Tauri runtime
- `cargo clippy --all-targets -- -D warnings` — clean
- `pnpm --filter app test` — 22/22 green, including 7 new IPC wrapper tests and 1 store-event-pump test
- `pnpm --filter app typecheck` — clean

## Notes for reviewers

- No changes to `forge-ipc` or `forge-session` — the bridge is a pure consumer of the existing UDS protocol
- Capabilities file left with `core:default` only; app-local commands do not require capability entries in Tauri 2
- `HelloAck` is returned directly from `session_hello` (re-using `forge_ipc::HelloAck` which already derives `Serialize`)
- `webview-test` feature opts in to `tauri/test` only for integration tests; the production binary does not ship test scaffolding

🤖 Generated with [Claude Code](https://claude.com/claude-code)