### PR TITLE
[F-027] Four-scope inline approval UI

### DIFF
--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
@@ -1,0 +1,202 @@
+/* ---------------------------------------------------------------------------
+   ApprovalPrompt — inline approval UI inside tool call cards
+   --------------------------------------------------------------------------- */
+
+.approval-prompt {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  padding: var(--sp-3) 0 0;
+}
+
+/* -------------------------------------------------------------------------
+   Preview
+   ---------------------------------------------------------------------- */
+
+.approval-prompt__preview {
+  border: 1px solid var(--color-warning-border);
+  border-radius: var(--r-sm);
+  background: var(--color-warning-bg);
+  overflow: hidden;
+}
+
+.approval-prompt__preview-text {
+  margin: 0;
+  padding: var(--sp-3) var(--sp-4);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/* -------------------------------------------------------------------------
+   Pattern editor
+   ---------------------------------------------------------------------- */
+
+.approval-prompt__pattern-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.approval-prompt__pattern-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+
+.approval-prompt__pattern-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.approval-prompt__pattern-input {
+  flex: 1 1 auto;
+  padding: var(--sp-1) var(--sp-2);
+  background: var(--color-surface-3);
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-primary);
+  outline: none;
+}
+
+.approval-prompt__pattern-input:focus {
+  border-color: var(--color-ember-400);
+}
+
+/* -------------------------------------------------------------------------
+   Actions row
+   ---------------------------------------------------------------------- */
+
+.approval-prompt__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+}
+
+.approval-prompt__approve-group {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+/* -------------------------------------------------------------------------
+   Buttons
+   ---------------------------------------------------------------------- */
+
+.approval-prompt__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: var(--ease);
+  line-height: 1;
+}
+
+.approval-prompt__btn--ghost {
+  background: transparent;
+  border: 1px solid var(--color-border-2);
+  color: var(--color-text-secondary);
+}
+
+.approval-prompt__btn--ghost:hover {
+  border-color: var(--color-text-secondary);
+  color: var(--color-text-primary);
+}
+
+.approval-prompt__btn--primary {
+  background: var(--color-ember-400);
+  border: 1px solid var(--color-ember-400);
+  color: var(--color-text-primary);
+}
+
+.approval-prompt__btn--primary:hover {
+  background: var(--color-ember-300);
+  border-color: var(--color-ember-300);
+}
+
+.approval-prompt__btn--primary:active {
+  background: var(--color-ember-500);
+  border-color: var(--color-ember-500);
+}
+
+/* Split-button seam between Approve and ▾ */
+.approval-prompt__approve-group .approval-prompt__btn--primary:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right-color: var(--color-ember-500);
+}
+
+.approval-prompt__dropdown-toggle {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  padding-left: var(--sp-2);
+  padding-right: var(--sp-2);
+  font-size: 9px;
+}
+
+/* -------------------------------------------------------------------------
+   Keyboard hint badges
+   ---------------------------------------------------------------------- */
+
+.approval-prompt__kbd {
+  display: inline-block;
+  padding: 0 var(--sp-1);
+  border: 1px solid currentColor;
+  border-radius: 2px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  opacity: 0.6;
+  line-height: 1.4;
+}
+
+/* -------------------------------------------------------------------------
+   Scope dropdown menu
+   ---------------------------------------------------------------------- */
+
+.approval-prompt__menu {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  right: 0;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  min-width: 160px;
+  z-index: 100;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.approval-prompt__menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  background: transparent;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  text-align: left;
+  transition: var(--ease);
+}
+
+.approval-prompt__menu-item:hover {
+  background: var(--color-surface-3);
+  color: var(--color-ember-300);
+}

