### PR TITLE
[F-041] Tool call card shows one-line arg summary (path)

### DIFF
--- a/web/packages/app/src/routes/Session/ChatPane.css
+++ b/web/packages/app/src/routes/Session/ChatPane.css
@@ -151,12 +151,26 @@
 }
 
 .tool-placeholder__name {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   color: var(--color-text-primary);
+}
+
+/* F-041: one-line arg summary sits between the tool name and the status,
+   takes the remaining space, and truncates with an ellipsis when narrower
+   than the content. Muted so the tool name stays the primary read. */
+.tool-placeholder__args {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
 }
 
 .tool-placeholder__status {
   color: var(--color-text-tertiary);
+  flex: 0 0 auto;
 }
 
 /* -------------------------------------------------------------------------

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -74,6 +74,51 @@ describe('ChatPane rendering', () => {
     expect(getByTestId('tool-call-card-tc-1')).toBeInTheDocument();
   });
 
+  // F-041: collapsed tool call card renders a one-line arg summary to the
+  // right of the tool name. Path-taking tools show the path; other tools
+  // show a short stringified JSON; unparseable args render no summary.
+  it('renders the path as the arg summary when args_json has a path field', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-path',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'readable.txt' }),
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    const card = getByTestId('tool-call-card-tc-path');
+    expect(card).toHaveTextContent('readable.txt');
+  });
+
+  it('falls back to stringified args truncated to ~60 chars when no path field', () => {
+    const bigArgs = { query: 'x'.repeat(120), scope: 'everything' };
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-nopath',
+      tool_name: 'search',
+      args_json: JSON.stringify(bigArgs),
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    const card = getByTestId('tool-call-card-tc-nopath');
+    // Contains the leading tokens of the stringified JSON…
+    expect(card).toHaveTextContent('"query"');
+    // …but is bounded by the ~60-char cap, not the full 100+ char payload.
+    expect(card.textContent ?? '').not.toContain('x'.repeat(80));
+  });
+
+  it('omits the arg summary span when args_json is unparseable', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-bad',
+      tool_name: 'broken',
+      args_json: '{ this is not json',
+    });
+    const { getByTestId, queryByTestId } = render(() => <ChatPane />);
+    // Card still renders — the invalid JSON must not crash the component.
+    expect(getByTestId('tool-call-card-tc-bad')).toBeInTheDocument();
+    // No args span.
+    expect(queryByTestId('tool-call-args-tc-bad')).not.toBeInTheDocument();
+  });
+
   it('renders an error turn inline', () => {
     pushEvent(SID, { kind: 'Error', message: 'ECONNREFUSED 127.0.0.1:11434' });
     const { getByText } = render(() => <ChatPane />);

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -28,6 +28,32 @@ import './ChatPane.css';
 // ToolCallCard — inline tool call card with optional approval prompt (F-026/F-027)
 // ---------------------------------------------------------------------------
 
+/**
+ * One-line arg summary for the collapsed tool-call card (F-041). Path-taking
+ * tools (fs.read / fs.write / fs.edit / shell.exec) render their `path` whole;
+ * anything else gets `JSON.stringify(args)` capped near 60 chars with an
+ * ellipsis. Unparseable args_json returns null — the component skips the span
+ * via `<Show>`, so malformed payloads never crash the card.
+ */
+function summarizeArgs(argsJson: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(argsJson);
+  } catch {
+    return null;
+  }
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    const path = (parsed as Record<string, unknown>)['path'];
+    if (typeof path === 'string' && path.length > 0) {
+      return path;
+    }
+  }
+  const stringified = JSON.stringify(parsed);
+  if (stringified === undefined) return null;
+  const MAX = 60;
+  return stringified.length > MAX ? stringified.slice(0, MAX - 1) + '…' : stringified;
+}
+
 const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholder' }> }> = (
   props,
 ) => {
@@ -130,6 +156,19 @@ const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholde
           ⚙
         </span>
         <span class="tool-placeholder__name">{props.turn.tool_name}</span>
+
+        {/* One-line arg summary — path for path-taking tools, otherwise a
+            short stringified JSON. Skipped when args_json is unparseable. */}
+        <Show when={summarizeArgs(props.turn.args_json)}>
+          {(summary) => (
+            <span
+              class="tool-placeholder__args"
+              data-testid={`tool-call-args-${props.turn.tool_call_id}`}
+            >
+              {summary()}
+            </span>
+          )}
+        </Show>
 
         {/* Whitelisted pill when auto-approved */}
         <Show when={whitelistKey() !== null && whitelistLabel() !== null}>

--- a/web/packages/app/tests/phase1/uat-06-tool-call-card.spec.ts
+++ b/web/packages/app/tests/phase1/uat-06-tool-call-card.spec.ts
@@ -38,8 +38,9 @@ test.describe('UAT-06 — tool call card', () => {
 
     await expect(page.getByTestId('tool-call-card-tc-1')).toBeVisible();
     await expect(page.getByTestId('tool-call-card-tc-1')).toContainText('fs.read');
-    // The one-line path arg is tracked separately as F-041 (#77); the
-    // F-037 adapter PR only delivers the event; header arg rendering follows.
+    // F-041: the collapsed card header also shows a one-line path summary
+    // next to the tool name.
+    await expect(page.getByTestId('tool-call-card-tc-1')).toContainText('readable.txt');
   });
 
   test('expand/collapse toggle persists while window is open', async () => {


### PR DESCRIPTION
Closes forge-ide/forge#77

## Summary

- New `summarizeArgs(argsJson)` helper in `ChatPane.tsx` + gated `<span class="tool-placeholder__args" data-testid="tool-call-args-{id}">` in the card header. Path-taking tools render their `path` field whole; other tools render `JSON.stringify(args)` capped at 60 chars with `…`; unparseable JSON returns `null` and `<Show>` skips the span (no crash).
- CSS uses the canonical flex-ellipsis recipe: name becomes `flex: 0 0 auto`, args `flex: 1 1 auto; min-width: 0` + `overflow: hidden; text-overflow: ellipsis` — the `min-width: 0` is load-bearing (without it a long stringified-arg would push the status glyph off the card). Status gains `flex: 0 0 auto` to stay right-aligned.
- UAT-06 step 1's `toContainText('readable.txt')` assertion is restored — F-037 had trimmed it with a pointer to this ticket.
- Three new Vitest tests cover path-arg, fallback-truncated-JSON, and invalid-JSON branches.

## Test plan

- [x] `pnpm --filter app test` — 189/189 vitest tests pass across 17 files (was 186, +3 new tests)
- [x] `pnpm --filter app typecheck` clean
- [x] `./docs/testing/phase1-uat.sh --gui-only` — 12 passed, 24 skipped, 0 failed (UAT-06 step 1 asserts the path text successfully end-to-end)
- [x] No Rust changes; cargo workspace unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)