### PR TITLE
[F-024] Session window shell + single pane

### DIFF
--- a/web/packages/app/src/App.tsx
+++ b/web/packages/app/src/App.tsx
@@ -1,11 +1,13 @@
 import type { Component } from 'solid-js';
 import { Router, Route } from '@solidjs/router';
 import { Dashboard } from './routes/Dashboard';
+import { SessionWindow } from './routes/Session/SessionWindow';
 
 export const App: Component = () => {
   return (
     <Router>
       <Route path="/" component={Dashboard} />
+      <Route path="/session/:id" component={SessionWindow} />
     </Router>
   );
 };

--- a/web/packages/app/src/routes/Session/ChatPane.css
+++ b/web/packages/app/src/routes/Session/ChatPane.css
@@ -1,0 +1,26 @@
+.chat-pane {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 320px;
+  padding: var(--sp-5);
+  gap: var(--sp-4);
+  background: var(--color-surface-1);
+  color: var(--color-text-primary);
+}
+
+.chat-pane__type-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.chat-pane__placeholder {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  line-height: 1.55;
+}

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -1,0 +1,16 @@
+import type { Component } from 'solid-js';
+import './ChatPane.css';
+
+/**
+ * Chat pane placeholder. Message list, composer, and streaming UX
+ * land in F-025; this component exists so the Session window can
+ * render the default single-pane layout today.
+ */
+export const ChatPane: Component = () => {
+  return (
+    <section class="chat-pane" data-testid="chat-pane" aria-label="Chat pane">
+      <span class="chat-pane__type-label">CHAT</span>
+      <p class="chat-pane__placeholder">Chat pane awaiting F-025.</p>
+    </section>
+  );
+};

--- a/web/packages/app/src/routes/Session/PaneHeader.css
+++ b/web/packages/app/src/routes/Session/PaneHeader.css
@@ -1,0 +1,63 @@
+.pane-header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  height: 28px;
+  padding: 0 var(--sp-4);
+  background: var(--color-surface-2);
+  border-bottom: 1px solid var(--color-border-1);
+  font-family: var(--font-body);
+}
+
+.pane-header__type-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.pane-header__subject {
+  font-size: 13px;
+  color: var(--color-text-primary);
+}
+
+.pane-header__provider {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 0 var(--sp-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-provider-local);
+  background: var(--color-surface-3);
+  border: 1px solid var(--color-border-1);
+  border-radius: var(--r-sm);
+}
+
+.pane-header__cost {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
+}
+
+.pane-header__close {
+  background: transparent;
+  border: 1px solid transparent;
+  padding: 0 var(--sp-2);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: color var(--ease), border-color var(--ease);
+}
+
+.pane-header__close:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-border-2);
+  border-radius: var(--r-sm);
+}

--- a/web/packages/app/src/routes/Session/PaneHeader.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.tsx
@@ -1,0 +1,39 @@
+import type { Component } from 'solid-js';
+import './PaneHeader.css';
+
+export interface PaneHeaderProps {
+  subject: string;
+  providerLabel: string;
+  costLabel: string;
+  onClose: () => void;
+}
+
+/**
+ * Pane header (28px) per docs/ui-specs/layout-panes.md §3.3. Shows the
+ * session subject, provider label, and a cost meter placeholder, with a
+ * close action on the right.
+ */
+export const PaneHeader: Component<PaneHeaderProps> = (props) => {
+  return (
+    <header class="pane-header" role="banner">
+      <span class="pane-header__type-label">CHAT</span>
+      <span class="pane-header__subject" data-testid="pane-header-subject">
+        {props.subject}
+      </span>
+      <span class="pane-header__provider" data-testid="pane-header-provider">
+        {props.providerLabel}
+      </span>
+      <span class="pane-header__cost" data-testid="pane-header-cost">
+        {props.costLabel}
+      </span>
+      <button
+        type="button"
+        class="pane-header__close"
+        aria-label="Close session window"
+        onClick={props.onClose}
+      >
+        close
+      </button>
+    </header>
+  );
+};

--- a/web/packages/app/src/routes/Session/SessionWindow.css
+++ b/web/packages/app/src/routes/Session/SessionWindow.css
@@ -1,0 +1,23 @@
+.session-window {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--color-bg);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+}
+
+.session-window__pane {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 320px;
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-1);
+}
+
+.session-window__pane-body {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}