--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.test.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.test.tsx
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import { ApprovalPrompt } from './ApprovalPrompt';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FS_EDIT_ARGS = JSON.stringify({ path: '/src/foo.ts', patch: '...' });
+const SHELL_ARGS = JSON.stringify({ command: '/bin/sh', args: ['-c', 'echo hi'] });
+const PREVIEW = { description: 'Edit file /src/foo.ts: 3 hunks, +47 -21' };
+
+function makeContainer(): HTMLDivElement {
+  const el = document.createElement('div');
+  el.tabIndex = 0;
+  document.body.appendChild(el);
+  return el;
+}
+
+function renderPrompt(
+  overrides: Partial<{
+    toolName: string;
+    argsJson: string;
+    onApprove: ReturnType<typeof vi.fn>;
+    onReject: ReturnType<typeof vi.fn>;
+  }> = {},
+) {
+  const container = makeContainer();
+  const onApprove = overrides.onApprove ?? vi.fn();
+  const onReject = overrides.onReject ?? vi.fn();
+
+  const result = render(
+    () => (
+      <ApprovalPrompt
+        toolCallId="tc-test"
+        toolName={overrides.toolName ?? 'fs.edit'}
+        argsJson={overrides.argsJson ?? FS_EDIT_ARGS}
+        preview={PREVIEW}
+        containerRef={container}
+        onApprove={onApprove}
+        onReject={onReject}
+      />
+    ),
+    { container },
+  );
+
+  return { ...result, container, onApprove, onReject };
+}
+
+beforeEach(() => {
+  // Remove any appended containers from the previous test
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe('ApprovalPrompt rendering', () => {
+  it('renders the approval prompt container', () => {
+    const { getByTestId } = renderPrompt();
+    expect(getByTestId('approval-prompt')).toBeInTheDocument();
+  });
+
+  it('renders the preview text', () => {
+    const { getByTestId } = renderPrompt();
+    expect(getByTestId('approval-preview')).toHaveTextContent('Edit file /src/foo.ts');
+  });
+
+  it('renders reject and approve buttons', () => {
+    const { getByTestId } = renderPrompt();
+    expect(getByTestId('reject-btn')).toBeInTheDocument();
+    expect(getByTestId('approve-once-btn')).toBeInTheDocument();
+    expect(getByTestId('approve-dropdown-btn')).toBeInTheDocument();
+  });
+
+  it('shows file-scope buttons for fs.edit with a path', () => {
+    const { getByTestId } = renderPrompt({ toolName: 'fs.edit', argsJson: FS_EDIT_ARGS });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    expect(getByTestId('scope-file-btn')).toBeInTheDocument();
+    expect(getByTestId('scope-pattern-btn')).toBeInTheDocument();
+  });
+
+  it('shows file-scope buttons for fs.write with a path', () => {
+    const { getByTestId } = renderPrompt({
+      toolName: 'fs.write',
+      argsJson: JSON.stringify({ path: '/src/foo.ts', content: 'hello' }),
+    });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    expect(getByTestId('scope-file-btn')).toBeInTheDocument();
+  });
+
+  it('does not show file-scope buttons for shell.exec', () => {
+    const { getByTestId, queryByTestId } = renderPrompt({
+      toolName: 'shell.exec',
+      argsJson: SHELL_ARGS,
+    });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    expect(queryByTestId('scope-file-btn')).not.toBeInTheDocument();
+    expect(queryByTestId('scope-pattern-btn')).not.toBeInTheDocument();
+  });
+
+  it('always shows ThisTool scope in dropdown', () => {
+    const { getByTestId } = renderPrompt({ toolName: 'shell.exec', argsJson: SHELL_ARGS });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    expect(getByTestId('scope-tool-btn')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope selection via buttons
+// ---------------------------------------------------------------------------
+
+describe('Scope selection — button clicks', () => {
+  it('calls onApprove with Once when approve button is clicked', () => {
+    const onApprove = vi.fn();
+    const { getByTestId } = renderPrompt({ onApprove });
+    fireEvent.click(getByTestId('approve-once-btn'));
+    expect(onApprove).toHaveBeenCalledWith('Once', undefined);
+  });
+
+  it('calls onApprove with Once from scope menu', () => {
+    const onApprove = vi.fn();
+    const { getByTestId } = renderPrompt({ onApprove });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-once-btn'));
+    expect(onApprove).toHaveBeenCalledWith('Once', undefined);
+  });
+
+  it('calls onApprove with ThisFile from scope menu', () => {
+    const onApprove = vi.fn();
+    const { getByTestId } = renderPrompt({ onApprove });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-file-btn'));
+    expect(onApprove).toHaveBeenCalledWith('ThisFile', undefined);
+  });
+
+  it('opens pattern editor when ThisPattern is selected', () => {
+    const { getByTestId } = renderPrompt();
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-pattern-btn'));
+    expect(getByTestId('pattern-editor')).toBeInTheDocument();
+    expect(getByTestId('pattern-input')).toBeInTheDocument();
+  });
+
+  it('pre-fills pattern input with directory glob', () => {
+    const { getByTestId } = renderPrompt();
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-pattern-btn'));
+    const input = getByTestId('pattern-input') as HTMLInputElement;
+    expect(input.value).toBe('/src/*');
+  });
+
+  it('calls onApprove with ThisPattern and edited glob on confirm', () => {
+    const onApprove = vi.fn();
+    const { getByTestId } = renderPrompt({ onApprove });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-pattern-btn'));
+    const input = getByTestId('pattern-input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: '/src/**' } });
+    fireEvent.click(getByTestId('pattern-confirm-btn'));
+    expect(onApprove).toHaveBeenCalledWith('ThisPattern', '/src/**');
+  });
+
+  it('cancels pattern editor without calling onApprove', () => {
+    const onApprove = vi.fn();
+    const { getByTestId, queryByTestId } = renderPrompt({ onApprove });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-pattern-btn'));
+    fireEvent.click(getByTestId('pattern-cancel-btn'));
+    expect(queryByTestId('pattern-editor')).not.toBeInTheDocument();
+    expect(onApprove).not.toHaveBeenCalled();
+  });
+
+  it('calls onApprove with ThisTool from scope menu', () => {
+    const onApprove = vi.fn();
+    const { getByTestId } = renderPrompt({ onApprove });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-tool-btn'));
+    expect(onApprove).toHaveBeenCalledWith('ThisTool', undefined);
+  });
+
+  it('calls onReject when reject button is clicked', () => {
+    const onReject = vi.fn();
+    const { getByTestId } = renderPrompt({ onReject });
+    fireEvent.click(getByTestId('reject-btn'));
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard shortcuts
+// ---------------------------------------------------------------------------
+
+describe('Keyboard shortcuts', () => {
+  it('R key calls onReject', () => {
+    const onReject = vi.fn();
+    const { container } = renderPrompt({ onReject });
+    fireEvent.keyDown(container, { key: 'r' });
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+
+  it('Shift+R also calls onReject', () => {
+    const onReject = vi.fn();
+    const { container } = renderPrompt({ onReject });
+    fireEvent.keyDown(container, { key: 'R' });
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+
+  it('A key calls onApprove with Once', () => {
+    const onApprove = vi.fn();
+    const { container } = renderPrompt({ onApprove });
+    fireEvent.keyDown(container, { key: 'a' });
+    expect(onApprove).toHaveBeenCalledWith('Once', undefined);
+  });
+
+  it('Enter key calls onApprove with Once', () => {
+    const onApprove = vi.fn();
+    const { container } = renderPrompt({ onApprove });
+    fireEvent.keyDown(container, { key: 'Enter' });
+    expect(onApprove).toHaveBeenCalledWith('Once', undefined);
+  });
+
+  it('F key calls onApprove with ThisFile for fs.edit', () => {
+    const onApprove = vi.fn();
+    const { container } = renderPrompt({ onApprove, toolName: 'fs.edit', argsJson: FS_EDIT_ARGS });
+    fireEvent.keyDown(container, { key: 'f' });
+    expect(onApprove).toHaveBeenCalledWith('ThisFile', undefined);
+  });
+
+  it('F key does nothing for shell.exec (no file scopes)', () => {
+    const onApprove = vi.fn();
+    const { container } = renderPrompt({
+      onApprove,
+      toolName: 'shell.exec',
+      argsJson: SHELL_ARGS,
+    });
+    fireEvent.keyDown(container, { key: 'f' });
+    expect(onApprove).not.toHaveBeenCalled();
+  });
+
+  it('P key opens pattern editor for fs.edit', () => {
+    const { container, getByTestId } = renderPrompt({
+      toolName: 'fs.edit',
+      argsJson: FS_EDIT_ARGS,
+    });
+    fireEvent.keyDown(container, { key: 'p' });
+    expect(getByTestId('pattern-editor')).toBeInTheDocument();
+  });
+
+  it('P key does nothing for shell.exec', () => {
+    const { container, queryByTestId } = renderPrompt({
+      toolName: 'shell.exec',
+      argsJson: SHELL_ARGS,
+    });
+    fireEvent.keyDown(container, { key: 'p' });
+    expect(queryByTestId('pattern-editor')).not.toBeInTheDocument();
+  });
+
+  it('T key calls onApprove with ThisTool', () => {
+    const onApprove = vi.fn();
+    const { container } = renderPrompt({ onApprove });
+    fireEvent.keyDown(container, { key: 't' });
+    expect(onApprove).toHaveBeenCalledWith('ThisTool', undefined);
+  });
+
+  it('Escape key closes pattern editor', () => {
+    const { container, getByTestId, queryByTestId } = renderPrompt();
+    fireEvent.keyDown(container, { key: 'p' });
+    expect(getByTestId('pattern-editor')).toBeInTheDocument();
+    fireEvent.keyDown(container, { key: 'Escape' });
+    expect(queryByTestId('pattern-editor')).not.toBeInTheDocument();
+  });
+
+  it('shortcuts do not fire while pattern editor is open (except Escape)', () => {
+    const onApprove = vi.fn();
+    const { container } = renderPrompt({ onApprove });
+    fireEvent.keyDown(container, { key: 'p' }); // open pattern editor
+    fireEvent.keyDown(container, { key: 'a' }); // should not approve
+    expect(onApprove).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tsx
@@ -1,0 +1,238 @@
+import {
+  type Component,
+  createSignal,
+  Show,
+  onMount,
+  onCleanup,
+} from 'solid-js';
+import type { ApprovalScope } from '@forge/ipc';
+import type { ApprovalPreview } from '../../stores/messages';
+import { defaultPatternForPath } from '../../stores/approvals';
+import './ApprovalPrompt.css';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ApprovalPromptProps {
+  toolCallId: string;
+  toolName: string;
+  argsJson: string;
+  preview: ApprovalPreview;
+  /** Container element to attach keyboard listeners to (the card div). */
+  containerRef: HTMLElement;
+  onApprove: (scope: ApprovalScope, pattern?: string) => void;
+  onReject: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractPath(argsJson: string): string {
+  try {
+    const args = JSON.parse(argsJson) as Record<string, unknown>;
+    return typeof args['path'] === 'string' ? args['path'] : '';
+  } catch {
+    return '';
+  }
+}
+
+function isFileTool(toolName: string): boolean {
+  return toolName === 'fs.edit' || toolName === 'fs.write';
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
+  const [menuOpen, setMenuOpen] = createSignal(false);
+  const [patternMode, setPatternMode] = createSignal(false);
+  const [pattern, setPattern] = createSignal('');
+
+  const path = () => extractPath(props.argsJson);
+  const showFileScopes = () => isFileTool(props.toolName) && path() !== '';
+
+  const openPatternEditor = () => {
+    setPattern(defaultPatternForPath(path()));
+    setMenuOpen(false);
+    setPatternMode(true);
+  };
+
+  const approveWithScope = (scope: ApprovalScope, pat?: string) => {
+    setMenuOpen(false);
+    setPatternMode(false);
+    props.onApprove(scope, pat);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    // Don't intercept if user is editing pattern input
+    if (patternMode()) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setPatternMode(false);
+      }
+      return;
+    }
+    if (e.key === 'r' || e.key === 'R') {
+      e.preventDefault();
+      props.onReject();
+    } else if (e.key === 'a' || e.key === 'A' || e.key === 'Enter') {
+      e.preventDefault();
+      approveWithScope('Once');
+    } else if ((e.key === 'f' || e.key === 'F') && showFileScopes()) {
+      e.preventDefault();
+      approveWithScope('ThisFile');
+    } else if ((e.key === 'p' || e.key === 'P') && showFileScopes()) {
+      e.preventDefault();
+      openPatternEditor();
+    } else if (e.key === 't' || e.key === 'T') {
+      e.preventDefault();
+      approveWithScope('ThisTool');
+    }
+  };
+
+  onMount(() => {
+    props.containerRef.addEventListener('keydown', handleKeyDown);
+  });
+
+  onCleanup(() => {
+    props.containerRef.removeEventListener('keydown', handleKeyDown);
+  });
+
+  return (
+    <div class="approval-prompt" data-testid="approval-prompt">
+      {/* Preview */}
+      <div class="approval-prompt__preview" data-testid="approval-preview">
+        <pre class="approval-prompt__preview-text">{props.preview.description}</pre>
+      </div>
+
+      {/* Pattern editor */}
+      <Show when={patternMode()}>
+        <div class="approval-prompt__pattern-editor" data-testid="pattern-editor">
+          <label class="approval-prompt__pattern-label" for="approval-pattern-input">
+            Approve this pattern:
+          </label>
+          <div class="approval-prompt__pattern-row">
+            <input
+              id="approval-pattern-input"
+              class="approval-prompt__pattern-input"
+              data-testid="pattern-input"
+              type="text"
+              value={pattern()}
+              onInput={(e) => setPattern(e.currentTarget.value)}
+            />
+            <button
+              type="button"
+              class="approval-prompt__btn approval-prompt__btn--primary"
+              data-testid="pattern-confirm-btn"
+              onClick={() => approveWithScope('ThisPattern', pattern())}
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              class="approval-prompt__btn approval-prompt__btn--ghost"
+              data-testid="pattern-cancel-btn"
+              onClick={() => setPatternMode(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </Show>
+
+      {/* Actions */}
+      <Show when={!patternMode()}>
+        <div class="approval-prompt__actions">
+          <button
+            type="button"
+            class="approval-prompt__btn approval-prompt__btn--ghost"
+            data-testid="reject-btn"
+            onClick={() => props.onReject()}
+          >
+            Reject
+            <kbd class="approval-prompt__kbd">R</kbd>
+          </button>
+
+          <div class="approval-prompt__approve-group">
+            {/* Primary approve button — Once (default) */}
+            <button
+              type="button"
+              class="approval-prompt__btn approval-prompt__btn--primary"
+              data-testid="approve-once-btn"
+              onClick={() => approveWithScope('Once')}
+            >
+              Approve
+              <kbd class="approval-prompt__kbd">A</kbd>
+            </button>
+
+            {/* Dropdown toggle */}
+            <button
+              type="button"
+              class="approval-prompt__btn approval-prompt__btn--primary approval-prompt__dropdown-toggle"
+              data-testid="approve-dropdown-btn"
+              aria-label="More approval scopes"
+              aria-expanded={menuOpen()}
+              onClick={() => setMenuOpen((v) => !v)}
+            >
+              ▾
+            </button>
+
+            {/* Scope menu */}
+            <Show when={menuOpen()}>
+              <div class="approval-prompt__menu" data-testid="scope-menu" role="menu">
+                <button
+                  type="button"
+                  class="approval-prompt__menu-item"
+                  data-testid="scope-once-btn"
+                  role="menuitem"
+                  onClick={() => approveWithScope('Once')}
+                >
+                  Once
+                  <kbd class="approval-prompt__kbd">A</kbd>
+                </button>
+
+                <Show when={showFileScopes()}>
+                  <button
+                    type="button"
+                    class="approval-prompt__menu-item"
+                    data-testid="scope-file-btn"
+                    role="menuitem"
+                    onClick={() => approveWithScope('ThisFile')}
+                  >
+                    This file
+                    <kbd class="approval-prompt__kbd">F</kbd>
+                  </button>
+
+                  <button
+                    type="button"
+                    class="approval-prompt__menu-item"
+                    data-testid="scope-pattern-btn"
+                    role="menuitem"
+                    onClick={openPatternEditor}
+                  >
+                    This pattern
+                    <kbd class="approval-prompt__kbd">P</kbd>
+                  </button>
+                </Show>
+
+                <button
+                  type="button"
+                  class="approval-prompt__menu-item"
+                  data-testid="scope-tool-btn"
+                  role="menuitem"
+                  onClick={() => approveWithScope('ThisTool')}
+                >
+                  This tool
+                  <kbd class="approval-prompt__kbd">T</kbd>
+                </button>
+              </div>
+            </Show>
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.css
+++ b/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.css
@@ -1,0 +1,70 @@
+/* ---------------------------------------------------------------------------
+   WhitelistedPill — shown in tool card header when a scope has been approved
+   --------------------------------------------------------------------------- */
+
+.whitelisted-pill-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.whitelisted-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 2px var(--sp-2);
+  background: var(--color-success-bg);
+  border: 1px solid var(--color-success-border);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-success);
+  cursor: pointer;
+  transition: var(--ease);
+}
+
+.whitelisted-pill:hover {
+  background: rgba(61, 220, 132, 0.14);
+}
+
+.whitelisted-pill__dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-success);
+  flex: 0 0 auto;
+}
+
+/* -------------------------------------------------------------------------
+   Popover
+   ---------------------------------------------------------------------- */
+
+.whitelisted-pill__popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  min-width: 180px;
+  overflow: hidden;
+}
+
+.whitelisted-pill__revoke-btn {
+  display: block;
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  background: transparent;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-error);
+  cursor: pointer;
+  text-align: left;
+  transition: var(--ease);
+}
+
+.whitelisted-pill__revoke-btn:hover {
+  background: var(--color-error-bg);
+}

--- a/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.test.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import { WhitelistedPill } from './WhitelistedPill';
+
+beforeEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+describe('WhitelistedPill', () => {
+  it('renders the pill with the label', () => {
+    const { getByTestId } = render(() => (
+      <WhitelistedPill label="this file" onRevoke={vi.fn()} />
+    ));
+    const pill = getByTestId('whitelisted-pill');
+    expect(pill).toBeInTheDocument();
+    expect(pill).toHaveTextContent('whitelisted · this file');
+  });
+
+  it('does not show popover initially', () => {
+    const { queryByTestId } = render(() => (
+      <WhitelistedPill label="this tool" onRevoke={vi.fn()} />
+    ));
+    expect(queryByTestId('whitelist-popover')).not.toBeInTheDocument();
+  });
+
+  it('opens popover on pill click', () => {
+    const { getByTestId } = render(() => (
+      <WhitelistedPill label="this file" onRevoke={vi.fn()} />
+    ));
+    fireEvent.click(getByTestId('whitelisted-pill'));
+    expect(getByTestId('whitelist-popover')).toBeInTheDocument();
+  });
+
+  it('closes popover on second click', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <WhitelistedPill label="this file" onRevoke={vi.fn()} />
+    ));
+    fireEvent.click(getByTestId('whitelisted-pill'));
+    fireEvent.click(getByTestId('whitelisted-pill'));
+    expect(queryByTestId('whitelist-popover')).not.toBeInTheDocument();
+  });
+
+  it('calls onRevoke when revoke button is clicked', () => {
+    const onRevoke = vi.fn();
+    const { getByTestId } = render(() => (
+      <WhitelistedPill label="this file" onRevoke={onRevoke} />
+    ));
+    fireEvent.click(getByTestId('whitelisted-pill'));
+    fireEvent.click(getByTestId('revoke-btn'));
+    expect(onRevoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes popover after revoke', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <WhitelistedPill label="this file" onRevoke={vi.fn()} />
+    ));
+    fireEvent.click(getByTestId('whitelisted-pill'));
+    fireEvent.click(getByTestId('revoke-btn'));
+    expect(queryByTestId('whitelist-popover')).not.toBeInTheDocument();
+  });
+});

--- a/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.tsx
@@ -1,0 +1,43 @@
+import { type Component, createSignal, Show } from 'solid-js';
+import './WhitelistedPill.css';
+
+export interface WhitelistedPillProps {
+  label: string;
+  onRevoke: () => void;
+}
+
+export const WhitelistedPill: Component<WhitelistedPillProps> = (props) => {
+  const [popoverOpen, setPopoverOpen] = createSignal(false);
+
+  return (
+    <div class="whitelisted-pill-wrapper">
+      <button
+        type="button"
+        class="whitelisted-pill"
+        data-testid="whitelisted-pill"
+        aria-haspopup="true"
+        aria-expanded={popoverOpen()}
+        onClick={() => setPopoverOpen((v) => !v)}
+      >
+        <span class="whitelisted-pill__dot" aria-hidden="true" />
+        whitelisted · {props.label}
+      </button>
+
+      <Show when={popoverOpen()}>
+        <div class="whitelisted-pill__popover" data-testid="whitelist-popover" role="dialog">
+          <button
+            type="button"
+            class="whitelisted-pill__revoke-btn"
+            data-testid="revoke-btn"
+            onClick={() => {
+              setPopoverOpen(false);
+              props.onRevoke();
+            }}
+          >
+            Revoke for this session
+          </button>
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/web/packages/app/src/routes/Session/ChatPane.css
+++ b/web/packages/app/src/routes/Session/ChatPane.css
@@ -115,8 +115,7 @@
 
 .tool-placeholder {
   display: flex;
-  align-items: center;
-  gap: var(--sp-2);
+  flex-direction: column;
   padding: var(--sp-2) var(--sp-3);
   background: var(--color-surface-2);
   border: 1px solid var(--color-border-1);
@@ -126,12 +125,29 @@
   color: var(--color-text-secondary);
 }
 
+.tool-placeholder--awaiting {
+  border-color: var(--color-warning-border);
+  background: var(--color-surface-2);
+}
+
+.tool-placeholder--awaiting:focus {
+  outline: none;
+  border-color: var(--color-ember-400);
+}
+
 .tool-placeholder--completed {
   color: var(--color-text-tertiary);
 }
 
+.tool-placeholder__header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
 .tool-placeholder__icon {
   color: var(--color-text-tertiary);
+  flex: 0 0 auto;
 }
 
 .tool-placeholder__name {

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -15,13 +15,16 @@ import {
   resetMessagesStore,
 } from '../../stores/messages';
 import { setActiveSessionId } from '../../stores/session';
+import { resetApprovalsStore } from '../../stores/approvals';
 import { ChatPane } from './ChatPane';
 
 const SID = 'session-chat-test' as SessionId;
 
 beforeEach(() => {
   invokeMock.mockReset();
+  invokeMock.mockResolvedValue(undefined);
   resetMessagesStore();
+  resetApprovalsStore();
   setActiveSessionId(SID);
 });
 
@@ -185,5 +188,211 @@ describe('Auto-scroll behavior', () => {
 
     // After a delta, the list should be pinned to bottom (scrollTop === scrollHeight)
     expect(list.scrollTop).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inline approval prompt (F-027)
+// ---------------------------------------------------------------------------
+
+describe('Inline approval prompt', () => {
+  const PREVIEW = { description: 'Edit file /src/foo.ts: 3 hunks, +47 -21' };
+  const FS_EDIT_ARGS = JSON.stringify({ path: '/src/foo.ts', patch: '...' });
+
+  it('renders the approval prompt when ToolCallApprovalRequested arrives', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-ap-1',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('approval-prompt')).toBeInTheDocument();
+  });
+
+  it('displays preview description inside the prompt', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-ap-2',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('approval-preview')).toHaveTextContent('Edit file /src/foo.ts');
+  });
+
+  it('invokes session_approve_tool with Once when approve is clicked', async () => {
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-ap-3',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('approve-once-btn'));
+    expect(invokeMock).toHaveBeenCalledWith('session_approve_tool', {
+      sessionId: SID,
+      toolCallId: 'tc-ap-3',
+      scope: 'Once',
+    });
+  });
+
+  it('invokes session_reject_tool when reject is clicked', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-ap-4',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('reject-btn'));
+    expect(invokeMock).toHaveBeenCalledWith('session_reject_tool', {
+      sessionId: SID,
+      toolCallId: 'tc-ap-4',
+    });
+  });
+
+  it('invokes session_approve_tool with ThisFile from scope menu', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-ap-5',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-file-btn'));
+    expect(invokeMock).toHaveBeenCalledWith('session_approve_tool', {
+      sessionId: SID,
+      toolCallId: 'tc-ap-5',
+      scope: 'ThisFile',
+    });
+  });
+
+  it('invokes session_approve_tool with ThisTool from scope menu', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-ap-6',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-tool-btn'));
+    expect(invokeMock).toHaveBeenCalledWith('session_approve_tool', {
+      sessionId: SID,
+      toolCallId: 'tc-ap-6',
+      scope: 'ThisTool',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitelist auto-approve + pill rendering (F-027)
+// ---------------------------------------------------------------------------
+
+describe('Whitelist auto-approve', () => {
+  const PREVIEW = { description: 'Edit file /src/foo.ts' };
+  const FS_EDIT_ARGS = JSON.stringify({ path: '/src/foo.ts', patch: '...' });
+
+  it('shows whitelisted pill when ThisFile scope was granted for same path', async () => {
+    // First render — approve ThisFile scope
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-wl-1',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getByTestId, unmount } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-file-btn'));
+    unmount();
+
+    // Reset message store but keep approvals store so whitelist persists
+    resetMessagesStore();
+
+    // Second call — same tool + path, should show whitelisted pill
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-wl-2',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getAllByTestId } = render(() => <ChatPane />);
+    const pills = getAllByTestId('whitelisted-pill');
+    expect(pills).toHaveLength(1);
+    expect(pills[0]).toHaveTextContent('whitelisted · this file');
+  });
+
+  it('auto-invokes session_approve_tool for whitelisted match', async () => {
+    // First render — approve ThisTool scope
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-wl-auto-1',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getByTestId, unmount } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-tool-btn'));
+    unmount();
+
+    // Reset messages but keep approvals whitelist
+    resetMessagesStore();
+    invokeMock.mockClear();
+
+    // Second call — same tool, auto-approve effect fires on mount
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-wl-auto-2',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    render(() => <ChatPane />);
+    expect(invokeMock).toHaveBeenCalledWith('session_approve_tool', expect.objectContaining({
+      toolCallId: 'tc-wl-auto-2',
+      scope: 'ThisTool',
+    }));
+  });
+
+  it('hides approval prompt and shows pill when auto-approved', async () => {
+    // First render — approve ThisFile scope
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-wl-hide-1',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { getByTestId, unmount } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-file-btn'));
+    unmount();
+
+    // Reset messages but keep approvals whitelist
+    resetMessagesStore();
+
+    // Second call — pill shown, no approval-prompt
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-wl-hide-2',
+      tool_name: 'fs.edit',
+      args_json: FS_EDIT_ARGS,
+      preview: PREVIEW,
+    });
+    const { queryByTestId, getAllByTestId } = render(() => <ChatPane />);
+    expect(queryByTestId('approval-prompt')).not.toBeInTheDocument();
+    const pills = getAllByTestId('whitelisted-pill');
+    expect(pills).toHaveLength(1);
   });
 });

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -13,25 +13,156 @@ import {
   setAwaitingResponse,
   type ChatTurn,
 } from '../../stores/messages';
