### PR TITLE
[F-026] Tool call card data-layer plumbing

### DIFF
--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -60,7 +60,7 @@ describe('ChatPane rendering', () => {
     expect(queryByTestId('streaming-cursor')).not.toBeInTheDocument();
   });
 
-  it('renders a tool call placeholder', () => {
+  it('renders a tool call card', () => {
     pushEvent(SID, {
       kind: 'ToolCallStarted',
       tool_call_id: 'tc-1',
@@ -68,7 +68,7 @@ describe('ChatPane rendering', () => {
       args_json: '{}',
     });
     const { getByTestId } = render(() => <ChatPane />);
-    expect(getByTestId('tool-placeholder-tc-1')).toBeInTheDocument();
+    expect(getByTestId('tool-call-card-tc-1')).toBeInTheDocument();
   });
 
   it('renders an error turn inline', () => {

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -16,19 +16,19 @@ import {
 import './ChatPane.css';
 
 // ---------------------------------------------------------------------------
-// ToolCallPlaceholder — stub replaced in F-026
+// ToolCallCard — inline tool call card (F-026)
 // ---------------------------------------------------------------------------
 
-const ToolCallPlaceholder: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholder' }> }> = (props) => (
+const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholder' }> }> = (props) => (
   <div
     class="tool-placeholder"
-    data-testid={`tool-placeholder-${props.turn.tool_call_id}`}
-    classList={{ 'tool-placeholder--completed': props.turn.completed }}
+    data-testid={`tool-call-card-${props.turn.tool_call_id}`}
+    classList={{ 'tool-placeholder--completed': props.turn.status === 'completed' }}
   >
     <span class="tool-placeholder__icon" aria-hidden="true">⚙</span>
     <span class="tool-placeholder__name">{props.turn.tool_name}</span>
     <span class="tool-placeholder__status">
-      {props.turn.completed ? 'completed' : 'running'}
+      {props.turn.status}
     </span>
   </div>
 );
@@ -193,7 +193,7 @@ export const ChatPane: Component = () => {
               case 'assistant':
                 return <AssistantBubble turn={turn} />;
               case 'tool_placeholder':
-                return <ToolCallPlaceholder turn={turn} />;
+                return <ToolCallCard turn={turn} />;
               case 'error':
                 return <ErrorTurn turn={turn} />;
             }

--- a/web/packages/app/src/stores/messages.test.ts
+++ b/web/packages/app/src/stores/messages.test.ts
@@ -85,7 +85,7 @@ describe('messages store', () => {
   });
 
   describe('ToolCallStarted / ToolCallCompleted events', () => {
-    it('appends a tool placeholder on ToolCallStarted', () => {
+    it('appends a tool placeholder with status in-progress on ToolCallStarted', () => {
       pushEvent(SID, {
         kind: 'ToolCallStarted',
         tool_call_id: 'tc-1',
@@ -98,11 +98,76 @@ describe('messages store', () => {
         type: 'tool_placeholder',
         tool_call_id: 'tc-1',
         tool_name: 'fs.read',
-        completed: false,
+        status: 'in-progress',
       });
     });
 
-    it('marks the placeholder completed on ToolCallCompleted', () => {
+    it('preserves args_json on the turn', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-1',
+        tool_name: 'fs.read',
+        args_json: '{"path":"/foo"}',
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns[0]).toMatchObject({
+        type: 'tool_placeholder',
+        args_json: '{"path":"/foo"}',
+      });
+    });
+
+    it('preserves batch_id on the turn when provided', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-1',
+        tool_name: 'fs.read',
+        args_json: '{}',
+        batch_id: 'batch-42',
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns[0]).toMatchObject({
+        type: 'tool_placeholder',
+        batch_id: 'batch-42',
+      });
+    });
+
+    it('records started_at as a number on ToolCallStarted', () => {
+      const before = Date.now();
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-1',
+        tool_name: 'fs.read',
+        args_json: '{}',
+      });
+      const after = Date.now();
+      const state = getMessagesState(SID);
+      const turn = state.turns[0] as { started_at: number };
+      expect(typeof turn.started_at).toBe('number');
+      expect(turn.started_at).toBeGreaterThanOrEqual(before);
+      expect(turn.started_at).toBeLessThanOrEqual(after);
+    });
+
+    it('marks status completed and stores result_summary on ToolCallCompleted', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-2',
+        tool_name: 'fs.write',
+        args_json: '{}',
+      });
+      pushEvent(SID, {
+        kind: 'ToolCallCompleted',
+        tool_call_id: 'tc-2',
+        result_summary: 'wrote 42 bytes',
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns[0]).toMatchObject({
+        type: 'tool_placeholder',
+        status: 'completed',
+        result_summary: 'wrote 42 bytes',
+      });
+    });
+
+    it('computes a non-negative duration_ms on ToolCallCompleted', () => {
       pushEvent(SID, {
         kind: 'ToolCallStarted',
         tool_call_id: 'tc-2',
@@ -115,10 +180,47 @@ describe('messages store', () => {
         result_summary: 'ok',
       });
       const state = getMessagesState(SID);
+      const turn = state.turns[0] as { duration_ms?: number };
+      expect(typeof turn.duration_ms).toBe('number');
+      expect(turn.duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it('sets status errored and stores error on ToolCallFailed', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-3',
+        tool_name: 'shell.exec',
+        args_json: '{"cmd":"rm -rf /"}',
+      });
+      pushEvent(SID, {
+        kind: 'ToolCallFailed',
+        tool_call_id: 'tc-3',
+        error: 'permission denied',
+      });
+      const state = getMessagesState(SID);
       expect(state.turns[0]).toMatchObject({
         type: 'tool_placeholder',
-        completed: true,
+        status: 'errored',
+        error: 'permission denied',
       });
+    });
+
+    it('computes a non-negative duration_ms on ToolCallFailed', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-3',
+        tool_name: 'shell.exec',
+        args_json: '{}',
+      });
+      pushEvent(SID, {
+        kind: 'ToolCallFailed',
+        tool_call_id: 'tc-3',
+        error: 'timeout',
+      });
+      const state = getMessagesState(SID);
+      const turn = state.turns[0] as { duration_ms?: number };
+      expect(typeof turn.duration_ms).toBe('number');
+      expect(turn.duration_ms).toBeGreaterThanOrEqual(0);
     });
   });
 

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -9,8 +9,9 @@ export type SessionEvent =
   | { kind: 'UserMessage'; text: string; message_id: string }
   | { kind: 'AssistantMessage'; text: string; message_id: string }
   | { kind: 'AssistantDelta'; delta: string; message_id: string }
-  | { kind: 'ToolCallStarted'; tool_call_id: string; tool_name: string; args_json: string }
+  | { kind: 'ToolCallStarted'; tool_call_id: string; tool_name: string; args_json: string; batch_id?: string }
   | { kind: 'ToolCallCompleted'; tool_call_id: string; result_summary: string }
+  | { kind: 'ToolCallFailed'; tool_call_id: string; error: string }
   | { kind: 'Error'; message: string }
   | { kind: 'StreamingStarted' }
   | { kind: 'StreamingStopped' };
@@ -19,10 +20,23 @@ export type SessionEvent =
 // Chat turn shapes (derived, used for rendering)
 // ---------------------------------------------------------------------------
 
+export type ToolCallStatus = 'in-progress' | 'awaiting-approval' | 'completed' | 'errored';
+
 export type ChatTurn =
   | { type: 'user'; text: string; message_id: string }
   | { type: 'assistant'; text: string; message_id: string; isStreaming: boolean }
-  | { type: 'tool_placeholder'; tool_call_id: string; tool_name: string; completed: boolean }
+  | {
+      type: 'tool_placeholder';
+      tool_call_id: string;
+      tool_name: string;
+      args_json: string;
+      batch_id?: string;
+      status: ToolCallStatus;
+      started_at: number;
+      duration_ms?: number;
+      result_summary?: string;
+      error?: string;
+    }
   | { type: 'error'; message: string };
 
 // ---------------------------------------------------------------------------
@@ -137,7 +151,10 @@ export function pushEvent(sessionId: SessionId, event: SessionEvent): void {
             type: 'tool_placeholder',
             tool_call_id: event.tool_call_id,
             tool_name: event.tool_name,
-            completed: false,
+            args_json: event.args_json,
+            ...(event.batch_id !== undefined ? { batch_id: event.batch_id } : {}),
+            status: 'in-progress',
+            started_at: Date.now(),
           });
         }),
       );
