### PR TITLE
Add milestone workflow skill family (10 skills)

### DIFF
--- a/.claude/skills/forge-close-milestone/SKILL.md
+++ b/.claude/skills/forge-close-milestone/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: forge-close-milestone
+description: Use when actually shipping a Forge milestone after forge-milestone-release-readiness has returned GO (or GO WITH WAIVERS) — bumps the workspace and package versions to the release version, commits and tags, pushes, creates the GitHub release with notes pulled from CHANGELOG.md, closes the GitHub milestone, closes the consolidated audit-report issues, and then bumps main to the next dev cycle. Refuses to run without a GO decision on record. Every action is idempotent so a partial run can be safely resumed. Trigger on phrases like "close out and ship Phase N", "cut the release for this milestone", "tag and release the milestone", "we got a GO — ship it", or any actual release-cut invocation.
+---
+
+# forge-close-milestone
+
+## Overview
+
+The **execution skill** that ships a milestone after the gauntlet has returned GO. This is the only milestone skill that performs destructive / irreversible actions (tag push, `gh release create`, milestone close) — so it gates heavily, builds a manifest the user confirms before any state change, and makes every action idempotent.
+
+Ordering context in the skill family:
+1. `forge-complete-milestone` runs the audit gauntlet and ends with `forge-milestone-release-readiness` returning a decision.
+2. If the decision is **GO** or **GO WITH WAIVERS**, *this* skill ships it.
+3. If the decision is **NO-GO**, this skill refuses to run until the blockers are cleared and release-readiness is re-run.
+
+Not in scope: creating the next milestone, announcements, changelog authorship (the release-readiness skill already verified the changelog is complete).
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone to close and release |
+
+## Phase 0: Precondition checks — fail fast
+
+These are all hard refusals — do not proceed past any failure.
+
+```bash
+# 1. Fetch the release-readiness report for this milestone
+gh issue list --repo forge-ide/forge --milestone "<milestone>" \
+  --search 'label:"release: audit"' --json number,title,state,body --limit 1
+```
+
+From that report body, confirm the **Decision** line reads `GO` or `GO WITH WAIVERS`. If it reads `NO-GO` or the report does not exist: stop and tell the user to run `forge-complete-milestone` (or `forge-milestone-release-readiness` directly) first.
+
+```bash
+# 2. Working tree must be clean
+git status --short
+# 3. Must be on main, up to date with origin/main
+git rev-parse --abbrev-ref HEAD
+git fetch origin main
+git rev-list --count HEAD..origin/main     # must be 0
+git rev-list --count origin/main..HEAD     # must be 0
+```
+
+Any mismatch → stop. Do **not** auto-checkout, auto-pull, or auto-rebase — surface the divergence and let the user settle it.
+
+## Phase 1: Build the release manifest — invoke `Explore`
+
+Delegate to an `Explore` subagent. Brief:
+
+> For milestone `"<milestone>"`, build a release manifest.
+>
+> 1. **Current versions**: read `[workspace.package].version` from the root `Cargo.toml`. Then find every `package.json` under `web/` (including `web/package.json` and every `web/packages/*/package.json`) and return each file's `version`. Return the full list: `(path, current_version)`.
+> 2. **Proposed release version**: the release-readiness report's Step 2 criteria recorded the expected version-bump regime (major/minor/patch/none). Read that from the report body. If it says "no bump needed", the release version equals the current version. Otherwise, propose the bumped value (e.g. current `0.2.0-dev` → release `0.2.0`; current `0.2.0` → release `0.3.0` if the criteria say minor). Return the proposed value.
+> 3. **Tag name**: look at existing git tags to derive the convention: `git tag -l --sort=-v:refname | head -5`. Propose a tag name that matches — usually `v<release_version>`. If there's a phase-marker convention (e.g. `v0.2.0-phase2`), match it.
+> 4. **Post-release dev version**: propose the next dev value (e.g. release `0.2.0` → `0.3.0-dev`, or `0.2.1-dev`, depending on the repo's precedent from tag history). If the repo has never used a `-dev` suffix, propose the same-version continuation and note it.
+> 5. **Release notes source**: read the CHANGELOG.md section for the release version. Extract it verbatim (that's the release-note body). If the section is missing or empty, flag it — release-readiness is supposed to have caught this, so surface the discrepancy.
+> 6. **Milestone number**: from `gh api repos/forge-ide/forge/milestones`.
+> 7. **Close-list of consolidated audit report issues** under this milestone: `gh issue list --milestone "<milestone>" --search 'label:"security: audit" OR label:"docs: audit" OR label:"quality: audit" OR label:"frontend: audit" OR label:"perf: audit" OR label:"compat: audit" OR label:"release: audit"' --state open --json number,title,labels`.
+> 8. **Open finding issues** under this milestone (i.e. non-audit issues still open): `gh issue list --milestone "<milestone>" --state open --json number,title,labels`. These are deferred findings that will NOT be closed by this skill; they're candidates for roll-over to the next milestone.
+>
+> Return: manifest as a single structured object.
+
+## Phase 2: HARD GATE — present manifest and confirm
+
+Display the full manifest in a single block, ordered by the execution sequence. Example shape (substitute real values):
+
+```
+Release manifest for <milestone>
+
+Version bumps — release:
+  Cargo.toml (workspace)    0.2.0-dev  →  0.2.0
+  web/package.json          0.0.0      →  0.2.0
+  web/packages/app/         0.0.0      →  0.2.0
+  web/packages/design/      0.0.0      →  0.2.0
+  web/packages/ipc/         0.0.0      →  0.2.0
+
+Git operations:
+  Commit:  chore(release): v0.2.0
+  Tag:     v0.2.0  (annotated)
+  Push:    origin main + origin v0.2.0
+
+GitHub release:
+  Title:   Phase 2: Full Layout + MCP — v0.2.0
+  Tag:     v0.2.0
+  Notes:   <first 10 lines of CHANGELOG section, truncated with "…">
+
+GitHub milestone:
+  Close:   Phase 2: Full Layout + MCP  (#NN)
+
+Audit-report issues to close:
+  #123  Security audit report: Phase 2
+  #124  Quality review report: Phase 2
+  #125  Release readiness report: Phase 2
+  ... (N total)
+
+Deferred findings to stay open (will NOT be closed by this skill):
+  #130  [perf: low] ...
+  #131  [docs: medium] ...
+  ... (M total)
+
+Version bumps — post-release (second commit, to resume dev on main):
+  Cargo.toml (workspace)    0.2.0  →  0.3.0-dev
+  web/package.json          0.2.0  →  0.3.0-dev
+  ... (same paths)
+
+Commit:  chore(release): bump to v0.3.0-dev
+Push:    origin main
+```
+
+Explicitly ask: **"Close and release <milestone> using this manifest? Type 'yes' to proceed, or say which values to change."**
+
+Do not proceed without a `yes`. If the user edits any value, redisplay the full manifest and ask again — iterations are cheap; a wrong tag is not.
+
+**Hard rule:** never take a `yes` implied from context. A distinct confirmation turn is required because the next step pushes to a shared remote.
+
+## Phase 3: Execute the release
+
+Each sub-step checks its done-state first and skips cleanly if already applied. This is what makes the skill re-runnable after a partial failure.
+
+### 3a. Release-version bump
+
+For each `(path, current, proposed)` in the manifest's release-bump list:
+
+```bash
+# Check if already at proposed version (idempotence)
+current_in_file=$(<parse the file at path>)
+if [ "$current_in_file" = "<proposed>" ]; then
+  echo "skip: $path already at <proposed>"
+else
+  # Apply the edit
+  <sed/edit the version field in the file>
+fi
+```
+
+Use the `Edit` tool for each file, not bash `sed`, so the change is reviewable inline.
+
+### 3b. Release commit
+
+```bash
+# Idempotence: if the top commit is already "chore(release): v<version>", skip
+git log -1 --pretty=%s
+# Otherwise:
+git add <listed files>
+git commit -m "chore(release): v<version>"
+```
+
+### 3c. Tag the release
+
+```bash
+# Idempotence: check if tag exists
+git tag -l "<tag>"
+# If empty, create:
+git tag -a "<tag>" -m "Release <tag>: <milestone>"
+```
+
+### 3d. Push commit and tag
+
+```bash
+git push origin main
+git push origin "<tag>"
+```
+
+After this point the release is **public** — cannot be cleanly undone. If the user interrupts here, re-running the skill will detect the tag and skip to 3e.
+
+### 3e. Create the GitHub release
+
+```bash
+# Idempotence: check if release exists for this tag
+gh release view "<tag>" --repo forge-ide/forge >/dev/null 2>&1
+# If missing, create:
+gh release create "<tag>" \
+  --repo forge-ide/forge \
+  --title "<title>" \
+  --notes "$(cat <<'EOF'
+<CHANGELOG section, verbatim>
+EOF
+)"
+```
+
+### 3f. Close the GitHub milestone
+
+```bash
+# Idempotence: check state
+gh api "repos/forge-ide/forge/milestones/<N>" --jq .state
+# If "open":
+gh api --method PATCH "repos/forge-ide/forge/milestones/<N>" -f state=closed
+```
+
+### 3g. Close the consolidated audit-report issues
+
+For each report issue in the close-list, if state is `open`:
+
+```bash
+gh issue close <number> --repo forge-ide/forge \
+  --reason completed \
+  --comment "Closed by forge-close-milestone for $(git describe --tags --exact-match)."
+```
+
+**Do not close the open-findings list** — those are deferred issues that roll forward to be triaged into the next milestone.
+
+### 3h. Offer roll-over for deferred findings
+
+Ask the user: "There are M open findings that were filed during this milestone. Move them to the next milestone now, leave them unassigned, or decide later?" Three options:
+
+- **Move**: require the user to name the next milestone title; apply via `gh issue edit --milestone "<next>"` per issue
+- **Unassign**: `gh issue edit --remove-milestone` per issue (they become backlog)
+- **Later**: do nothing; surface the list in the Phase 5 summary so the user can handle it separately
+
+Never default — always ask.
+
+## Phase 4: Post-release dev-version bump
+
+This bumps main back onto a dev track so continuing work isn't accidentally on the release version.
+
+### 4a. Post-release version edits
+
+Same idempotence pattern as 3a — check current, skip if already at the dev value.
+
+### 4b. Post-release commit
+
+```bash
+git add <files>
+git commit -m "chore(release): bump to v<dev-version>"
+```
+
+### 4c. Push
+
+```bash
+git push origin main
+```
+
+**If the user elected no post-release bump** (they can override this in Phase 2), skip Phase 4 entirely.
+
+## Phase 5: Summary
+
+Print a single-screen summary with direct links:
+
+- **Release**: `gh release view <tag> --json url --jq .url`
+- **Tag**: `https://github.com/forge-ide/forge/releases/tag/<tag>`
+- **Milestone**: `https://github.com/forge-ide/forge/milestone/<N>?closed=1`
+- **HEAD**: `git log -1 --pretty='%h %s'` (should be the post-release dev-bump commit)
+- **Closed report issues**: list
+- **Deferred findings**: list with their roll-over fate (moved / unassigned / pending)
+
+## Delegation rules
+
+| Work type | Where it runs |
+|-----------|---------------|
+| GO-decision verification, clean-tree verification | Main context (Bash, cheap) |
+| Manifest gathering (versions, tags, CHANGELOG, issues) | `Explore` subagent |
+| Manifest confirmation | Main context (user-facing, must be explicit) |
+| Version edits to files | `Edit` tool, main context — each edit reviewable |
+| Git commit / tag / push | Bash, main context, sequential with idempotence guards |
+| `gh release create`, milestone close, issue close | Bash, main context |
+| Roll-over decision for deferred findings | Main context — always ask, never default |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Running without a GO decision | Hard-refuse — release-readiness must have signed off; running on a NO-GO ships bugs |
+| Auto-pulling or auto-rebasing on behalf of the user | Surface divergence from `origin/main`; the user settles it, not the skill |
+| Skipping the manifest confirmation | A HARD GATE before anything touches the remote is non-negotiable — a wrong tag is awkward to undo |
+| Using `sed` in bash for version edits | Use the `Edit` tool so the change is visible in the tool log |
+| Re-tagging when the tag exists | Every step checks idempotence first; re-running a partial close is supposed to be safe |
+| Force-pushing a retagged release | Don't — a published tag is effectively immutable; if the tag is wrong, make a new one |
+| Closing open finding issues | Only the *consolidated audit report* issues close here; individual findings carry forward |
+| Auto-defaulting deferred findings into a target milestone | Always ask the user which milestone, or whether to unassign |
+| Forgetting the post-release dev bump | Leaving main at the release version lets the next commit accidentally overwrite the tagged version — dev bump is part of the ritual |
+| Writing a release note that differs from CHANGELOG | The CHANGELOG is authoritative; the release note is a direct extract, not a rephrasing |
+| Claiming the close is done without checking Phase 5 links | `verification-before-completion` applies here too — the release URL is the evidence |

--- a/.claude/skills/forge-complete-milestone/SKILL.md
+++ b/.claude/skills/forge-complete-milestone/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: forge-complete-milestone
+description: Use when running the end-of-milestone workflow for a Forge milestone — orchestrates the code audits (security/docs/quality/frontend), UAT authorship, regression gates (performance/backcompat), and the release-readiness go/no-go decision in the right order, with user checkpoints between phases so you can pause on any critical finding and resume later. This is the milestone-level analogue of forge-complete-task. Trigger on phrases like "close out Phase N", "run the end-of-milestone workflow", "wrap up the milestone", "ship Phase N", or whenever the user wants to kick off the milestone-completion gauntlet rather than invoke individual audit skills one-by-one.
+---
+
+# forge-complete-milestone
+
+## Overview
+
+End-to-end milestone-completion workflow. Four phases in a load-bearing order: **audits → UAT → regression gates → release-readiness**. The main context is a coordination layer — delegate every discrete unit of work to the child skills. Do not re-implement their logic inline.
+
+This skill is the milestone-level analogue of `forge-complete-task`. Like that skill, it runs in phases with explicit gates between them, and the user can pause after any phase.
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone to close out |
+| Skip (optional) | `--skip <skill-name>[,<skill-name>...]` | Named skills to skip (e.g. `--skip perf,backcompat`) |
+| Only (optional) | `--only <skill-name>[,<skill-name>...]` | Run only named skills, in the listed order |
+
+Resolve skill names to the short form of each child skill: `security`, `docs`, `quality`, `frontend`, `uat`, `perf`, `backcompat`, `release`.
+
+## Resumability
+
+Every child skill produces a **consolidated report issue** with a distinctive audit label. Before invoking any child skill, check whether its report exists under this milestone — if it does, the audit was already run, so skip unless the user explicitly opts in to re-run.
+
+```bash
+gh issue list --repo forge-ide/forge --milestone "<milestone>" \
+  --search 'label:"<domain>: audit"' --json number,title --limit 1
+```
+
+Labels to check: `security: audit`, `docs: audit`, `quality: audit`, `frontend: audit`, `perf: audit`, `compat: audit`, `release: audit`. UAT is detected differently — see Phase B.
+
+Resuming an interrupted run is automatic: re-invoke with the same milestone argument and previously-completed phases will be skipped.
+
+## Auto-skip conditions
+
+Detect these with `Explore` at the start of Phase 0; they save the user from manually passing `--skip`:
+
+- **frontend review** — skip if no file under `web/` was touched by any PR merged under this milestone
+- **backcompat audit** — skip if no interface surface file changed (the child skill's Phase 1 will detect this; we can pre-detect too by diffing the milestone-start baseline against current on the interface files listed in `docs/architecture/ipc-contracts.md`)
+- **UAT authorship** — skip if `docs/testing/phase<N>-uat.md` already exists and was last touched during this milestone's time window, OR a PR titled `docs(testing): Phase <N> UAT ...` is open/merged
+
+## Phase 0: Setup — invoke `Explore`
+
+Delegate once to build the workflow plan:
+
+> For milestone `"<milestone>"`:
+>
+> 1. Fetch milestone metadata and state.
+> 2. List open vs. closed issues under the milestone. Flag if open-issue count is non-trivial — the workflow can still run, but incomplete milestones may produce noisy UAT plans and premature release-readiness decisions.
+> 3. List merged PRs. Compute which top-level areas were touched.
+> 4. Derive **auto-skip decisions**: any `web/` touched? (drives frontend-review). Any interface-contract file changed? (drives backcompat). Does `docs/testing/phase<N>-uat.md` exist with a recent mtime, or is a UAT PR open? (drives UAT).
+> 5. For each of the eight child skills, check whether its report already exists (see Resumability). Return a **per-skill status**: `ready | done | auto-skip | user-skip`.
+> 6. Verify the working tree is clean. Return `git status --short` output.
+>
+> Return: milestone facts, per-skill status table, working-tree state.
+
+Present the plan to the user: "Here are the eight child skills, N already done, M auto-skipped, K ready to run. Proceed?"
+
+**Gate:** Wait for user acknowledgement before Phase A begins.
+
+## Phase A: Code audits
+
+These four can run in any order — they are independent of each other. Run them sequentially because each one involves the user in its own brainstorming steps; parallel invocation would compete for user attention.
+
+Default order (security first so its critical findings surface early; docs last as least likely to block):
+
+1. `forge-milestone-security-audit "<milestone>"`
+2. `forge-milestone-quality-review "<milestone>"`
+3. `forge-milestone-frontend-review "<milestone>"` (auto-skipped if no `web/` changed)
+4. `forge-milestone-docs-audit "<milestone>"`
+
+**Between each audit, present a checkpoint:**
+
+> Audit complete: <skill>
+> - New issues: <count by severity>
+> - Highest severity opened: <critical | high | medium | low | none>
+> - Critical/high findings: <list titles inline>
+>
+> Next: <next skill>. Continue, pause, or skip this next audit?
+
+Pause semantics: "pause" stops the workflow here. The user can resume later by re-invoking this skill; completed audits are auto-skipped.
+
+**Hard gate on critical findings:** if any audit opens a `critical` issue, do *not* auto-advance — always ask the user explicitly. Critical findings often change downstream decisions (e.g. a critical security issue may make release-readiness a guaranteed no-go, at which point running the rest is wasted effort).
+
+## Phase B: UAT authorship
+
+Invoke `forge-milestone-uat-author "<milestone>"` unless auto-skipped.
+
+Rationale for ordering after Phase A: the UAT plan should be authored *after* the milestone's defects have been triaged — that way the plan's "Known gap" section can reference already-filed audit issues, and the plan doesn't need rewriting when audits surface blocked deliverables.
+
+**Gate after UAT:** verify the UAT PR was opened (Phase A doesn't need this since audits produce issues in-place). Confirm with:
+
+```bash
+gh pr list --repo forge-ide/forge --head "docs/phase<N>-uat" --json number,title,state
+```
+
+If the PR does not exist, stop — something went wrong in the UAT skill; investigate before proceeding.
+
+## Phase C: Regression gates
+
+These two need a **clean working tree** because they `git checkout` to the milestone-start baseline for measurement.
+
+Precondition check:
+
+```bash
+git status --short
+```
+
+If the tree is not clean, present the dirty state to the user and require them to commit or stash before proceeding. Do **not** run `git stash` or `git reset` automatically — unexpected destructive operations on user state violate the coordinator-only contract.
+
+Then:
+
+1. `forge-milestone-performance-audit "<milestone>"`
+2. `forge-milestone-backcompat-audit "<milestone>"`
+
+**Serial, not parallel** — both skills check out the baseline SHA. Running them simultaneously would produce a checkout race.
+
+**Between each, same checkpoint format as Phase A.**
+
+Post-Phase-C sanity check: confirm the working tree is back on the original HEAD. Both child skills are supposed to return to HEAD after measurement, but a failed skill can leave the tree detached. Verify:
+
+```bash
+git rev-parse HEAD
+git status --short
+```
+
+If the tree is not back on the expected HEAD, surface the discrepancy — do not continue into Phase D on a detached tree.
+
+## Phase D: Release-readiness
+
+Invoke `forge-milestone-release-readiness "<milestone>"` last.
+
+This is the final gate. It will surface every unresolved critical/high finding from Phases A and C as a blocker, and verify the UAT plan from Phase B covers every deliverable. Running it last is the whole point — its inputs are the outputs of everything before it.
+
+The release-readiness skill produces a go/no-go decision in its consolidated report. Present that decision to the user as this workflow's final output.
+
+## Post-workflow summary
+
+After Phase D, present a one-paragraph summary:
+
+- Milestone: `<name>`
+- Phases run: `<list>` (with skipped phases noted)
+- Total new issues opened: `<count>` (link to `gh issue list --milestone "<m>" --search 'label:"type: bug" OR label:"type: security"' state:open`)
+- UAT PR: `<link or "existed already">`
+- Release decision: **GO | NO-GO | GO WITH WAIVERS**
+- If NO-GO: the blocking issues
+
+## Delegation rules
+
+| Phase | Delegated to |
+|-------|--------------|
+| 0 | `Explore` subagent |
+| A.1 | `forge-milestone-security-audit` |
+| A.2 | `forge-milestone-quality-review` |
+| A.3 | `forge-milestone-frontend-review` |
+| A.4 | `forge-milestone-docs-audit` |
+| B | `forge-milestone-uat-author` |
+| C.1 | `forge-milestone-performance-audit` |
+| C.2 | `forge-milestone-backcompat-audit` |
+| D | `forge-milestone-release-readiness` |
+| Checkpoints / pauses | Main context (user-facing coordination only) |
+| Final summary | Main context |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Re-implementing any child-skill step inline | The main context here is *only* a coordinator — every unit of work is delegated |
+| Running phases out of order | The order is load-bearing: Phase D consumes Phase A/B/C outputs; reordering breaks the go/no-go gate's dependencies |
+| Running Phase C on a dirty tree | Perf and backcompat do `git checkout` to baseline; a dirty tree risks losing uncommitted work — require clean tree explicitly |
+| Auto-stashing or auto-resetting user state | Never run destructive git operations to "clean up" — surface the dirty state and let the user decide |
+| Running perf and backcompat in parallel | Both check out the baseline SHA; simultaneous runs race each other — serial only |
+| Forcing the user past a critical finding | On any `critical`-severity issue from an audit, require explicit user acknowledgement before continuing — don't auto-advance |
+| Ignoring auto-skip conditions | A frontend review for a backend-only milestone produces noisy empty findings; detect and skip in Phase 0 |
+| Re-running completed audits on resume | Check for each skill's report-issue label before invoking; idempotence is the resumption mechanism |
+| Running without checking working-tree state between phases | Both child-skill checkouts should return to HEAD; verify after Phase C so a leftover detachment doesn't silently break Phase D |
+| Declaring the milestone closed without Phase D | Release-readiness is the final gate — the skill's name is "complete-milestone", and the completion certificate is the go/no-go decision, not just "all audits ran" |

--- a/.claude/skills/forge-milestone-backcompat-audit/SKILL.md
+++ b/.claude/skills/forge-milestone-backcompat-audit/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: forge-milestone-backcompat-audit
+description: Use when checking whether a Forge milestone broke any public-facing interface — diffs IPC message shapes (docs/architecture/ipc-contracts.md + the Rust/TS types that back it), config schema, CLI flags, and any exposed plugin/extension API from the milestone-start baseline to current, classifies each change as safe/breaking, and flags unannounced breaks. Produces one GitHub issue per breaking change plus a consolidated report. Trigger on phrases like "did we break compatibility in Phase N", "backcompat audit for the milestone", "check for breaking changes", "IPC contract diff for the milestone", or any pre-release compatibility pass.
+---
+
+# forge-milestone-backcompat-audit
+
+## Overview
+
+Milestone-scoped backwards-compatibility audit. Unlike the other milestone audits, scope is **genuinely diff-based** — the question "did we break anyone" is intrinsically about a delta, not a current state. The baseline is the milestone-start commit; the comparison point is current HEAD.
+
+**Scope is restricted to public-facing interfaces only**:
+- IPC message shapes defined on the crate side and consumed by the webview (`docs/architecture/ipc-contracts.md` is the authoritative catalog)
+- Config schema — files under `crates/forge_core/src/config*` or wherever the config lives
+- CLI flags — the `clap`-annotated struct (or equivalent) in the CLI entry point
+- Any exposed plugin/extension API, if the project has one yet
+
+Output is **one GitHub issue per breaking change** plus **one consolidated report**. Every breaking change must have either (a) a migration note in the changelog / release notes / an ADR, or (b) an explicit decision to document it now — this skill surfaces the ones with neither.
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone title to audit |
+
+If the argument is missing, list candidate milestones and ask:
+
+```bash
+gh api repos/forge-ide/forge/milestones --jq '.[] | {title, state, open_issues, closed_issues}'
+```
+
+## Steps
+
+### 1. Locate interfaces and derive the baseline — invoke `Explore`
+
+Delegate to an `Explore` subagent. Brief:
+
+> For milestone `"<milestone>"`:
+>
+> 1. Fetch milestone metadata and merged PRs sorted ascending by merge date: `gh pr list --repo forge-ide/forge --search 'milestone:"<milestone>" is:merged sort:created-asc' --json number,mergeCommit,baseRefOid,mergedAt,files,title,body --limit 200`.
+> 2. **Derive the baseline SHA**: the `baseRefOid` of the earliest merged PR. Return it.
+> 3. Locate the interface surfaces. Forge's:
+>    - **IPC**: read `docs/architecture/ipc-contracts.md` and follow it to the Rust type definitions that back each contract (typically under `crates/forge_*` as `#[derive(Serialize, Deserialize)]` types). List each contract surface as a (doc section, file path, type name) triple.
+>    - **Config schema**: find the type(s) that represent user config — likely a `Config` struct under `crates/forge_core` or similar. Return file path and type name.
+>    - **CLI flags**: find the `clap` `Parser` / `Args` types in the CLI crate. Return file path and type name.
+>    - **Any exposed plugin/extension API**: if the repo has one yet, list the public traits/types; if not, say so.
+> 4. For each interface surface, check whether it changed between baseline and HEAD: `git diff <baseline>..HEAD -- <file>` on each listed file. Return pass-through if no diff, or the full diff hunks if changed.
+> 5. Look for PRs in the milestone whose title or body contains "breaking", "migration", or "backcompat" markers — these are self-declared breaking changes. Return their PR numbers and what each claims.
+>
+> Return: milestone facts, baseline SHA, interface-surface inventory, per-surface diff (or pass-through), self-declared breaking PR list.
+
+### 2. Derive the change-class model — invoke `superpowers:brainstorming`
+
+Not every diff is a breaking change. The load-bearing reason this is brainstormed and not checklisted: whether a change is breaking depends on what *consumers* depend on, and that depends on the interface. For serde-tagged enums, adding a variant can break consumers that match exhaustively; for plain structs with `#[serde(default)]`, adding a field is usually safe. Forge's IPC boundary is a JSON contract, so the rules are specific to JSON-shape compatibility.
+
+Use brainstorming with the user, seeded by Phase 1 findings, to settle the classification rules for *this* audit:
+
+- **Type-level changes**:
+  - Struct field removed → breaking
+  - Struct field renamed (serialized name changed) → breaking
+  - Struct field type narrowed (e.g. `String` → specific enum) → breaking
+  - Struct field type widened (e.g. integer → number) → usually safe if consumers are permissive
+  - New required field → breaking
+  - New optional field (`#[serde(default)]` or `Option<T>`) → safe
+  - Enum variant removed → breaking
+  - Enum variant renamed → breaking
+  - New enum variant → breaking for exhaustive matchers, safe for permissive ones (IPC consumers in JS are typically permissive; Rust consumers typically aren't)
+  - Tagged-enum tag renamed or discriminator shape changed → breaking
+- **Config schema**: same rules as types, plus: default value change is **behavior-breaking** even if schema-compatible
+- **CLI flags**: removed flag, renamed flag, semantically-changed flag → breaking; new flag with default → safe
+- **Consumer asymmetry**: the IPC boundary has *two* consumers — Rust core and TS webview. A change is breaking if *either* side depends on the old shape. Be explicit about which side is affected.
+
+Output: a concrete classification rule sheet for this milestone, plus a note for each interface surface saying which consumer directions matter.
+
+**HARD GATE:** Do not begin Step 3 until the classification rules are presented and approved.
+
+### 3. Classify each diff — invoke `superpowers:dispatching-parallel-agents`
+
+For each interface surface that changed (from Phase 1), dispatch a subagent. Each one takes a single surface's diff and applies the Step 2 rules.
+
+Brief each identically (substituting the surface):
+
+> Classify the changes on this interface surface using the approved rule sheet.
+>
+> **Surface:** `<path>` — `<type name>`
+> **Consumer directions that matter:** `<e.g. "Rust core → TS webview", "user config file → crates/forge_core">`
+> **Rule sheet:** `<from Step 2, verbatim>`
+> **Diff:**
+> ```
+> <full diff hunks for this surface>
+> ```
+> **Self-declared breaking PRs for this surface (if any):** `<from Phase 1>`
+>
+> For each atomic change in the diff (field added/removed, variant added/removed, type changed, etc.), return an object with these fields:
+>
+> - `change` — one-line description (e.g. "removed field `ToolCallEvent.request_id`")
+> - `classification` — safe | breaking | behavior-breaking
+> - `rule_applied` — which rule from the sheet justified the classification
+> - `consumer_impact` — which side breaks: Rust-side consumers, TS-side consumers, or both; and a one-line "what breaks" explanation
+> - `self_declared` — yes | no (whether a PR in the milestone already called this change out)
+> - `migration_note_present` — yes | no | unknown (was a migration note written in changelog/release notes/ADR?)
+> - `suggested_migration` — if breaking and no note exists: the note that should be written
+>
+> Rules:
+> - When in doubt between safe and breaking, classify breaking — false positives are cheap; missed breaks are expensive
+> - If the rule sheet doesn't cover a case, say so explicitly — do not invent a classification
+
+Aggregate. Group by classification. The report pivots here: every `breaking` or `behavior-breaking` without a migration note is a finding.
+
+### 4. Triage — invoke `superpowers:brainstorming`
+
+Present the classified change list. Brainstorm:
+
+- Any `breaking` classifications the user wants to reclassify (they know consumer realities the skill doesn't)
+- Self-declared breaking changes: were the migration notes adequate, or do they need revision?
+- Unannounced breaks: must every one get a new migration note, or is some scope OK to leave unannounced pre-1.0?
+- Severity: default is `compat: high` for breaking, `compat: medium` for behavior-breaking, `compat: critical` for a silent break that would shatter live consumers (like existing IPC sessions)
+
+**HARD GATE:** Do not create any GitHub issues until the triaged list is approved.
+
+### 5. Create finding issues — sequential
+
+One issue per **unannounced or inadequately-announced breaking change**. Self-declared breaks with adequate migration notes don't need a new issue — they get recorded in the report.
+
+Find the next F-number, then:
+
+```bash
+gh issue create \
+  --repo forge-ide/forge \
+  --title "[F-NNN] <imperative title>" \
+  --milestone "<milestone>" \
+  --label "type: bug,compat: <severity>" \
+  --body "$(cat <<'EOF'
+## Scope
+
+<One paragraph: which interface surface, which consumer direction breaks, why this was not caught in PR review.>
+
+## Change
+
+- **Interface:** `<path>` — `<type name>`
+- **Classification:** breaking | behavior-breaking
+- **Rule applied:** <from classification rule sheet>
+- **Consumer impact:** <Rust | TS | both> — <what breaks>
+
+### Diff
+
+```diff
+<relevant hunks>
+```
+
+### PR(s) responsible
+
+- #<number>: <title>
+
+## Migration note needed
+
+<The migration note that should be written — where (changelog / release notes / ADR) and what it should say.>
+
+## Remediation
+
+One of:
+- Write the migration note (and optionally revert-and-reland with a proper note)
+- Revert the breaking change if it was accidental
+- Document the break in the release notes as an intentional decision
+
+## Definition of Done
+
+- [ ] Migration note written at <target location>
+- [ ] (If applicable) consumer side updated to handle the new shape
+- [ ] Backcompat audit re-run and this change is `self_declared: yes` with `migration_note_present: yes`
+EOF
+)"
+```
+
+### 6. Create the consolidated report issue
+
+```
+Title:  [F-NNN] Backcompat audit report: <milestone>
+Milestone: <milestone>
+Labels: type: bug, compat: audit
+```
+
+Body template:
+
+```markdown
+## Summary
+
+Milestone: <milestone>
+Baseline SHA: <short-sha>
+Interface surfaces inspected: <N>
+Surfaces changed: <M>
+Classified changes: safe <a> / breaking <b> / behavior-breaking <c>
+Unannounced breaks (new issues filed): <k>
+
+## Classification rules (from Step 2)
+
+<Verbatim.>
+
+## Interface surface inventory
+
+| Surface | Type | Consumer directions | Changed? |
+|---------|------|---------------------|----------|
+| `docs/architecture/ipc-contracts.md#session-events` | `SessionEvent` | Rust → TS | yes |
+| config schema | `Config` | user → Rust | no |
+| CLI | `Args` | user → binary | yes |
+
+## Classified changes
+
+| ID | Interface | Change | Classification | Self-declared | Note present | Issue |
+|----|-----------|--------|----------------|---------------|--------------|-------|
+| C-01 | `SessionEvent` | removed `request_id` | breaking | no | no | #123 |
+| C-02 | `Args` | new `--verbose` flag with default | safe | — | — | — |
+
+## Self-declared breaking changes (no new issue needed)
+
+| PR | Change | Migration note location |
+|----|--------|-------------------------|
+| #N | ... | CHANGELOG.md §<milestone> |
+
+Raw diff output: `/tmp/forge-backcompat-audit-<milestone-slug>/diffs/`
+```
+
+### 7. Verify — invoke `superpowers:verification-before-completion`
+
+```bash
+gh issue list --repo forge-ide/forge \
+  --milestone "<milestone>" \
+  --search 'label:"compat: audit" OR label:"compat: critical" OR label:"compat: high" OR label:"compat: medium" OR label:"compat: low"' \
+  --json number,title,labels
+```
+
+Confirm every triaged unannounced-break has an issue and the consolidated report exists with the full surface inventory. Do not claim done without this evidence.
+
+## Delegation rules
+
+| Work type | Where it runs |
+|-----------|---------------|
+| Interface inventory, baseline derivation, per-surface diffs, self-declared-PR sweep | `Explore` subagent |
+| Classification rule derivation | `superpowers:brainstorming` with the user |
+| Per-surface change classification | parallel subagents via `superpowers:dispatching-parallel-agents` |
+| Triage of classifications and migration-note adequacy | `superpowers:brainstorming` with the user |
+| Issue creation | Main context, strictly sequential |
+| Final verification | `superpowers:verification-before-completion` |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Treating every diff as breaking | Most diffs are safe; classification requires rules, not alarm |
+| Treating every diff as safe | When in doubt, classify breaking — false positives are cheap, missed breaks expensive |
+| Forgetting consumer asymmetry at the IPC boundary | Every IPC change must be classified for *both* Rust and TS consumer directions |
+| Collapsing schema-compatible default-value changes to "safe" | Default-value changes are behavior-breaking even when schema-compatible |
+| Not checking for self-declared breaking PRs | A PR that already announced its break doesn't need a new issue — just record it in the report |
+| Running this on a milestone with no interface changes | Exit early after Phase 1 if no surface actually changed — don't create an empty report |
+| Confusing this with quality-review's "API consistency" | That is about internal shape; this is about whether external consumers break |
+| Creating issues in parallel | Sequential only — F-number collisions |
+| Claiming done without `gh issue list` evidence | `verification-before-completion` requires it |

--- a/.claude/skills/forge-milestone-docs-audit/SKILL.md
+++ b/.claude/skills/forge-milestone-docs-audit/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: forge-milestone-docs-audit
+description: Use when auditing documentation for a Forge milestone — checks whether every capability shipped under the milestone is documented, whether existing docs have gone stale or inaccurate, whether derived artifacts (like tokens.css vs docs/design/token-reference.md) have drifted from their authoritative source, and whether markdown links still resolve. Produces one GitHub issue per finding plus a consolidated report. Trigger on phrases like "docs audit for Phase N", "check the milestone docs", "are our docs up to date after this phase", "sweep Phase N for missing docs", or whenever milestone-level documentation review is wanted.
+---
+
+# forge-milestone-docs-audit
+
+## Overview
+
+Milestone-scoped documentation audit. Scope is the **current state** of every `docs/` subtree and inline-doc surface (rustdoc, tsdoc, README.md) belonging to crates and packages touched by the milestone's merged PRs. Output is **one GitHub issue per finding** plus **one consolidated report issue**. The main context coordinates; scope gathering and per-area audits are delegated.
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone title to audit |
+
+If the argument is missing, list candidate milestones and ask:
+
+```bash
+gh api repos/forge-ide/forge/milestones --jq '.[] | {title, state, open_issues, closed_issues}'
+```
+
+## Steps
+
+### 1. Gather scope — invoke `Explore`
+
+Delegate to an `Explore` subagent. Brief:
+
+> For milestone `"<milestone>"`:
+>
+> 1. Fetch milestone metadata: `gh api repos/forge-ide/forge/milestones --jq '.[] | select(.title == "<milestone>")'`.
+> 2. List merged PRs: `gh pr list --repo forge-ide/forge --search 'milestone:"<milestone>" is:merged' --json number,title,files,mergedAt --limit 200`.
+> 3. Produce **two paired lists**, both deduped:
+>    - **Code areas** (first two path segments of each changed file): `crates/forge_ipc`, `web/packages/app`, `scripts`, etc.
+>    - **Doc surfaces implicated** — for each code area, return the matching doc surfaces that *should* describe it. Forge's mapping:
+>      - `crates/<crate>` → `docs/architecture/*.md` (by topic), that crate's `README.md`, and its rustdoc
+>      - `web/packages/<pkg>` → `docs/frontend/*.md` and that package's `README.md`
+>      - Any UI component under `web/packages/app/src/features/*` → `docs/ui-specs/<component>.md`
+>      - Design tokens → `docs/design/token-reference.md` (authoritative) vs `web/packages/design/src/tokens.css` (derived)
+>      - Any milestone adds a testing story → `docs/testing/phase<N>-uat.md` should cover it
+>      - Changes to build, CI, or release shape → `docs/build/*.md`
+> 4. Report which doc files exist vs. which the mapping says should exist. Flag **missing mapping rows** as preliminary findings (no final severity yet).
+>
+> Return: milestone facts, code-areas list, paired doc-surfaces list, preliminary missing-doc list.
+
+### 2. Derive the concern model — invoke `superpowers:brainstorming`
+
+Do not bring a generic checklist. The load-bearing reason is that *what counts as a docs gap* depends on what the milestone actually shipped — a milestone that changed an IPC contract creates completeness concerns for `docs/architecture/ipc-contracts.md` specifically; a milestone that added UI creates concerns for `docs/ui-specs/` and token drift. A generic "do all docs exist" checklist produces noise.
+
+Brainstorm with the user, seeded by Phase 1 findings, to produce a concern model covering:
+
+- **Missing** — what capability shipped without a doc that the mapping implies should exist?
+- **Stale** — what docs describe superseded behavior (renamed symbols, removed features, old API shapes)?
+- **Inaccurate** — where do docs claim one thing and the code do another? (subagents need to read both sides for this)
+- **Broken** — which internal markdown links or symbol references no longer resolve?
+- **Drift** — which derived artifacts diverged from their authoritative source? (tokens.css vs token-reference.md is the known example; surface others if the milestone introduced them)
+- **Compliance** — does every new UI component have a matching `docs/ui-specs/*.md` entry? Does every new IPC message type appear in `docs/architecture/ipc-contracts.md`?
+
+Output: a bulleted concern model — concern class, one-line rationale for this milestone, and an expected severity ceiling.
+
+**HARD GATE:** Do not begin Step 3 until the concern model has been presented and approved.
+
+### 3. Run automated checks — Bash, parallel
+
+Cheap deterministic signal first. Run whichever apply; skip the rest.
+
+```bash
+OUT=/tmp/forge-docs-audit-<milestone-slug>/checks
+mkdir -p "$OUT"
+
+# Token drift (authoritative source: docs/design/token-reference.md)
+node scripts/check-tokens.mjs              > "$OUT/check-tokens.txt"   2>&1 || true
+
+# Rustdoc build — warnings surface broken intra-doc links and malformed doctests
+cargo doc --no-deps --all-features         > "$OUT/cargo-doc.txt"      2>&1 || true
+
+# Markdown link sanity — if `lychee` is installed, otherwise skip
+command -v lychee >/dev/null && \
+  lychee --offline --no-progress 'docs/**/*.md' 'crates/**/README.md' 'web/packages/**/README.md' \
+    > "$OUT/lychee.txt" 2>&1 || true
+```
+
+Summarize: count issues per check. Do not dump raw output into the main context.
+
+### 4. Per-area docs audit — invoke `superpowers:dispatching-parallel-agents`
+
+One subagent per (code area + paired doc surface) pair, all dispatched in the same turn. Brief each identically:
+
+> Audit the documentation for this paired code area and doc surface.
+>
+> **Code area:** `<path>`
+> **Doc surfaces (paired):** `<list>`
+> **Concern classes to weight:** `<from Step 2>`
+>
+> Read the code area AND its paired docs. For each *finding*, return an object with these fields exactly:
+>
+> - `title` — imperative, ≤60 chars (e.g. "Document new `ToolCallEvent::ApprovalRequested` variant")
+> - `severity` — critical | high | medium | low
+> - `location` — path to the doc that should change, with line range if pointing at an existing section; or the code symbol if arguing a missing doc
+> - `concern_class` — missing | stale | inaccurate | broken | drift | compliance
+> - `evidence` — *both sides*: what the code says vs what the docs say (or don't say). Quote the relevant lines.
+> - `remediation` — concrete edit: which file to touch, which section, what to add/replace
+> - `references` — link to ADR / issue / PR if relevant
+>
+> Rules:
+> - Only report findings with **both sides present as evidence** — "this seems undocumented" without a code pointer is not a finding.
+> - Do not report `// TODO` comments as docs gaps unless the TODO references a shipped capability that lacks a user-facing doc.
+> - If the paired docs are fully in sync, return `[]` with a one-sentence rationale.
+
+Aggregate, deduplicate.
+
+### 5. Triage — invoke `superpowers:brainstorming`
+
+Present the deduped finding list + check summary. Brainstorm:
+
+- Findings to merge (one missing doc that entails several smaller gaps should be one issue)
+- False positives to drop
+- Severity adjustments (e.g., drift enforced by CI is higher severity than a broken external link)
+
+**HARD GATE:** Do not create any GitHub issues until the triaged list is approved.
+
+### 6. Create finding issues — sequential
+
+Find the next available F-number:
+
+```bash
+gh issue list --repo forge-ide/forge --state all --json title \
+  --jq '[.[].title | scan("F-([0-9]+)") | .[0] | tonumber] | max + 1'
+```
+
+One issue per finding, **sequentially**:
+
+```bash
+gh issue create \
+  --repo forge-ide/forge \
+  --title "[F-NNN] <imperative title>" \
+  --milestone "<milestone>" \
+  --label "type: bug,docs: <severity>" \
+  --body "$(cat <<'EOF'
+## Scope
+
+<One paragraph: which code area and doc surface, which concern class, why it matters for this milestone.>
+
+## Finding
+
+- **Location:** `<path>` (or symbol)
+- **Severity:** <severity>
+- **Concern class:** missing | stale | inaccurate | broken | drift | compliance
+
+### Evidence
+
+**Code says:**
+```<language>
+<quoted code>
+```
+
+**Docs say (or don't say):**
+```
+<quoted docs, or "no matching section">
+```
+
+## Remediation
+
+<Concrete edit — name the file and section, say what to add or replace.>
+
+## References
+
+<ADR / PR / issue links, or "none".>
+
+## Definition of Done
+
+- [ ] <Docs change applied — name the file and section>
+- [ ] If the finding was drift-class: rerun the drift check and confirm it passes
+- [ ] Tests (and CI doc checks) pass
+EOF
+)"
+```
+
+### 7. Create the consolidated report issue
+
+```
+Title:  [F-NNN] Docs audit report: <milestone>
+Milestone: <milestone>
+Labels: type: bug, docs: audit
+```
+
+Body template:
+
+```markdown
+## Summary
+
+Milestone: <milestone>
+Code areas audited: <N>
+Doc surfaces audited: <M>
+Findings by severity: critical <a> / high <b> / medium <c> / low <d>
+Findings by class: missing <w> / stale <x> / inaccurate <y> / broken <z> / drift <u> / compliance <v>
+
+## Concern model
+
+<Bulleted list from Step 2, verbatim.>
+
+## Scope mapping
+
+| Code area | Paired doc surfaces | Touched by PRs |
+|-----------|---------------------|----------------|
+| `crates/forge_ipc` | `docs/architecture/ipc-contracts.md`, rustdoc | #41, #52 |
+| ... | ... | ... |
+
+## Findings
+
+| ID | Severity | Class | Title | Location | Issue |
+|----|----------|-------|-------|----------|-------|
+| DOC-01 | high | missing | ... | `docs/architecture/ipc-contracts.md` | #123 |
+
+## Automated checks
+
+- check-tokens: <summary>
+- cargo doc: <N> warnings (<summary>)
+- lychee (if run): <N> broken links
+
+Raw output: `/tmp/forge-docs-audit-<milestone-slug>/checks/`
+```
+
+### 8. Verify — invoke `superpowers:verification-before-completion`
+
+```bash
+gh issue list --repo forge-ide/forge \
+  --milestone "<milestone>" \
+  --search 'label:"docs: audit" OR label:"docs: critical" OR label:"docs: high" OR label:"docs: medium" OR label:"docs: low"' \
+  --json number,title,labels
+```
+
+Confirm every triaged finding has an open issue with the right label, and the consolidated report exists with table rows that resolve. Do not claim done without this evidence.
+
+## Delegation rules
+
+| Work type | Where it runs |
+|-----------|---------------|
+| Milestone metadata, PR listing, code-area → doc-surface mapping | `Explore` subagent |
+| Concern model derivation | `superpowers:brainstorming` with the user |
+| Per-pair docs audit | parallel subagents via `superpowers:dispatching-parallel-agents` |
+| Drift / rustdoc / link checks | Bash; results summarized, raw output on disk |
+| Finding triage | `superpowers:brainstorming` with the user |
+| Issue creation | Main context, strictly sequential |
+| Final verification | `superpowers:verification-before-completion` |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Auditing docs without reading the code | Every finding requires evidence from *both* sides — code and docs — or it is speculation |
+| Generic "is this doc complete" pass | Derive concern classes from what the milestone actually shipped |
+| Treating `// TODO` as a docs finding | Only if the TODO references a user-facing shipped capability with no doc |
+| Skipping `check-tokens.mjs` | Token drift is CI-enforced; it is the cheapest, highest-signal check here |
+| Missing UI-spec compliance | Every new feature under `web/packages/app/src/features/*` needs a `docs/ui-specs/*.md` entry |
+| Flagging every old doc as stale | Staleness requires contradiction evidence, not age |
+| Creating issues in parallel | Sequential only — F-number collisions |
+| Dumping link-check raw output into the main context | Summarize counts; keep raw output on disk |
+| Claiming done without `gh issue list` evidence | `verification-before-completion` requires it |

--- a/.claude/skills/forge-milestone-frontend-review/SKILL.md
+++ b/.claude/skills/forge-milestone-frontend-review/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: forge-milestone-frontend-review
+description: Use when reviewing frontend changes from a Forge milestone — checks accessibility, design-token adherence (via scripts/check-tokens.mjs), spec compliance against docs/ui-specs/, interaction-state coverage (loading/empty/error/success), design-system consistency against the @forge/design package, and React/TS hygiene. Scope is the current state of every touched web/packages/* area plus any crates defining IPC types that cross into the webview. Produces one GitHub issue per finding plus a consolidated report. Trigger on phrases like "review the frontend for Phase N", "audit the UI changes from this milestone", "check the milestone's frontend", "sweep Phase N for a11y and design issues", or any milestone-level frontend pass.
+---
+
+# forge-milestone-frontend-review
+
+## Overview
+
+Milestone-scoped frontend review. Scope is the **current state** of every `web/packages/*` area touched by the milestone's merged PRs, plus neighboring code in the same packages, plus any crate-side IPC types consumed by the webview (the boundary where prop shapes originate). The distinct value vs. PR-level frontend review is seeing how **new UI fits against the design system as a whole** — easy to miss on a single PR but visible when you inspect several components at once.
+
+Output is **one GitHub issue per finding** plus **one consolidated report issue**. Uses `frontend-design:frontend-design` to seed the concern model with the repo's aesthetic direction.
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone title to review |
+
+If the argument is missing, list candidate milestones and ask:
+
+```bash
+gh api repos/forge-ide/forge/milestones --jq '.[] | {title, state, open_issues, closed_issues}'
+```
+
+## Steps
+
+### 1. Gather scope — invoke `Explore`
+
+Delegate to an `Explore` subagent. Brief:
+
+> For milestone `"<milestone>"`:
+>
+> 1. Fetch milestone metadata: `gh api repos/forge-ide/forge/milestones --jq '.[] | select(.title == "<milestone>")'`.
+> 2. List merged PRs: `gh pr list --repo forge-ide/forge --search 'milestone:"<milestone>" is:merged' --json number,title,files,mergedAt --limit 200`.
+> 3. Filter changed files to `web/**` plus any `crates/**` file that defines IPC types consumed by the web (look for types re-exported through `web/packages/ipc/`). Reduce to first-two-segment areas (e.g. `web/packages/app`, `web/packages/design`, `web/packages/ipc`). Dedupe.
+> 4. For each frontend area, return: package name, one-line purpose, public entry points, and — for `web/packages/app` specifically — the list of component directories under `src/features/*`.
+> 5. For every component directory found under `web/packages/app/src/features/*`, check whether a matching `docs/ui-specs/<component>.md` exists. Return the pairing list (`component path → spec path | MISSING`).
+> 6. Read `web/packages/design/src/` — list the primitives exported (`Button`, `Panel`, `Input`, etc.), and report whether any of the milestone's PRs added inline alternatives to these primitives (grep for raw `<button>`, `<input>`, inline styles, etc. in the touched `app` code).
+> 7. Check runnable tooling: `pnpm --version`, `pnpm typecheck` feasibility, whether `scripts/check-tokens.mjs` exists.
+>
+> Return: milestone facts, frontend-areas list, component↔spec pairing, design-system primitives, raw-element sightings, tooling availability.
+
+### 2. Seed aesthetic direction — invoke `frontend-design:frontend-design`
+
+Invoke `frontend-design:frontend-design` not to generate code, but to surface:
+
+- The product's aesthetic direction (this repo has `docs/design/philosophy.md`, `docs/design/component-principles.md`, `docs/design/voice-terminology.md` — read them to ground the review in the established direction, not a generic design sensibility)
+- The principles the review should weigh components against
+- The interaction-state expectations (loading/empty/error/success) the design system implies
+
+Output: a short **design brief** — the aesthetic direction, the principles, and the state-coverage expectations — in the review's own voice. This grounds the concern model in Step 3.
+
+### 3. Derive the concern model — invoke `superpowers:brainstorming`
+
+The load-bearing reason this is brainstormed: *which frontend concerns matter most* depends on what the milestone shipped. A milestone that added a new UI surface concentrates on spec compliance and novel-component scrutiny; a milestone that refactored shared primitives concentrates on consistency regressions across callers.
+
+Seeded with the Phase 1 scope and the Phase 2 design brief, brainstorm with the user to produce a concern model covering whichever apply:
+
+- **Accessibility** — keyboard nav, focus management, ARIA where needed, sufficient contrast, screen-reader landmarks
+- **Design-token adherence** — CSS uses `var(--token-name)` rather than magic numbers; `check-tokens` passes
+- **Spec compliance** — every component under `src/features/*` matches its `docs/ui-specs/*.md` entry (or the spec is updated)
+- **Interaction-state coverage** — loading, empty, error, success all handled for async-driven UI (the repo's design ethos calls this out)
+- **Design-system consistency** — new UI uses `@forge/design` primitives; no parallel re-implementations
+- **React/TS hygiene** — `key` prop on lists, effect cleanup, no escaping `any`, no unchecked non-null assertions, controlled inputs wired end-to-end
+- **IPC boundary typing** — prop shapes derived from IPC types stay in sync with their crate-side origin (look for ad-hoc types duplicating an IPC shape)
+- **Voice and terminology** — component copy consistent with `docs/design/voice-terminology.md`
+
+Output: a bulleted concern model — concern, one-line rationale for this milestone, expected severity ceiling.
+
+**HARD GATE:** Do not begin Step 4 until the concern model is presented and approved.
+
+### 4. Run automated checks — Bash, parallel
+
+```bash
+OUT=/tmp/forge-frontend-review-<milestone-slug>/checks
+mkdir -p "$OUT"
+
+( cd web && pnpm -r typecheck )                  > "$OUT/typecheck.txt"     2>&1 || true
+node scripts/check-tokens.mjs                    > "$OUT/check-tokens.txt"  2>&1 || true
+( cd web && pnpm -r build )                      > "$OUT/build.txt"         2>&1 || true
+( cd web && pnpm -r test )                       > "$OUT/test.txt"          2>&1 || true
+```
+
+Summarize: pass/fail per check, count of issues. Do not dump raw output into the main context.
+
+### 5. Per-area frontend review — invoke `superpowers:dispatching-parallel-agents`
+
+One subagent per frontend area, all dispatched in the same turn. Brief each identically:
+
+> Review this frontend area at milestone scope.
+>
+> **Area:** `<path>`
+> **Purpose:** `<from Step 1>`
+> **Component ↔ spec pairings (if any):** `<from Step 1>`
+> **Design brief:** `<from Step 2>`
+> **Concern classes to weight, in order:** `<from Step 3>`
+>
+> Read every file in the area. For each component under `src/features/*`, read its paired `docs/ui-specs/*.md` if one exists.
+>
+> Your distinct job vs. per-PR review: look at components *in relation to each other and to the design system*. Ask: "Does this new UI use the primitives the design system already provides? Does it match the states the design ethos calls out? Does it drift from its spec?"
+>
+> For each *finding*, return an object with these fields exactly:
+>
+> - `title` — imperative, ≤60 chars
+> - `severity` — critical | high | medium | low
+> - `location` — `path:line` (add more sites if cross-file)
+> - `concern_class` — from the Step 3 concern model
+> - `evidence` — a concrete quote or reference: the offending code AND either the design-system primitive it should have used, the spec it drifts from, or the interaction state it missed
+> - `remediation` — concrete fix: use which primitive, update which spec, add which state
+> - `estimated_effort` — small | medium | large
+>
+> Rules:
+> - Every finding must cite a concrete comparison target — primitive, spec, token, or state expectation. "Looks wrong" is not a finding.
+> - Do not report typecheck errors covered by the scanners.
+> - If the area matches the design brief and concern model cleanly, return `[]` with a one-sentence rationale.
+
+Aggregate, deduplicate.
+
+### 6. Triage — invoke `superpowers:brainstorming`
+
+Present the deduped finding list + scanner summary. Brainstorm:
+
+- Merges (one pattern found across several components → one issue)
+- Severity adjustments — the user knows which flows are user-facing critical vs internal
+- Spec compliance: when the component is right and the spec is stale, the fix is to update the spec — not the code (surface this explicitly so the DoD points at the right file)
+- Issue-creation ordering
+
+**HARD GATE:** Do not create any GitHub issues until the triaged list is approved.
+
+### 7. Create finding issues — sequential
+
+Find the next F-number (same pattern as `forge-create-task`), then:
+
+```bash
+gh issue create \
+  --repo forge-ide/forge \
+  --title "[F-NNN] <imperative title>" \
+  --milestone "<milestone>" \
+  --label "type: bug,frontend: <severity>" \
+  --body "$(cat <<'EOF'
+## Scope
+
+<One paragraph: which area/component, which concern class, how it reads against the design brief.>
+
+## Finding
+
+- **Location:** `<path:line>` (list all sites for cross-file patterns)
+- **Severity:** <severity>
+- **Concern class:** <class from concern model>
+- **Estimated effort:** small | medium | large
+
+### Evidence
+
+**Current code:**
+```tsx
+<quoted code>
+```
+
+**Expected per design system / spec / state model:**
+<primitive to use, or spec excerpt, or state expectation>
+
+## Remediation
+
+<Concrete fix — use which primitive, update which spec, add which state.>
+
+## Definition of Done
+
+- [ ] <Fix applied — name the symbol/file/spec>
+- [ ] <Test added (interaction, a11y, or visual as appropriate)>
+- [ ] `pnpm -r typecheck` clean
+- [ ] `node scripts/check-tokens.mjs` passes (if tokens involved)
+- [ ] Tests pass in CI
+EOF
+)"
+```
+
+### 8. Create the consolidated report issue
+
+```
+Title:  [F-NNN] Frontend review report: <milestone>
+Milestone: <milestone>
+Labels: type: bug, frontend: audit
+```
+
+Body template:
+
+```markdown
+## Summary
+
+Milestone: <milestone>
+Frontend areas reviewed: <N>
+Components with specs / without specs: <X> / <Y>
+Findings by severity: critical <a> / high <b> / medium <c> / low <d>
+Findings by class: <counts per concern class>
+
+## Design brief
+
+<From Step 2, verbatim.>
+
+## Concern model
+
+<From Step 3, verbatim.>
+
+## Scope
+
+| Area | Purpose | Components | Touched by PRs |
+|------|---------|-----------|----------------|
+| `web/packages/app` | main app | 5 features | #41, #52 |
+| ... | ... | ... | ... |
+
+## Component ↔ spec pairings
+
+| Component path | Spec | Status |
+|----------------|------|--------|
+| `src/features/session` | `docs/ui-specs/session-roster.md` | paired |
+| `src/features/new-thing` | — | MISSING SPEC |
+
+## Findings
+
+| ID | Severity | Class | Title | Area | Effort | Issue |
+|----|----------|-------|-------|------|--------|-------|
+| FE-01 | high | design-system | ... | `web/packages/app/src/features/session` | small | #123 |
+
+## Automated checks
+
+- pnpm typecheck: <status>
+- check-tokens: <status>
+- pnpm build: <status>
+- pnpm test: <status>
+
+Raw output: `/tmp/forge-frontend-review-<milestone-slug>/checks/`
+```
+
+### 9. Verify — invoke `superpowers:verification-before-completion`
+
+```bash
+gh issue list --repo forge-ide/forge \
+  --milestone "<milestone>" \
+  --search 'label:"frontend: audit" OR label:"frontend: critical" OR label:"frontend: high" OR label:"frontend: medium" OR label:"frontend: low"' \
+  --json number,title,labels
+```
+
+Confirm every triaged finding has an open issue with the right label, and the consolidated report exists. Do not claim done without this evidence.
+
+## Delegation rules
+
+| Work type | Where it runs |
+|-----------|---------------|
+| Milestone metadata, PR listing, scope + component/spec pairing | `Explore` subagent |
+| Design brief / aesthetic direction | `frontend-design:frontend-design` |
+| Concern model derivation | `superpowers:brainstorming` with the user |
+| Per-area frontend review | parallel subagents via `superpowers:dispatching-parallel-agents` |
+| Scanner invocations | Bash; results summarized, raw output on disk |
+| Finding triage | `superpowers:brainstorming` with the user |
+| Issue creation | Main context, strictly sequential |
+| Final verification | `superpowers:verification-before-completion` |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Reviewing components in isolation | The cross-milestone value is seeing *consistency* across components and against the design system |
+| Skipping `frontend-design:frontend-design` | Without the design brief the concern model collapses into generic "is this nice-looking" — not actionable |
+| Generic a11y checklist | Derive the a11y concerns from what the milestone actually added (forms? dialogs? menus?) |
+| Inline re-implementing a design-system primitive | Flag it — the `@forge/design` package exists precisely to prevent this |
+| Flagging spec drift as a code bug | If the component is right and the spec is stale, the DoD should name the spec file to update |
+| Ignoring IPC-type drift at the boundary | Prop shapes duplicated at the webview boundary rot fast; flag them |
+| Treating voice/terminology as nit-tier | It's a listed concern because `docs/design/voice-terminology.md` is authoritative |
+| Reporting typecheck errors as findings | Scanners already ran; findings should be things scanners can't see |
+| Creating issues in parallel | Sequential only — F-number collisions |
+| Claiming done without `gh issue list` evidence | `verification-before-completion` requires it |

--- a/.claude/skills/forge-milestone-performance-audit/SKILL.md
+++ b/.claude/skills/forge-milestone-performance-audit/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: forge-milestone-performance-audit
+description: Use when auditing performance regressions accumulated across a Forge milestone — compares current state against the milestone-start baseline on startup latency, IPC roundtrip time, binary size, bundle size, and memory/allocation hot paths, and scans touched code for perf anti-patterns (sync I/O in async, unnecessary clones, O(n²) loops, heavy imports). Produces one GitHub issue per finding plus a consolidated report. Trigger on phrases like "perf audit for Phase N", "did we regress on performance this milestone", "check the milestone for perf drift", "startup time sweep", or any milestone-level performance pass before a release cut.
+---
+
+# forge-milestone-performance-audit
+
+## Overview
+
+Milestone-scoped performance audit. The distinct value vs. any single PR's perf review is **cumulative regression detection** — each PR may add 2ms of startup, 50KB of bundle, or one extra allocation, but ten of them together become a user-visible regression no individual review caught.
+
+This skill combines **two signal sources**:
+- **Empirical measurement** — benchmarks and binary/bundle sizes compared against a *milestone-start baseline*
+- **Static perf review** — parallel subagents reading touched code for perf anti-patterns
+
+Output is **one GitHub issue per finding** plus **one consolidated report issue**.
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone title to audit |
+
+If the argument is missing, list candidate milestones and ask:
+
+```bash
+gh api repos/forge-ide/forge/milestones --jq '.[] | {title, state, open_issues, closed_issues}'
+```
+
+## Steps
+
+### 1. Gather scope and derive the baseline — invoke `Explore`
+
+Delegate to an `Explore` subagent. Brief:
+
+> For milestone `"<milestone>"`:
+>
+> 1. Fetch milestone metadata: `gh api repos/forge-ide/forge/milestones --jq '.[] | select(.title == "<milestone>")'`.
+> 2. List merged PRs sorted by merge date ascending: `gh pr list --repo forge-ide/forge --search 'milestone:"<milestone>" is:merged sort:created-asc' --json number,mergeCommit,baseRefOid,mergedAt,files --limit 200`.
+> 3. **Derive the milestone-start baseline commit**: the `baseRefOid` of the *earliest* merged PR under the milestone. This is the point `main` was at when the milestone began. Return its SHA.
+> 4. Reduce changed file paths to first-two-segment areas. Dedupe. This is the **touched-areas list**.
+> 5. For each area, identify perf-relevant surface: hot paths (IPC dispatch, serialization, session boot), async entry points, any `criterion` bench modules (`benches/` directories), and any bundle-size-sensitive entry points (`web/packages/app/src/main.tsx`, etc.).
+> 6. Check runnable tooling: `cargo bench --version` (cargo itself), availability of `criterion` in `Cargo.toml`, `pnpm --version`, `hyperfine --version`. Report what can run.
+>
+> Return: milestone facts, baseline SHA, touched-areas list with perf-relevant surface, tooling availability.
+
+### 2. Derive the concern model — invoke `superpowers:brainstorming`
+
+The load-bearing reason this is brainstormed and not checklisted: which perf concerns matter depends on what the milestone touched. A milestone that rewrote IPC framing concentrates on serialization throughput; a milestone that added UI concentrates on bundle size and render cost; a milestone of internal refactors may barely move any meaningful metric.
+
+Seeded with Phase 1 findings, brainstorm with the user to produce a concern model covering whichever apply:
+
+- **Startup latency** — cold start, first session ready
+- **IPC roundtrip** — message dispatch latency, serialization cost, frame-size growth
+- **Bundle size** — JS bundle byte count; tree-shaking regressions; new heavy deps
+- **Binary size** — release binary growth
+- **Allocation hot paths** — new `clone()`/`to_string()` in hot loops, `Arc`/`Box` where a reference would do
+- **Concurrency / blocking** — sync I/O or CPU-heavy work on async runtimes; lock contention
+- **Render cost** — unneeded re-renders, layout thrash, missing memoization (frontend)
+- **Big-O regressions** — O(n²) introduced over a loop over collections
+- **Cold cache behavior** — disk reads added to hot paths
+
+Output: a bulleted concern model — concern, one-line rationale for this milestone, target metric where there is one (e.g. "startup ≤ X ms", "bundle ≤ Y KB").
+
+**HARD GATE:** Do not begin Step 3 until the concern model is presented and approved.
+
+### 3. Measure baseline vs. current — Bash
+
+Check out the baseline, measure; check out current, measure; diff.
+
+```bash
+BASELINE=<sha-from-step-1>
+OUT=/tmp/forge-perf-audit-<milestone-slug>
+mkdir -p "$OUT/baseline" "$OUT/current"
+
+# Save current HEAD to return to
+CURRENT=$(git rev-parse HEAD)
+
+# --- baseline ---
+git checkout "$BASELINE" --quiet
+cargo build --release                                   > "$OUT/baseline/build.txt"    2>&1 || true
+ls -la target/release/forge* 2>/dev/null                > "$OUT/baseline/binsize.txt"
+( cd web && pnpm -r build )                             > "$OUT/baseline/webbuild.txt" 2>&1 || true
+find web/packages/*/dist -type f -name '*.js' -exec du -b {} + 2>/dev/null \
+                                                         > "$OUT/baseline/bundlesize.txt"
+# Criterion benches if present — keep to small/fast ones; note which ran
+cargo bench --all -- --quick 2>&1 | tee                 "$OUT/baseline/bench.txt" || true
+
+# --- current ---
+git checkout "$CURRENT" --quiet
+cargo build --release                                   > "$OUT/current/build.txt"    2>&1 || true
+ls -la target/release/forge* 2>/dev/null                > "$OUT/current/binsize.txt"
+( cd web && pnpm -r build )                             > "$OUT/current/webbuild.txt" 2>&1 || true
+find web/packages/*/dist -type f -name '*.js' -exec du -b {} + 2>/dev/null \
+                                                         > "$OUT/current/bundlesize.txt"
+cargo bench --all -- --quick 2>&1 | tee                 "$OUT/current/bench.txt" || true
+```
+
+Summarize the deltas: binary size (bytes + %), bundle size (bytes + % per JS file), bench results (if any, report per-bench delta). Do not dump raw output into the main context.
+
+**If the baseline checkout fails** (e.g., build breakage at that SHA), note it and proceed with only the static review in Step 4 — a partial audit with clearly-labeled gaps beats no audit.
+
+### 4. Per-area static perf review — invoke `superpowers:dispatching-parallel-agents`
+
+One subagent per touched area. Brief each identically:
+
+> Perf-review this code area at milestone scope.
+>
+> **Area:** `<path>`
+> **Purpose:** `<from Step 1>`
+> **Concern classes to weight, in order:** `<from Step 2>`
+> **Baseline SHA:** `<from Step 1>` (so you can `git diff <baseline>..HEAD -- <area>` to focus on what changed)
+>
+> Your job: read the *current* state of the area and the *diff since baseline*. Flag findings with a plausible perf cost. Examples of what to look for, not a fixed list — use the concern model:
+>
+> - Sync I/O / blocking ops added to async paths
+> - `clone()` / `to_string()` / `to_vec()` added to code on a hot path
+> - New deps that widen binary or bundle measurably (check `Cargo.toml`, `package.json` for adds)
+> - Loop nesting or inner loops over newly-larger collections
+> - New re-renders (frontend): missing `useMemo`/`useCallback`/`React.memo` on objects that cross hot boundaries
+> - Missing batching on IPC/event dispatch added during the milestone
+>
+> For each *finding*, return an object with these fields exactly:
+>
+> - `title` — imperative, ≤60 chars
+> - `severity` — critical | high | medium | low (ground severity in user-visible impact, not theoretical cycles)
+> - `location` — `path:line` (list all sites for cross-file patterns)
+> - `concern_class` — from the Step 2 concern model
+> - `cost_hypothesis` — *why* this likely costs — name the hot path it sits on and the operation's frequency; speculation is fine if labeled as such
+> - `remediation` — concrete fix: remove which clone, move which op off the hot path, lazy-load which import, memoize which value
+> - `bench_suggestion` — if applicable: "add a `criterion` bench at `<path>` measuring `<operation>`" to catch regression next time
+>
+> Rules:
+> - Only report findings where a plausible cost story can be told. "This could be slow" with no hot-path claim is not a finding.
+> - If the area is clean, return `[]` with a one-sentence rationale.
+
+Aggregate, deduplicate.
+
+### 5. Triage — invoke `superpowers:brainstorming`
+
+Present the measurement deltas + static findings. Brainstorm:
+
+- Which static findings are likely the *cause* of measured regressions? (Pairing measurements to causes is the interpretive step.)
+- Which measurement regressions have no obvious static cause? (Those may need deeper investigation; treat as an open question for the user.)
+- Findings to merge, split, or drop
+- Severity adjustments
+- Which findings warrant a **new criterion bench** or bundle-size budget (surface these — preventing regression is cheaper than catching it)
+
+**HARD GATE:** Do not create any GitHub issues until the triaged list is approved.
+
+### 6. Create finding issues — sequential
+
+Find the next F-number, then:
+
+```bash
+gh issue create \
+  --repo forge-ide/forge \
+  --title "[F-NNN] <imperative title>" \
+  --milestone "<milestone>" \
+  --label "type: bug,perf: <severity>" \
+  --body "$(cat <<'EOF'
+## Scope
+
+<One paragraph: which area, which concern class, how it connects (if it does) to a measured regression.>
+
+## Finding
+
+- **Location:** `<path:line>` (list all sites)
+- **Severity:** <severity>
+- **Concern class:** <class>
+
+### Cost hypothesis
+
+<Why this likely costs — name the hot path, the operation frequency, and the user-visible symptom.>
+
+### Measured delta (if pairable)
+
+- Metric: <startup | IPC | binary | bundle | bench name>
+- Baseline: <value>
+- Current: <value>
+- Delta: <absolute + %>
+
+## Remediation
+
+<Concrete fix — remove which clone, lazy-load which import, etc.>
+
+## Bench / budget suggestion
+
+<If applicable: "add criterion bench at <path>" or "add bundle-size budget for <file>".>
+
+## Definition of Done
+
+- [ ] <Fix applied — name the symbol/file>
+- [ ] If a bench/budget was suggested: added and failing without the fix
+- [ ] `cargo build --release` size within baseline + <threshold>
+- [ ] `pnpm -r build` bundle size within baseline + <threshold>
+- [ ] Tests pass in CI
+EOF
+)"
+```
+
+### 7. Create the consolidated report issue
+
+```
+Title:  [F-NNN] Performance audit report: <milestone>
+Milestone: <milestone>
+Labels: type: bug, perf: audit
+```
+
+Body template:
+
+```markdown
+## Summary
+
+Milestone: <milestone>
+Baseline SHA: <short-sha>
+Areas reviewed: <N>
+Findings by severity: critical <a> / high <b> / medium <c> / low <d>
+
+## Concern model
+
+<Bulleted list from Step 2, verbatim.>
+
+## Measured deltas
+
+| Metric | Baseline | Current | Delta |
+|--------|----------|---------|-------|
+| Release binary | X MB | Y MB | +Z KB (+N%) |
+| `forge-web` bundle | X KB | Y KB | +Z KB (+N%) |
+| bench: `ipc_roundtrip` | X µs | Y µs | +Z µs (+N%) |
+
+## Findings
+
+| ID | Severity | Class | Title | Area | Paired metric | Issue |
+|----|----------|-------|-------|------|---------------|-------|
+| P-01 | high | bundle-size | ... | `web/packages/app` | bundle +Z KB | #123 |
+
+## Suggested benches / budgets
+
+- `criterion` bench at `crates/forge_ipc/benches/frame.rs` for `encode_frame`
+- Bundle-size budget: `web/packages/app/dist/main.js` ≤ <budget>
+
+Raw measurement output: `/tmp/forge-perf-audit-<milestone-slug>/`
+```
+
+### 8. Verify — invoke `superpowers:verification-before-completion`
+
+```bash
+gh issue list --repo forge-ide/forge \
+  --milestone "<milestone>" \
+  --search 'label:"perf: audit" OR label:"perf: critical" OR label:"perf: high" OR label:"perf: medium" OR label:"perf: low"' \
+  --json number,title,labels
+```
+
+Confirm every triaged finding has an issue, and the consolidated report exists. Do not claim done without this evidence.
+
+## Delegation rules
+
+| Work type | Where it runs |
+|-----------|---------------|
+| Milestone metadata, PR listing, baseline-SHA derivation, tooling detection | `Explore` subagent |
+| Concern model derivation | `superpowers:brainstorming` with the user |
+| Baseline-vs-current measurement | Bash (`git checkout`, `cargo build`, `pnpm build`, `cargo bench`); raw output on disk |
+| Per-area static perf review | parallel subagents via `superpowers:dispatching-parallel-agents` |
+| Pairing measurements to causes | `superpowers:brainstorming` with the user |
+| Issue creation | Main context, strictly sequential |
+| Final verification | `superpowers:verification-before-completion` |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Skipping the baseline measurement | Perf audit without a baseline is vibes — the *delta* is the signal |
+| Not recording the baseline SHA in the report | Future audits need a chain of baselines to catch slow drift |
+| Static findings without a hot-path claim | "This allocates" is not a perf finding unless you name the path it sits on |
+| Pairing every static finding to a measurement | Not every finding has a measured delta; say so explicitly rather than forcing a pairing |
+| Chasing micro-optimizations on cold paths | Severity is grounded in user-visible impact, not theoretical cycles |
+| Running full `cargo bench` on slow benches | Use `--quick` or filter; a perf audit that takes hours won't get run before releases |
+| Ignoring bundle size | In a webview-based app, KB of JS is the user's latency story |
+| Forgetting to `git checkout` back to current | Leaving the tree detached at baseline breaks the session — always return |
+| Dumping raw bench output into the main context | Summarize the deltas; keep raw output on disk |
+| Creating issues in parallel | Sequential only — F-number collisions |
+| Claiming done without `gh issue list` evidence | `verification-before-completion` requires it |

--- a/.claude/skills/forge-milestone-quality-review/SKILL.md
+++ b/.claude/skills/forge-milestone-quality-review/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: forge-milestone-quality-review
+description: Use when reviewing code quality across an entire Forge milestone — catches cross-PR patterns that per-PR review misses, like parallel APIs for the same concept accumulated across several PRs, duplicated logic, test-coverage gaps in critical paths, architectural drift, inconsistent error handling, and missing observability. Runs cargo clippy, cargo fmt --check, and pnpm typecheck as cheap scanners. Produces one GitHub issue per finding plus a consolidated report. Trigger on phrases like "quality review for Phase N", "audit the milestone for code quality", "check the milestone for tech debt", "sweep Phase N for inconsistencies", or any milestone-level quality pass.
+---
+
+# forge-milestone-quality-review
+
+## Overview
+
+Milestone-scoped code-quality review. Scope is the **current state** of every crate and top-level area touched by the milestone's merged PRs, plus adjacent code in the same crates. The distinct value is **cross-PR pattern detection** — individual PR review looks at one diff at a time and cannot see parallel APIs, duplicated logic, or architectural drift that only becomes visible across several merges together. Output is **one GitHub issue per finding** plus **one consolidated report issue**.
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone title to review |
+
+If the argument is missing, list candidate milestones and ask:
+
+```bash
+gh api repos/forge-ide/forge/milestones --jq '.[] | {title, state, open_issues, closed_issues}'
+```
+
+## Steps
+
+### 1. Gather scope — invoke `Explore`
+
+Delegate to an `Explore` subagent. Brief:
+
+> For milestone `"<milestone>"`:
+>
+> 1. Fetch milestone metadata: `gh api repos/forge-ide/forge/milestones --jq '.[] | select(.title == "<milestone>")'`.
+> 2. List merged PRs: `gh pr list --repo forge-ide/forge --search 'milestone:"<milestone>" is:merged' --json number,title,files,mergedAt --limit 200`.
+> 3. Reduce the union of changed file paths to their first two path segments. Dedupe. This is the **touched-areas list**.
+> 4. For each area, return: package name, one-line purpose, public entry points (`lib.rs`, `src/index.ts`, etc.), and which *other* areas in the list it depends on or is depended on by. Cross-area dependencies are where architectural drift tends to show up.
+> 5. Sample 3–5 PRs from the milestone and note what each added or changed. You are not doing the review yet — just building a *feel* for what themes run across the milestone. Return a one-line summary of the recurring themes (e.g. "many PRs touched IPC event dispatching", "repeated work on session state management").
+> 6. Check which scanners are runnable: `cargo clippy --version`, `cargo fmt --version`, `pnpm --version`. Report available scanners and their scope.
+>
+> Return: milestone facts, touched-areas list with cross-area dependency hints, recurring themes, scanner availability.
+
+### 2. Derive the concern model — invoke `superpowers:brainstorming`
+
+The load-bearing reason this step is not a fixed checklist: the point of a milestone-level review is to catch *emergent* patterns — and which patterns are relevant depends on what the milestone was about. A milestone that built a new subsystem has different quality concerns (API design, abstraction boundaries) than a milestone of incremental fixes (consistency, regressions).
+
+Brainstorm with the user, seeded by Phase 1 findings (especially the recurring themes), to produce a concern model covering whichever of these apply:
+
+- **API consistency across PRs** — did multiple PRs introduce parallel ways to do the same thing? (e.g. two shapes of IPC dispatch, two session-state stores, two error types for the same condition)
+- **Duplicated logic** — code that could be shared but was rewritten in parallel files
+- **Abstraction boundaries** — leaks across crate or layer boundaries (IPC types in UI code, DB types in domain code)
+- **Error handling consistency** — same failure handled differently in different code paths without justification
+- **Test coverage gaps** — critical paths added without tests, or tests that only cover happy paths
+- **Observability** — new flows that should log but don't
+- **Dead code** — symbols shipped, then orphaned by a later PR in the same milestone
+- **Rust-specific** — `unwrap`/`expect` on untrusted input, `Clone` on large structs in hot paths, unnecessary `Arc`/`Mutex`
+- **TS-specific** — `any` escapes, unchecked non-null assertions, prop-drilling that a context would clarify
+- **Architectural drift** — new code that violates patterns established earlier in the project
+
+Output: a bulleted concern model — concern, one-line rationale for this milestone, expected severity ceiling.
+
+**HARD GATE:** Do not begin Step 3 until the concern model is presented and approved.
+
+### 3. Run automated scanners — Bash, parallel
+
+Cheap deterministic signal first. Run whichever Step 1 reported as available.
+
+```bash
+OUT=/tmp/forge-quality-review-<milestone-slug>/scanners
+mkdir -p "$OUT"
+
+cargo fmt --all -- --check                                       > "$OUT/fmt.txt"       2>&1 || true
+cargo clippy --all-targets --all-features -- -D warnings         > "$OUT/clippy.txt"    2>&1 || true
+( cd web && pnpm -r typecheck )                                  > "$OUT/typecheck.txt" 2>&1 || true
+cargo test --no-run --all-targets                                > "$OUT/build.txt"     2>&1 || true
+```
+
+Summarize: count findings per scanner. Do not dump raw output into the main context.
+
+### 4. Per-area quality review — invoke `superpowers:dispatching-parallel-agents`
+
+One subagent per touched area, all dispatched in the same turn. Brief each identically:
+
+> Quality-review this code area at milestone scope.
+>
+> **Area:** `<path>`
+> **Purpose:** `<from Step 1>`
+> **Concern classes to weight, in order:** `<from Step 2>`
+> **Recurring milestone themes:** `<from Step 1>`
+>
+> Your distinct job vs. per-PR review: find patterns that only emerge when you see *multiple PRs' worth of change together*. Compare files against each other. Ask: "Is there more than one way to do <thing> in this milestone's changes? Is that justified?"
+>
+> Read every file in the area. Read the tests. For each *finding*, return an object with these fields exactly:
+>
+> - `title` — imperative, ≤60 chars
+> - `severity` — critical | high | medium | low
+> - `location` — `path:line` (or multiple if a cross-file pattern — list all)
+> - `concern_class` — from the Step 2 concern model
+> - `description` — *what is wrong in this codebase specifically*, with at least one concrete code reference. If it is a cross-PR pattern, name the pattern and show both sides.
+> - `remediation` — concrete fix: unify to which shape? move which code where? add which test?
+> - `estimated_effort` — small | medium | large (guide to help the user prioritize)
+>
+> Rules:
+> - Only report findings you can defend against a skeptical reviewer. Do **not** pad with style or lint nits — `cargo clippy` and `cargo fmt` already ran.
+> - If a "finding" is fully covered by one of those scanners' output, skip it here.
+> - If the area is clean under the concern model, return `[]` with a one-sentence rationale.
+
+Aggregate, deduplicate — cross-file patterns may surface from multiple subagents reporting the same underlying issue.
+
+### 5. Triage — invoke `superpowers:brainstorming`
+
+Present the deduped finding list + scanner summary. Brainstorm:
+
+- Merges: several findings may be one pattern with multiple instances
+- Severity adjustments — context the subagents lacked
+- Effort vs. value — what should block the release cut vs. what goes on the debt backlog
+- Issue-creation ordering
+
+**HARD GATE:** Do not create any GitHub issues until the triaged list is approved.
+
+### 6. Create finding issues — sequential
+
+Find the next F-number (same pattern as `forge-create-task`), then:
+
+```bash
+gh issue create \
+  --repo forge-ide/forge \
+  --title "[F-NNN] <imperative title>" \
+  --milestone "<milestone>" \
+  --label "type: bug,quality: <severity>" \
+  --body "$(cat <<'EOF'
+## Scope
+
+<One paragraph: which area(s), which concern class, why this matters at milestone scope (cross-PR pattern, not a single-PR nit).>
+
+## Finding
+
+- **Location:** `<path:line>` (list all sites for cross-file patterns)
+- **Severity:** <severity>
+- **Concern class:** <class from concern model>
+- **Estimated effort:** small | medium | large
+
+<Description — what is wrong, with code references. If cross-PR pattern, name the pattern and show both shapes.>
+
+## Remediation
+
+<Concrete fix — unify to which shape, move which code where, add which test.>
+
+## Definition of Done
+
+- [ ] <Fix applied — name the symbol/file>
+- [ ] <Test added or updated that would have caught this>
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
+- [ ] `pnpm -r typecheck` clean (if TS touched)
+- [ ] Tests pass in CI
+EOF
+)"
+```
+
+### 7. Create the consolidated report issue
+
+```
+Title:  [F-NNN] Quality review report: <milestone>
+Milestone: <milestone>
+Labels: type: bug, quality: audit
+```
+
+Body template:
+
+```markdown
+## Summary
+
+Milestone: <milestone>
+Areas reviewed: <N>
+Findings by severity: critical <a> / high <b> / medium <c> / low <d>
+Findings by class: <counts per concern class>
+
+## Concern model
+
+<Bulleted list from Step 2, verbatim.>
+
+## Recurring milestone themes
+
+<From Step 1, verbatim.>
+
+## Scope
+
+| Area | Purpose | Touched by PRs |
+|------|---------|----------------|
+| `crates/forge_ipc` | IPC framing | #41, #52, #78 |
+| ... | ... | ... |
+
+## Findings
+
+| ID | Severity | Class | Title | Area | Effort | Issue |
+|----|----------|-------|-------|------|--------|-------|
+| Q-01 | high | api-consistency | ... | `crates/forge_ipc` | medium | #123 |
+
+## Automated scanners
+
+- cargo fmt: <N> deltas
+- cargo clippy: <N> lints (<top offenders>)
+- pnpm typecheck: <N> errors
+- cargo test build: <status>
+
+Raw output: `/tmp/forge-quality-review-<milestone-slug>/scanners/`
+```
+
+### 8. Verify — invoke `superpowers:verification-before-completion`
+
+```bash
+gh issue list --repo forge-ide/forge \
+  --milestone "<milestone>" \
+  --search 'label:"quality: audit" OR label:"quality: critical" OR label:"quality: high" OR label:"quality: medium" OR label:"quality: low"' \
+  --json number,title,labels
+```
+
+Confirm every triaged finding has an open issue with the right label, and the consolidated report exists. Do not claim done without this evidence.
+
+## Delegation rules
+
+| Work type | Where it runs |
+|-----------|---------------|
+| Milestone metadata, PR listing, theme sampling, scanner detection | `Explore` subagent |
+| Concern model derivation | `superpowers:brainstorming` with the user |
+| Per-area review | parallel subagents via `superpowers:dispatching-parallel-agents` |
+| Scanner invocations | Bash; results summarized, raw output on disk |
+| Finding triage | `superpowers:brainstorming` with the user |
+| Issue creation | Main context, strictly sequential |
+| Final verification | `superpowers:verification-before-completion` |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Duplicating per-PR review | The distinct value is **cross-PR patterns** — look for things visible only when several PRs are read together |
+| Reporting clippy/fmt findings | Scanners already ran; the finding list should be things scanners can't see |
+| Style nits dressed as quality findings | Every finding must name a concrete cross-file pattern or a gap the scanners missed |
+| Vague remediation ("refactor this") | Name the symbol, the target shape, or the unification point |
+| Treating large-effort findings the same as small ones | Tag effort; triage may defer large fixes to a debt backlog issue |
+| Skipping cross-area dependency review | Cross-area leaks (e.g. IPC types in UI code) are a core milestone-scope signal |
+| Creating issues in parallel | Sequential only — F-number collisions |
+| Claiming done without `gh issue list` evidence | `verification-before-completion` requires it |
+| Skipping the consolidated report | Per-finding issues lose the milestone-level picture |

--- a/.claude/skills/forge-milestone-release-readiness/SKILL.md
+++ b/.claude/skills/forge-milestone-release-readiness/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: forge-milestone-release-readiness
+description: Use when verifying a Forge milestone is ready to ship — checks whether the changelog covers every merged PR, whether the version is bumped appropriately for the scope of change (semver), whether breaking changes have migration notes, whether the UAT script under docs/testing/phase-N-uat covers the milestone's deliverables, whether any open issues tagged critical/high are still blocking, and whether CI on main is green. This is the final-gate skill — run it after the other milestone audits so it can surface their unresolved findings as blockers. Trigger on phrases like "is Phase N ready to release", "release-readiness check for the milestone", "pre-release audit", "blockers before cutting the release", or any pre-release go/no-go gate.
+---
+
+# forge-milestone-release-readiness
+
+## Overview
+
+The **final-gate** milestone audit. Scope is not the code — it is the **release artifacts**: changelog, version, release notes, UAT coverage, outstanding blockers, and CI state. This skill depends on the other milestone audits having been run; it surfaces any unresolved critical/high findings from them as release blockers.
+
+Unlike the code-auditing siblings, this skill is **mostly mechanical** — the checks are fixed (changelog, version, notes, UAT, blockers, CI). It still uses brainstorming, but for a narrower purpose: deciding whether what's missing is actually a blocker *for this milestone specifically* (some milestones don't need migration notes; some don't bump the version).
+
+Output: **one GitHub issue per missing artifact / unresolved blocker** (labeled `type: bug, release: <severity>`), plus **one consolidated go/no-go report** (labeled `type: bug, release: audit`).
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone title to assess |
+
+If the argument is missing, list candidate milestones and ask:
+
+```bash
+gh api repos/forge-ide/forge/milestones --jq '.[] | {title, state, open_issues, closed_issues}'
+```
+
+## Steps
+
+### 1. Gather release artifacts — invoke `Explore`
+
+Delegate to an `Explore` subagent. Brief:
+
+> For milestone `"<milestone>"`, collect release-readiness evidence:
+>
+> 1. **Milestone stats**: `gh api repos/forge-ide/forge/milestones --jq '.[] | select(.title == "<milestone>")'`. Return open vs. closed counts; a milestone with open issues is generally not ready.
+> 2. **Merged PRs**: `gh pr list --repo forge-ide/forge --search 'milestone:"<milestone>" is:merged' --json number,title,body,mergedAt,labels,mergeCommit --limit 200`. Collect titles, bodies, and labels (so we can see which are feat vs chore vs bug).
+> 3. **Open issues under the milestone**: `gh issue list --repo forge-ide/forge --milestone "<milestone>" --state open --json number,title,labels`. These are unfinished work.
+> 4. **Outstanding audit blockers** — issues created by the sibling milestone audits that are still open and labeled critical or high: `gh issue list --repo forge-ide/forge --milestone "<milestone>" --state open --search 'label:"security: critical" OR label:"security: high" OR label:"docs: critical" OR label:"quality: critical" OR label:"quality: high" OR label:"frontend: critical" OR label:"perf: critical" OR label:"perf: high" OR label:"compat: critical" OR label:"compat: high"' --json number,title,labels`.
+> 5. **Changelog**: look for `CHANGELOG.md` (repo root or `docs/`). If it exists, read the section that should cover this milestone.
+> 6. **Versions**: read `Cargo.toml` workspace `version` and every `package.json` version under `web/`. Note any baseline (last release tag) for comparison: `git describe --tags --abbrev=0` if tags exist.
+> 7. **UAT doc**: `docs/testing/phase<N>-uat.md` and the matching `phase<N>-uat.sh` — report existence, last-modified date, and whether it was touched during this milestone's time window.
+> 8. **CI state on main**: `gh run list --repo forge-ide/forge --branch main --limit 5 --json status,conclusion,workflowName,createdAt`.
+> 9. **Release notes draft**: any file under `docs/` or the repo root matching `release-notes*`, `RELEASE_NOTES*`, or similar.
+>
+> Return: a structured summary grouped as {milestone stats, PR list with labels, open-issue count, audit-blocker list, changelog excerpt (or MISSING), version(s), UAT status, CI status, release-notes status}.
+
+### 2. Derive the go/no-go criteria — invoke `superpowers:brainstorming`
+
+Release readiness is not universal — what *must* be done before cutting this milestone's release depends on what the milestone actually did.
+
+The load-bearing reason this is brainstormed and not a fixed checklist: a milestone that only refactored internals doesn't need migration notes; a Phase-0 foundation milestone pre-1.0 probably doesn't bump the version the way a post-1.0 feature would; a milestone whose UAT was manual doesn't need a script.
+
+Use brainstorming with the user, seeded by Phase 1 evidence, to settle:
+
+- **Changelog expectation**: is it expected for this milestone? What entry shape? (if none exists, is that OK?)
+- **Version-bump expectation**: major / minor / patch / none (pre-1.0 rules differ)? Should the workspace version change? Which `package.json` versions?
+- **Breaking changes**: did the milestone introduce any? If yes, migration notes are a hard requirement
+- **UAT expectation**: does a `phase<N>-uat.md` exist, is it current, does it cover the merged PRs?
+- **Open-issue tolerance**: must *every* milestone issue be closed, or are some deferrable? (the user knows which)
+- **Audit-blocker policy**: which severity levels block release? (default: critical + high)
+
+Output: a checklist of concrete release-readiness criteria for *this* milestone, each phrased as a pass/fail test.
+
+**HARD GATE:** Do not begin Step 3 until the criteria list is approved. Shipping on vibes is how bugs escape.
+
+### 3. Run mechanical checks — invoke `superpowers:dispatching-parallel-agents`
+
+These artifacts are independent; dispatch a subagent per artifact class in the same turn. Each subagent checks one criterion and returns pass/fail with evidence.
+
+**Subagent A — Changelog coverage:**
+> Given the merged-PR list (titles + numbers) and the changelog excerpt from Phase 1, verify every PR has a corresponding changelog entry. Return a table of `PR # | title | entry present | notes`. If no changelog exists and the criteria require one, flag as failing with severity per the criteria.
+
+**Subagent B — Version correctness:**
+> Given the current `Cargo.toml` / `package.json` versions and the version-bump expectation from the criteria, verify:
+> - The workspace version (if expected to change) moved in the right direction
+> - Per-package versions moved consistently
+> - No accidental downgrades
+> Return pass/fail with evidence. If the criteria say no bump is needed, confirm versions are unchanged.
+
+**Subagent C — UAT coverage:**
+> Given `docs/testing/phase<N>-uat.md` (if present) and the merged-PR list, verify every PR's deliverable is covered by at least one UAT step. Flag undiscoverable/untested deliverables. If the UAT file is missing or stale relative to the milestone's time window, say so.
+
+**Subagent D — Migration / breaking-change notes:**
+> Given the PR list and their bodies, identify PRs that introduce breaking changes (look for label `breaking-change` if used, or PR body sections labeled "Breaking" / "Migration"). For each, verify a migration note exists — in the changelog, in release-notes draft, or in an ADR under `docs/architecture/`. Flag any breaking PR without a migration note.
+
+**Subagent E — Blocker sweep:**
+> Given the audit-blocker list from Phase 1 (open issues labeled critical/high under the milestone), for each issue return: number, title, severity label, and one-line status summary from its body. These are release blockers; the report will list them.
+
+**Subagent F — CI sanity:**
+> Given the CI run list from Phase 1, verify the latest main CI run is `success`. If the latest is `failure` / `in_progress` / `cancelled`, that is a blocker. Return the latest run's state and link.
+
+Aggregate all six returns.
+
+### 4. Consolidate and decide — invoke `superpowers:brainstorming`
+
+Present all check results side-by-side to the user. Each becomes either:
+- **Pass** — recorded in the report, no issue needed
+- **Blocker** — becomes a `type: bug, release: <severity>` issue
+- **Waived** — the user says "ship anyway" with a recorded rationale in the report
+
+The go/no-go call is the user's, not the skill's. But the skill must surface every failing criterion and require an explicit waive decision — silent passing is what lets bad releases out.
+
+**HARD GATE:** Do not create any GitHub issues until every failing criterion has been classified (blocker vs. waived) and the decision is recorded.
+
+### 5. Create blocker issues — sequential
+
+One issue per classified blocker. Find the next F-number, then:
+
+```bash
+gh issue create \
+  --repo forge-ide/forge \
+  --title "[F-NNN] <imperative title>" \
+  --milestone "<milestone>" \
+  --label "type: bug,release: <severity>" \
+  --body "$(cat <<'EOF'
+## Scope
+
+<One paragraph: which release-readiness criterion failed and why it blocks ship.>
+
+## Criterion
+
+- **Criterion:** <from Step 2>
+- **Severity:** <severity>
+- **Check subagent:** <A|B|C|D|E|F>
+
+### Evidence
+
+<Concrete failing evidence — missing changelog entry for PR #N, untouched UAT doc, critical security finding #M still open, etc.>
+
+## Remediation
+
+<Concrete fix — write which entry, bump which version, complete which issue, fix CI, etc.>
+
+## Definition of Done
+
+- [ ] <Concrete action>
+- [ ] Release-readiness skill re-run and this criterion passes
+EOF
+)"
+```
+
+### 6. Create the consolidated go/no-go report
+
+```
+Title:  [F-NNN] Release readiness report: <milestone>
+Milestone: <milestone>
+Labels: type: bug, release: audit
+```
+
+Body template:
+
+```markdown
+## Decision
+
+**<GO | NO-GO | GO WITH WAIVERS>**
+
+<One-paragraph rationale.>
+
+## Criteria (from Step 2)
+
+<Bulleted list, verbatim.>
+
+## Check results
+
+| Check | Result | Blocker? | Issue |
+|-------|--------|----------|-------|
+| Changelog coverage | pass | — | — |
+| Version correctness | fail | blocker | #123 |
+| UAT coverage | fail | waived (see below) | — |
+| Migration notes | pass | — | — |
+| Audit blockers | fail (3 open) | blockers | #124, #125, #126 |
+| CI green on main | pass | — | — |
+
+## Waivers
+
+- **UAT coverage**: <rationale for waiving — who made the call, why it is acceptable for this milestone>
+
+## Open blockers
+
+| Issue | Severity | Title |
+|-------|----------|-------|
+| #123 | high | ... |
+| #124 | critical | (from security audit) ... |
+
+## Versions at release
+
+- Workspace (Cargo.toml): <version>
+- web/packages/app: <version>
+- ... (list relevant packages)
+
+## CI at release candidate
+
+- Latest main run: <status> — <link>
+```
+
+### 7. Verify — invoke `superpowers:verification-before-completion`
+
+```bash
+gh issue list --repo forge-ide/forge \
+  --milestone "<milestone>" \
+  --search 'label:"release: audit" OR label:"release: critical" OR label:"release: high" OR label:"release: medium" OR label:"release: low"' \
+  --json number,title,labels
+```
+
+Confirm every classified blocker has an issue, the go/no-go report exists, and every waived criterion is named in the waivers section. Do not claim done without this evidence.
+
+## Delegation rules
+
+| Work type | Where it runs |
+|-----------|---------------|
+| Artifact gathering (PRs, issues, changelog, versions, UAT, CI) | `Explore` subagent |
+| Go/no-go criteria derivation | `superpowers:brainstorming` with the user |
+| Per-criterion mechanical checks | six parallel subagents via `superpowers:dispatching-parallel-agents` |
+| Classifying failures (blocker vs. waived) | `superpowers:brainstorming` with the user |
+| Blocker-issue creation | Main context, strictly sequential |
+| Final verification | `superpowers:verification-before-completion` |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Running this skill before the sibling audits | Release-readiness surfaces their findings as blockers — run it *after* security/docs/quality/frontend/perf/compat |
+| Silent passing on a failing criterion | Every failing criterion must be classified blocker or waived-with-rationale — never silently waived |
+| Hard-coding "every PR needs a changelog entry" | Some milestones don't; derive the criteria per-milestone in Step 2 |
+| Treating pre-1.0 version bumps like post-1.0 | The rules differ; the criteria step settles which regime applies |
+| Skipping the waiver rationale | Waivers without recorded reasons become future mysteries |
+| Declaring GO with an unreviewed waiver | The user makes the call; the skill surfaces the decision |
+| Creating issues in parallel | Sequential only — F-number collisions |
+| Forgetting to record the baseline state in the report | The report is the release's provenance — versions and CI run must be captured |
+| Claiming done without `gh issue list` evidence | `verification-before-completion` requires it |

--- a/.claude/skills/forge-milestone-security-audit/SKILL.md
+++ b/.claude/skills/forge-milestone-security-audit/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: forge-milestone-security-audit
+description: Use when auditing a Forge milestone for security issues — derives a per-milestone threat model, audits the current state of every crate and area touched by the milestone's merged PRs, runs whichever automated scanners apply (cargo audit, cargo deny, pnpm audit), and produces one GitHub issue per finding plus a consolidated report issue. Trigger on phrases like "security audit for Phase N", "audit the milestone", "do a security pass on Phase N before release", "sweep the milestone for vulns", or any time the user wants milestone-scoped security review rather than PR-diff review.
+---
+
+# forge-milestone-security-audit
+
+## Overview
+
+Milestone-scoped security audit. Scope is **not a diff** — it is the full current state of every crate and top-level area (`crates/*`, `web/packages/*`, `scripts/*`, etc.) touched by any PR merged under the milestone, plus adjacent code owned by the same crates. Output is **one GitHub issue per finding** plus **one consolidated report issue**. The main context coordinates; scope gathering, per-area audits, and scanner runs are delegated.
+
+This skill is complementary to `/security-review` — that one reviews pending branch changes, this one audits a completed milestone worth of landed work before a release cut.
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone title to audit |
+
+If the argument is missing, list candidate milestones and ask the user to pick:
+
+```bash
+gh api repos/forge-ide/forge/milestones --jq '.[] | {title, state, open_issues, closed_issues}'
+```
+
+## Steps
+
+### 1. Gather scope — invoke `Explore`
+
+Delegate to an `Explore` subagent. Brief:
+
+> Read the forge repo at the current working directory. For milestone `"<milestone>"`:
+>
+> 1. Fetch milestone metadata: `gh api repos/forge-ide/forge/milestones --jq '.[] | select(.title == "<milestone>")'`. Return title, description, state.
+> 2. List PRs merged under this milestone: `gh pr list --repo forge-ide/forge --search 'milestone:"<milestone>" is:merged' --json number,title,files,mergedAt --limit 200`.
+> 3. Reduce the union of changed file paths to their first two path segments (e.g. `crates/forge_ipc`, `web/packages/session-ui`). Dedupe. This is the **touched-areas list**.
+> 4. For each touched area, read `Cargo.toml` / `package.json` and the crate's main entry (`lib.rs`, `src/index.ts`) and return: package name, one-line purpose, public entry points, and any security-relevant modules you can spot by name (auth, ipc, exec, sandbox, fs, net, creds).
+> 5. Check which automated scanners are available and what they cover here: run `cargo audit --version`, `cargo deny --version`, `pnpm --version`, and look for `deny.toml`, `pnpm-lock.yaml`, `Cargo.lock`. Report which scanners are runnable and over what scope.
+>
+> Return: milestone facts, ordered touched-areas list with per-area context, available-scanners list.
+
+The main context takes this scope forward; do not re-explore inline.
+
+### 2. Derive the threat model — invoke `superpowers:brainstorming`
+
+Do not bring a fixed vulnerability checklist. The load-bearing reason is that a milestone's *new capabilities* drive which threat classes actually apply — a Phase 0 IPC handshake and a Phase 3 container runtime share almost no threat surface, and a generic checklist either over-audits (noise) or under-audits (misses the real risks).
+
+Use brainstorming with the user, seeded by the Phase 1 findings, to produce a short threat model:
+
+- What new capabilities did this milestone add? What trust boundaries do they cross?
+- Where does untrusted input enter? (user content, LLM output used as control flow, file paths, env, network responses, IPC frames)
+- What secrets or credentials does the affected code handle?
+- New dependencies — any that deserialize, exec, network, or parse untrusted formats?
+- Rust-specific concerns: `unsafe` blocks, panics on untrusted input, `serde` with untagged enums
+- TS/webview-specific concerns: HTML-injection sinks (raw-HTML props, direct `innerHTML` writes), eval-like patterns, CSP gaps
+- Tool-call / sandbox escape concerns if the milestone touched agent-exec code
+
+Output: a bulleted **threat model** — threat class, one-line rationale for why it matters to *this* milestone, and expected severity ceiling.
+
+**HARD GATE:** Do not begin Step 3 until the threat model has been presented to the user and approved. An ad-hoc threat model produces ad-hoc findings.
+
+### 3. Run automated scanners — Bash, parallel
+
+Cheap deterministic signal first. Run whatever Step 1 reported as available; skip the rest. Save raw output for the report.
+
+```bash
+OUT=/tmp/forge-audit-<milestone-slug>/scanners
+mkdir -p "$OUT"
+
+cargo audit --json                  > "$OUT/cargo-audit.json"     2>&1 || true
+cargo deny check --format json      > "$OUT/cargo-deny.json"      2>&1 || true
+( cd web && pnpm audit --json )     > "$OUT/pnpm-audit.json"      2>&1 || true
+```
+
+Summarize: count advisories per severity per scanner. Do not dump raw output into the main context — just the summary.
+
+### 4. Per-area code audit — invoke `superpowers:dispatching-parallel-agents`
+
+One subagent per touched area, all dispatched in the same turn. Brief each identically (substituting area-specific values):
+
+> Security-audit this code area.
+>
+> **Area:** `<path>`
+> **Purpose:** `<from Step 1>`
+> **Threat classes to weight, in order:** `<from Step 2>`
+>
+> Read every file in the area. Read tests too — they document intended invariants. For each *finding*, return an object with these fields exactly:
+>
+> - `title` — imperative, ≤60 chars
+> - `severity` — critical | high | medium | low
+> - `location` — `path:line` (primary); add more in `description` if spread
+> - `threat_class` — the class from the threat model this maps to
+> - `description` — what is wrong and why it matters *in this codebase* (not generic CWE prose)
+> - `reproduction` — concrete steps, a PoC sketch, or a pointer to the untrusted input path
+> - `remediation` — concrete fix; name the symbol, file, or config to change
+> - `references` — CWE, advisory, RFC, or doc URL if any
+>
+> Rules:
+> - Only report findings you can defend against a skeptical reviewer. Do **not** pad with style or lint nits.
+> - If the area is clean, return `[]` with a one-sentence rationale.
+> - If a file is auto-generated or vendored, say so and skip it.
+
+Aggregate all returns into one list. Deduplicate across agents — the same `path:line` may surface from neighboring areas.
+
+### 5. Triage — invoke `superpowers:brainstorming`
+
+Present the deduped finding list + scanner summary to the user. Brainstorm:
+
+- Findings to merge, split, or drop (false positives)
+- Severity adjustments — subagents lack cross-milestone context the user has
+- Issue-creation ordering (typically: highest severity first, grouped by area)
+
+**HARD GATE:** Do not create any GitHub issues until the triaged list is approved.
+
+### 6. Create finding issues — sequential
+
+Find the next available F-number (same pattern as `forge-create-task`):
+
+```bash
+gh issue list --repo forge-ide/forge --state all --json title \
+  --jq '[.[].title | scan("F-([0-9]+)") | .[0] | tonumber] | max + 1'
+```
+
+Create one issue per finding, **sequentially** — parallel creation causes F-number collisions. Title format matches the repo convention (`[F-NNN] <imperative title>`); severity rides on labels.
+
+```bash
+gh issue create \
+  --repo forge-ide/forge \
+  --title "[F-NNN] <imperative title>" \
+  --milestone "<milestone>" \
+  --label "type: security,security: <severity>" \
+  --body "$(cat <<'EOF'
+## Scope
+
+<One paragraph: which area, which threat class from the milestone's threat model, why it matters here specifically.>
+
+## Finding
+
+- **Location:** `<path:line>`
+- **Severity:** <severity>
+- **Threat class:** <from threat model>
+
+<Description — what is wrong, grounded in this codebase.>
+
+## Reproduction
+
+<Steps, PoC sketch, or untrusted-input path.>
+
+## Remediation
+
+<Concrete fix — name the symbol, file, or config.>
+
+## References
+
+<CWE / advisory / doc URLs, or "none".>
+
+## Definition of Done
+
+- [ ] <Fix applied — name the symbol or file>
+- [ ] Regression test added that fails without the fix
+- [ ] Tests pass in CI
+EOF
+)"
+```
+
+### 7. Create the consolidated report issue
+
+One final issue, sequential with the running next F-number. Internal finding IDs (`SEC-01`, `SEC-02`, …) exist only inside this report to keep the table readable — they are *not* a new numbering namespace in the repo.
+
+```
+Title:  [F-NNN] Security audit report: <milestone>
+Milestone: <milestone>
+Labels: type: security, security: audit
+```
+
+Body template:
+
+```markdown
+## Summary
+
+Milestone: <milestone>
+Areas audited: <N>
+Findings by severity: critical <a> / high <b> / medium <c> / low <d>
+
+## Threat model
+
+<Bulleted list from Step 2, verbatim.>
+
+## Scope
+
+| Area | Purpose | Touched by PRs |
+|------|---------|----------------|
+| `crates/forge_ipc` | IPC framing | #41, #52, #78 |
+| ... | ... | ... |
+
+## Findings
+
+| ID | Severity | Title | Area | Issue |
+|----|----------|-------|------|-------|
+| SEC-01 | high | ... | `crates/forge_ipc` | #123 |
+| SEC-02 | medium | ... | `web/packages/session-ui` | #124 |
+
+## Automated scanners
+
+- cargo audit: <N> advisories (<summary>)
+- cargo deny: <N> issues (<summary>)
+- pnpm audit: <N> advisories (<summary>)
+
+Raw output: `/tmp/forge-audit-<milestone-slug>/scanners/`
+```
+
+### 8. Verify — invoke `superpowers:verification-before-completion`
+
+```bash
+gh issue list --repo forge-ide/forge \
+  --milestone "<milestone>" \
+  --label "type: security" \
+  --json number,title,labels
+```
+
+Confirm:
+- Every triaged finding has a corresponding open issue with the right severity label
+- The consolidated report issue exists and every row in its table links to a real issue number
+- No unlabeled or orphan security issues under the milestone
+
+Do not claim the audit is complete until this evidence is in hand.
+
+## Required labels
+
+The skill relies on these labels existing on the repo. Create them once (e.g. via `gh label create`) before first run; `gh issue create` will fail loudly otherwise.
+
+| Label | Purpose |
+|-------|---------|
+| `type: security` | Marks any security-audit output (both findings and the report) |
+| `security: critical` / `high` / `medium` / `low` | Severity on finding issues |
+| `security: audit` | Marks the consolidated report issue |
+
+## Delegation rules
+
+| Work type | Where it runs |
+|-----------|---------------|
+| Milestone metadata, PR listing, scope reduction, scanner detection | `Explore` subagent |
+| Threat model derivation | `superpowers:brainstorming` with the user |
+| Per-area code audit | parallel subagents via `superpowers:dispatching-parallel-agents` |
+| Scanner invocations | Bash; results summarized, raw output saved to disk |
+| Finding triage | `superpowers:brainstorming` with the user |
+| Issue creation | Main context, strictly sequential |
+| Final verification | `superpowers:verification-before-completion` |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Auditing only the PR diffs | Scope is the **current state** of every touched area + adjacent code in the same crates |
+| Using `/security-review` instead | That is diff-scoped; this skill is milestone-scoped — different surface, different output shape |
+| Hard-coding a vulnerability checklist | Derive the threat model per-milestone — new capabilities drive threat classes |
+| Skipping scanner runs | Cheap deterministic signal; always run whichever apply |
+| Creating finding issues in parallel | Sequential only — F-number collisions otherwise |
+| Padding findings with style/lint nits | Each finding must survive a skeptical reviewer |
+| Vague remediation ("harden the parser") | Name the symbol, file, or config to change |
+| No regression test in DoD | Every fix needs a test that fails without it — otherwise the class returns |
+| Skipping the consolidated report | Individual issues lose the milestone-level picture a release reviewer needs |
+| Dumping raw scanner output into the main context | Summarize by severity; keep raw output on disk and link it |
+| Claiming done without `gh issue list` evidence | `verification-before-completion` requires evidence, not a summary |

--- a/.claude/skills/forge-milestone-uat-author/SKILL.md
+++ b/.claude/skills/forge-milestone-uat-author/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: forge-milestone-uat-author
+description: Use when authoring the User Acceptance Test plan for a Forge milestone — clusters the milestone's closed-issue Definitions of Done into user-observable outcomes, drafts docs/testing/phase-N-uat.md, phase-N-uat.sh, and phase-N-uat-setup.md in the established house style (matching phase0 and phase1), verifies every DoD checkbox is either covered by a UAT scenario, deferred to unit tests with rationale, or honestly flagged as a known gap, and opens a PR. Trigger on phrases like "write UAT for Phase N", "author the milestone UAT plan", "draft phase-N-uat.md", "we need UAT tests for this phase", or any milestone UAT authorship task. This is the only milestone-level skill that produces source files (committed via PR) rather than GitHub issues.
+---
+
+# forge-milestone-uat-author
+
+## Overview
+
+Authors the three UAT files for a Forge milestone:
+- `docs/testing/phase<N>-uat.md` — the plan
+- `docs/testing/phase<N>-uat.sh` — the harness
+- `docs/testing/phase<N>-uat-setup.md` — the one-time setup doc
+
+**Structurally different from the seven audit siblings**: the audits produce GitHub *issues*; this skill produces committed *files*. Output is a **PR**, not issues. Everything else (scope gathering → brainstorming → hard gates → verification) mirrors the audit spine.
+
+## The philosophy of a good UAT plan
+
+Read this before doing anything else — it is the load-bearing framing that separates a useful UAT plan from a useless one. Prior phases encoded this in `docs/testing/phase1-uat.md`'s "What this plan covers" section; the skill must honor it.
+
+1. **A UAT verifies user-observable behavior that depends on multiple tickets working together.** It is not a restatement of each ticket's DoD. Individual DoDs are enforced by unit tests; UAT is the integration gate.
+2. **Cluster DoDs into outcomes.** A milestone with 14 tickets does not need 14 UATs. It needs 6–10 UATs, each exercising a chain of tickets through a user-observable flow.
+3. **Backend primitives with no user surface are deferred to unit tests**, with a dedicated section at the bottom of the plan that names them and explains why. This is not a dodge — it is a contract that keeps the UAT plan focused.
+4. **Be honest about shippable vs. claimed.** If the milestone description says X but the code ships Y, the plan must flag the gap explicitly (`phase1-uat.md` does this with its "Known gap" section and the UAT-01c Blocked variant). Papering over the delta produces a UAT plan that passes while the actual feature is broken.
+5. **The outcome gate comes first.** UAT-01 (or UAT-01a) is the milestone's headline capability, written as a single end-to-end flow. If it passes, the milestone's top-level promise was shipped.
+
+## Arguments
+
+| Argument | Form | Meaning |
+|----------|------|---------|
+| Milestone (required) | `"Phase N: Title"` | The GitHub milestone title to author UAT for |
+
+If the argument is missing, list candidate milestones and ask:
+
+```bash
+gh api repos/forge-ide/forge/milestones --jq '.[] | {title, state, open_issues, closed_issues}'
+```
+
+## Steps
+
+### 1. Gather scope and house style — invoke `Explore`
+
+Delegate to an `Explore` subagent. Brief:
+
+> For milestone `"<milestone>"`:
+>
+> 1. Fetch milestone metadata: `gh api repos/forge-ide/forge/milestones --jq '.[] | select(.title == "<milestone>")'`. Return title, description (the **outcome statement** + bullet list), and state.
+> 2. List the milestone's **closed issues** (each one is a ticket that shipped): `gh issue list --repo forge-ide/forge --milestone "<milestone>" --state closed --json number,title,body,labels --limit 200`. Return the list.
+> 3. For **every closed issue**, extract the Definition of Done checkboxes from the issue body. Return the full DoD set — one entry per (issue number, checkbox text) pair. This is what coverage will be verified against.
+> 4. List the milestone's **merged PRs**: `gh pr list --repo forge-ide/forge --search 'milestone:"<milestone>" is:merged' --json number,title,body,mergedAt --limit 200`. Return titles, bodies (look for "Known gap" or "Not wired" language), and merge dates.
+> 5. **Read prior-phase UAT files for house style** — whichever exist in `docs/testing/`:
+>    - `phase0-uat.md`, `phase0-uat.sh`
+>    - `phase1-uat.md`, `phase1-uat.sh`, `phase1-uat-setup.md`
+>    - etc.
+>    Return a summary of the conventions you observed: section ordering, per-UAT structure, scope labeling (F-numbers), vehicle declarations, preparation-block format, steps-table format, failure-criteria format, shell-script flag set, PASS/FAIL/SKIP coloring, setup-doc section structure.
+> 6. Identify **shippable-vs-claimed deltas**: milestone description bullets that do not correspond to a closed issue, or PRs whose body flags a "not wired" condition. Return these as candidate "Known gap" items.
+> 7. Determine the phase number (`<N>`) for the filenames.
+>
+> Return: milestone facts, full DoD set with (issue, checkbox) provenance, PR list, house-style summary, candidate known-gap list, phase number.
+
+### 2. Derive the scenario list — invoke `superpowers:brainstorming`
+
+The load-bearing reason this is brainstormed and not mechanical: **clustering DoDs into outcomes** is exactly the interpretive step where a machine-generated plan goes wrong. Dumping one UAT per DoD is easy and useless. A good plan collapses ten DoDs into three outcomes, explicitly defers the four backend DoDs that have no user surface, and names the one scenario that is Blocked because the milestone shipped less than it claimed.
+
+Work through with the user, seeded by the Phase 1 findings:
+
+- **The outcome gate** — what is the milestone's headline capability? Which DoDs combine to deliver it? This is UAT-01 (or UAT-01a if variants are needed).
+- **Secondary user-observable outcomes** — for each remaining user-facing flow, identify the DoDs it exercises and draft a one-line scenario summary. Aim for 5–10 total UATs, not 14+.
+- **Variants (a/b/c...)** — when an outcome has a reachable path (e.g. mock provider) and a blocked path (e.g. real Ollama not yet wired), both get entries; the blocked one is marked Blocked with a forward-looking note.
+- **Backend primitives to defer to unit tests** — DoDs with no user surface. Name each, explain why it has no UAT, and say which crate's tests cover it.
+- **Known gaps** — any milestone bullet without a shipping issue, or any PR that did less than its title implies. These appear in the plan's "Known gap" section.
+- **Automation vehicle per UAT** — GUI (Playwright + tauri-driver), disk/state (bash), or hybrid. Match prior-phase patterns.
+
+Output: an **outcome matrix** with columns: `UAT-ID | title | covered DoD checkboxes | vehicle | variant | status`.
+
+**HARD GATE:** Do not begin Step 3 until the outcome matrix has been presented and approved. This is the point where a bad cluster is cheap to fix; after drafting, it is expensive.
+
+### 3. If UI is in scope — invoke `frontend-design:frontend-design`
+
+Any UAT whose vehicle is Playwright exercises a UI flow. For each such UAT, invoke `frontend-design:frontend-design` to surface:
+
+- The expected visual/interaction states the flow should exhibit (loading, empty, error, success)
+- The specific selectors or semantic landmarks the UAT should assert against (match the design system's conventions, not ad-hoc IDs)
+- Any accessibility expectations the UAT should verify (keyboard operability, focus management)
+
+These feed into the Preparation and Steps blocks of the affected UATs.
+
+**Skip this step entirely** if the milestone has no UI-exercising UATs.
+
+### 4. Draft `phase<N>-uat.md` — main context
+
+Match the house-style summary from Phase 1. The structure (verbatim from `docs/testing/phase1-uat.md`):
+
+```markdown
+# Phase <N> User Acceptance Test Plan
+
+**Scope:** <milestone title> — <one-line summary of the capability set>.
+**Outcome gate:** <one-to-two-sentence statement of the milestone's headline capability, restricted to what actually shipped>.
+
+---
+
+## Known gap before reading further          ← include only if there are known gaps
+
+<Paragraph honestly describing shippable-vs-claimed deltas, with file/line references where applicable. This section is load-bearing; do not soften it.>
+
+---
+
+## What this plan covers
+
+<Paragraph explaining the philosophy: UATs verify user-observable behavior that depends on multiple tickets, not each DoD individually. Name the count of tickets shipped vs. the count of UATs.>
+
+Automation vehicle:
+- **GUI UATs** — Playwright driving the Tauri app via `tauri-driver` [...]
+- **Disk / state UATs** — bash harness invoking `forge` / `forged` [...]
+
+---
+
+## Prerequisites
+
+<Table: Item | Requirement — match the phase1 shape. Include Ollama / mock-provider rows only if applicable.>
+
+---
+
+## UAT-01[a]: Outcome gate — <one-line title>
+
+**Scope:** <F-NN + F-NN + ... covered DoDs>
+**Vehicle:** <Playwright+tauri-driver | bash | hybrid>
+**Why this test exists:** <one line — this is the milestone's outcome gate restricted to what shipped>
+
+<Preparation block with mock scripts / fixtures / env vars, matching phase1's fenced-bash style.>
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | ... | ... |
+| N | ... | ... |
+
+**Failure criteria:** <one line — enumerate the specific observations that would fail this UAT>
+
+---
+
+## UAT-02: <title>
+
+<same shape as above>
+
+... continue for each outcome ...
+
+---
+
+## Backend primitives covered by unit tests, not UAT
+
+<List each deferred DoD with: symbol/crate, covering unit test file, one-line rationale for why it has no user surface.>
+
+---
+
+## Known-gap follow-up
+
+<If there were known gaps: list the forward-looking actions — e.g. "UAT-0Nc unblocks when F-XXX lands; either a Phase <N> cleanup ticket or a Phase <N+1> item to triage before declaring this milestone complete".>
+```
+
+Draft inline; do not delegate. Generative writing benefits from full context over the whole plan.
+
+### 5. Draft `phase<N>-uat.sh` — main context
+
+Match the phase1 harness shape (read it first if memory is not fresh). Required elements:
+
+- Shebang + header comment with usage, flags, prerequisites pointer
+- `set -euo pipefail`
+- `REPO_ROOT` detection via `BASH_SOURCE`
+- Color helpers (RED/GREEN/YELLOW/BOLD/RESET) and `pass`/`fail`/`skip`/`header` functions
+- PASS/FAIL/SKIP counters and `FAILED_TESTS` array
+- Argument parsing — at minimum `--build`, `--test UAT-NN`, and the gui-only / cli-only split if the plan has both vehicles
+- One function per UAT (`uat_01a`, `uat_02`, …). Each function wraps either a Playwright invocation (`pnpm --filter app exec playwright test ...`) or bash-driven `forge`/`forged` commands plus filesystem assertions
+- A final summary block printing PASS / FAIL / SKIP counts and the failed-test list, returning non-zero on FAIL > 0
+
+Wire the GUI UATs' Playwright specs under `web/packages/app/tests/phase<N>/` — note this in the plan's Prerequisites table.
+
+### 6. Draft `phase<N>-uat-setup.md` — main context
+
+Match the phase1 setup doc shape. Numbered sections for each setup class that appears in Prerequisites. Typical sections (include only those that apply):
+
+1. Rust binaries — `cargo build --workspace`, note which binaries live where
+2. pnpm workspace — install, build, `check-tokens`
+3. Playwright + tauri-driver install
+4. Ollama (if applicable)
+5. Mock provider + fixture placement
+6. Scratch workspace convention
+
+Each section: short prose explaining what the user is doing + the exact commands.
+
+### 7. Coverage verification — HARD GATE — invoke a subagent
+
+Delegate to a fresh general-purpose subagent. Brief:
+
+> Given:
+> - The full DoD checkbox set for milestone `"<milestone>"` — one entry per (issue number, checkbox text) — attached as `dod.json`
+> - The draft `phase<N>-uat.md` — attached
+> - The outcome matrix from Step 2 — attached
+>
+> For **every** DoD checkbox, return a row classifying it as:
+> - `covered` — a UAT scenario in the plan exercises it; name the UAT-ID
+> - `deferred-unit-test` — the plan's "Backend primitives" section names it with rationale
+> - `known-gap` — the plan's "Known gap" section honestly flags that this DoD did not ship as described
+> - `unmapped` — neither of the above
+>
+> Also return the reverse check: for every UAT scenario in the plan, list the DoDs it claims to cover, and whether each claimed DoD is actually in the DoD set.
+>
+> Output: two tables — `dod → classification + UAT-ID | section | status`, and `UAT → claimed DoDs (valid | invalid)`.
+
+**HARD GATE:** If any DoD is `unmapped`, or any UAT claims a DoD not in the set, fix the drafts and re-run the verification. Do not proceed until the mapping is clean.
+
+### 8. Self-review against prior phase — optional subagent
+
+Delegate to an `Explore` subagent (or skip if this is Phase 0 / no prior phase exists):
+
+> Compare the three new files (`phase<N>-uat.md`, `phase<N>-uat.sh`, `phase<N>-uat-setup.md`) to the matching prior-phase files. Flag:
+> - Section ordering that diverges without cause
+> - Per-UAT field ordering that diverges (Scope / Vehicle / Why / Preparation / Steps / Failure criteria)
+> - Harness flag set that diverges — new plans should be a superset or match, not a subset
+> - Shell function naming conventions (snake_case `uat_NNx`) that diverge
+>
+> Return: a short drift list, or "no material drift".
+
+Address any drift flagged.
+
+### 9. Create the branch, commit, and open the PR
+
+Branch + commit from the main context:
+
+```bash
+git checkout -b "docs/phase<N>-uat"
+git add docs/testing/phase<N>-uat.md \
+        docs/testing/phase<N>-uat.sh \
+        docs/testing/phase<N>-uat-setup.md
+# If new Playwright specs were stubbed out, add them too:
+# git add web/packages/app/tests/phase<N>/
+
+git commit -m "$(cat <<'EOF'
+docs(testing): add Phase <N> UAT plan, harness, and setup
+
+Covers milestone "<milestone>": <N> UATs across <vehicle mix>.
+Outcome gate: UAT-01 (<one-line>).
+Backend primitives deferred to unit tests are listed in the plan.
+<If applicable:> Known gap: <one-line> (see plan for details).
+EOF
+)"
+
+git push -u origin "docs/phase<N>-uat"
+
+gh pr create \
+  --repo forge-ide/forge \
+  --base main \
+  --title "docs(testing): Phase <N> UAT plan, harness, and setup" \
+  --milestone "<milestone>" \
+  --label "type: chore" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Adds the Phase <N> UAT trio:
+- `docs/testing/phase<N>-uat.md` — plan
+- `docs/testing/phase<N>-uat.sh` — harness
+- `docs/testing/phase<N>-uat-setup.md` — one-time setup
+
+<Short paragraph on vehicle mix and outcome gate.>
+
+## Coverage
+
+<Paste the `dod → UAT-ID | section` table from Step 7 verbatim. Reviewers can scan it to confirm every DoD is accounted for.>
+
+## Known gaps flagged in the plan
+
+<Bulleted list, or "none".>
+
+## Reviewer checklist
+
+- [ ] Every closed issue's DoD appears in the coverage table
+- [ ] Outcome gate (UAT-01[a]) matches the milestone's headline capability
+- [ ] Backend-primitive deferrals each name a covering unit test
+- [ ] Known gaps are honestly described (not softened)
+- [ ] Harness flags match the prior phase's flag set
+EOF
+)"
+```
+
+### 10. Verify — invoke `superpowers:verification-before-completion`
+
+```bash
+gh pr list --repo forge-ide/forge --head "docs/phase<N>-uat" --json number,title,labels,milestone
+```
+
+Confirm:
+- The PR exists
+- All three files are in the diff
+- The PR body contains the full coverage table from Step 7
+- The milestone and label are set
+
+Do not claim done until this evidence is in hand.
+
+## Delegation rules
+
+| Work type | Where it runs |
+|-----------|---------------|
+| Milestone metadata, DoD extraction, prior-phase style read, known-gap detection | `Explore` subagent |
+| Outcome matrix / DoD clustering | `superpowers:brainstorming` with the user |
+| UI-flow / state expectations for Playwright-vehicle UATs | `frontend-design:frontend-design` |
+| Drafting the three files | Main context (generative writing benefits from full context) |
+| DoD coverage verification | Fresh general-purpose subagent |
+| Style-drift check vs. prior phase | `Explore` subagent (optional) |
+| Git branch + commit + PR open | Main context, sequential |
+| Final verification | `superpowers:verification-before-completion` |
+
+## Common mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| Generating one UAT per DoD | Cluster DoDs into user-observable outcomes; a 14-ticket milestone should produce ~6–10 UATs, not 14 |
+| Skipping the deferred-unit-test section | Every DoD without a user surface must be explicitly named and paired with its unit-test location — silent omission is a bug |
+| Softening shippable-vs-claimed gaps | "Known gap" sections are load-bearing; phase1 set the precedent — match its honesty |
+| Generic UAT steps ("verify it works") | Every step must name a specific observation (selector, file content, stdout line) that distinguishes pass from fail |
+| Inventing a new harness flag set | The `.sh` file's flag set should match or be a superset of the prior phase's — contributors shouldn't re-learn the CLI each phase |
+| Wiring GUI UATs without Playwright selectors grounded in the design system | Use semantic landmarks / data attributes the design system already exposes, not ad-hoc IDs |
+| Skipping coverage verification because "it looks complete" | The hard gate exists because unmapped DoDs escape notice; evidence before assertions |
+| Writing UATs for features that did not ship | If a milestone bullet has no closed issue, the UAT goes in the Known-gap section, not the main plan |
+| Opening issues instead of a PR | This skill's output is a PR with committed files — a structural departure from the audit siblings; don't reach for `gh issue create` |
+| Forgetting to link Playwright specs under `web/packages/app/tests/phase<N>/` | If the plan cites Playwright, the specs directory should be created (even if stubbed) so the harness has somewhere to point |
+| Claiming done without `gh pr list` evidence | `verification-before-completion` requires it |


### PR DESCRIPTION
## Summary

Adds ten `.claude/skills` entries covering the full end-to-end milestone lifecycle, complementing the existing `forge-milestone-planner` and task-level workflow skills. Collectively they let a contributor take a milestone from "code is complete" through audits, UAT authorship, go/no-go, and actual release cutting — via a single orchestrator skill, or individually.

## What's in this PR

**Audit & review skills** (each produces per-finding GitHub issues + one consolidated report issue):

- `forge-milestone-security-audit` — threats, CVEs; runs `cargo audit`, `cargo deny`, `pnpm audit`
- `forge-milestone-docs-audit` — completeness, staleness, authoritative-vs-derived drift (e.g. `tokens.css` vs `token-reference.md`)
- `forge-milestone-quality-review` — cross-PR patterns per-PR review misses (parallel APIs, duplicated logic, abstraction leaks)
- `forge-milestone-frontend-review` — a11y, design-system adherence, `docs/ui-specs/` compliance, interaction-state coverage
- `forge-milestone-performance-audit` — baseline-vs-current deltas (binary size, bundle size, `criterion` benches) + static perf review
- `forge-milestone-backcompat-audit` — diffs IPC message shapes, config schema, CLI flags; classifies each change safe/breaking
- `forge-milestone-release-readiness` — final GO/NO-GO gate, surfaces unresolved critical/high findings from the other audits as blockers

**Authorship skill** (produces a PR, not issues):

- `forge-milestone-uat-author` — drafts `docs/testing/phase<N>-uat.md`, `.sh`, and `-setup.md` in the house style set by `phase1-uat.*`; clusters DoDs into user-observable outcomes; hard-gated DoD coverage verification

**Orchestrators** (coordinate the above, delegate everything):

- `forge-complete-milestone` — runs the audit gauntlet + UAT + readiness in order with user checkpoints between phases; auto-skips based on milestone content (no `web/` → skip frontend review, etc.); resumable via report-issue labels
- `forge-close-milestone` — ships after GO: release-version bumps → commit → tag → push → `gh release create` (notes from CHANGELOG) → close milestone → close consolidated audit reports → post-release dev bump. Every step idempotent; `HARD GATE` on the manifest before anything touches the remote.

## Design principles shared across the family

- Every audit has the same 8-step spine: scope → concern model → scanners → parallel per-area subagents → triage → sequential issue creation → consolidated report → verification
- Two hard gates per audit: before brainstorming commitments, and before any `gh issue create`
- Concern models are derived **per-milestone** (not checklisted) because a Phase 0 IPC handshake and a Phase 3 container runtime share almost no threat surface
- Heavy delegation — main context coordinates; scope gathering, per-area review, and DoD coverage verification all spawn subagents
- The close skill refuses to run without a GO decision on record, and never auto-stashes/resets user working-tree state

## Labels used

These domain-prefixed label families were already created on `forge-ide/forge`:

- `type: security` + `security: {critical,high,medium,low,audit}`
- `{docs,quality,frontend,perf,compat,release}: {critical,high,medium,low,audit}`

Non-security audit findings are labeled `type: bug` + the relevant domain severity.

## Test plan

These are workflow skills, not code, so no unit tests. Sanity-checks:

- [ ] Each `SKILL.md` parses as valid YAML frontmatter + markdown body
- [ ] Each `description` is specific enough to trigger reliably (includes example user phrasings)
- [ ] Every bash command referenced either targets an existing tool (`cargo`, `pnpm`, `gh`, `node scripts/check-tokens.mjs`) or is gracefully skipped if unavailable
- [ ] All referenced peer skills (`Explore`, `superpowers:brainstorming`, `superpowers:dispatching-parallel-agents`, `superpowers:verification-before-completion`, `frontend-design:frontend-design`) exist in the session
- [ ] No reference to paths outside the repo
- [ ] Dry-run candidate: `forge-milestone-docs-audit "Phase 1: Single Provider + GUI"` is the safest first invocation — read-only, produces issues only after user confirmation at the triage gate

## Milestone lifecycle with this suite

1. `forge-milestone-planner` — kick off the milestone, create `[F-NNN]` issues
2. `forge-complete-task` × N — implement each ticket
3. `forge-complete-milestone` — run the end-of-milestone gauntlet, ends with GO/NO-GO
4. `forge-close-milestone` — ship it: bump, tag, release, close

🤖 Generated with [Claude Code](https://claude.com/claude-code)