### PR TITLE
fix(forge-shell): replace null CSP with restrictive policy (F-050)

### DIFF
--- a/crates/forge-shell/src-tauri/tauri.conf.json
+++ b/crates/forge-shell/src-tauri/tauri.conf.json
@@ -13,7 +13,7 @@
     "withGlobalTauri": false,
     "windows": [],
     "security": {
-      "csp": null
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost; connect-src 'self' ipc: http://ipc.localhost; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
     }
   },
   "bundle": {

--- a/web/packages/app/index.html
+++ b/web/packages/app/index.html
@@ -3,6 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Content-Security-Policy (F-050 / H9).
+      Source of truth for the Tauri webview is crates/forge-shell/src-tauri/tauri.conf.json
+      (app.security.csp). This meta tag mirrors that policy for the Vite dev
+      server and the Playwright harness, which do not read tauri.conf.json.
+      Keep both in sync.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost; connect-src 'self' ipc: http://ipc.localhost; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
+    />
     <title>Forge</title>
   </head>
   <body>

--- a/web/packages/app/tests/phase1/uat-csp-meta.spec.ts
+++ b/web/packages/app/tests/phase1/uat-csp-meta.spec.ts
@@ -1,0 +1,34 @@
+// F-050 / H9 — Restrictive CSP regression.
+//
+// Asserts that the bootstrap document carries a Content-Security-Policy meta
+// tag whose content contains the anchor directives that define the policy's
+// defense-in-depth posture against webview XSS:
+//
+//   - script-src 'self'       — blocks inline + remote scripts
+//   - object-src 'none'       — blocks <object>/<embed> plugin injection
+//   - frame-ancestors 'none'  — blocks embedding the app in a frame
+//
+// The Tauri webview reads CSP from tauri.conf.json; the Vite dev server and
+// this Playwright harness read it from the <meta> tag in index.html. Both
+// must carry the same policy — see the source-of-truth comment in index.html.
+//
+// This test runs against the Vite dev server (Playwright harness), so only
+// the meta-tag path is exercised here. The tauri.conf.json path is covered
+// by build verification (pnpm --filter app build) and manual smoke.
+
+import { test, expect } from '@playwright/test';
+
+test.describe('F-050 — restrictive CSP', () => {
+  test('bootstrap document exposes CSP meta tag with anchor directives', async ({ page }) => {
+    await page.goto('/');
+
+    const meta = page.locator('meta[http-equiv="Content-Security-Policy"]');
+    await expect(meta, 'CSP meta tag must be present in index.html').toHaveCount(1);
+
+    const cspContent = await meta.getAttribute('content');
+    expect(cspContent).not.toBeNull();
+    expect(cspContent).toContain("script-src 'self'");
+    expect(cspContent).toContain("object-src 'none'");
+    expect(cspContent).toContain("frame-ancestors 'none'");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #92 (F-050, H9 — `forge-shell` CSP is null).

- Replaces `"csp": null` in `crates/forge-shell/src-tauri/tauri.conf.json` with the exact remediation policy from the H9 audit finding.
- Mirrors the same policy as a `<meta http-equiv="Content-Security-Policy">` in `web/packages/app/index.html`, with a source-of-truth comment pointing back to `tauri.conf.json`. The Vite dev server and the Playwright harness do not read `tauri.conf.json`; without the meta tag, CSP would be absent on those paths.
- Adds Playwright regression test `web/packages/app/tests/phase1/uat-csp-meta.spec.ts` asserting the bootstrap document carries the CSP meta tag and that its `content` contains the three anchor directives: `script-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`.

### CSP string shipped (identical in both locations)

```
default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost; connect-src 'self' ipc: http://ipc.localhost; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
```

This is verbatim the remediation CSP from the issue body — no relaxations beyond the issue's remediation. `'unsafe-inline'` appears on `style-src` only; `script-src` is `'self'` with no exceptions. `ipc:` / `http://ipc.localhost` on `connect-src` are required for Tauri IPC; `asset:` / `https://asset.localhost` on `img-src` are required for Tauri's asset protocol.

### Pre-verified safety

Discovery before implementation confirmed:
- `index.html` loads scripts via `<script type="module">` with same-origin `src`; no inline scripts.
- No `innerHTML`, `eval`, `new Function`, `document.write`, or dynamic `import()` usage anywhere in `web/packages/*`.
- No WASM, no dynamic `<style>` injection (CSS is loaded via `<link>` only).

So `script-src 'self'` does not break the app today, and the `'unsafe-inline'` on `style-src` is margin for Solid's `style={}` prop path rather than a current requirement.

## DoD checklist

- [x] Restrictive CSP set in `tauri.conf.json` (covers `script-src`, `connect-src`, `object-src`, `frame-ancestors`)
- [x] Matching `<meta>` tag in `index.html` for dev-time & Playwright enforcement
- [x] Playwright regression test asserts the policy is present and contains the three anchor directives
- [x] `pnpm --filter app build` succeeds
- [ ] Manual smoke (app starts via `pnpm --filter app dev`, session panel renders, DevTools console shows no CSP violations) — deferred to reviewer; build pipeline + Playwright cover the structural cases

## Test plan

- [x] `pnpm --filter app build` — succeeds
- [x] `cargo check -p forge-shell` — succeeds
- [x] `cargo clippy -p forge-shell --all-targets -- -D warnings` — clean
- [x] `pnpm exec playwright test tests/phase1/uat-csp-meta.spec.ts` — passes
- [x] RED-verified: removing the meta tag from `index.html` makes the new Playwright test fail with "CSP meta tag must be present in index.html" (confirmed locally)
- [ ] Reviewer manual smoke: `pnpm --filter app dev`, open DevTools console on the app window, exercise the golden path (list sessions → open a session → send a message), confirm no CSP violation entries.

## Files touched

- `crates/forge-shell/src-tauri/tauri.conf.json` — CSP string
- `web/packages/app/index.html` — mirrored meta tag + source-of-truth comment
- `web/packages/app/tests/phase1/uat-csp-meta.spec.ts` — new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)