--- a/web/packages/app/src/routes/Session/SessionWindow.test.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@solidjs/testing-library';
+
+const { invokeMock, listenMock, unlistenMock, closeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  listenMock: vi.fn(),
+  unlistenMock: vi.fn(),
+  closeMock: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: listenMock,
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ close: closeMock }),
+}));
+
+import { MemoryRouter, Route, createMemoryHistory } from '@solidjs/router';
+import { SessionWindow } from './SessionWindow';
+import { resetSessionEventStore } from '../../stores/session';
+
+const helloAck = {
+  session_id: 'abc123',
+  workspace: '/ws',
+  started_at: '2026-04-18T00:00:00Z',
+  event_seq: 0,
+  schema_version: 1,
+};
+
+function renderAt(path: string) {
+  const history = createMemoryHistory();
+  history.set({ value: path });
+  return render(() => (
+    <MemoryRouter history={history}>
+      <Route path="/session/:id" component={SessionWindow} />
+    </MemoryRouter>
+  ));
+}
+
+describe('SessionWindow', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    listenMock.mockReset();
+    unlistenMock.mockReset();
+    closeMock.mockReset();
+    resetSessionEventStore();
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'session_hello') return helloAck;
+      return undefined;
+    });
+    listenMock.mockResolvedValue(unlistenMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the session id from the route', async () => {
+    const { findByTestId } = renderAt('/session/abc123');
+    const subject = await findByTestId('pane-header-subject');
+    expect(subject.textContent).toContain('abc123');
+  });
+
+  it('calls session_hello on mount with the route-param id', async () => {
+    renderAt('/session/abc123');
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('session_hello', {
+        sessionId: 'abc123',
+        socketPath: undefined,
+      }),
+    );
+  });
+
+  it('calls session_subscribe on mount after hello resolves', async () => {
+    renderAt('/session/abc123');
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('session_subscribe', {
+        sessionId: 'abc123',
+        since: 0,
+      }),
+    );
+    // hello must run before subscribe
+    const helloIdx = invokeMock.mock.calls.findIndex((c) => c[0] === 'session_hello');
+    const subIdx = invokeMock.mock.calls.findIndex((c) => c[0] === 'session_subscribe');
+    expect(helloIdx).toBeGreaterThanOrEqual(0);
+    expect(subIdx).toBeGreaterThan(helloIdx);
+  });
+
+  it('attaches a session:event listener on mount', async () => {
+    renderAt('/session/abc123');
+    await waitFor(() =>
+      expect(listenMock).toHaveBeenCalledWith('session:event', expect.any(Function)),
+    );
+  });
+
+  it('detaches the session:event listener on unmount', async () => {
+    const { unmount } = renderAt('/session/abc123');
+    await waitFor(() => expect(listenMock).toHaveBeenCalled());
+    unmount();
+    await waitFor(() => expect(unlistenMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('renders exactly one pane slot (no splitter or dock zones)', async () => {
+    const { container, findByTestId } = renderAt('/session/abc123');
+    await findByTestId('pane-header-subject');
+    const panes = container.querySelectorAll('.session-window__pane');
+    expect(panes.length).toBe(1);
+    expect(container.querySelector('.session-window__splitter')).toBeNull();
+    expect(container.querySelector('.session-window__dock-zone')).toBeNull();
+  });
+
+  it('pane header shows subject, ollama provider label, cost placeholder, close action', async () => {
+    const { findByTestId, findByRole } = renderAt('/session/abc123');
+    const subject = await findByTestId('pane-header-subject');
+    expect(subject.textContent).toContain('abc123');
+    const provider = await findByTestId('pane-header-provider');
+    expect(provider.textContent?.toLowerCase()).toContain('ollama');
+    const cost = await findByTestId('pane-header-cost');
+    expect(cost.textContent).toMatch(/in\s+0.*out\s+0.*\$0/i);
+    const close = await findByRole('button', { name: /close/i });
+    expect(close).toBeInTheDocument();
+  });
+
+  it('close button invokes the current window close()', async () => {
+    const { findByRole } = renderAt('/session/abc123');
+    const close = await findByRole('button', { name: /close/i });
+    close.click();
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a ChatPane placeholder with the CHAT type label', async () => {
+    const { findByTestId } = renderAt('/session/abc123');
+    const chatPane = await findByTestId('chat-pane');
+    expect(chatPane.textContent).toContain('CHAT');
+  });
+});

--- a/web/packages/app/src/routes/Session/SessionWindow.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.tsx
@@ -1,0 +1,88 @@
+import { type Component, onCleanup, onMount } from 'solid-js';
+import { useParams } from '@solidjs/router';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import type { SessionId } from '@forge/ipc';
+import {
+  onSessionEvent,
+  sessionHello,
+  sessionSubscribe,
+} from '../../ipc/session';
+import {
+  setActiveSessionId,
+  setSessionEvents,
+  setSessions,
+} from '../../stores/session';
+import { PaneHeader } from './PaneHeader';
+import { ChatPane } from './ChatPane';
+import './SessionWindow.css';
+
+/**
+ * Session window shell — default single-pane layout from
+ * docs/ui-specs/layout-panes.md §3.4. Splitters and drag-to-dock are
+ * deferred to Phase 2. Subscribes to the session event stream on mount
+ * (via the F-020 IPC wrappers) and cleanly detaches on unmount.
+ */
+export const SessionWindow: Component = () => {
+  const params = useParams<{ id: string }>();
+  const sessionId = () => params.id as SessionId;
+
+  let unlisten: (() => void) | null = null;
+
+  onMount(() => {
+    const id = sessionId();
+    setActiveSessionId(id);
+    setSessions(id, { id, state: 'Active' });
+
+    void (async () => {
+      try {
+        await sessionHello(id);
+        await sessionSubscribe(id);
+      } catch (err) {
+        console.error('session_hello/subscribe failed', err);
+      }
+      unlisten = await onSessionEvent((payload) => {
+        if (payload.session_id !== id) return;
+        setSessionEvents(payload.session_id, {
+          lastSeq: payload.seq,
+          lastEvent: payload.event,
+        });
+      });
+    })();
+  });
+
+  onCleanup(() => {
+    if (unlisten) {
+      unlisten();
+      unlisten = null;
+    }
+    setActiveSessionId(null);
+  });
+
+  const handleClose = () => {
+    try {
+      void getCurrentWindow().close();
+    } catch (err) {
+      console.error('window close failed', err);
+    }
+  };
+
+  const subject = () => `Session ${sessionId()}`;
+  const providerLabel = () => 'ollama \u00b7 pending';
+  const costLabel = () => 'in 0 \u00b7 out 0 \u00b7 $0.00';
+
+  return (
+    <main class="session-window">
+      <section class="session-window__pane" aria-label="Session pane">
+        <PaneHeader
+          subject={subject()}
+          providerLabel={providerLabel()}
+          costLabel={costLabel()}
+          onClose={handleClose}
+        />
+        <div class="session-window__pane-body">
+          <ChatPane />
+        </div>
+      </section>
+    </main>
+  );
+};


### PR DESCRIPTION
Closes #42

## Summary

Adds the `/session/:id` route opened by `open_session(id)` from the Dashboard. Renders the default single-pane layout from `docs/ui-specs/layout-panes.md` §3.4 — one chat pane filling the window with a pane header (subject, Ollama provider label, cost placeholder, close action). Splits, drag-to-dock, and additional pane types are deferred to Phase 2; `ChatPane` is a placeholder awaiting F-025.

On mount, `SessionWindow` drives the F-020 IPC bridge (`session_hello` then `session_subscribe`) and attaches a `session:event` listener that fans events into the `session.ts` store. On unmount, the listener is detached and the active session id is cleared.

## Definition of Done

- [x] Solid route `web/packages/app/src/routes/Session/SessionWindow.tsx` renders when opened via `open_session(id)`
- [x] Layout root contains exactly one pane slot; no splitter or dock zones (deferred)
- [x] Pane header shows session subject, Ollama provider label, cost meter placeholder, and close action
- [x] On mount: `session_hello` then `session_subscribe` via the F-020 wrappers
- [x] On unmount: cleanly detaches the `session:event` listener
- [x] Window feeds off `session.ts` store; pane body renders `<ChatPane />` placeholder
- [x] Visual uses tokens from `docs/design/token-reference.md`; token lint passes
- [x] Unit tests verify subscribe/unsubscribe lifecycle (attach on mount, detach on unmount)
- [x] Tests pass (36 app tests, full Rust workspace)

## Test coverage

`SessionWindow.test.tsx` adds 9 specs covering: route-param rendering, `session_hello` → `session_subscribe` ordering, `session:event` listener attach on mount and detach on unmount, single-pane invariant (no splitter/dock zones), pane header content (subject, Ollama label, cost placeholder, close button), close action invoking `getCurrentWindow().close()`, and the ChatPane placeholder label.

## Gates

- `cargo fmt --check`, `cargo check --workspace`, `cargo test --workspace`, `cargo clippy --all-targets -- -D warnings`
- `pnpm --filter app test` — 36 passed
- `pnpm --filter app exec tsc --noEmit` — clean
- `pnpm --filter app build` — clean
- `scripts/check-tokens.mjs` — 56 tokens match

## Deviations

None. Files live under `routes/Session/` (with `SessionWindow.tsx` and its siblings co-located) rather than `routes/SessionWindow.tsx` at the top of `routes/`. The DoD path `web/packages/app/src/routes/Session/SessionWindow.tsx` is satisfied exactly.