+import {
+  getApprovalWhitelist,
+  addWhitelistEntry,
+  revokeWhitelistEntry,
+  matchWhitelistKey,
+} from '../../stores/approvals';
+import { ApprovalPrompt } from '../../components/ApprovalPrompt/ApprovalPrompt';
+import { WhitelistedPill } from '../../components/ApprovalPrompt/WhitelistedPill';
+import type { ApprovalScope } from '@forge/ipc';
 import './ChatPane.css';
 
 // ---------------------------------------------------------------------------
-// ToolCallCard — inline tool call card (F-026)
+// ToolCallCard — inline tool call card with optional approval prompt (F-026/F-027)
 // ---------------------------------------------------------------------------
 
-const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholder' }> }> = (props) => (
-  <div
-    class="tool-placeholder"
-    data-testid={`tool-call-card-${props.turn.tool_call_id}`}
-    classList={{ 'tool-placeholder--completed': props.turn.status === 'completed' }}
-  >
-    <span class="tool-placeholder__icon" aria-hidden="true">⚙</span>
-    <span class="tool-placeholder__name">{props.turn.tool_name}</span>
-    <span class="tool-placeholder__status">
-      {props.turn.status}
-    </span>
-  </div>
-);
+const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholder' }> }> = (
+  props,
+) => {
+  let cardRef: HTMLDivElement | undefined;
+  const sessionId = () => activeSessionId();
+
+  // Check whitelist on each render
+  const whitelistKey = createMemo(() => {
+    const id = sessionId();
+    if (!id) return null;
+    if (props.turn.status !== 'awaiting-approval') return null;
+    let path = '';
+    try {
+      const args = JSON.parse(props.turn.args_json) as Record<string, unknown>;
+      if (typeof args['path'] === 'string') path = args['path'];
+    } catch {
+      // ignore
+    }
+    const wl = getApprovalWhitelist(id);
+    const keys = new Set(Object.keys(wl.entries));
+    return matchWhitelistKey(keys, props.turn.tool_name, path);
+  });
+
+  const whitelistLabel = createMemo(() => {
+    const id = sessionId();
+    const key = whitelistKey();
+    if (!id || !key) return null;
+    return getApprovalWhitelist(id).entries[key] ?? null;
+  });
+
+  // Auto-approve when whitelist matches
+  createEffect(() => {
+    const id = sessionId();
+    const key = whitelistKey();
+    if (!id || !key || props.turn.status !== 'awaiting-approval') return;
+    void invoke('session_approve_tool', {
+      sessionId: id,
+      toolCallId: props.turn.tool_call_id,
+      // Derive scope from key prefix
+      scope: key.startsWith('tool:')
+        ? ('ThisTool' as ApprovalScope)
+        : key.startsWith('pattern:')
+          ? ('ThisPattern' as ApprovalScope)
+          : ('ThisFile' as ApprovalScope),
+    });
+  });
+
+  const handleApprove = (scope: ApprovalScope, pattern?: string) => {
+    const id = sessionId();
+    if (!id) return;
+
+    // Record whitelist for scopes > Once
+    if (scope !== 'Once') {
+      let path = '';
+      try {
+        const args = JSON.parse(props.turn.args_json) as Record<string, unknown>;
+        if (typeof args['path'] === 'string') path = args['path'];
+      } catch {
+        // ignore
+      }
+      addWhitelistEntry(id, scope, props.turn.tool_name, path, pattern);
+    }
+
+    void invoke('session_approve_tool', {
+      sessionId: id,
+      toolCallId: props.turn.tool_call_id,
+      scope,
+    });
+  };
+
+  const handleReject = () => {
+    const id = sessionId();
+    if (!id) return;
+    void invoke('session_reject_tool', {
+      sessionId: id,
+      toolCallId: props.turn.tool_call_id,
+    });
+  };
+
+  const handleRevoke = () => {
+    const id = sessionId();
+    const key = whitelistKey();
+    if (!id || !key) return;
+    revokeWhitelistEntry(id, key);
+  };
+
+  return (
+    <div
+      class="tool-placeholder"
+      data-testid={`tool-call-card-${props.turn.tool_call_id}`}
+      classList={{
+        'tool-placeholder--completed': props.turn.status === 'completed',
+        'tool-placeholder--awaiting': props.turn.status === 'awaiting-approval',
+      }}
+      tabIndex={props.turn.status === 'awaiting-approval' ? 0 : undefined}
+      ref={cardRef}
+    >
+      <div class="tool-placeholder__header">
+        <span class="tool-placeholder__icon" aria-hidden="true">
+          ⚙
+        </span>
+        <span class="tool-placeholder__name">{props.turn.tool_name}</span>
+
+        {/* Whitelisted pill when auto-approved */}
+        <Show when={whitelistKey() !== null && whitelistLabel() !== null}>
+          <WhitelistedPill label={whitelistLabel()!} onRevoke={handleRevoke} />
+        </Show>
+
+        {/* Status label (hidden when awaiting — prompt fills that role) */}
+        <Show when={props.turn.status !== 'awaiting-approval' || whitelistKey() !== null}>
+          <span class="tool-placeholder__status">{props.turn.status}</span>
+        </Show>
+      </div>
+
+      {/* Inline approval prompt */}
+      <Show
+        when={
+          props.turn.status === 'awaiting-approval' &&
+          props.turn.preview !== undefined &&
+          whitelistKey() === null
+        }
+      >
+        <ApprovalPrompt
+          toolCallId={props.turn.tool_call_id}
+          toolName={props.turn.tool_name}
+          argsJson={props.turn.args_json}
+          preview={props.turn.preview!}
+          containerRef={cardRef!}
+          onApprove={handleApprove}
+          onReject={handleReject}
+        />
+      </Show>
+    </div>
+  );
+};
 
 // ---------------------------------------------------------------------------
 // Message turn renderers
