### PR TITLE
fix(forge-shell): per-session Tauri IPC authorization (F-051)

### DIFF
--- a/crates/forge-shell/src/dashboard_sessions.rs
+++ b/crates/forge-shell/src/dashboard_sessions.rs
@@ -257,7 +257,10 @@ pub fn default_workspaces_toml() -> PathBuf {
 /// Tauri command: return the sessions panel's data for the Dashboard.
 #[cfg(feature = "webview")]
 #[tauri::command]
-pub async fn session_list() -> Result<Vec<SessionSummary>, String> {
+pub async fn session_list<R: tauri::Runtime>(
+    webview: tauri::Webview<R>,
+) -> Result<Vec<SessionSummary>, String> {
+    crate::ipc::require_window_label(&webview, "dashboard")?;
     collect_sessions(&default_workspaces_toml(), &UdsPinger)
         .await
         .map_err(|e| e.to_string())
@@ -269,8 +272,10 @@ pub async fn session_list() -> Result<Vec<SessionSummary>, String> {
 #[tauri::command]
 pub async fn open_session<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
+    webview: tauri::Webview<R>,
     id: String,
 ) -> Result<(), String> {
+    crate::ipc::require_window_label(&webview, "dashboard")?;
     crate::window_manager::WindowManager::new(app)
         .open_session(&id)
         .map(|_| ())

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -3,14 +3,41 @@
 //! Every command is a thin wrapper over [`crate::bridge::SessionBridge`],
 //! plus an [`EventSink`] implementation that forwards payloads to the
 //! webview via `AppHandle::emit("session:event", …)`.
+//!
+//! **Authorization (F-051 / H10):** each session command requires the
+//! calling webview's label to equal `format!("session-{session_id}")`.
+//! Window labels are set by `window_manager` at window creation and cannot
+//! be forged from webview JS, so they serve as the per-window authenticator
+//! binding a session's control channel to its review channel. Mismatches
+//! return [`LABEL_MISMATCH_ERROR`] and never reach the daemon.
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use forge_ipc::HelloAck;
-use tauri::{AppHandle, Emitter, Manager, Runtime, State};
+use tauri::{AppHandle, Emitter, Manager, Runtime, State, Webview};
 
 use crate::bridge::{EventSink, SessionBridge, SessionConnections, SessionEventPayload};
+
+/// F-051 / H10: structured error returned when the calling webview's label
+/// does not match the expected owner for a command's scope. Kept as a plain
+/// `String` so it matches every `#[tauri::command]`'s existing `Err(String)`
+/// wire shape — never a panic.
+pub(crate) const LABEL_MISMATCH_ERROR: &str = "forbidden: window label mismatch";
+
+/// Assert the calling webview's label equals `expected`. Used at the top of
+/// every session/dashboard `#[tauri::command]` to reject cross-window invokes
+/// before the bridge sees the frame.
+pub(crate) fn require_window_label<R: Runtime>(
+    webview: &Webview<R>,
+    expected: &str,
+) -> Result<(), String> {
+    if webview.label() == expected {
+        Ok(())
+    } else {
+        Err(LABEL_MISMATCH_ERROR.to_string())
+    }
+}
 
 /// Tauri-managed bridge state. One per App; commands resolve it via
 /// `State<BridgeState>`.
@@ -41,11 +68,14 @@ impl<R: Runtime> EventSink for AppHandleSink<R> {
 }
 
 #[tauri::command]
-pub async fn session_hello(
+pub async fn session_hello<R: Runtime>(
     session_id: String,
     socket_path: Option<String>,
+    webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<HelloAck, String> {
+    require_window_label(&webview, &format!("session-{session_id}"))?;
+    // TODO(F-052): validate socket_path here — see issue #94.
     let socket_path = socket_path.as_deref().map(PathBuf::from);
     state
         .bridge
@@ -59,8 +89,10 @@ pub async fn session_subscribe<R: Runtime>(
     session_id: String,
     since: Option<u64>,
     app: AppHandle<R>,
+    webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     let sink: Arc<dyn EventSink> = Arc::new(AppHandleSink { app });
     state
         .bridge
@@ -70,11 +102,13 @@ pub async fn session_subscribe<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn session_send_message(
+pub async fn session_send_message<R: Runtime>(
     session_id: String,
     text: String,
+    webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     state
         .bridge
         .send_message(&session_id, text)
@@ -83,12 +117,14 @@ pub async fn session_send_message(
 }
 
 #[tauri::command]
-pub async fn session_approve_tool(
+pub async fn session_approve_tool<R: Runtime>(
     session_id: String,
     tool_call_id: String,
     scope: String,
+    webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     state
         .bridge
         .approve_tool(&session_id, tool_call_id, scope)
@@ -97,12 +133,14 @@ pub async fn session_approve_tool(
 }
 
 #[tauri::command]
-pub async fn session_reject_tool(
+pub async fn session_reject_tool<R: Runtime>(
     session_id: String,
     tool_call_id: String,
     reason: Option<String>,
+    webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     state
         .bridge
         .reject_tool(&session_id, tool_call_id, reason)

--- a/crates/forge-shell/tests/ipc_authz.rs
+++ b/crates/forge-shell/tests/ipc_authz.rs
@@ -1,0 +1,243 @@
+//! F-051 / H10: per-session IPC authorization.
+//!
+//! These tests assert that every `#[tauri::command]` handler validates
+//! `webview.label()` against the expected owner for its scope:
+//! - Session handlers in `ipc.rs` require label `format!("session-{session_id}")`
+//! - Dashboard handlers in `dashboard_sessions.rs` require label `"dashboard"`
+//!
+//! Strategy: build `mock_builder()` apps with `WebviewWindowBuilder` using
+//! specific labels, then fire `tauri::test::get_ipc_response` and assert the
+//! result shape. For forged-session tests, intentionally leave the *target*
+//! session unregistered in `BridgeState`. If authz fires first (as intended)
+//! the response is the label-mismatch error; if it silently falls through
+//! to the bridge, the response would be a "no active connection" error —
+//! which would prove the check is missing.
+
+#![cfg(feature = "webview-test")]
+
+use forge_shell::bridge::SessionConnections;
+use forge_shell::ipc::{build_invoke_handler, BridgeState};
+use tauri::test::{get_ipc_response, mock_builder, mock_context, noop_assets, INVOKE_KEY};
+use tauri::Manager;
+
+const LABEL_MISMATCH: &str = "forbidden: window label mismatch";
+
+fn make_app_with_session_bridge() -> tauri::App<tauri::test::MockRuntime> {
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::new(SessionConnections::new()));
+    app
+}
+
+fn make_app_with_dashboard_handler() -> tauri::App<tauri::test::MockRuntime> {
+    mock_builder()
+        .invoke_handler(tauri::generate_handler![
+            forge_shell::dashboard_sessions::session_list,
+        ])
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app")
+}
+
+fn build_window(
+    app: &tauri::App<tauri::test::MockRuntime>,
+    label: &str,
+) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
+    tauri::WebviewWindowBuilder::new(app, label, tauri::WebviewUrl::App("index.html".into()))
+        .build()
+        .expect("mock window")
+}
+
+fn invoke(
+    window: &tauri::WebviewWindow<tauri::test::MockRuntime>,
+    cmd: &str,
+    payload: serde_json::Value,
+) -> Result<tauri::ipc::InvokeResponseBody, String> {
+    get_ipc_response(
+        window,
+        tauri::webview::InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    )
+    .map_err(|v| match v {
+        serde_json::Value::String(s) => s,
+        other => other.to_string(),
+    })
+}
+
+#[test]
+fn dashboard_window_invoking_session_approve_tool_is_rejected() {
+    let app = make_app_with_session_bridge();
+    let window = build_window(&app, "dashboard");
+
+    let err = invoke(
+        &window,
+        "session_approve_tool",
+        serde_json::json!({
+            "sessionId": "sess-a",
+            "toolCallId": "tc-1",
+            "scope": "ThisTool",
+        }),
+    )
+    .expect_err("dashboard window must not call session_approve_tool");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}
+
+#[test]
+fn session_a_window_invoking_session_approve_tool_for_session_b_is_rejected() {
+    // Bridge state has no entries for either session. If the authz check is
+    // present the rejection is the label-mismatch error. If it is missing,
+    // the bridge would return a "no active connection" error — which would
+    // prove the authz layer is absent.
+    let app = make_app_with_session_bridge();
+    let window = build_window(&app, "session-A");
+
+    let err = invoke(
+        &window,
+        "session_approve_tool",
+        serde_json::json!({
+            "sessionId": "B",
+            "toolCallId": "tc-forged",
+            "scope": "ThisTool",
+        }),
+    )
+    .expect_err("session-A must not approve tool for session B");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error (not a bridge error), got: {err}"
+    );
+}
+
+#[test]
+fn session_a_window_invoking_session_send_message_for_session_b_is_rejected() {
+    let app = make_app_with_session_bridge();
+    let window = build_window(&app, "session-A");
+
+    let err = invoke(
+        &window,
+        "session_send_message",
+        serde_json::json!({
+            "sessionId": "B",
+            "text": "hello",
+        }),
+    )
+    .expect_err("session-A must not send message for session B");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}
+
+#[test]
+fn session_a_window_invoking_session_reject_tool_for_session_b_is_rejected() {
+    let app = make_app_with_session_bridge();
+    let window = build_window(&app, "session-A");
+
+    let err = invoke(
+        &window,
+        "session_reject_tool",
+        serde_json::json!({
+            "sessionId": "B",
+            "toolCallId": "tc-forged",
+            "reason": null,
+        }),
+    )
+    .expect_err("session-A must not reject tool for session B");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}
+
+#[test]
+fn session_a_window_invoking_session_subscribe_for_session_b_is_rejected() {
+    let app = make_app_with_session_bridge();
+    let window = build_window(&app, "session-A");
+
+    let err = invoke(
+        &window,
+        "session_subscribe",
+        serde_json::json!({
+            "sessionId": "B",
+            "since": 0,
+        }),
+    )
+    .expect_err("session-A must not subscribe to session B");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}
+
+#[test]
+fn session_a_window_invoking_session_hello_for_session_b_is_rejected() {
+    let app = make_app_with_session_bridge();
+    let window = build_window(&app, "session-A");
+
+    let err = invoke(
+        &window,
+        "session_hello",
+        serde_json::json!({
+            "sessionId": "B",
+            "socketPath": "/tmp/nonexistent.sock",
+        }),
+    )
+    .expect_err("session-A must not perform hello for session B");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}
+
+#[test]
+fn non_dashboard_window_invoking_session_list_is_rejected() {
+    let app = make_app_with_dashboard_handler();
+    let window = build_window(&app, "session-A");
+
+    let err = invoke(&window, "session_list", serde_json::json!({}))
+        .expect_err("non-dashboard window must not call session_list");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}
+
+#[test]
+fn non_dashboard_window_invoking_open_session_is_rejected() {
+    let app = mock_builder()
+        .invoke_handler(tauri::generate_handler![
+            forge_shell::dashboard_sessions::open_session,
+        ])
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    let window = build_window(&app, "session-A");
+
+    let err = invoke(
+        &window,
+        "open_session",
+        serde_json::json!({ "id": "some-session-id" }),
+    )
+    .expect_err("non-dashboard window must not call open_session");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}

--- a/crates/forge-shell/tests/ipc_commands.rs
+++ b/crates/forge-shell/tests/ipc_commands.rs
@@ -67,10 +67,15 @@ async fn session_hello_command_round_trips_via_tauri_invoke() {
     let app = make_app();
     app.manage(BridgeState::new(SessionConnections::new()));
 
-    let window =
-        tauri::WebviewWindowBuilder::new(&app, "main", tauri::WebviewUrl::App("index.html".into()))
-            .build()
-            .expect("mock window");
+    // F-051: window label must match `session-{session_id}` for the
+    // session_hello authz check to pass.
+    let window = tauri::WebviewWindowBuilder::new(
+        &app,
+        "session-tauri-hello",
+        tauri::WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("mock window");
 
     let payload = serde_json::json!({
         "sessionId": "tauri-hello",


### PR DESCRIPTION
Closes forge-ide/forge#93

## Summary

- Every `#[tauri::command]` handler in `crates/forge-shell/src/ipc.rs` and the dashboard-scoped commands in `crates/forge-shell/src/dashboard_sessions.rs` now require that the calling webview's label matches the expected owner for the command's scope.
  - Session handlers (`session_hello`, `session_subscribe`, `session_send_message`, `session_approve_tool`, `session_reject_tool`) require `format!("session-{session_id}")`.
  - Dashboard handlers (`session_list`, `open_session`) require `"dashboard"`.
- Mismatched frames return a structured error (`"forbidden: window label mismatch"`) and never reach the bridge or the session daemon.
- New integration tests in `crates/forge-shell/tests/ipc_authz.rs` exercise forged-session and cross-window invokes for every handler; all 8 tests verified FAILING before the fix and PASSING after.
- Existing `session_hello_command_round_trips_via_tauri_invoke` test updated to use the correct session-scoped window label so the happy path still passes end-to-end against a real daemon.

## Authorization design

- **Authenticator:** the Tauri webview label. Labels are set by Rust at `WebviewWindowBuilder::new(.., label, ..)` call time (see `crates/forge-shell/src/window_spec.rs` and `window_manager.rs`) and cannot be forged from webview JS. This is the per-window binding the threat model needs — no separate token store required.
- **Storage:** none. The label is an intrinsic property of each `Webview<R>` Tauri injects into command handlers.
- **Validation:** a small `require_window_label(&webview, expected) -> Result<(), String>` helper at the top of each handler. Returns `Err` before any bridge call runs, so the daemon never sees the frame.

## Coordination with concurrent work

- **F-050 (#114):** zero file overlap — this PR touches `crates/forge-shell/src/*` only; F-050 touches `tauri.conf.json` + `index.html`.
- **F-052 (#94, H11):** the authz check in `session_hello` is placed as the first statement of the body. The existing `socket_path` handling (which F-052 will revisit) is untouched. A `// TODO(F-052): validate socket_path here — see issue #94.` comment marks the seam so the H11 diff is targeted.

## Scope note

The audit finding's "each `#[tauri::command]`" is applied to every session-scoped and dashboard-scoped command (7 total). `provider_status` in `dashboard.rs` is a provider-reachability probe — not in the T1 threat class and not bound to a specific session. It is intentionally left out of scope here; a broader dashboard-origin enforcement pass would be a follow-up if desired.

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo clippy --all-targets --features forge-shell/webview-test -- -D warnings` passes
- `cargo test --workspace --features forge-shell/webview-test` passes (8 new authz tests + all existing tests)

Generated with [Claude Code](https://claude.com/claude-code)