### PR TITLE
[F-039] forged: archive persistent sessions on SIGTERM

### DIFF
--- a/crates/forge-core/src/ids.rs
+++ b/crates/forge-core/src/ids.rs
@@ -14,6 +14,13 @@ macro_rules! id_type {
                 let bytes: [u8; 8] = rand::thread_rng().gen();
                 Self(bytes.iter().map(|b| format!("{b:02x}")).collect())
             }
+
+            /// Wrap an existing string as this id type. Use when the id was
+            /// generated elsewhere (e.g. read from env, a meta file, or a
+            /// client message) and the wire shape is just a string.
+            pub fn from_string(s: String) -> Self {
+                Self(s)
+            }
         }
 
         impl Default for $name {

--- a/crates/forge-core/src/meta.rs
+++ b/crates/forge-core/src/meta.rs
@@ -33,7 +33,20 @@ pub async fn write_meta(path: &Path, meta: &SessionMeta) -> Result<()> {
         tokio::fs::create_dir_all(parent).await?;
     }
     let contents = toml::to_string(meta).map_err(|e| anyhow::anyhow!(e))?;
-    tokio::fs::write(path, contents).await?;
+    // Atomic write: stage in a sibling temp file then rename in. A plain
+    // `write` is truncate-then-write, so a concurrent reader (e.g. the
+    // dashboard polling meta.toml) can otherwise observe a zero-byte or
+    // half-written file. The rename is atomic on the same filesystem.
+    let tmp = match path.file_name() {
+        Some(name) => {
+            let mut tmp_name = name.to_os_string();
+            tmp_name.push(".tmp");
+            path.with_file_name(tmp_name)
+        }
+        None => path.with_extension("toml.tmp"),
+    };
+    tokio::fs::write(&tmp, &contents).await?;
+    tokio::fs::rename(&tmp, path).await?;
     Ok(())
 }
 

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 libc = "0.2"
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync", "process", "time"] }
+tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync", "process", "time", "signal"] }
 
 [dev-dependencies]
 similar = "2"

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -3,10 +3,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
-use forge_core::{read_since, SessionId, SessionPersistence};
+use chrono::Utc;
+use forge_core::{
+    meta::{write_meta, SessionMeta},
+    read_since, SessionId, SessionPersistence, SessionState, WorkspaceId,
+};
 use forge_ipc::{HelloAck, IpcEvent, IpcMessage, PROTO_VERSION, SCHEMA_VERSION};
 use forge_providers::{MockProvider, Provider};
 use tokio::net::{UnixListener, UnixStream};
+use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::{broadcast, Mutex};
 
 use crate::archive::archive_or_purge;
@@ -98,34 +103,99 @@ pub async fn serve_with_session<P: Provider + 'static>(
         .await;
     }
 
