### PR TITLE
[F-025] Chat pane rendering

### DIFF
--- a/docs/ui-specs/chat-pane.md
+++ b/docs/ui-specs/chat-pane.md
@@ -67,11 +67,11 @@
 
 **Bottom bar.**
 - Left: provider pill (clickable, opens selector §8), then `@ for context`, `/ for commands` ghost pills
-- Right: `Stop` (ghost), `Send ⌘↵` (primary, ember)
+- Right: `Stop` (ghost), `Send ↵` (primary, ember)
 
-**Keyboard.**
-- `Enter`: newline
-- `Cmd/Ctrl+Enter`: send
+**Keyboard.** Option B: bare Enter sends; modifier+Enter inserts a newline.
+- `Enter`: send
+- `Shift+Enter` / `Ctrl+Enter` / `Cmd+Enter`: newline
 - `@`: opens context picker
 - `/`: opens command palette filtered to session commands
 - `Esc` while streaming: stop (same as Stop button)

--- a/web/packages/app/src/routes/Session/ChatPane.css
+++ b/web/packages/app/src/routes/Session/ChatPane.css
@@ -3,13 +3,19 @@
   flex-direction: column;
   flex: 1 1 auto;
   min-width: 320px;
-  padding: var(--sp-5);
-  gap: var(--sp-4);
+  min-height: 0;
   background: var(--color-surface-1);
   color: var(--color-text-primary);
+  overflow: hidden;
 }
 
+/* -------------------------------------------------------------------------
+   Type label
+   ---------------------------------------------------------------------- */
+
 .chat-pane__type-label {
+  flex: 0 0 auto;
+  padding: var(--sp-2) var(--sp-5) 0;
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.12em;
@@ -17,10 +23,238 @@
   color: var(--color-text-tertiary);
 }
 
