### PR TITLE
[F-040] Composer stays disabled through full assistant stream

### DIFF
--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -162,6 +162,30 @@ describe('Composer disabled state', () => {
     expect(textarea).not.toBeDisabled();
   });
 
+  // F-040: the AssistantDelta handler clears `awaitingResponse` to false on the
+  // first token, so a predicate based only on awaitingResponse re-enables the
+  // composer mid-stream. The composer must stay disabled until the stream
+  // finalises (streamingMessageId !== null), then re-enable on the final.
+  it('stays disabled across awaiting → delta → final, then re-enables', () => {
+    setAwaitingResponse(SID, true);
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    expect(textarea).toBeDisabled();
+
+    // First delta arrives — `awaitingResponse` flips to false in the store,
+    // but `streamingMessageId` is set; composer must STILL be disabled.
+    pushEvent(SID, { kind: 'AssistantDelta', delta: 'Hi', message_id: 'turn-1' });
+    expect(textarea).toBeDisabled();
+
+    // Mid-stream delta — still disabled.
+    pushEvent(SID, { kind: 'AssistantDelta', delta: ' there.', message_id: 'turn-1' });
+    expect(textarea).toBeDisabled();
+
+    // Stream finalises — composer re-enables.
+    pushEvent(SID, { kind: 'AssistantMessage', text: 'Hi there.', message_id: 'turn-1' });
+    expect(textarea).not.toBeDisabled();
+  });
+
   it('shows a streaming indicator while awaiting response', () => {
     setAwaitingResponse(SID, true);
     const { getByTestId } = render(() => <ChatPane />);

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -338,8 +338,15 @@ export const ChatPane: Component = () => {
         </For>
       </div>
 
-      {/* Composer */}
-      <Composer disabled={state().awaitingResponse} onSend={handleSend} />
+      {/* Composer — disabled while we are awaiting the first token OR a
+          stream is in flight. The store clears `awaitingResponse` on the
+          first AssistantDelta but leaves `streamingMessageId` set until
+          AssistantMessage(stream_finalised: true), so both must read
+          falsy before the composer re-enables. */}
+      <Composer
+        disabled={state().awaitingResponse || state().streamingMessageId !== null}
+        onSend={handleSend}
+      />
     </section>
   );
 };

--- a/web/packages/app/tests/phase1/uat-05-chat-pane-streaming.spec.ts
+++ b/web/packages/app/tests/phase1/uat-05-chat-pane-streaming.spec.ts
@@ -66,11 +66,34 @@ test.describe('UAT-05 — Chat pane streaming & composer', () => {
     await expect(page.getByTestId('message-list')).toContainText('Hi there.');
   });
 
-  test('composer stays disabled through the stream, re-enables on final', async () => {
-    test.skip(
-      true,
-      'Tracked separately as F-040 (#76): composer re-enables mid-stream because AssistantDelta clears awaitingResponse.',
+  test('composer stays disabled through the stream, re-enables on final (F-040)', async ({
+    tauri,
+    page,
+  }) => {
+    await mountSession(page, tauri);
+
+    // Send a user message via the composer so the store sets awaitingResponse=true.
+    const composer = page.getByTestId('composer-textarea');
+    await composer.click();
+    await composer.type('hello');
+    await composer.press('Enter');
+    await expect(composer).toBeDisabled();
+
+    // First delta arrives — store clears awaitingResponse but sets
+    // streamingMessageId. Composer must STILL be disabled.
+    await tauri.emit('session:event', assistantDelta(SESSION_ID, 'turn-1', 'Hi'));
+    await expect(composer).toBeDisabled();
+
+    // Mid-stream — still disabled.
+    await tauri.emit('session:event', assistantDelta(SESSION_ID, 'turn-1', ' there.'));
+    await expect(composer).toBeDisabled();
+
+    // Stream finalises — composer re-enables.
+    await tauri.emit(
+      'session:event',
+      assistantMessageFinal(SESSION_ID, 'turn-1', 'Hi there.'),
     );
+    await expect(composer).toBeEnabled();
   });
 
   test('auto-scroll pin releases on user scroll-up, re-engages on scroll-bottom', async ({


### PR DESCRIPTION
Closes forge-ide/forge#76

## Summary

- Composer's `disabled` prop in `ChatPane.tsx` derives from `state().awaitingResponse || state().streamingMessageId !== null`. The store's `AssistantDelta` handler clears `awaitingResponse` on the first token (so the streaming-indicator can swap from "Awaiting response…" to text), but it sets `streamingMessageId` and only clears it on `AssistantMessage(stream_finalised: true)` — so the composer now stays disabled for the entire turn and re-enables exactly when the stream finishes.
- Vitest lifecycle test added: send → delta (still disabled) → mid-stream delta (still disabled) → final (re-enabled).
- UAT-05's previously-skipped composer-disabled-mid-stream Playwright assertion is now active and passing — exercises the real production `handleSend` path via `composer.press('Enter')`.
- Sticky across turn boundaries (next AssistantDelta with a new `message_id` overwrites `streamingMessageId`); re-enables on `Error` events too (existing handler clears both flags — correct retry UX).

## Test plan

- [x] `pnpm --filter app test` — 186/186 vitest tests pass (was 185, +1 lifecycle test)
- [x] `pnpm --filter app typecheck` clean
- [x] `./docs/testing/phase1-uat.sh --gui-only` — 12 passed (was 11; composer-disabled now active), 24 skipped, 0 failed
- [x] No Rust changes; cargo workspace unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)