-    loop {
-        let (stream, _) = listener.accept().await?;
-        let session = Arc::clone(&session);
-        let provider = Arc::clone(&provider);
-        let workspace = Arc::clone(&workspace);
-        let session_id = Arc::clone(&session_id);
-        let socket_path = Arc::clone(&socket_path);
-        let workspace_path = workspace_path.clone();
-        let child_registry = child_registry.clone();
-        tokio::spawn(async move {
-            if let Err(e) = handle_connection(
-                stream,
-                session,
-                provider,
-                auto_approve,
-                false,
-                workspace,
-                session_id,
-                socket_path,
-                workspace_path,
-                child_registry,
-            )
-            .await
-            {
-                eprintln!("connection error: {e}");
-            }
-        });
+    // Persistent mode: write the initial meta.toml so `archive_or_purge`'s
+    // `update_meta_to_archived` call has something to update on shutdown.
+    // F-031's archive feature only updates an existing meta file; without
+    // this write, the archived directory ships with no meta.toml at all.
+    if let Some(session_dir) = session.log_path.parent() {
+        let meta_path = session_dir.join("meta.toml");
+        let meta = SessionMeta {
+            id: SessionId::from_string((*session_id).clone()),
+            // TODO: derive workspace_id from the workspace path so sessions
+            // sharing a workspace correlate. Today no production code groups
+            // on workspace_id (dashboard reads `workspace` string), so a
+            // synthetic per-session id is acceptable as a placeholder.
+            workspace_id: WorkspaceId::new(),
+            name: format!("session-{}", *session_id),
+            agent: None,
+            provider_id: None,
+            model: None,
+            state: SessionState::Active,
+            persistence: SessionPersistence::Persist,
+            started_at: Utc::now(),
+            ended_at: None,
+            tokens_in: 0,
+            tokens_out: 0,
+            cost_usd: 0.0,
+            pid: std::process::id(),
+            socket_path: (*socket_path).clone(),
+        };
+        write_meta(&meta_path, &meta).await?;
     }
+
+    // Persistent mode: race the accept loop against SIGTERM/SIGINT so the
+    // daemon can run `archive_or_purge` on its own session dir before exit.
+    // Without this, `forge session kill` SIGTERMs an unhandled signal and
+    // the live session dir is left behind under `sessions/<id>/`.
+    let mut sigterm = signal(SignalKind::terminate())?;
+    let mut sigint = signal(SignalKind::interrupt())?;
+
+    loop {
+        tokio::select! {
+            accept = listener.accept() => {
+                let (stream, _) = accept?;
+                let session = Arc::clone(&session);
+                let provider = Arc::clone(&provider);
+                let workspace = Arc::clone(&workspace);
+                let session_id = Arc::clone(&session_id);
+                let socket_path = Arc::clone(&socket_path);
+                let workspace_path = workspace_path.clone();
+                let child_registry = child_registry.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = handle_connection(
+                        stream,
+                        session,
+                        provider,
+                        auto_approve,
+                        false,
+                        workspace,
+                        session_id,
+                        socket_path,
+                        workspace_path,
+                        child_registry,
+                    )
+                    .await
+                    {
+                        eprintln!("connection error: {e}");
+                    }
+                });
+            }
+            _ = sigterm.recv() => break,
+            _ = sigint.recv() => break,
+        }
+    }
+
+    // Graceful shutdown for persistent mode: kill any sandboxed children,
+    // then archive the session dir + remove the socket. Errors propagate so
+    // `forged` exits non-zero on archive failure (so callers like a future
+    // `forge session kill --wait` can surface the failure).
+    //
+    // In-flight `tokio::spawn`'d connection tasks (above) are not joined —
+    // they're orphaned and the runtime drops them on process exit. On the
+    // normal (same-filesystem) archive path, `rename` preserves open file
+    // descriptors so any late EventLog write still lands on the correct
+    // inode; meta.toml writes are atomic via temp+rename in
+    // `forge_core::meta::write_meta`, so a torn-meta hazard is not possible.
+    // The EXDEV fallback in `archive_or_purge` (cross-filesystem copy +
+    // remove_dir_all) is theoretically unreachable here because the source
+    // and destination both live under `<workspace>/.forge/sessions/`. If
+    // shutdown ever needs to await in-flight turns, replace the spawn with
+    // a JoinSet drained here with a timeout.
+    child_registry.kill_all();
+    if let Some(session_dir) = session.log_path.parent() {
+        archive_or_purge(session_dir, SessionPersistence::Persist, &socket_path).await?;
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/forge-session/tests/archive_shutdown.rs
+++ b/crates/forge-session/tests/archive_shutdown.rs
@@ -3,6 +3,10 @@
 //! Spawns `forged --ephemeral` with an explicit workspace, drives a single
 //! turn, waits for `SessionEnded`, and asserts the session directory and
 //! socket are removed.
+//!
+//! Also covers F-039: a persistent (non-ephemeral) `forged` receiving
+//! SIGTERM must run the same archive path, moving the live session dir
+//! under `sessions/archived/` and rewriting `meta.toml`.
 
 use forge_core::Event;
 use forge_ipc::{
@@ -127,6 +131,130 @@ async fn ephemeral_shutdown_removes_session_dir_and_socket() {
         "ephemeral session dir must be purged on shutdown: {}",
         session_dir.display()
     );
+    assert!(
+        !sock_path.exists(),
+        "socket must be removed on shutdown: {}",
+        sock_path.display()
+    );
+}
+
+#[tokio::test]
+async fn persistent_sigterm_archives_session_dir_and_meta() {
+    // F-039: a persistent forged on SIGTERM must (a) exit cleanly with code 0,
+    // (b) move the live session dir to sessions/archived/<id>/ preserving the
+    // events.jsonl schema header, (c) rewrite meta.toml with state="archived",
+    // and (d) remove the socket file.
+    //
+    // NOTE: this test does not exercise the `child_registry.kill_all()` step
+    // of the shutdown path — no SendUserMessage is dispatched, so no tool
+    // subprocess is registered. That step is verified structurally (the call
+    // is one line above the archive call in server.rs) but not behaviorally.
+    // Adding behavioral coverage requires routing a real subprocess through
+    // run_turn → tool_dispatcher → SandboxedCommand and is left as future work.
+
+    let dir = TempDir::new().unwrap();
+    let workspace = dir.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let session_id = "sigterm-archive-test";
+    let sock_path = dir.path().join("session.sock");
+    let session_dir = workspace.join(".forge").join("sessions").join(session_id);
+    let archived_dir = workspace
+        .join(".forge")
+        .join("sessions")
+        .join("archived")
+        .join(session_id);
+
+    let mut child = tokio::process::Command::new(FORGED)
+        // No --ephemeral flag: persistent mode.
+        .env("FORGE_SESSION_ID", session_id)
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .env("FORGE_WORKSPACE", &workspace)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to spawn forged");
+
+    // Hello+Subscribe, then immediately drop the stream — this proves the
+    // server is up and serving before we signal it.
+    let mut stream = connect_with_retry(&sock_path).await;
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "test".into(),
+                pid: std::process::id(),
+                user: "tester".into(),
+            },
+        }),
+    )
+    .await
+    .unwrap();
+    let _ack = forge_ipc::read_frame(&mut stream).await.unwrap();
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+    drop(stream);
+
+    // SIGTERM the daemon.
+    let pid = child.id().expect("child pid available") as libc::pid_t;
+    // SAFETY: pid is the live child we just spawned; SIGTERM is a valid signal.
+    unsafe {
+        let rc = libc::kill(pid, libc::SIGTERM);
+        assert_eq!(
+            rc,
+            0,
+            "kill(SIGTERM) failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+        .await
+        .expect("forged did not exit after SIGTERM")
+        .expect("child.wait() failed");
+    assert!(
+        status.success(),
+        "forged exited non-zero after clean SIGTERM: {:?}",
+        status.code()
+    );
+
+    // Live dir gone.
+    assert!(
+        !session_dir.exists(),
+        "persistent session dir must be moved on archive: {}",
+        session_dir.display()
+    );
+
+    // Archived events.jsonl exists and starts with the schema header line.
+    let archived_log = archived_dir.join("events.jsonl");
+    assert!(
+        archived_log.exists(),
+        "archived events.jsonl missing: {}",
+        archived_log.display()
+    );
+    let log_contents = std::fs::read_to_string(&archived_log).expect("read archived log");
+    let first_line = log_contents.lines().next().unwrap_or("");
+    assert_eq!(
+        first_line, r#"{"schema_version":1}"#,
+        "archived events.jsonl must preserve the schema_version header"
+    );
+
+    // meta.toml exists and reports state = "Archived".
+    let archived_meta = archived_dir.join("meta.toml");
+    assert!(
+        archived_meta.exists(),
+        "archived meta.toml missing: {}",
+        archived_meta.display()
+    );
+    let meta_contents = std::fs::read_to_string(&archived_meta).expect("read archived meta");
+    assert!(
+        meta_contents.contains(r#"state = "Archived""#),
+        "archived meta.toml must have state = \"Archived\"; got:\n{meta_contents}"
+    );
+
+    // Socket removed.
     assert!(
         !sock_path.exists(),
         "socket must be removed on shutdown: {}",

--- a/docs/testing/phase1-uat.sh
+++ b/docs/testing/phase1-uat.sh
@@ -139,7 +139,9 @@ uat_09() {
     fail "UAT-09 archived log missing schema header (got: $first_line)"
     return
   fi
-  if ! grep -q 'state = "archived"' "$WORKSPACE/.forge/sessions/archived/$sid/meta.toml" 2>/dev/null; then
+  # SessionState serializes PascalCase (no #[serde(rename_all)]); meta.toml
+  # records `state = "Archived"`.
+  if ! grep -q 'state = "Archived"' "$WORKSPACE/.forge/sessions/archived/$sid/meta.toml" 2>/dev/null; then
     fail "UAT-09 meta.toml not rewritten"
     return
   fi


### PR DESCRIPTION
Closes forge-ide/forge#75

## Summary

- `serve_with_session` now installs `tokio::signal::unix` listeners for SIGTERM + SIGINT, races them against the accept loop in a `tokio::select!`, and runs `child_registry.kill_all()` + `archive_or_purge(session_dir, SessionPersistence::Persist, &socket_path)` on graceful shutdown. Errors propagate so `forged` exits non-zero on archive failure.
- Adds the missing initial `meta.toml` write at persistent-mode startup — `archive_or_purge`'s update step only updates an existing meta file, so without this write the archived directory shipped with no meta.toml at all (a pre-existing F-031 gap).
- Makes `forge_core::meta::write_meta` atomic via temp+rename, so concurrent dashboard reads can never observe a torn or zero-byte file.
- Adds `SessionId::from_string` (and siblings) to the ID macro — production code can now wrap externally-supplied ids without going through `serde_json::from_value`.
- New integration test in `crates/forge-session/tests/archive_shutdown.rs` spawns `forged` (no --ephemeral), SIGTERMs via `libc::kill`, asserts dir moved + schema header preserved + meta.toml with `state = "Archived"` + socket removed + exit code 0.
- `phase1-uat.sh` UAT-09 fixed to grep for the actual PascalCase `"Archived"` enum value (Rust serde default; the prior lowercase grep was a docs-time typo).
- `WorkspaceId::new()` per-session and orphaned-in-flight-task behavior documented inline as known limitations with TODOs.

## Test plan

- [x] `cargo test --workspace` — all green, including new `persistent_sigterm_archives_session_dir_and_meta` test
- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings` — clean
- [x] `./docs/testing/phase1-uat.sh --cli-only` — UAT-09 ✓, UAT-10 ✓, UAT-13 ✓ (3/3 pass, 0 fail)
- [x] `./docs/testing/phase1-uat.sh --gui-only` — 11 passed, 0 failed (no regressions from the Rust-side changes)
- [x] Vitest: 185/185 still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)