### PR TITLE
[F-038] forged: select provider from session meta (Mock | Ollama)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "forge-providers",
  "futures",
  "libc",
+ "reqwest 0.12.28",
  "serde_json",
  "similar",
  "tempfile",

--- a/crates/forge-cli/src/lib.rs
+++ b/crates/forge-cli/src/lib.rs
@@ -55,6 +55,10 @@ pub enum SessionNewKind {
         /// Workspace root directory.
         #[arg(long)]
         workspace: Option<PathBuf>,
+        /// Provider spec (e.g. "ollama:qwen2.5:0.5b" or "mock"). Falls back
+        /// to FORGE_PROVIDER env, then MockProvider.
+        #[arg(long)]
+        provider: Option<String>,
     },
     /// Start a bare provider session.
     Provider {

--- a/crates/forge-cli/src/main.rs
+++ b/crates/forge-cli/src/main.rs
@@ -43,8 +43,11 @@ async fn session_new(kind: SessionNewKind) -> Result<()> {
         .env("FORGE_WORKSPACE", workspace.to_str().unwrap_or(""));
 
     match &kind {
-        SessionNewKind::Agent { name, .. } => {
+        SessionNewKind::Agent { name, provider, .. } => {
             cmd.arg("--agent").arg(name);
+            if let Some(spec) = provider {
+                cmd.arg("--provider").arg(spec);
+            }
         }
         SessionNewKind::Provider { spec, .. } => {
             cmd.arg("--provider").arg(spec);

--- a/crates/forge-cli/tests/cli_args.rs
+++ b/crates/forge-cli/tests/cli_args.rs
@@ -20,7 +20,10 @@ fn parse_session_new_agent_with_workspace() {
     let Commands::Session {
         cmd:
             SessionCommands::New {
-                kind: SessionNewKind::Agent { name, workspace },
+                kind:
+                    SessionNewKind::Agent {
+                        name, workspace, ..
+                    },
             },
     } = cli.command
     else {
@@ -37,7 +40,10 @@ fn parse_session_new_agent_without_workspace() {
     let Commands::Session {
         cmd:
             SessionCommands::New {
-                kind: SessionNewKind::Agent { name, workspace },
+                kind:
+                    SessionNewKind::Agent {
+                        name, workspace, ..
+                    },
             },
     } = cli.command
     else {
@@ -45,6 +51,30 @@ fn parse_session_new_agent_without_workspace() {
     };
     assert_eq!(name, "helper");
     assert!(workspace.is_none());
+}
+
+#[test]
+fn parse_session_new_agent_with_provider_flag() {
+    let cli = Cli::try_parse_from([
+        "forge",
+        "session",
+        "new",
+        "agent",
+        "code-review",
+        "--provider",
+        "ollama:qwen2.5:0.5b",
+    ])
+    .expect("should parse");
+    let Commands::Session {
+        cmd:
+            SessionCommands::New {
+                kind: SessionNewKind::Agent { provider, .. },
+            },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(provider, Some("ollama:qwen2.5:0.5b".to_string()));
 }
 
 #[test]

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync", "process", "time", "signal"] }
 
 [dev-dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 similar = "2"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros", "time", "net", "process"] }
@@ -44,3 +45,7 @@ path = "tests/archive.rs"
 [[test]]
 name = "archive_shutdown"
 path = "tests/archive_shutdown.rs"
+
+[[test]]
+name = "provider_selection"
+path = "tests/provider_selection.rs"

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod archive;
 pub mod orchestrator;
+pub mod provider_spec;
 pub mod sandbox;
 pub mod server;
 pub mod session;

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
-use forge_providers::MockProvider;
+use forge_providers::{ollama::OllamaProvider, MockProvider};
 use forge_session::{
+    provider_spec::{parse_provider_spec, ProviderKind},
     server::{event_log_path, serve_with_session},
     session::Session,
 };
@@ -12,6 +13,11 @@ async fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let auto_approve = args.iter().any(|a| a == "--auto-approve-unsafe");
     let ephemeral = args.iter().any(|a| a == "--ephemeral");
+    let provider_spec = parse_flag(&args, "--provider").or_else(|| {
+        std::env::var("FORGE_PROVIDER")
+            .ok()
+            .filter(|s| !s.is_empty())
+    });
 
     // Allow the CLI to pre-assign the session ID and socket path so it can
     // print the path before forged starts and can track it for `session kill`.
@@ -31,30 +37,81 @@ async fn main() -> Result<()> {
     eprintln!("forged: listening on {}", socket_path.display());
 
     let log_path = event_log_path(&session_id, workspace.as_deref());
-
-    // FORGE_MOCK_SEQUENCE_FILE points to a JSON array of NDJSON scripts.
-    // Each element is used in order as the response for successive provider calls.
-    // Used by integration tests to inject scripted multi-turn responses.
-    let provider: Arc<MockProvider> =
-        if let Ok(seq_file) = std::env::var("FORGE_MOCK_SEQUENCE_FILE") {
-            let content = tokio::fs::read_to_string(&seq_file).await?;
-            let scripts: Vec<String> = serde_json::from_str(&content)?;
-            Arc::new(MockProvider::from_responses(scripts)?)
-        } else {
-            Arc::new(MockProvider::with_default_path())
-        };
-
     let session = Arc::new(Session::create(log_path).await?);
-    serve_with_session(
-        &socket_path,
-        session,
-        provider,
-        auto_approve,
-        ephemeral,
-        workspace,
-        Some(session_id),
-    )
-    .await
+
+    // Provider selection (F-038):
+    //   1. explicit `--provider <spec>` flag, OR `FORGE_PROVIDER` env, OR
+    //   2. Mock when `FORGE_MOCK_SEQUENCE_FILE` is set, OR
+    //   3. Mock from default path (legacy fallback for ad-hoc runs).
+    // The Provider trait uses `impl Future` (not object-safe), so we cannot
+    // box and dispatch — instead, match here and call `serve_with_session`
+    // with the concrete provider type from each branch.
+    match provider_spec {
+        Some(spec) => match parse_provider_spec(&spec)? {
+            ProviderKind::Mock => {
+                let provider = build_mock_provider().await?;
+                serve_with_session(
+                    &socket_path,
+                    session,
+                    provider,
+                    auto_approve,
+                    ephemeral,
+                    workspace,
+                    Some(session_id),
+                )
+                .await
+            }
+            ProviderKind::Ollama { model } => {
+                let base_url = std::env::var("OLLAMA_BASE_URL")
+                    .unwrap_or_else(|_| forge_providers::ollama::DEFAULT_BASE_URL.to_string());
+                let provider = Arc::new(OllamaProvider::new(base_url, model));
+                serve_with_session(
+                    &socket_path,
+                    session,
+                    provider,
+                    auto_approve,
+                    ephemeral,
+                    workspace,
+                    Some(session_id),
+                )
+                .await
+            }
+        },
+        None => {
+            let provider = build_mock_provider().await?;
+            serve_with_session(
+                &socket_path,
+                session,
+                provider,
+                auto_approve,
+                ephemeral,
+                workspace,
+                Some(session_id),
+            )
+            .await
+        }
+    }
+}
+
+/// Parse `--flag value` from a flat argv. Returns None if the flag isn't
+/// present or if it has no following value. Mirrors the shape of the other
+/// argv-walks in this file rather than introducing clap mid-task.
+fn parse_flag(args: &[String], flag: &str) -> Option<String> {
+    let idx = args.iter().position(|a| a == flag)?;
+    args.get(idx + 1).cloned()
+}
+
+/// FORGE_MOCK_SEQUENCE_FILE points to a JSON array of NDJSON scripts; each
+/// element is consumed in order. Falls back to `with_default_path()` when
+/// no file is configured.
+async fn build_mock_provider() -> Result<Arc<MockProvider>> {
+    if let Ok(seq_file) = std::env::var("FORGE_MOCK_SEQUENCE_FILE") {
+        let content = tokio::fs::read_to_string(&seq_file).await?;
+        let scripts: Vec<String> = serde_json::from_str(&content)?;
+        Ok(Arc::new(MockProvider::from_responses(scripts)?))
+    } else {
+        Ok(Arc::new(MockProvider::with_default_path()))
+    }
 }
 
 fn resolve_socket_path(session_id: &str) -> PathBuf {

--- a/crates/forge-session/src/provider_spec.rs
+++ b/crates/forge-session/src/provider_spec.rs
@@ -1,0 +1,91 @@
+//! Provider spec parser for `forged --provider <spec>` and `FORGE_PROVIDER` env.
+//!
+//! Grammar: `<kind>` or `<kind>:<rest>`. The first colon separates kind from
+//! rest — Ollama model values themselves contain colons (`qwen2.5:0.5b`), so
+//! the parser does not split on subsequent colons.
+
+use anyhow::{anyhow, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderKind {
+    Mock,
+    Ollama { model: String },
+}
+
+pub fn parse_provider_spec(spec: &str) -> Result<ProviderKind> {
+    if spec.is_empty() {
+        return Err(anyhow!("provider spec is empty"));
+    }
+    let (kind, rest) = match spec.split_once(':') {
+        Some((k, r)) => (k, Some(r)),
+        None => (spec, None),
+    };
+    match kind {
+        "mock" => Ok(ProviderKind::Mock),
+        "ollama" => {
+            let model = rest
+                .filter(|r| !r.is_empty())
+                .ok_or_else(|| anyhow!("ollama spec requires a model: ollama:<model>"))?;
+            Ok(ProviderKind::Ollama {
+                model: model.to_string(),
+            })
+        }
+        other => Err(anyhow!(
+            "unknown provider kind: {other:?} (supported: mock, ollama)"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bare_mock() {
+        assert_eq!(parse_provider_spec("mock").unwrap(), ProviderKind::Mock);
+    }
+
+    #[test]
+    fn parses_ollama_with_simple_model() {
+        assert_eq!(
+            parse_provider_spec("ollama:llama3").unwrap(),
+            ProviderKind::Ollama {
+                model: "llama3".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parses_ollama_with_colon_in_model() {
+        assert_eq!(
+            parse_provider_spec("ollama:qwen2.5:0.5b").unwrap(),
+            ProviderKind::Ollama {
+                model: "qwen2.5:0.5b".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_empty_spec() {
+        assert!(parse_provider_spec("").is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        let err = parse_provider_spec("anthropic:claude").unwrap_err();
+        assert!(err.to_string().contains("unknown"));
+    }
+
+    #[test]
+    fn rejects_ollama_without_model() {
+        let err = parse_provider_spec("ollama:").unwrap_err();
+        assert!(err.to_string().contains("model"));
+    }
+
+    #[test]
+    fn rejects_ollama_bare_no_colon() {
+        // `ollama` without `:<model>` is ambiguous — reject rather than guess.
+        let err = parse_provider_spec("ollama").unwrap_err();
+        assert!(err.to_string().contains("model"));
+    }
+}

--- a/crates/forge-session/tests/provider_selection.rs
+++ b/crates/forge-session/tests/provider_selection.rs
@@ -1,0 +1,210 @@
+//! Integration tests for `forged --provider <spec>` dispatch (F-038).
+//!
+//! Two scenarios:
+//!
+//! 1. `ollama_dispatch_surfaces_connection_error_at_unreachable_port` — proves
+//!    the daemon actually constructs an OllamaProvider when `--provider` is
+//!    passed (vs. silently falling back to MockProvider). We point it at an
+//!    unreachable URL and assert a `SessionEnded { reason: Error(..) }` whose
+//!    text mentions ollama. Runs in CI; no real Ollama needed.
+//!
+//! 2. `ollama_round_trip_against_local_qwen` — `#[ignore]`-gated. Requires a
+//!    local Ollama at 127.0.0.1:11434 with `qwen2.5:0.5b` pulled. Sends a
+//!    real chat and asserts at least one `AssistantDelta` arrives. Run with
+//!    `cargo test --test provider_selection -- --ignored`.
+
+use forge_core::{EndReason, Event};
+use forge_ipc::{
+    ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, PROTO_VERSION,
+};
+use std::process::Stdio;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+const FORGED: &str = env!("CARGO_BIN_EXE_forged");
+
+async fn connect_with_retry(path: &std::path::Path) -> UnixStream {
+    for _ in 0..50 {
+        if let Ok(s) = UnixStream::connect(path).await {
+            return s;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("forged did not create socket in time")
+}
+
+fn extract_event(msg: &IpcMessage) -> Option<Event> {
+    if let IpcMessage::Event(IpcEvent { event, .. }) = msg {
+        Some(serde_json::from_value::<Event>(event.clone()).unwrap())
+    } else {
+        None
+    }
+}
+
+async fn handshake(stream: &mut UnixStream) {
+    forge_ipc::write_frame(
+        stream,
+        &IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "test".into(),
+                pid: std::process::id(),
+                user: "tester".into(),
+            },
+        }),
+    )
+    .await
+    .unwrap();
+    let _ack = forge_ipc::read_frame(stream).await.unwrap();
+    forge_ipc::write_frame(stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn ollama_dispatch_surfaces_connection_error_at_unreachable_port() {
+    // Proves --provider ollama:<model> actually constructs an OllamaProvider:
+    // pointed at port 1 (always refused on Linux), the daemon must surface a
+    // connection error rather than scripted MockProvider output.
+
+    let dir = TempDir::new().unwrap();
+    let workspace = dir.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let session_id = "ollama-dispatch-test";
+    let sock_path = dir.path().join("session.sock");
+
+    let mut child = tokio::process::Command::new(FORGED)
+        .arg("--ephemeral")
+        .arg("--provider")
+        .arg("ollama:nonexistent-model")
+        .env("FORGE_SESSION_ID", session_id)
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .env("FORGE_WORKSPACE", &workspace)
+        .env("OLLAMA_BASE_URL", "http://127.0.0.1:1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to spawn forged");
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    handshake(&mut stream).await;
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "hello".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    let mut saw_error = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let frame = tokio::time::timeout_at(deadline, forge_ipc::read_frame(&mut stream)).await;
+        match frame {
+            Ok(Ok(msg)) => {
+                if let Some(Event::SessionEnded { reason, .. }) = extract_event(&msg) {
+                    if let EndReason::Error(text) = reason {
+                        // OllamaProvider prefixes every error with "ollama
+                        // chat request failed:". A MockProvider regression
+                        // could not produce that prefix — so this assertion
+                        // distinguishes "OllamaProvider was actually built"
+                        // from "any session error happened".
+                        assert!(
+                            text.to_lowercase().contains("ollama"),
+                            "SessionEnded error must come from OllamaProvider; got {text}"
+                        );
+                        saw_error = true;
+                    }
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    assert!(
+        saw_error,
+        "expected SessionEnded with ollama-related Error reason"
+    );
+
+    let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+}
+
+#[tokio::test]
+#[ignore = "requires local Ollama at 127.0.0.1:11434 with qwen2.5:0.5b pulled"]
+async fn ollama_round_trip_against_local_qwen() {
+    // Probe Ollama for the expected model; if missing, panic with a clear
+    // message rather than silently passing.
+    let probe = reqwest::get("http://127.0.0.1:11434/api/tags")
+        .await
+        .expect("Ollama not reachable at 127.0.0.1:11434 — start it with `ollama serve`");
+    let body: serde_json::Value = probe.json().await.expect("invalid /api/tags response");
+    let has_model = body
+        .get("models")
+        .and_then(|m| m.as_array())
+        .map(|arr| {
+            arr.iter()
+                .any(|m| m.get("name").and_then(|n| n.as_str()) == Some("qwen2.5:0.5b"))
+        })
+        .unwrap_or(false);
+    assert!(
+        has_model,
+        "qwen2.5:0.5b not pulled — run `ollama pull qwen2.5:0.5b`"
+    );
+
+    let dir = TempDir::new().unwrap();
+    let workspace = dir.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let session_id = "ollama-roundtrip-test";
+    let sock_path = dir.path().join("session.sock");
+
+    let mut child = tokio::process::Command::new(FORGED)
+        .arg("--ephemeral")
+        .arg("--provider")
+        .arg("ollama:qwen2.5:0.5b")
+        .env("FORGE_SESSION_ID", session_id)
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .env("FORGE_WORKSPACE", &workspace)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to spawn forged");
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    handshake(&mut stream).await;
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "Reply with a single word: hi".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    let mut saw_delta = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        let frame = tokio::time::timeout_at(deadline, forge_ipc::read_frame(&mut stream)).await;
+        match frame {
+            Ok(Ok(msg)) => match extract_event(&msg) {
+                Some(Event::AssistantDelta { delta, .. }) if !delta.is_empty() => {
+                    saw_delta = true;
+                }
+                Some(Event::SessionEnded { .. }) => break,
+                _ => {}
+            },
+            _ => break,
+        }
+    }
+    assert!(
+        saw_delta,
+        "expected at least one AssistantDelta from Ollama"
+    );
+
+    let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+}

--- a/docs/testing/phase1-uat-setup.md
+++ b/docs/testing/phase1-uat-setup.md
@@ -48,7 +48,35 @@ sudo dnf install -y alsa-lib nss atk cups-libs libdrm libxkbcommon \
   at-spi2-atk mesa-libgbm libXcomposite libXdamage libXrandr libXScrnSaver
 ```
 
-## 4. Ollama (for UAT-01b, UAT-03, UAT-12 variant A)
+## 4. Provider selection (F-038)
+
+`forged` picks its provider from, in precedence order:
+
+1. `--provider <spec>` flag (forwarded by `forge session new agent ... --provider <spec>` and `forge session new provider <spec>`)
+2. `FORGE_PROVIDER` env var
+3. `MockProvider` default (uses `FORGE_MOCK_SEQUENCE_FILE` if set, else default path)
+
+Spec grammar:
+
+| Spec | Effect |
+|------|--------|
+| `mock` | MockProvider |
+| `ollama:<model>` | OllamaProvider against `OLLAMA_BASE_URL` (default `http://127.0.0.1:11434`), e.g. `ollama:qwen2.5:0.5b` |
+
+Examples for the UAT harness:
+
+```bash
+# UAT-01a (default, MockProvider via FORGE_MOCK_SEQUENCE_FILE)
+./docs/testing/phase1-uat.sh --cli-only
+
+# UAT-01c (real Ollama)
+FORGE_PROVIDER=ollama:qwen2.5:0.5b ./docs/testing/phase1-uat.sh --cli-only
+
+# Direct: spawn a single session against Ollama
+forge session new agent test-agent --provider ollama:qwen2.5:0.5b --workspace "$WS"
+```
+
+## 5. Ollama (for UAT-01b, UAT-01c, UAT-03, UAT-12 variant A)
 
 Install, start, and pull one tiny model. The UAT only needs the Dashboard to
 enumerate models — any model smaller than ~1 GB is fine.
@@ -74,7 +102,7 @@ Stop the daemon when you want to exercise UAT-03's unreachable variant:
 pkill ollama
 ```
 
-## 5. tauri-driver (for real-shell Playwright specs, optional)
+## 6. tauri-driver (for real-shell Playwright specs, optional)
 
 Required for specs marked `requires tauri-driver` (UAT-01a/01b/03/12B). Until
 you wire a webdriverio harness, skip this step — the mocked-IPC specs cover
@@ -86,7 +114,7 @@ cargo install tauri-driver --locked
 sudo dnf install -y webkit2gtk4.1-driver   # Fedora
 ```
 
-## 6. Run the harness
+## 7. Run the harness
 
 ```bash
 # Full suite:
@@ -117,8 +145,11 @@ cd web/packages/app && pnpm run test:e2e:ui
   - **Skipped by design** until follow-up fixtures land: UAT-01a (needs a
     real `forged` bridge), UAT-03 (needs Ollama toggle harness), UAT-08
     (needs `forged` + tempdir workspace), UAT-11, UAT-12.
-  - **Blocked**: UAT-01c (session-level Ollama wiring is missing — see
-    `docs/testing/phase1-uat.md` *Known gap*).
+  - **Runnable with Ollama**: UAT-01c — `ollama pull qwen2.5:0.5b`, then
+    pass `--provider ollama:qwen2.5:0.5b` (or `FORGE_PROVIDER=ollama:...`).
+    The Playwright spec itself remains `test.skip` pending the real-shell
+    tauri-driver harness; the Rust integration round-trip covers the wiring
+    today (`cargo test -p forge-session --test provider_selection -- --ignored`).
 
 Spec files carry `test.skip(...)` with a human-readable reason; the
 `README.md` next to them maps every reason to its fix.

--- a/docs/testing/phase1-uat.md
+++ b/docs/testing/phase1-uat.md
@@ -1,13 +1,20 @@
 # Phase 1 User Acceptance Test Plan
 
 **Scope:** Phase 1: Single Provider + GUI — Dashboard, Session window, chat pane, tool calls, four-scope approval, Ollama provider, archive-on-end.
-**Outcome gate:** A user can launch Forge, open a session from the Dashboard, exchange messages (with streaming), trigger a tool call, approve it inline, and see the result rendered in the chat pane. See the **Known gap** note below for the provider wired into the session daemon.
+**Outcome gate:** A user can launch Forge, open a session from the Dashboard, exchange messages (with streaming) against either MockProvider or a real local Ollama model, trigger a tool call, approve it inline, and see the result rendered in the chat pane.
 
 ---
 
-## Known gap before reading further
+## Provider selection
 
-The Phase 1 milestone description states "chat with a local Ollama model." The `OllamaProvider` crate (F-021) and the Dashboard provider status card (F-023) are in place, but `crates/forge-session/src/main.rs:38-45` still hardcodes `MockProvider`. End-to-end chat-with-Ollama through a running session is therefore **not wired** as of the current head. This plan treats the shippable outcome gate as the **UI / session / tool-call / approval pipeline driven by `MockProvider`** (UAT-01a), and verifies the Ollama provider's real user surface (the Dashboard status card) separately (UAT-01b). A real-Ollama chat UAT is documented as UAT-01c but marked **Blocked** until the session provider selector lands — that's either a Phase 1 cleanup ticket or a Phase 3 item to triage before declaring Phase 1 complete.
+`forged` selects its provider from (in precedence order) the `--provider <spec>` CLI flag, the `FORGE_PROVIDER` env var, or — when neither is set — defaults to `MockProvider`. Spec grammar:
+
+| Spec | Effect |
+|------|--------|
+| `mock` | MockProvider (uses `FORGE_MOCK_SEQUENCE_FILE` if set, else default path) |
+| `ollama:<model>` | OllamaProvider against `OLLAMA_BASE_URL` (default `http://127.0.0.1:11434`) using the named model, e.g. `ollama:qwen2.5:0.5b` |
+
+UAT-01a runs against MockProvider by default; UAT-01c runs the same flow against a real local Ollama. See `phase1-uat-setup.md` for the harness env vars.
 
 ---
 
@@ -91,10 +98,35 @@ echo "hello from forge phase1 UAT" > "$WS/readable.txt"
 
 ---
 
-## UAT-01c: Real-Ollama chat round-trip — BLOCKED
+## UAT-01c: Real-Ollama chat round-trip
 
-**Scope:** Session-level `OllamaProvider` wiring — the milestone's original outcome statement.
-**Status:** **Blocked** pending session daemon provider selection. `crates/forge-session/src/main.rs` hardcodes `MockProvider`; `forge session new provider ollama` is parsed by the CLI but not honored by `forged`. This UAT is held here for reference once the wiring lands.
+**Scope:** Session-level `OllamaProvider` wiring — the milestone's original outcome statement (F-038).
+**Vehicle:** Same scenario as UAT-01a, with `--provider ollama:<model>` (or `FORGE_PROVIDER=ollama:<model>`) instead of MockProvider scripts.
+
+Preparation:
+
+```bash
+# Verify the model is pulled.
+ollama pull qwen2.5:0.5b
+curl -s http://127.0.0.1:11434/api/tags | jq -r '.models[].name'   # should include qwen2.5:0.5b
+
+# Launch a session against real Ollama.
+forge session new agent test-agent --workspace "$WS" --provider ollama:qwen2.5:0.5b
+```
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Run UAT-01a's script with the agent's `--provider` flag set to `ollama:qwen2.5:0.5b` | Session starts; `forged` constructs `OllamaProvider` not `MockProvider` |
+| 2 | Send a prompt | Tokens stream in from the real Ollama daemon (non-deterministic content; non-empty stream) |
+| 3 | Watch for tool calls | Phase 1 mock agents don't emit tool calls; for real tool flows use a model and prompt that intentionally invoke `fs.read` etc. — out of scope here |
+
+**Failure criteria:** session ends with an Ollama connection error despite the daemon being reachable, or `MockProvider` stub responses appear instead of real model output.
+
+The wiring is also exercised by an automated `#[ignore]`-gated integration test:
+```bash
+cargo test -p forge-session --test provider_selection -- --ignored
+```
+which sends a real prompt against `qwen2.5:0.5b` and asserts a non-empty assistant delta.
 
 Suggested follow-up ticket: "forged: select provider based on session meta (`MockProvider | OllamaProvider`)". Rerun UAT-01a's script against a real Ollama-backed session once that ships.
 
@@ -290,8 +322,8 @@ Suggested follow-up ticket: "forged: select provider based on session meta (`Moc
 **Scope:** IPC bridge + provider + chat pane resilience.
 **Vehicle:** Playwright + real Ollama (variant A) and signal-kill (variant B).
 
-**Variant A — Ollama crash mid-stream (BLOCKED with UAT-01c):**
-Requires session-level Ollama wiring (see gap note above). Held for reference once the wiring lands. Until then, rely on UAT-12 Variant B plus the OllamaProvider unit tests for HTTP error mapping (`cargo test -p forge-providers ollama`).
+**Variant A — Ollama crash mid-stream:**
+Requires session started against real Ollama (`--provider ollama:<model>` per the Provider selection section above).
 
 | Step | Action | Expected |
 |------|--------|----------|
@@ -355,8 +387,8 @@ UAT-01a (MockProvider outcome gate), UAT-01b (Ollama card smoke), UAT-02 (sessio
 **Stability bar — required before Phase 2 starts:**
 UAT-03 (cache + unreachable), UAT-04, UAT-06, UAT-10, UAT-11, UAT-12, UAT-13.
 
-**Decision required before declaring Phase 1 complete:**
-UAT-01c (real-Ollama chat) is blocked by missing session provider wiring. Either open a follow-up Phase 1 cleanup ticket to wire `OllamaProvider` into `forged`, or update the Phase 1 milestone description to match what shipped ("chat with a scripted mock provider; Ollama exposed via the Dashboard card only") and move real-Ollama chat to Phase 3 alongside credential management.
+**Real-Ollama bar:**
+UAT-01c is unblocked as of F-038 — `forged` selects its provider from `--provider <spec>` / `FORGE_PROVIDER`, so `forge session new agent test-agent --provider ollama:qwen2.5:0.5b` flows through `OllamaProvider`. The wiring is also exercised by an `#[ignore]`-gated integration test (`cargo test -p forge-session --test provider_selection -- --ignored`) so CI can opt in when an Ollama instance is available.
 
 ---
 

--- a/web/packages/app/tests/phase1/uat-01c-real-ollama-chat.spec.ts
+++ b/web/packages/app/tests/phase1/uat-01c-real-ollama-chat.spec.ts
@@ -1,15 +1,19 @@
-// UAT-01c — Real-Ollama chat round-trip (BLOCKED).
+// UAT-01c — Real-Ollama chat round-trip.
 // Plan: docs/testing/phase1-uat.md §UAT-01c
 //
-// BLOCKED: `crates/forge-session/src/main.rs:38-45` hardcodes MockProvider.
-// Session-level OllamaProvider wiring is not yet in place. This spec stays
-// skipped; open a follow-up ticket to select the provider in `forged` based
-// on session meta.
+// Provider wiring landed in F-038. This spec stays skipped at the Playwright
+// layer — the round-trip is exercised at the Rust integration level by
+// `crates/forge-session/tests/provider_selection.rs::ollama_round_trip_against_local_qwen`
+// (`#[ignore]`-gated). A real-shell Playwright variant requires the
+// tauri-driver harness that other 01-series specs are also waiting on.
 
 import { test } from '@playwright/test';
 
 test.describe('UAT-01c — real-Ollama chat round-trip', () => {
-  test.skip(true, 'blocked — forged hardcodes MockProvider; see phase1-uat.md §UAT-01c');
+  test.skip(
+    true,
+    'covered at the Rust integration layer; real-shell Playwright variant blocked on tauri-driver — see phase1-uat.md §UAT-01c',
+  );
 
   test('placeholder — rerun UAT-01a against a real Ollama-backed session', async () => {
     // no-op


### PR DESCRIPTION
Closes forge-ide/forge#74

## Summary

- `forged` now selects its provider from (in precedence order) the `--provider <spec>` CLI flag, the `FORGE_PROVIDER` env var, or `MockProvider` default. Match-dispatches to either `OllamaProvider` (with `OLLAMA_BASE_URL` env override) or `MockProvider` (honoring `FORGE_MOCK_SEQUENCE_FILE` for backwards compat).
- New `parse_provider_spec()` parser supports `<kind>` and `<kind>:<rest>`. Splits on first colon only — `ollama:qwen2.5:0.5b` parses to model `qwen2.5:0.5b` (the model literal contains a colon).
- `forge session new agent <name>` gains an optional `--provider <spec>` flag; forwarded to forged. `session new provider <spec>` works as before.
- Two integration tests at `crates/forge-session/tests/provider_selection.rs`:
  - `ollama_dispatch_surfaces_connection_error_at_unreachable_port` — runs in CI; proves OllamaProvider is constructed (asserts the error is prefixed with `"ollama"`, distinguishing dispatch from any other session error).
  - `ollama_round_trip_against_local_qwen` — `#[ignore]`-gated; sends a real prompt to a local Ollama with `qwen2.5:0.5b` and asserts a non-empty AssistantDelta. Run with `cargo test -p forge-session --test provider_selection -- --ignored`.
- Docs: `phase1-uat.md` Known-gap → Provider-selection section; UAT-01c unblocked with full prep + step list; UAT-12 Variant A no longer Blocked. `phase1-uat-setup.md` adds §4 Provider-selection (grammar table + harness examples) and flips the UAT-01c "What to expect" entry from Blocked to Runnable.

## Test plan

- [x] `cargo test --workspace` — all green (54 test groups, 0 failed)
- [x] `cargo test -p forge-cli` — 10 passed (including new agent `--provider` parsing test)
- [x] `cargo test -p forge-session --test provider_selection -- --ignored` — real Ollama round-trip ✓ (1.5s against local qwen2.5:0.5b)
- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings` clean
- [x] `./docs/testing/phase1-uat.sh --cli-only` — UAT-09/10/13 all pass (no regressions from F-039)

🤖 Generated with [Claude Code](https://claude.com/claude-code)