@@ -152,7 +169,28 @@ export function pushEvent(sessionId: SessionId, event: SessionEvent): void {
             (t) => t.type === 'tool_placeholder' && t.tool_call_id === event.tool_call_id,
           );
           if (idx >= 0) {
-            (state.turns[idx] as { type: 'tool_placeholder'; completed: boolean }).completed = true;
+            const turn = state.turns[idx] as Extract<ChatTurn, { type: 'tool_placeholder' }>;
+            turn.status = 'completed';
+            turn.result_summary = event.result_summary;
+            turn.duration_ms = Date.now() - turn.started_at;
+          }
+        }),
+      );
+      break;
+    }
+
+    case 'ToolCallFailed': {
+      setMessagesStore(
+        produce((s) => {
+          const state = s[sessionId]!;
+          const idx = state.turns.findIndex(
+            (t) => t.type === 'tool_placeholder' && t.tool_call_id === event.tool_call_id,
+          );
+          if (idx >= 0) {
+            const turn = state.turns[idx] as Extract<ChatTurn, { type: 'tool_placeholder' }>;
+            turn.status = 'errored';
+            turn.error = event.error;
+            turn.duration_ms = Date.now() - turn.started_at;
           }
         }),
       );


### PR DESCRIPTION
Closes forge-ide/forge#44

## Summary

Data-layer plumbing for the F-026 tool call card. All changes are TypeScript-only in `web/packages/app`.

- Add `batch_id?: string` to `ToolCallStarted` event type and preserve it on the `tool_placeholder` turn
- Preserve `args_json` on the turn shape (was previously dropped after event dispatch)
- Add `ToolCallFailed` event `{ kind, tool_call_id, error }` to `SessionEvent`
- Replace `completed: boolean` on `tool_placeholder` ChatTurn with 4-state `ToolCallStatus` enum: `'in-progress' | 'awaiting-approval' | 'completed' | 'errored'`
- Capture `started_at: number` via `Date.now()` on `ToolCallStarted`; compute `duration_ms` on `ToolCallCompleted` and `ToolCallFailed`
- Store `result_summary` string on turn from `ToolCallCompleted` (no backend protocol changes)
- Rename `ToolCallPlaceholder` → `ToolCallCard`; update `data-testid` prefix from `tool-placeholder-` to `tool-call-card-`
- 8 new tests covering all new fields and the `ToolCallFailed` path; all 83 tests pass

## Test plan

- `npx vitest run` passes (83/83)
- `npx tsc --noEmit` passes (zero type errors, including `exactOptionalPropertyTypes`)
- `cargo fmt --check && cargo check --workspace && cargo clippy --all-targets -- -D warnings` all pass (no Rust changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)