@@ -44,7 +175,9 @@ const UserBubble: Component<{ turn: Extract<ChatTurn, { type: 'user' }> }> = (pr
   </article>
 );
 
-const AssistantBubble: Component<{ turn: Extract<ChatTurn, { type: 'assistant' }> }> = (props) => (
+const AssistantBubble: Component<{ turn: Extract<ChatTurn, { type: 'assistant' }> }> = (
+  props,
+) => (
   <article class="turn turn--assistant">
     <header class="turn__author">● assistant</header>
     <p class="turn__body">
@@ -169,7 +302,11 @@ export const ChatPane: Component = () => {
       <span class="chat-pane__type-label">CHAT</span>
       {/* Streaming indicator shown while awaiting a response */}
       <Show when={state().awaitingResponse}>
-        <div class="chat-pane__streaming-indicator" data-testid="streaming-indicator" aria-live="polite">
+        <div
+          class="chat-pane__streaming-indicator"
+          data-testid="streaming-indicator"
+          aria-live="polite"
+        >
           <span class="streaming-cursor" aria-hidden="true" />
           <span>Awaiting response…</span>
         </div>

--- a/web/packages/app/src/stores/approvals.test.ts
+++ b/web/packages/app/src/stores/approvals.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import type { SessionId } from '@forge/ipc';
+import {
+  makeWhitelistKey,
+  defaultPatternForPath,
+  matchGlob,
+  matchWhitelistKey,
+  addWhitelistEntry,
+  revokeWhitelistEntry,
+  getApprovalWhitelist,
+  resetApprovalsStore,
+} from './approvals';
+
+const SID = 'session-approvals-test' as SessionId;
+
+beforeEach(() => {
+  resetApprovalsStore();
+});
+
+// ---------------------------------------------------------------------------
+// makeWhitelistKey
+// ---------------------------------------------------------------------------
+
+describe('makeWhitelistKey', () => {
+  it('produces a file key for ThisFile scope', () => {
+    expect(makeWhitelistKey('ThisFile', 'fs.write', '/src/foo.ts')).toBe('file:fs.write:/src/foo.ts');
+  });
+
+  it('produces a pattern key for ThisPattern scope with explicit pattern', () => {
+    expect(makeWhitelistKey('ThisPattern', 'fs.edit', '/src/foo.ts', '/src/*')).toBe('pattern:fs.edit:/src/*');
+  });
+
+  it('falls back to path when pattern is undefined for ThisPattern', () => {
+    expect(makeWhitelistKey('ThisPattern', 'fs.edit', '/src/foo.ts')).toBe('pattern:fs.edit:/src/foo.ts');
+  });
+
+  it('produces a tool key for ThisTool scope', () => {
+    expect(makeWhitelistKey('ThisTool', 'shell.exec', '')).toBe('tool:shell.exec');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultPatternForPath
+// ---------------------------------------------------------------------------
+
+describe('defaultPatternForPath', () => {
+  it('returns directory glob for a full path', () => {
+    expect(defaultPatternForPath('/home/user/src/foo.ts')).toBe('/home/user/src/*');
+  });
+
+  it('returns * when no directory component', () => {
+    expect(defaultPatternForPath('foo.ts')).toBe('*');
+  });
+
+  it('handles trailing slash gracefully', () => {
+    expect(defaultPatternForPath('/src/')).toBe('/src/*');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchGlob
+// ---------------------------------------------------------------------------
+
+describe('matchGlob', () => {
+  it('matches path with single-level *', () => {
+    expect(matchGlob('/src/*', '/src/foo.ts')).toBe(true);
+  });
+
+  it('does not match across directory boundaries with *', () => {
+    expect(matchGlob('/src/*', '/src/sub/bar.ts')).toBe(false);
+  });
+
+  it('exact path matches itself', () => {
+    expect(matchGlob('/src/foo.ts', '/src/foo.ts')).toBe(true);
+  });
+
+  it('does not match different paths', () => {
+    expect(matchGlob('/src/*', '/other/foo.ts')).toBe(false);
+  });
+
+  it('handles dot in path', () => {
+    expect(matchGlob('/src/*.ts', '/src/foo.ts')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchWhitelistKey
+// ---------------------------------------------------------------------------
+
+describe('matchWhitelistKey', () => {
+  it('returns null when whitelist is empty', () => {
+    const wl = new Set<string>();
+    expect(matchWhitelistKey(wl, 'fs.write', '/src/foo.ts')).toBeNull();
+  });
+
+  it('matches ThisTool key', () => {
+    const wl = new Set(['tool:fs.write']);
+    expect(matchWhitelistKey(wl, 'fs.write', '/src/foo.ts')).toBe('tool:fs.write');
+  });
+
+  it('matches ThisFile key', () => {
+    const wl = new Set(['file:fs.write:/src/foo.ts']);
+    expect(matchWhitelistKey(wl, 'fs.write', '/src/foo.ts')).toBe('file:fs.write:/src/foo.ts');
+  });
+
+  it('does not match a file key for a different path', () => {
+    const wl = new Set(['file:fs.write:/src/bar.ts']);
+    expect(matchWhitelistKey(wl, 'fs.write', '/src/foo.ts')).toBeNull();
+  });
+
+  it('matches a pattern key via glob', () => {
+    const wl = new Set(['pattern:fs.edit:/src/*']);
+    expect(matchWhitelistKey(wl, 'fs.edit', '/src/foo.ts')).toBe('pattern:fs.edit:/src/*');
+  });
+
+  it('does not match a pattern key when glob does not apply', () => {
+    const wl = new Set(['pattern:fs.edit:/src/*']);
+    expect(matchWhitelistKey(wl, 'fs.edit', '/other/foo.ts')).toBeNull();
+  });
+
+  it('does not match keys for a different tool', () => {
+    const wl = new Set(['tool:fs.write', 'file:fs.write:/src/foo.ts']);
+    expect(matchWhitelistKey(wl, 'fs.edit', '/src/foo.ts')).toBeNull();
+  });
+
+  it('prefers ThisTool over ThisFile when both present', () => {
+    const wl = new Set(['tool:fs.write', 'file:fs.write:/src/foo.ts']);
+    expect(matchWhitelistKey(wl, 'fs.write', '/src/foo.ts')).toBe('tool:fs.write');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitelist store operations
+// ---------------------------------------------------------------------------
+
+describe('addWhitelistEntry', () => {
+  it('adds a ThisFile entry and records label', () => {
+    addWhitelistEntry(SID, 'ThisFile', 'fs.write', '/src/foo.ts');
+    const wl = getApprovalWhitelist(SID);
+    expect('file:fs.write:/src/foo.ts' in wl.entries).toBe(true);
+    expect(wl.entries['file:fs.write:/src/foo.ts']).toBe('this file');
+  });
+
+  it('adds a ThisPattern entry with explicit pattern', () => {
+    addWhitelistEntry(SID, 'ThisPattern', 'fs.edit', '/src/foo.ts', '/src/*');
+    const wl = getApprovalWhitelist(SID);
+    expect('pattern:fs.edit:/src/*' in wl.entries).toBe(true);
+    expect(wl.entries['pattern:fs.edit:/src/*']).toBe('pattern /src/*');
+  });
+
+  it('adds a ThisTool entry', () => {
+    addWhitelistEntry(SID, 'ThisTool', 'shell.exec', '');
+    const wl = getApprovalWhitelist(SID);
+    expect('tool:shell.exec' in wl.entries).toBe(true);
+    expect(wl.entries['tool:shell.exec']).toBe('this tool');
+  });
+
+  it('returns the generated key', () => {
+    const key = addWhitelistEntry(SID, 'ThisFile', 'fs.write', '/src/foo.ts');
+    expect(key).toBe('file:fs.write:/src/foo.ts');
+  });
+});
+
+describe('revokeWhitelistEntry', () => {
+  it('removes a key from the whitelist', () => {
+    addWhitelistEntry(SID, 'ThisFile', 'fs.write', '/src/foo.ts');
+    revokeWhitelistEntry(SID, 'file:fs.write:/src/foo.ts');
+    const wl = getApprovalWhitelist(SID);
+    expect('file:fs.write:/src/foo.ts' in wl.entries).toBe(false);
+  });
+
+  it('is a no-op for a key that does not exist', () => {
+    expect(() => revokeWhitelistEntry(SID, 'tool:noop')).not.toThrow();
+  });
+});
+
+describe('multi-session isolation', () => {
+  it('keeps whitelist entries isolated per session', () => {
+    const SID2 = 'session-approvals-other' as SessionId;
+    addWhitelistEntry(SID, 'ThisTool', 'fs.write', '');
+    expect('tool:fs.write' in getApprovalWhitelist(SID).entries).toBe(true);
+    expect('tool:fs.write' in getApprovalWhitelist(SID2).entries).toBe(false);
+  });
+});

--- a/web/packages/app/src/stores/approvals.ts
+++ b/web/packages/app/src/stores/approvals.ts
@@ -1,0 +1,172 @@
+import { createStore, produce, reconcile } from 'solid-js/store';
+import type { SessionId, ApprovalScope } from '@forge/ipc';
+
+// ---------------------------------------------------------------------------
+// Whitelist key derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the whitelist key for a given scope + tool context.
+ * Keys must be deterministic so subsequent matching calls can check membership.
+ *
+ * Once      → never added to whitelist (per-call only)
+ * ThisFile   → "file:<toolName>:<path>"
+ * ThisPattern → "pattern:<toolName>:<glob>"
+ * ThisTool   → "tool:<toolName>"
+ */
+export function makeWhitelistKey(
+  scope: Exclude<ApprovalScope, 'Once'>,
+  toolName: string,
+  path: string,
+  pattern?: string,
+): string {
+  switch (scope) {
+    case 'ThisFile':
+      return `file:${toolName}:${path}`;
+    case 'ThisPattern':
+      return `pattern:${toolName}:${pattern ?? path}`;
+    case 'ThisTool':
+      return `tool:${toolName}`;
+  }
+}
+
+/**
+ * Derive the default glob pattern for a file path.
+ * e.g. /home/user/src/foo.ts → /home/user/src/*
+ */
+export function defaultPatternForPath(path: string): string {
+  const slash = path.lastIndexOf('/');
+  if (slash > 0) {
+    return path.slice(0, slash) + '/*';
+  }
+  return '*';
+}
+
+/**
+ * Check whether a given tool call + scope combination is whitelisted.
+ * Returns the matching key if whitelisted, null otherwise.
+ */
+export function matchWhitelistKey(
+  whitelistKeys: Set<string>,
+  toolName: string,
+  path: string,
+): string | null {
+  // Check ThisTool first (broadest)
+  const toolKey = `tool:${toolName}`;
+  if (whitelistKeys.has(toolKey)) return toolKey;
+
+  // Check ThisFile
+  if (path) {
+    const fileKey = `file:${toolName}:${path}`;
+    if (whitelistKeys.has(fileKey)) return fileKey;
+
+    // Check any ThisPattern entry that matches the path
+    for (const key of whitelistKeys) {
+      if (key.startsWith(`pattern:${toolName}:`)) {
+        const glob = key.slice(`pattern:${toolName}:`.length);
+        if (matchGlob(glob, path)) return key;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Simple glob matcher supporting * wildcard (not recursive).
+ * e.g. /src/* matches /src/foo.ts but not /src/sub/bar.ts
+ */
+export function matchGlob(glob: string, path: string): boolean {
+  // Escape all regex special chars except *
+  const regex = new RegExp(
+    '^' +
+      glob
+        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+        .replace(/\*/g, '[^/]*') +
+      '$',
+  );
+  return regex.test(path);
+}
+
+// ---------------------------------------------------------------------------
+// Per-session whitelist store
+//
+// We use a plain object record keyed by whitelist-key for SolidJS reactive
+// tracking. Storing Set/Map inside a store would not be tracked reactively.
+// ---------------------------------------------------------------------------
+
+export interface ApprovalWhitelist {
+  /**
+   * Record of whitelist-key → human-readable label.
+   * A key is present iff it is whitelisted. Use Object.keys() to enumerate.
+   */
+  entries: Record<string, string>;
+}
+
+const [approvalsStore, setApprovalsStore] = createStore<
+  Record<string, ApprovalWhitelist>
+>({});
+
+function ensureSession(sessionId: SessionId): void {
+  if (!approvalsStore[sessionId]) {
+    setApprovalsStore(sessionId, { entries: {} });
+  }
+}
+
+export function getApprovalWhitelist(sessionId: SessionId): ApprovalWhitelist {
+  ensureSession(sessionId);
+  return approvalsStore[sessionId]!;
+}
+
+/**
+ * Record a whitelist entry for a scope > Once.
+ * Returns the key that was added.
+ */
+export function addWhitelistEntry(
+  sessionId: SessionId,
+  scope: Exclude<ApprovalScope, 'Once'>,
+  toolName: string,
+  path: string,
+  pattern?: string,
+): string {
+  ensureSession(sessionId);
+  const key = makeWhitelistKey(scope, toolName, path, pattern);
+  const label = scopeLabel(scope, pattern ?? path);
+  setApprovalsStore(
+    produce((s) => {
+      s[sessionId]!.entries[key] = label;
+    }),
+  );
+  return key;
+}
+
+/**
+ * Revoke a whitelist entry by its key.
+ */
+export function revokeWhitelistEntry(sessionId: SessionId, key: string): void {
+  ensureSession(sessionId);
+  setApprovalsStore(
+    produce((s) => {
+      delete s[sessionId]!.entries[key];
+    }),
+  );
+}
+
+function scopeLabel(
+  scope: Exclude<ApprovalScope, 'Once'>,
+  pathOrPattern: string,
+): string {
+  switch (scope) {
+    case 'ThisFile':
+      return 'this file';
+    case 'ThisPattern':
+      return `pattern ${pathOrPattern}`;
+    case 'ThisTool':
+      return 'this tool';
+  }
+}
+
+/** Test helper — clears all approval whitelist state. */
+export function resetApprovalsStore(): void {
+  setApprovalsStore(reconcile({}));
+}

--- a/web/packages/app/src/stores/messages.test.ts
+++ b/web/packages/app/src/stores/messages.test.ts
@@ -224,6 +224,82 @@ describe('messages store', () => {
     });
   });
 
+  describe('ToolCallApprovalRequested events', () => {
+    it('transitions an existing placeholder to awaiting-approval', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-approval',
+        tool_name: 'fs.edit',
+        args_json: '{"path":"/src/foo.ts"}',
+      });
+      pushEvent(SID, {
+        kind: 'ToolCallApprovalRequested',
+        tool_call_id: 'tc-approval',
+        tool_name: 'fs.edit',
+        args_json: '{"path":"/src/foo.ts"}',
+        preview: { description: 'Edit file /src/foo.ts: 2 hunks' },
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+      expect(state.turns[0]).toMatchObject({
+        type: 'tool_placeholder',
+        tool_call_id: 'tc-approval',
+        status: 'awaiting-approval',
+        preview: { description: 'Edit file /src/foo.ts: 2 hunks' },
+      });
+    });
+
+    it('creates a fresh placeholder when no prior ToolCallStarted', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallApprovalRequested',
+        tool_call_id: 'tc-fresh',
+        tool_name: 'fs.write',
+        args_json: '{"path":"/src/bar.ts"}',
+        preview: { description: 'Write file /src/bar.ts' },
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+      expect(state.turns[0]).toMatchObject({
+        type: 'tool_placeholder',
+        tool_call_id: 'tc-fresh',
+        tool_name: 'fs.write',
+        status: 'awaiting-approval',
+        preview: { description: 'Write file /src/bar.ts' },
+      });
+    });
+
+    it('attaches the preview description to the turn', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallApprovalRequested',
+        tool_call_id: 'tc-preview',
+        tool_name: 'shell.exec',
+        args_json: '{}',
+        preview: { description: 'Run: /bin/sh -c echo hi (cwd /workspace)' },
+      });
+      const state = getMessagesState(SID);
+      const turn = state.turns[0] as { preview?: { description: string } };
+      expect(turn.preview?.description).toBe('Run: /bin/sh -c echo hi (cwd /workspace)');
+    });
+
+    it('does not duplicate turns if both ToolCallStarted and ApprovalRequested arrive', () => {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: 'tc-dup',
+        tool_name: 'fs.edit',
+        args_json: '{}',
+      });
+      pushEvent(SID, {
+        kind: 'ToolCallApprovalRequested',
+        tool_call_id: 'tc-dup',
+        tool_name: 'fs.edit',
+        args_json: '{}',
+        preview: { description: 'Edit' },
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+    });
+  });
+
   describe('Error events', () => {
     it('appends an error turn', () => {
       pushEvent(SID, { kind: 'Error', message: 'ECONNREFUSED 127.0.0.1:11434' });

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -5,11 +5,18 @@ import type { SessionId } from '@forge/ipc';
 // Event shapes arriving from the IPC bridge (session:event payload)
 // ---------------------------------------------------------------------------
 
+/** Preview data from the shell for a pending tool call approval. */
+export interface ApprovalPreview {
+  /** Human-readable description of what the tool call will do. */
+  description: string;
+}
+
 export type SessionEvent =
   | { kind: 'UserMessage'; text: string; message_id: string }
   | { kind: 'AssistantMessage'; text: string; message_id: string }
   | { kind: 'AssistantDelta'; delta: string; message_id: string }
   | { kind: 'ToolCallStarted'; tool_call_id: string; tool_name: string; args_json: string; batch_id?: string }
+  | { kind: 'ToolCallApprovalRequested'; tool_call_id: string; tool_name: string; args_json: string; preview: ApprovalPreview }
   | { kind: 'ToolCallCompleted'; tool_call_id: string; result_summary: string }
   | { kind: 'ToolCallFailed'; tool_call_id: string; error: string }
   | { kind: 'Error'; message: string }
@@ -36,6 +43,8 @@ export type ChatTurn =
       duration_ms?: number;
       result_summary?: string;
       error?: string;
+      /** Populated when status is 'awaiting-approval'. */
+      preview?: ApprovalPreview;
     }
   | { type: 'error'; message: string };
 
@@ -156,6 +165,36 @@ export function pushEvent(sessionId: SessionId, event: SessionEvent): void {
             status: 'in-progress',
             started_at: Date.now(),
           });
+        }),
+      );
+      break;
+    }
+
+    case 'ToolCallApprovalRequested': {
+      setMessagesStore(
+        produce((s) => {
+          const state = s[sessionId]!;
+          // If there's already a tool_placeholder for this call (from ToolCallStarted),
+          // transition it to awaiting-approval and attach the preview.
+          const idx = state.turns.findIndex(
+            (t) => t.type === 'tool_placeholder' && t.tool_call_id === event.tool_call_id,
+          );
+          if (idx >= 0) {
+            const turn = state.turns[idx] as Extract<ChatTurn, { type: 'tool_placeholder' }>;
+            turn.status = 'awaiting-approval';
+            turn.preview = event.preview;
+          } else {
+            // No prior ToolCallStarted — push a fresh placeholder.
+            state.turns.push({
+              type: 'tool_placeholder',
+              tool_call_id: event.tool_call_id,
+              tool_name: event.tool_name,
+              args_json: event.args_json,
+              status: 'awaiting-approval',
+              started_at: Date.now(),
+              preview: event.preview,
+            });
+          }
         }),
       );
       break;


### PR DESCRIPTION
Closes forge-ide/forge#45

## Summary

- `ApprovalPrompt` component renders inline inside `ToolCallCard` when `ToolCallApprovalRequested` fires — never modal
- Four-scope split-button dropdown: Once, This file, This pattern, This tool; plus a Reject ghost button
- Keyboard shortcuts R/A/F/P/T attached to the card container element (tab-focused), not the global window
- Preview description from `ApprovalPreview.description` rendered verbatim in a monospace block; file scopes (F/P) hidden for non-file tools like `shell.exec`
- Pattern editor opens on `P` keypress or dropdown click, pre-filled with directory glob from the path; user can edit before confirming
- Session-local whitelist store (`approvals.ts`) using plain object entries for SolidJS reactive tracking; key hierarchy: `tool:<name>` > `file:<name>:<path>` > `pattern:<name>:<glob>`
- Auto-approve `createEffect` fires `session_approve_tool` for matching whitelist entries; `WhitelistedPill` with revoke popover renders in card header
- `ToolCallApprovalRequested` event added to `SessionEvent` union in `messages.ts`; handler transitions existing placeholder or creates a fresh one

## Test plan

- `npm test` (web/packages/app): 156/156 tests pass
- `npm run typecheck` (web/packages/app): clean
- New test suites: `ApprovalPrompt.test.tsx` (27 tests), `WhitelistedPill.test.tsx` (6 tests), `approvals.test.ts` (27 tests)
- Integration tests in `ChatPane.test.tsx`: approval prompt rendering, each scope selection, reject, whitelist auto-approve, pill rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)