-.chat-pane__placeholder {
-  margin: 0;
+/* -------------------------------------------------------------------------
+   Streaming indicator (while awaiting response)
+   ---------------------------------------------------------------------- */
+
+.chat-pane__streaming-indicator {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-5);
+  font-family: var(--font-mono);
+  font-size: 11px;
   color: var(--color-text-secondary);
+}
+
+/* -------------------------------------------------------------------------
+   Message list
+   ---------------------------------------------------------------------- */
+
+.chat-pane__messages {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: var(--sp-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-5);
+}
+
+/* -------------------------------------------------------------------------
+   Turn bubbles
+   ---------------------------------------------------------------------- */
+
+.turn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.turn__author {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.turn--user .turn__author {
+  color: var(--color-text-primary);
+}
+
+.turn__body {
+  margin: 0;
   font-family: var(--font-body);
   font-size: 13.5px;
   line-height: 1.55;
+  color: var(--color-text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Error turn */
+
+.turn--error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  border-radius: var(--r-sm);
+}
+
+.turn__error-icon {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-error);
+}
+
+.turn__error-message {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-error);
+  word-break: break-all;
+}
+
+/* -------------------------------------------------------------------------
+   Tool call placeholder (F-026 will replace this)
+   ---------------------------------------------------------------------- */
+
+.tool-placeholder {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-1);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.tool-placeholder--completed {
+  color: var(--color-text-tertiary);
+}
+
+.tool-placeholder__icon {
+  color: var(--color-text-tertiary);
+}
+
+.tool-placeholder__name {
+  flex: 1 1 auto;
+  color: var(--color-text-primary);
+}
+
+.tool-placeholder__status {
+  color: var(--color-text-tertiary);
+}
+
+/* -------------------------------------------------------------------------
+   Streaming cursor — 5×12px ember blink per streaming-states.md §11.1
+   ---------------------------------------------------------------------- */
+
+@keyframes cursor-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+.streaming-cursor {
+  display: inline-block;
+  width: 5px;
+  height: 12px;
+  border-radius: 1px;
+  background: var(--color-ember-400);
+  vertical-align: text-bottom;
+  margin-left: 2px;
+  animation: cursor-blink 1s steps(1, end) infinite;
+}
+
+/* -------------------------------------------------------------------------
+   Composer
+   ---------------------------------------------------------------------- */
+
+.composer {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--color-border-1);
+  background: var(--color-surface-2);
+  display: flex;
+  flex-direction: column;
+}
+
+.composer__textarea {
+  flex: 1 1 auto;
+  padding: var(--sp-3) var(--sp-4);
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: none;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--color-text-primary);
+  min-height: 72px;
+  max-height: 40vh;
+  overflow-y: auto;
+}
+
+.composer__textarea::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+.composer__textarea:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Focus ring on the whole composer when textarea is focused */
+.composer:focus-within {
+  border-top-color: var(--color-ember-400);
+  transition: border-top-color var(--ease);
+}
+
+.composer__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--sp-2) var(--sp-3) var(--sp-3);
+  border-top: 1px solid var(--color-border-1);
+}
+
+.composer__hints {
+  display: flex;
+  gap: var(--sp-3);
+}
+
+.composer__hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--color-text-tertiary);
+}
+
+.composer__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.composer__btn {
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: var(--ease);
+}
+
+.composer__btn--ghost {
+  background: transparent;
+  border: 1px solid var(--color-border-2);
+  color: var(--color-text-secondary);
+}
+
+.composer__btn--ghost:hover {
+  border-color: var(--color-ember-400);
+  color: var(--color-ember-400);
+}
+
+.composer__send-hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--color-text-tertiary);
 }

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import type { SessionId } from '@forge/ipc';
+
+// --- Mocks (hoisted so vi.mock works) ---
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock('../../lib/tauri', () => ({ invoke: invokeMock }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
+
+// --- Store imports (after mocks) ---
+import {
+  pushEvent,
+  setAwaitingResponse,
+  resetMessagesStore,
+} from '../../stores/messages';
+import { setActiveSessionId } from '../../stores/session';
+import { ChatPane } from './ChatPane';
+
+const SID = 'session-chat-test' as SessionId;
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  resetMessagesStore();
+  setActiveSessionId(SID);
+});
+
+describe('ChatPane rendering', () => {
+  it('renders the message list container', () => {
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('message-list')).toBeInTheDocument();
+  });
+
+  it('renders the composer textarea', () => {
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('composer-textarea')).toBeInTheDocument();
+  });
+
+  it('renders a user message turn', () => {
+    pushEvent(SID, { kind: 'UserMessage', text: 'Hello world', message_id: 'u1' });
+    const { getByText } = render(() => <ChatPane />);
+    expect(getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('renders an assistant message turn', () => {
+    pushEvent(SID, { kind: 'AssistantMessage', text: 'Hi there', message_id: 'a1' });
+    const { getByText } = render(() => <ChatPane />);
+    expect(getByText('Hi there')).toBeInTheDocument();
+  });
+
+  it('renders a streaming assistant turn with blinking cursor', () => {
+    pushEvent(SID, { kind: 'AssistantDelta', delta: 'Typing...', message_id: 'a2' });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('streaming-cursor')).toBeInTheDocument();
+  });
+
+  it('does not render streaming cursor on completed messages', () => {
+    pushEvent(SID, { kind: 'AssistantMessage', text: 'Done', message_id: 'a3' });
+    const { queryByTestId } = render(() => <ChatPane />);
+    expect(queryByTestId('streaming-cursor')).not.toBeInTheDocument();
+  });
+
+  it('renders a tool call placeholder', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-1',
+      tool_name: 'fs.read',
+      args_json: '{}',
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-placeholder-tc-1')).toBeInTheDocument();
+  });
+
+  it('renders an error turn inline', () => {
+    pushEvent(SID, { kind: 'Error', message: 'ECONNREFUSED 127.0.0.1:11434' });
+    const { getByText } = render(() => <ChatPane />);
+    expect(getByText(/ECONNREFUSED/)).toBeInTheDocument();
+  });
+});
+
+describe('Composer keyboard behavior (Option B)', () => {
+  it('sends message on Enter key', async () => {
+    invokeMock.mockResolvedValue(undefined);
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.input(textarea, { target: { value: 'send this' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', shiftKey: false, ctrlKey: false, metaKey: false });
+
+    expect(invokeMock).toHaveBeenCalledWith('session_send_message', {
+      sessionId: SID,
+      text: 'send this',
+    });
+  });
+
+  it('inserts newline on Shift+Enter instead of sending', () => {
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.input(textarea, { target: { value: 'line1' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', shiftKey: true });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('inserts newline on Ctrl+Enter instead of sending', () => {
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.input(textarea, { target: { value: 'line1' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', ctrlKey: true });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('inserts newline on Cmd+Enter instead of sending', () => {
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.input(textarea, { target: { value: 'line1' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', metaKey: true });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the textarea after sending', async () => {
+    invokeMock.mockResolvedValue(undefined);
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.input(textarea, { target: { value: 'hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: false });
+
+    expect(textarea.value).toBe('');
+  });
+
+  it('does not send an empty message', () => {
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: false });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('Composer disabled state', () => {
+  it('disables the textarea while awaiting response', () => {
+    setAwaitingResponse(SID, true);
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    expect(textarea).toBeDisabled();
+  });
+
+  it('enables the textarea when not awaiting', () => {
+    setAwaitingResponse(SID, false);
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    expect(textarea).not.toBeDisabled();
+  });
+
+  it('shows a streaming indicator while awaiting response', () => {
+    setAwaitingResponse(SID, true);
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('streaming-indicator')).toBeInTheDocument();
+  });
+});
+
+describe('Auto-scroll behavior', () => {
+  it('message list has data-autoscroll attribute for pinning', () => {
+    const { getByTestId } = render(() => <ChatPane />);
+    const list = getByTestId('message-list');
+    expect(list).toHaveAttribute('data-autoscroll');
+  });
+
+  it('scrolls to bottom when a new streaming delta arrives', () => {
+    const { getByTestId } = render(() => <ChatPane />);
+    const list = getByTestId('message-list');
+
+    // Mock scrollTop/scrollHeight so we can verify scrollTop was set
+    Object.defineProperty(list, 'scrollHeight', { value: 500, configurable: true });
+    Object.defineProperty(list, 'clientHeight', { value: 200, configurable: true });
+
+    pushEvent(SID, { kind: 'AssistantDelta', delta: 'streaming text', message_id: 'stream-1' });
+
+    // After a delta, the list should be pinned to bottom (scrollTop === scrollHeight)
+    expect(list.scrollTop).toBe(500);
+  });
+});

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -1,16 +1,208 @@
-import type { Component } from 'solid-js';
+import {
+  type Component,
+  createSignal,
+  createEffect,
+  For,
+  Show,
+  createMemo,
+} from 'solid-js';
+import { invoke } from '../../lib/tauri';
+import { activeSessionId } from '../../stores/session';
+import {
+  getMessagesState,
+  setAwaitingResponse,
+  type ChatTurn,
+} from '../../stores/messages';
 import './ChatPane.css';
 
-/**
- * Chat pane placeholder. Message list, composer, and streaming UX
- * land in F-025; this component exists so the Session window can
- * render the default single-pane layout today.
- */
+// ---------------------------------------------------------------------------
+// ToolCallPlaceholder — stub replaced in F-026
+// ---------------------------------------------------------------------------
+
+const ToolCallPlaceholder: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholder' }> }> = (props) => (
+  <div
+    class="tool-placeholder"
+    data-testid={`tool-placeholder-${props.turn.tool_call_id}`}
+    classList={{ 'tool-placeholder--completed': props.turn.completed }}
+  >
+    <span class="tool-placeholder__icon" aria-hidden="true">⚙</span>
+    <span class="tool-placeholder__name">{props.turn.tool_name}</span>
+    <span class="tool-placeholder__status">
+      {props.turn.completed ? 'completed' : 'running'}
+    </span>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Message turn renderers
+// ---------------------------------------------------------------------------
+
+const UserBubble: Component<{ turn: Extract<ChatTurn, { type: 'user' }> }> = (props) => (
+  <article class="turn turn--user">
+    <header class="turn__author">● you</header>
+    <p class="turn__body">{props.turn.text}</p>
+  </article>
+);
+
+const AssistantBubble: Component<{ turn: Extract<ChatTurn, { type: 'assistant' }> }> = (props) => (
+  <article class="turn turn--assistant">
+    <header class="turn__author">● assistant</header>
+    <p class="turn__body">
+      {props.turn.text}
+      <Show when={props.turn.isStreaming}>
+        <span class="streaming-cursor" data-testid="streaming-cursor" aria-hidden="true" />
+      </Show>
+    </p>
+  </article>
+);
+
+const ErrorTurn: Component<{ turn: Extract<ChatTurn, { type: 'error' }> }> = (props) => (
+  <div class="turn turn--error" role="alert">
+    <span class="turn__error-icon" aria-hidden="true">!</span>
+    <span class="turn__error-message">{props.turn.message}</span>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Composer
+// ---------------------------------------------------------------------------
+
+const Composer: Component<{ disabled: boolean; onSend: (text: string) => void }> = (props) => {
+  const [text, setText] = createSignal('');
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key !== 'Enter') return;
+
+    // Option B: modifier keys = newline, bare Enter = send
+    if (e.shiftKey || e.ctrlKey || e.metaKey) return;
+
+    e.preventDefault();
+    const value = text().trim();
+    if (!value) return;
+    props.onSend(value);
+    setText('');
+  };
+
+  return (
+    <div class="composer">
+      <textarea
+        class="composer__textarea"
+        data-testid="composer-textarea"
+        placeholder="Ask, refine, or @-reference context"
+        disabled={props.disabled}
+        value={text()}
+        onInput={(e) => setText(e.currentTarget.value)}
+        onKeyDown={handleKeyDown}
+        rows={3}
+      />
+      <div class="composer__bar">
+        <span class="composer__hints">
+          <span class="composer__hint">@ for context</span>
+          <span class="composer__hint">/ for commands</span>
+        </span>
+        <div class="composer__actions">
+          <Show when={props.disabled}>
+            <button type="button" class="composer__btn composer__btn--ghost">
+              Stop
+            </button>
+          </Show>
+          <span class="composer__send-hint">
+            {props.disabled ? 'Streaming…' : 'Send ↵'}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// ChatPane root
+// ---------------------------------------------------------------------------
+
 export const ChatPane: Component = () => {
+  const sessionId = () => activeSessionId();
+  const state = createMemo(() => {
+    const id = sessionId();
+    if (!id) return { turns: [], awaitingResponse: false, streamingMessageId: null };
+    return getMessagesState(id);
+  });
+
+  let listRef: HTMLDivElement | undefined;
+  // Track whether the user has scrolled up (released auto-pin)
+  const [userScrolledUp, setUserScrolledUp] = createSignal(false);
+
+  const scrollToBottom = () => {
+    if (listRef) {
+      listRef.scrollTop = listRef.scrollHeight;
+    }
+  };
+
+  // Auto-scroll to bottom when turns change or streaming progresses,
+  // as long as the user hasn't scrolled up to read earlier content.
+  createEffect(() => {
+    const { turns, streamingMessageId } = state();
+    // Access both to establish reactive dependencies; values unused directly.
+    const _len = turns.length;
+    const _sid = streamingMessageId;
+    if (!userScrolledUp()) {
+      scrollToBottom();
+    }
+  });
+
+  const handleListScroll = () => {
+    if (!listRef) return;
+    const atBottom = listRef.scrollHeight - listRef.scrollTop - listRef.clientHeight < 8;
+    setUserScrolledUp(!atBottom);
+  };
+
+  const handleSend = (text: string) => {
+    const id = sessionId();
+    if (!id) return;
+    setAwaitingResponse(id, true);
+    // Re-pin on new user message
+    setUserScrolledUp(false);
+    void invoke('session_send_message', { sessionId: id, text });
+  };
+
   return (
     <section class="chat-pane" data-testid="chat-pane" aria-label="Chat pane">
       <span class="chat-pane__type-label">CHAT</span>
-      <p class="chat-pane__placeholder">Chat pane awaiting F-025.</p>
+      {/* Streaming indicator shown while awaiting a response */}
+      <Show when={state().awaitingResponse}>
+        <div class="chat-pane__streaming-indicator" data-testid="streaming-indicator" aria-live="polite">
+          <span class="streaming-cursor" aria-hidden="true" />
+          <span>Awaiting response…</span>
+        </div>
+      </Show>
+
+      {/* Message list */}
+      <div
+        class="chat-pane__messages"
+        data-testid="message-list"
+        data-autoscroll=""
+        role="log"
+        aria-live="polite"
+        ref={listRef}
+        onScroll={handleListScroll}
+      >
+        <For each={state().turns}>
+          {(turn) => {
+            switch (turn.type) {
+              case 'user':
+                return <UserBubble turn={turn} />;
+              case 'assistant':
+                return <AssistantBubble turn={turn} />;
+              case 'tool_placeholder':
+                return <ToolCallPlaceholder turn={turn} />;
+              case 'error':
+                return <ErrorTurn turn={turn} />;
+            }
+          }}
+        </For>
+      </div>
+
+      {/* Composer */}
+      <Composer disabled={state().awaitingResponse} onSend={handleSend} />
     </section>
   );
 };

--- a/web/packages/app/src/routes/Session/SessionWindow.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.tsx
@@ -12,6 +12,7 @@ import {
   setSessionEvents,
   setSessions,
 } from '../../stores/session';
+import { pushEvent, type SessionEvent } from '../../stores/messages';
 import { PaneHeader } from './PaneHeader';
 import { ChatPane } from './ChatPane';
 import './SessionWindow.css';
@@ -27,6 +28,7 @@ export const SessionWindow: Component = () => {
   const sessionId = () => params.id as SessionId;
 
   let unlisten: (() => void) | null = null;
+  let mounted = true;
 
   onMount(() => {
     const id = sessionId();
@@ -40,17 +42,26 @@ export const SessionWindow: Component = () => {
       } catch (err) {
         console.error('session_hello/subscribe failed', err);
       }
-      unlisten = await onSessionEvent((payload) => {
+      const listener = await onSessionEvent((payload) => {
         if (payload.session_id !== id) return;
         setSessionEvents(payload.session_id, {
           lastSeq: payload.seq,
           lastEvent: payload.event,
         });
+        // Route typed events to the messages store for ChatPane rendering.
+        pushEvent(payload.session_id, payload.event as SessionEvent);
       });
+      if (mounted) {
+        unlisten = listener;
+      } else {
+        // Component unmounted before the async setup completed — detach immediately.
+        listener();
+      }
     })();
   });
 
   onCleanup(() => {
+    mounted = false;
     if (unlisten) {
       unlisten();
       unlisten = null;

--- a/web/packages/app/src/stores/messages.test.ts
+++ b/web/packages/app/src/stores/messages.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  pushEvent,
+  setAwaitingResponse,
+  getMessagesState,
+  resetMessagesStore,
+} from './messages';
+import type { SessionId } from '@forge/ipc';
+
+const SID = 'session-test' as SessionId;
+
+describe('messages store', () => {
+  beforeEach(() => {
+    resetMessagesStore();
+  });
+
+  describe('UserMessage events', () => {
+    it('appends a user turn', () => {
+      pushEvent(SID, { kind: 'UserMessage', text: 'hello', message_id: 'msg-1' });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+      expect(state.turns[0]).toMatchObject({ type: 'user', text: 'hello', message_id: 'msg-1' });
+    });
+  });
+
+  describe('AssistantMessage events (complete)', () => {
+    it('appends a non-streaming assistant turn', () => {
+      pushEvent(SID, { kind: 'AssistantMessage', text: 'hi there', message_id: 'msg-2' });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+      expect(state.turns[0]).toMatchObject({
+        type: 'assistant',
+        text: 'hi there',
+        message_id: 'msg-2',
+        isStreaming: false,
+      });
+    });
+
+    it('clears streamingMessageId on AssistantMessage', () => {
+      pushEvent(SID, { kind: 'AssistantDelta', delta: 'partial', message_id: 'msg-3' });
+      pushEvent(SID, { kind: 'AssistantMessage', text: 'partial complete', message_id: 'msg-3' });
+      const state = getMessagesState(SID);
+      expect(state.streamingMessageId).toBeNull();
+    });
+
+    it('clears awaitingResponse on AssistantMessage', () => {
+      setAwaitingResponse(SID, true);
+      pushEvent(SID, { kind: 'AssistantMessage', text: 'response', message_id: 'msg-4' });
+      expect(getMessagesState(SID).awaitingResponse).toBe(false);
+    });
+  });
+
+  describe('AssistantDelta events (streaming)', () => {
+    it('creates a streaming assistant turn on first delta', () => {
+      pushEvent(SID, { kind: 'AssistantDelta', delta: 'Hello', message_id: 'msg-5' });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+      expect(state.turns[0]).toMatchObject({
+        type: 'assistant',
+        isStreaming: true,
+        message_id: 'msg-5',
+      });
+      expect(state.streamingMessageId).toBe('msg-5');
+    });
+
+    it('accumulates delta text across multiple deltas', () => {
+      pushEvent(SID, { kind: 'AssistantDelta', delta: 'Hello', message_id: 'msg-6' });
+      pushEvent(SID, { kind: 'AssistantDelta', delta: ' world', message_id: 'msg-6' });
+      pushEvent(SID, { kind: 'AssistantDelta', delta: '!', message_id: 'msg-6' });
+      const state = getMessagesState(SID);
+      expect(state.turns[0]).toMatchObject({ text: 'Hello world!' });
+    });
+
+    it('clears awaitingResponse when first delta arrives', () => {
+      setAwaitingResponse(SID, true);
+      pushEvent(SID, { kind: 'AssistantDelta', delta: 'start', message_id: 'msg-7' });
+      expect(getMessagesState(SID).awaitingResponse).toBe(false);
+    });
+
+    it('does not create duplicate turns for the same message_id', () => {
+      pushEvent(SID, { kind: 'AssistantDelta', delta: 'chunk1', message_id: 'msg-8' });
+      pushEvent(SID, { kind: 'AssistantDelta', delta: 'chunk2', message_id: 'msg-8' });
+      expect(getMessagesState(SID).turns).toHaveLength(1);
+    });
+  });
+
+  describe('ToolCallStarted / ToolCallCompleted events', () => {
+    it('appends a tool placeholder on ToolCallStarted', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-1',
+        tool_name: 'fs.read',
+        args_json: '{"path":"/foo"}',
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+      expect(state.turns[0]).toMatchObject({
+        type: 'tool_placeholder',
+        tool_call_id: 'tc-1',
+        tool_name: 'fs.read',
+        completed: false,
+      });
+    });
+
+    it('marks the placeholder completed on ToolCallCompleted', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-2',
+        tool_name: 'fs.write',
+        args_json: '{}',
+      });
+      pushEvent(SID, {
+        kind: 'ToolCallCompleted',
+        tool_call_id: 'tc-2',
+        result_summary: 'ok',
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns[0]).toMatchObject({
+        type: 'tool_placeholder',
+        completed: true,
+      });
+    });
+  });
+
+  describe('Error events', () => {
+    it('appends an error turn', () => {
+      pushEvent(SID, { kind: 'Error', message: 'ECONNREFUSED 127.0.0.1:11434' });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+      expect(state.turns[0]).toMatchObject({
+        type: 'error',
+        message: 'ECONNREFUSED 127.0.0.1:11434',
+      });
+    });
+
+    it('clears awaitingResponse on Error', () => {
+      setAwaitingResponse(SID, true);
+      pushEvent(SID, { kind: 'Error', message: 'failed' });
+      expect(getMessagesState(SID).awaitingResponse).toBe(false);
+    });
+
+    it('clears streamingMessageId on Error', () => {
+      pushEvent(SID, { kind: 'AssistantDelta', delta: 'partial', message_id: 'msg-9' });
+      pushEvent(SID, { kind: 'Error', message: 'stream cut' });
+      expect(getMessagesState(SID).streamingMessageId).toBeNull();
+    });
+  });
+
+  describe('awaitingResponse', () => {
+    it('defaults to false', () => {
+      expect(getMessagesState(SID).awaitingResponse).toBe(false);
+    });
+
+    it('can be set to true', () => {
+      setAwaitingResponse(SID, true);
+      expect(getMessagesState(SID).awaitingResponse).toBe(true);
+    });
+  });
+
+  describe('multi-session isolation', () => {
+    it('keeps turns isolated per session', () => {
+      const SID2 = 'session-other' as SessionId;
+      pushEvent(SID, { kind: 'UserMessage', text: 'hello sid1', message_id: 'a' });
+      pushEvent(SID2, { kind: 'UserMessage', text: 'hello sid2', message_id: 'b' });
+      expect(getMessagesState(SID).turns).toHaveLength(1);
+      expect(getMessagesState(SID2).turns).toHaveLength(1);
+      expect(getMessagesState(SID).turns[0]!.type).toBe('user');
+    });
+  });
+});

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -1,0 +1,184 @@
+import { createStore, produce, reconcile } from 'solid-js/store';
+import type { SessionId } from '@forge/ipc';
+
+// ---------------------------------------------------------------------------
+// Event shapes arriving from the IPC bridge (session:event payload)
+// ---------------------------------------------------------------------------
+
+export type SessionEvent =
+  | { kind: 'UserMessage'; text: string; message_id: string }
+  | { kind: 'AssistantMessage'; text: string; message_id: string }
+  | { kind: 'AssistantDelta'; delta: string; message_id: string }
+  | { kind: 'ToolCallStarted'; tool_call_id: string; tool_name: string; args_json: string }
+  | { kind: 'ToolCallCompleted'; tool_call_id: string; result_summary: string }
+  | { kind: 'Error'; message: string }
+  | { kind: 'StreamingStarted' }
+  | { kind: 'StreamingStopped' };
+
+// ---------------------------------------------------------------------------
+// Chat turn shapes (derived, used for rendering)
+// ---------------------------------------------------------------------------
+
+export type ChatTurn =
+  | { type: 'user'; text: string; message_id: string }
+  | { type: 'assistant'; text: string; message_id: string; isStreaming: boolean }
+  | { type: 'tool_placeholder'; tool_call_id: string; tool_name: string; completed: boolean }
+  | { type: 'error'; message: string };
+
+// ---------------------------------------------------------------------------
+// Per-session messages state
+// ---------------------------------------------------------------------------
+
+export interface MessagesState {
+  turns: ChatTurn[];
+  awaitingResponse: boolean;
+  streamingMessageId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const [messagesStore, setMessagesStore] = createStore<Record<string, MessagesState>>({});
+
+function ensureSession(sessionId: SessionId): void {
+  if (!messagesStore[sessionId]) {
+    setMessagesStore(sessionId, {
+      turns: [],
+      awaitingResponse: false,
+      streamingMessageId: null,
+    });
+  }
+}
+
+export function getMessagesState(sessionId: SessionId): MessagesState {
+  ensureSession(sessionId);
+  return messagesStore[sessionId]!;
+}
+
+export function setAwaitingResponse(sessionId: SessionId, value: boolean): void {
+  ensureSession(sessionId);
+  setMessagesStore(sessionId, 'awaitingResponse', value);
+}
+
+export function pushEvent(sessionId: SessionId, event: SessionEvent): void {
+  ensureSession(sessionId);
+
+  switch (event.kind) {
+    case 'UserMessage': {
+      setMessagesStore(
+        produce((s) => {
+          s[sessionId]!.turns.push({
+            type: 'user',
+            text: event.text,
+            message_id: event.message_id,
+          });
+        }),
+      );
+      break;
+    }
+
+    case 'AssistantMessage': {
+      setMessagesStore(
+        produce((s) => {
+          const state = s[sessionId]!;
+          // If there's a streaming turn for this message_id, update it in place.
+          const idx = state.turns.findIndex(
+            (t) => t.type === 'assistant' && t.message_id === event.message_id,
+          );
+          if (idx >= 0) {
+            const turn = state.turns[idx] as { type: 'assistant'; text: string; message_id: string; isStreaming: boolean };
+            turn.text = event.text;
+            turn.isStreaming = false;
+          } else {
+            state.turns.push({
+              type: 'assistant',
+              text: event.text,
+              message_id: event.message_id,
+              isStreaming: false,
+            });
+          }
+          state.streamingMessageId = null;
+          state.awaitingResponse = false;
+        }),
+      );
+      break;
+    }
+
+    case 'AssistantDelta': {
+      setMessagesStore(
+        produce((s) => {
+          const state = s[sessionId]!;
+          state.awaitingResponse = false;
+          const idx = state.turns.findIndex(
+            (t) => t.type === 'assistant' && t.message_id === event.message_id,
+          );
+          if (idx >= 0) {
+            const turn = state.turns[idx] as { type: 'assistant'; text: string; message_id: string; isStreaming: boolean };
+            turn.text += event.delta;
+          } else {
+            state.turns.push({
+              type: 'assistant',
+              text: event.delta,
+              message_id: event.message_id,
+              isStreaming: true,
+            });
+            state.streamingMessageId = event.message_id;
+          }
+        }),
+      );
+      break;
+    }
+
+    case 'ToolCallStarted': {
+      setMessagesStore(
+        produce((s) => {
+          s[sessionId]!.turns.push({
+            type: 'tool_placeholder',
+            tool_call_id: event.tool_call_id,
+            tool_name: event.tool_name,
+            completed: false,
+          });
+        }),
+      );
+      break;
+    }
+
+    case 'ToolCallCompleted': {
+      setMessagesStore(
+        produce((s) => {
+          const state = s[sessionId]!;
+          const idx = state.turns.findIndex(
+            (t) => t.type === 'tool_placeholder' && t.tool_call_id === event.tool_call_id,
+          );
+          if (idx >= 0) {
+            (state.turns[idx] as { type: 'tool_placeholder'; completed: boolean }).completed = true;
+          }
+        }),
+      );
+      break;
+    }
+
+    case 'Error': {
+      setMessagesStore(
+        produce((s) => {
+          const state = s[sessionId]!;
+          state.turns.push({ type: 'error', message: event.message });
+          state.awaitingResponse = false;
+          state.streamingMessageId = null;
+        }),
+      );
+      break;
+    }
+
+    case 'StreamingStarted':
+    case 'StreamingStopped':
+      // Handled implicitly via delta/message events.
+      break;
+  }
+}
+
+/** Test helper — clears all message state between tests. */
+export function resetMessagesStore(): void {
+  setMessagesStore(reconcile({}));
+}


### PR DESCRIPTION
Closes forge-ide/forge#43

## Summary

- Implements the full `ChatPane` body: message list, streaming states, and composer, replacing the F-024 placeholder
- Adds `messages.ts` store processing session IPC events (`UserMessage`, `AssistantMessage`, `AssistantDelta`, `ToolCallStarted/Completed`, `Error`) into typed turn records
- **Keyboard: Option B** (user-selected) — bare `Enter` sends, `Shift+Enter` / `Ctrl+Enter` / `Cmd+Enter` inserts a newline; `chat-pane.md §4.1` updated to match
- Auto-scroll pins to bottom while streaming, releases on user scroll-up; re-pins on new user send
- `ToolCallPlaceholder` stub renders tool events (replaced in F-026)
- Error turns render exact technical identifiers inline per voice-terminology.md
- Fixes an async cleanup race in `SessionWindow`: uses a `mounted` flag so listeners are detached immediately if the component unmounts before async setup completes
- 35 new tests (16 store, 19 component), 77 total passing

## Test plan

- `cd web && pnpm --filter app test` — 77/77 pass
- `pnpm --filter app typecheck` — clean
- `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)