### PR TITLE
fix(forge-cli): reject non-positive pids before libc::kill (F-048)

### DIFF
--- a/crates/forge-cli/src/main.rs
+++ b/crates/forge-cli/src/main.rs
@@ -185,12 +185,13 @@ async fn session_kill(id: &str) -> Result<()> {
     let raw = tokio::fs::read_to_string(&pid_file)
         .await
         .map_err(|_| anyhow::anyhow!("no pid file for session {id} — is it running?"))?;
-    let pid: libc::pid_t = raw
-        .trim()
-        .parse()
-        .map_err(|_| anyhow::anyhow!("invalid pid file for session {id}"))?;
+    let pid = forge_cli::socket::parse_session_pid(&raw)
+        .map_err(|e| anyhow::anyhow!("invalid pid file for session {id}: {e}"))?;
 
-    // SAFETY: pid comes from a file we wrote; SIGTERM is a valid signal number.
+    // SAFETY: pid has been validated as > 0 by `parse_session_pid`, so it
+    // cannot select the caller's process group (pid == 0), every signalable
+    // process (pid == -1), or a process group (pid < -1). SIGTERM is a valid
+    // signal number.
     let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
     if rc != 0 {
         let err = std::io::Error::last_os_error();
@@ -236,8 +237,8 @@ async fn run_agent(name: &str, input_source: &str) -> Result<()> {
         .env("FORGE_SOCKET_PATH", sock.to_str().unwrap_or(""))
         .spawn()?;
 
-    let pid = child.id().unwrap_or(0);
-    tokio::fs::write(&pid_file, pid.to_string()).await?;
+    let pid_contents = forge_cli::socket::pid_file_contents(child.id())?;
+    tokio::fs::write(&pid_file, &pid_contents).await?;
 
     wait_for_socket(&sock).await?;
 

--- a/crates/forge-cli/src/socket.rs
+++ b/crates/forge-cli/src/socket.rs
@@ -28,6 +28,38 @@ pub fn pid_path(session_id: &str) -> PathBuf {
     socket_path(session_id).with_extension("pid")
 }
 
+/// Parse and validate the contents of a session pid file.
+///
+/// Returns an error if the contents do not parse as an integer, or if the
+/// resulting pid is less than or equal to zero. POSIX `kill(2)` treats
+/// `pid == 0` as "signal every process in the caller's process group" and
+/// `pid == -1` as "signal every process the user may signal"; both would
+/// detonate far outside the intended target, so they must never reach
+/// `libc::kill`.
+pub fn parse_session_pid(raw: &str) -> anyhow::Result<libc::pid_t> {
+    let trimmed = raw.trim();
+    let pid: libc::pid_t = trimmed
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid pid file contents: {trimmed:?}"))?;
+    anyhow::ensure!(pid > 0, "refusing to signal non-positive pid {pid}");
+    Ok(pid)
+}
+
+/// Render the contents to write to a session pid file, given the result of
+/// `std::process::Child::id()` / `tokio::process::Child::id()`.
+///
+/// Rejects `None` — a missing pid means the child was already reaped before
+/// we could record it, and writing `"0"` to the pid file would later cause
+/// `libc::kill(0, SIGTERM)` to signal the caller's entire process group.
+/// Also rejects `Some(0)` defensively so that neither helper in this module
+/// can ever emit a non-positive pid for `libc::kill`.
+pub fn pid_file_contents(pid: Option<u32>) -> anyhow::Result<String> {
+    let pid =
+        pid.ok_or_else(|| anyhow::anyhow!("forged child exited before its pid could be recorded"))?;
+    anyhow::ensure!(pid > 0, "refusing to write non-positive pid {pid}");
+    Ok(pid.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,5 +100,71 @@ mod tests {
             "got: {}",
             dir.display()
         );
+    }
+
+    #[test]
+    fn parse_session_pid_accepts_positive() {
+        let pid = parse_session_pid("4242").expect("positive pid should parse");
+        assert_eq!(pid, 4242);
+    }
+
+    #[test]
+    fn parse_session_pid_trims_whitespace_and_newlines() {
+        let pid = parse_session_pid("  1234\n").expect("trimmed pid should parse");
+        assert_eq!(pid, 1234);
+    }
+
+    #[test]
+    fn parse_session_pid_rejects_zero() {
+        let err = parse_session_pid("0").expect_err("pid 0 must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("non-positive") && msg.contains('0'),
+            "expected non-positive rejection mentioning 0, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_session_pid_rejects_negative_one() {
+        let err = parse_session_pid("-1").expect_err("pid -1 must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("non-positive") && msg.contains("-1"),
+            "expected non-positive rejection mentioning -1, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_session_pid_rejects_negative_group() {
+        let err = parse_session_pid("-42").expect_err("negative pid must be rejected");
+        assert!(err.to_string().contains("non-positive"));
+    }
+
+    #[test]
+    fn parse_session_pid_rejects_garbage() {
+        let err = parse_session_pid("not-a-number").expect_err("garbage must be rejected");
+        assert!(err.to_string().contains("invalid"));
+    }
+
+    #[test]
+    fn pid_file_contents_returns_string_for_known_pid() {
+        let s = pid_file_contents(Some(4242)).expect("known pid should produce contents");
+        assert_eq!(s, "4242");
+    }
+
+    #[test]
+    fn pid_file_contents_rejects_none() {
+        let err = pid_file_contents(None).expect_err("None pid must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.to_lowercase().contains("pid"),
+            "expected message to mention pid, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pid_file_contents_rejects_zero_defensively() {
+        let err = pid_file_contents(Some(0)).expect_err("pid 0 must be rejected");
+        assert!(err.to_string().contains("non-positive"));
     }
 }


### PR DESCRIPTION
Closes forge-ide/forge#90

## Summary

`session_kill` parsed the pid file and passed the result straight to `libc::kill`. POSIX `kill(2)` treats `pid == 0` as "signal every process in the caller's process group" and `pid == -1` as "signal every process the user may signal", so a pid file containing `0` or `-1` — either planted by a same-uid attacker or written legitimately by a buggy code path — would broadcast SIGTERM across the user's login session instead of terminating the session daemon.

A concrete reachable source of `0` was `run_agent` (`main.rs:239`), which wrote `child.id().unwrap_or(0)` into the pid file; if the forged child was reaped before `id()` could be read, the file received `"0"` verbatim.

## Design

Two small helpers now live in `forge_cli::socket`:

- `parse_session_pid(raw: &str) -> Result<libc::pid_t>` — parses the pid file contents and rejects any value that is not a strictly positive integer via `anyhow::ensure!(pid > 0, ...)`. `session_kill` calls it, and the `?` operator short-circuits to a typed error before reaching the unsafe `libc::kill` block. The `SAFETY` comment cites this invariant.
- `pid_file_contents(pid: Option<u32>) -> Result<String>` — renders the `Option<u32>` returned by `std::process::Child::id()` / `tokio::process::Child::id()` for the pid file. Rejects `None` (child was already reaped) and defensively rejects `Some(0)`. `run_agent` now propagates the error via `?` instead of writing `"0"`, closing the source of the bad value.

Placing the helpers in `socket.rs` keeps them next to `pid_path` (the existing owner of pid-file concerns) and lets follow-up work layer cleanly without restructuring `session_kill`.

## Definition of Done

- [x] `session_kill` validates `pid > 0` before `libc::kill`
- [x] `run_agent` no longer writes pid file with value `0`
- [x] Regression test: a pid file containing `0` causes `session_kill` to return a typed error, never calling `libc::kill` (`socket::tests::parse_session_pid_rejects_zero` + straight `?` chain in `session_kill` provably short-circuits before the unsafe block)
- [x] Tests pass in CI

## Scope discipline

Deliberately constrained to the T12 raw-PID sign check. Not addressed here, and tracked separately:

- **F-049 (#91, H2)** — PID ownership / reuse race. Wraps around `parse_session_pid`'s validated output (pidfd or start-time verification added after the sign check). No restructuring of `session_kill` required.
- **F-057 (#99, M1)** — session-id path-traversal validation. Orthogonal code path; lands upstream at clap parse time, before any call to `pid_path` / `socket_path`. Does not touch the helpers introduced here.

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (adds 8 new unit tests in `forge_cli::socket::tests`)
- `cargo clippy --all-targets -- -D warnings` passes

Unit tests added:

- `parse_session_pid_accepts_positive`
- `parse_session_pid_trims_whitespace_and_newlines`
- `parse_session_pid_rejects_zero`
- `parse_session_pid_rejects_negative_one`
- `parse_session_pid_rejects_negative_group`
- `parse_session_pid_rejects_garbage`
- `pid_file_contents_returns_string_for_known_pid`
- `pid_file_contents_rejects_none`
- `pid_file_contents_rejects_zero_defensively`

Generated with [Claude Code](https://claude.com/claude-code)