### PR TITLE
fix(forge-providers): bound ollama NDJSON stream against DoS (F-045)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ name = "forge-providers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "dirs 6.0.0",
  "forge-core",
  "futures",
@@ -1082,6 +1083,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
  "wiremock",
 ]
 

--- a/crates/forge-providers/Cargo.toml
+++ b/crates/forge-providers/Cargo.toml
@@ -5,16 +5,18 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+bytes = "1"
 dirs = "6.0.0"
 forge-core = { path = "../forge-core" }
 futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["fs", "rt", "macros"] }
+tokio = { version = "1", features = ["fs", "rt", "macros", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
 
 [dev-dependencies]
 tempfile = "3"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "time"] }
 futures = "0.3"
 wiremock = "0.6"

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -52,6 +52,25 @@ pub enum ChatChunk {
         args: serde_json::Value,
     },
     Done(String),
+    /// Terminal, structured stream failure. The chunk stream closes after
+    /// yielding this variant — callers should treat the current turn as aborted.
+    Error {
+        kind: StreamErrorKind,
+        message: String,
+    },
+}
+
+/// Why a provider stream terminated abnormally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamErrorKind {
+    /// A single NDJSON line exceeded the per-line byte cap.
+    LineTooLong,
+    /// No bytes received within the inter-chunk idle window.
+    IdleTimeout,
+    /// The overall stream exceeded its wall-clock budget.
+    WallClockTimeout,
+    /// Transport-level error from the underlying reader.
+    Transport,
 }
 
 // ── Provider trait ────────────────────────────────────────────────────────────

--- a/crates/forge-providers/src/ollama.rs
+++ b/crates/forge-providers/src/ollama.rs
@@ -1,17 +1,59 @@
 //! Ollama provider — NDJSON streaming against a local Ollama daemon.
 //!
 //! No credentials; the daemon is expected at `http://127.0.0.1:11434` by default.
+//!
+//! # Streaming bounds
+//!
+//! A local squatter on port 11434 (race at startup, Ollama crash, malicious
+//! binary) controls the byte stream we consume. The decoder is hardened with
+//! three independent bounds — per-line byte cap, inter-chunk idle timeout, and
+//! overall wall-clock timeout — any of which terminates the stream with a
+//! typed [`ChatChunk::Error`] rather than panicking or growing unbounded.
 
-use crate::{ChatChunk, ChatMessage, ChatRequest, Provider};
+use std::time::Duration;
+
+use crate::{ChatChunk, ChatMessage, ChatRequest, Provider, StreamErrorKind};
 use forge_core::Result;
 use futures::stream::{BoxStream, StreamExt};
 
 pub const DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434";
 
+/// Per-line NDJSON byte cap (1 MiB). Real Ollama chunks are <100 KB.
+pub const DEFAULT_MAX_LINE_BYTES: usize = 1 << 20;
+/// Wall-clock gap between consecutive chunks. 30 s is generous for local
+/// models but still bounds half-open and slow-drip peers.
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Wall-clock cap on the entire stream. 10 min accommodates slow local
+/// inference; pathological runs can be re-attempted by the user.
+pub const DEFAULT_WALL_CLOCK_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Bounds that make the NDJSON decoder DoS-resistant against a hostile peer.
+#[derive(Debug, Clone, Copy)]
+pub struct StreamConfig {
+    pub max_line_bytes: usize,
+    pub idle_timeout: Duration,
+    pub wall_clock_timeout: Duration,
+}
+
+impl StreamConfig {
+    pub const DEFAULT: StreamConfig = StreamConfig {
+        max_line_bytes: DEFAULT_MAX_LINE_BYTES,
+        idle_timeout: DEFAULT_IDLE_TIMEOUT,
+        wall_clock_timeout: DEFAULT_WALL_CLOCK_TIMEOUT,
+    };
+}
+
+impl Default for StreamConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
 pub struct OllamaProvider {
     base_url: String,
     model: String,
     client: reqwest::Client,
+    stream_cfg: StreamConfig,
 }
 
 impl OllamaProvider {
@@ -20,11 +62,28 @@ impl OllamaProvider {
             base_url: base_url.into(),
             model: model.into(),
             client: reqwest::Client::new(),
+            stream_cfg: StreamConfig::DEFAULT,
         }
     }
 
     pub fn with_default_url(model: impl Into<String>) -> Self {
         Self::new(DEFAULT_BASE_URL, model)
+    }
+
+    /// Construct a provider with explicit streaming bounds. Primarily a test
+    /// affordance; production code should use [`OllamaProvider::new`].
+    #[doc(hidden)]
+    pub fn with_config(
+        base_url: impl Into<String>,
+        model: impl Into<String>,
+        stream_cfg: StreamConfig,
+    ) -> Self {
+        Self {
+            base_url: base_url.into(),
+            model: model.into(),
+            client: reqwest::Client::new(),
+            stream_cfg,
+        }
     }
 
     pub async fn list_models(&self) -> Result<Vec<String>> {
@@ -77,6 +136,7 @@ impl Provider for OllamaProvider {
             "stream": true,
         });
         let client = self.client.clone();
+        let cfg = self.stream_cfg;
 
         async move {
             let resp = client
@@ -94,59 +154,130 @@ impl Provider for OllamaProvider {
                 );
             }
 
-            let byte_stream = resp.bytes_stream();
-
-            // Buffered NDJSON decoder: accumulate bytes, flush complete lines per chunk.
-            let state = (
-                byte_stream,
-                String::new(),
-                std::collections::VecDeque::<ChatChunk>::new(),
-                false,
-            );
-            let chunk_stream = futures::stream::unfold(
-                state,
-                |(mut bytes, mut buf, mut pending, mut upstream_done)| async move {
-                    loop {
-                        if let Some(chunk) = pending.pop_front() {
-                            return Some((chunk, (bytes, buf, pending, upstream_done)));
-                        }
-
-                        if upstream_done {
-                            // Flush any trailing partial line as a final parse attempt.
-                            if !buf.is_empty() {
-                                let line = std::mem::take(&mut buf);
-                                if let Some(c) = parse_line(line.trim()) {
-                                    return Some((c, (bytes, buf, pending, upstream_done)));
-                                }
-                            }
-                            return None;
-                        }
-
-                        match bytes.next().await {
-                            Some(Ok(b)) => {
-                                buf.push_str(&String::from_utf8_lossy(&b));
-                                while let Some(pos) = buf.find('\n') {
-                                    let line: String = buf.drain(..=pos).collect();
-                                    let trimmed = line.trim();
-                                    if trimmed.is_empty() {
-                                        continue;
-                                    }
-                                    if let Some(c) = parse_line(trimmed) {
-                                        pending.push_back(c);
-                                    }
-                                }
-                            }
-                            Some(Err(_)) | None => {
-                                upstream_done = true;
-                            }
-                        }
-                    }
-                },
-            );
-
-            Ok(Box::pin(chunk_stream) as BoxStream<'static, ChatChunk>)
+            Ok(decode_ndjson_stream(resp.bytes_stream(), cfg))
         }
     }
+}
+
+/// Decode a byte stream of NDJSON into [`ChatChunk`]s under the configured
+/// bounds. Terminal failures (cap exceeded, idle/wall-clock elapsed, transport
+/// error) surface as a single [`ChatChunk::Error`] and close the stream. This
+/// helper is factored out to keep the `chat()` body readable and to give
+/// future changes (e.g. F-046's reqwest client timeouts) a single seam to
+/// extend without reshaping the decoder.
+fn decode_ndjson_stream<S, E>(byte_stream: S, cfg: StreamConfig) -> BoxStream<'static, ChatChunk>
+where
+    S: futures::Stream<Item = std::result::Result<bytes::Bytes, E>> + Send + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    use tokio_util::codec::{FramedRead, LinesCodec};
+    use tokio_util::io::StreamReader;
+
+    // Adapt reqwest's `bytes_stream()` to an `AsyncRead`, then decode bounded
+    // NDJSON lines. `LinesCodec::new_with_max_length` returns
+    // `MaxLineLengthExceeded` cleanly instead of growing the buffer past the cap.
+    // `reqwest::Response::bytes_stream()` is `!Unpin`, so pin the adapter chain
+    // once here; `FramedRead` requires `AsyncRead + Unpin`.
+    let pinned = Box::pin(byte_stream.map(|r| r.map_err(std::io::Error::other)));
+    let reader = StreamReader::new(pinned);
+    let framed = FramedRead::new(reader, LinesCodec::new_with_max_length(cfg.max_line_bytes));
+
+    let deadline = tokio::time::Instant::now() + cfg.wall_clock_timeout;
+    let state = (framed, cfg, deadline, false);
+
+    let chunks = futures::stream::unfold(
+        state,
+        |(mut framed, cfg, deadline, mut terminated)| async move {
+            if terminated {
+                return None;
+            }
+
+            loop {
+                let now = tokio::time::Instant::now();
+                if now >= deadline {
+                    terminated = true;
+                    return Some((
+                        ChatChunk::Error {
+                            kind: StreamErrorKind::WallClockTimeout,
+                            message: format!(
+                                "ollama stream exceeded wall-clock budget of {:?}",
+                                cfg.wall_clock_timeout
+                            ),
+                        },
+                        (framed, cfg, deadline, terminated),
+                    ));
+                }
+
+                // Idle timeout between consecutive lines. Whichever expires
+                // first — the idle window or the wall-clock deadline — wins.
+                let idle = cfg.idle_timeout.min(deadline - now);
+                match tokio::time::timeout(idle, framed.next()).await {
+                    Err(_) => {
+                        terminated = true;
+                        let kind = if tokio::time::Instant::now() >= deadline {
+                            StreamErrorKind::WallClockTimeout
+                        } else {
+                            StreamErrorKind::IdleTimeout
+                        };
+                        let message = match kind {
+                            StreamErrorKind::WallClockTimeout => format!(
+                                "ollama stream exceeded wall-clock budget of {:?}",
+                                cfg.wall_clock_timeout
+                            ),
+                            _ => format!("ollama stream idle for more than {:?}", cfg.idle_timeout),
+                        };
+                        return Some((
+                            ChatChunk::Error { kind, message },
+                            (framed, cfg, deadline, terminated),
+                        ));
+                    }
+                    Ok(None) => return None,
+                    Ok(Some(Err(e))) => {
+                        // Decoder errors are terminal — critically,
+                        // `MaxLineLengthExceeded` must NOT be swallowed; that
+                        // would let `FramedRead` keep reading-and-discarding
+                        // bytes from a hostile peer until a newline finally
+                        // arrives. Emit the typed error and stop.
+                        use tokio_util::codec::LinesCodecError;
+                        let (kind, message) = match e {
+                            LinesCodecError::MaxLineLengthExceeded => (
+                                StreamErrorKind::LineTooLong,
+                                format!(
+                                    "ollama NDJSON line exceeded cap of {} bytes",
+                                    cfg.max_line_bytes
+                                ),
+                            ),
+                            LinesCodecError::Io(err) => (
+                                StreamErrorKind::Transport,
+                                format!("ollama stream transport error: {err}"),
+                            ),
+                        };
+                        terminated = true;
+                        return Some((
+                            ChatChunk::Error { kind, message },
+                            (framed, cfg, deadline, terminated),
+                        ));
+                    }
+                    Ok(Some(Ok(line))) => {
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        if let Some(chunk) = parse_line(trimmed) {
+                            return Some((chunk, (framed, cfg, deadline, terminated)));
+                        }
+                        // Unparseable but valid-shaped line — keep reading.
+                        continue;
+                    }
+                }
+            }
+        },
+    );
+
+    // `.fuse()` turns polls-after-`None` into more `None`s instead of the
+    // `unfold` panic, which matters for callers that poll once more after
+    // the terminal error chunk.
+    Box::pin(chunks.fuse())
 }
 
 fn truncate(s: &str, max: usize) -> String {

--- a/crates/forge-providers/tests/ollama.rs
+++ b/crates/forge-providers/tests/ollama.rs
@@ -1,7 +1,11 @@
 //! Integration tests for `OllamaProvider` using a mocked `reqwest` server.
 
-use forge_providers::ollama::OllamaProvider;
-use forge_providers::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider};
+use std::time::Duration;
+
+use forge_providers::ollama::{OllamaProvider, StreamConfig};
+use forge_providers::{
+    ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider, StreamErrorKind,
+};
 use futures::StreamExt;
 use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -93,6 +97,159 @@ async fn chat_maps_http_errors() {
         msg.contains("model not found"),
         "error should include body: {msg}"
     );
+}
+
+/// A peer that refuses to emit a newline must not grow the decoder buffer
+/// without bound; the stream must terminate with a typed error.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_oversized_line_yields_typed_error_and_terminates() {
+    let server = MockServer::start().await;
+
+    // 10 MiB of non-newline bytes (matches the issue reproduction); the
+    // decoder must not accumulate past its cap, which in this test is 64 KiB.
+    let oversized: String = "A".repeat(10 * 1024 * 1024);
+
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(oversized))
+        .mount(&server)
+        .await;
+
+    // Sub-default line cap keeps the test fast without changing default semantics.
+    let cfg = StreamConfig {
+        max_line_bytes: 64 * 1024,
+        idle_timeout: Duration::from_secs(5),
+        wall_clock_timeout: Duration::from_secs(30),
+    };
+    let provider = OllamaProvider::with_config(server.uri(), "llama3", cfg);
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+    };
+    let mut stream = provider.chat(req).await.expect("chat call succeeds");
+
+    let mut chunks = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        chunks.push(chunk);
+    }
+
+    let last = chunks.last().expect("at least one chunk (the error)");
+    assert!(
+        matches!(
+            last,
+            ChatChunk::Error {
+                kind: StreamErrorKind::LineTooLong,
+                ..
+            }
+        ),
+        "expected terminal LineTooLong error, got: {chunks:?}"
+    );
+    // Stream is closed after the error.
+    assert!(
+        stream.next().await.is_none(),
+        "stream must terminate after a fatal error"
+    );
+}
+
+/// A peer that opens a response, emits one line, then stalls forever must be
+/// cut by the per-chunk idle timer, not block the session indefinitely.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_idle_timeout_yields_typed_error_and_terminates() {
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    // Bind a raw TCP server we fully control (wiremock can't stall mid-stream).
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Accept one connection, send headers + one NDJSON line, then hold the
+    // socket open without writing anything further.
+    let server_task = tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+
+        // Drain enough of the request to let the client's send() complete.
+        let mut buf = [0u8; 4096];
+        let mut total = Vec::new();
+        loop {
+            let n = match tokio::time::timeout(
+                Duration::from_millis(500),
+                tokio::io::AsyncReadExt::read(&mut sock, &mut buf),
+            )
+            .await
+            {
+                Ok(Ok(0)) | Err(_) => break,
+                Ok(Ok(n)) => n,
+                Ok(Err(_)) => break,
+            };
+            total.extend_from_slice(&buf[..n]);
+            if total.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let headers = b"HTTP/1.1 200 OK\r\nContent-Type: application/x-ndjson\r\nTransfer-Encoding: chunked\r\n\r\n";
+        sock.write_all(headers).await.unwrap();
+
+        // First (and only) NDJSON chunk: one short line followed by \n.
+        let ndjson = br#"{"message":{"role":"assistant","content":"hi"},"done":false}"#;
+        let chunk_header = format!("{:x}\r\n", ndjson.len() + 1);
+        sock.write_all(chunk_header.as_bytes()).await.unwrap();
+        sock.write_all(ndjson).await.unwrap();
+        sock.write_all(b"\n\r\n").await.unwrap();
+        sock.flush().await.unwrap();
+
+        // Hold the socket open indefinitely — never send another chunk.
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        drop(sock);
+    });
+
+    let cfg = StreamConfig {
+        max_line_bytes: 1 << 20,
+        idle_timeout: Duration::from_millis(150),
+        wall_clock_timeout: Duration::from_secs(30),
+    };
+    let provider = OllamaProvider::with_config(format!("http://{addr}"), "llama3", cfg);
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+    };
+
+    // The chat() call itself must not hang after headers arrive.
+    let stream_fut = provider.chat(req);
+    let mut stream = tokio::time::timeout(Duration::from_secs(5), stream_fut)
+        .await
+        .expect("chat() must not hang after headers arrive")
+        .expect("chat call succeeds");
+
+    let collect_fut = async {
+        let mut chunks = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            chunks.push(chunk);
+        }
+        chunks
+    };
+    let chunks = tokio::time::timeout(Duration::from_secs(5), collect_fut)
+        .await
+        .expect("stream must terminate via idle timeout, not hang");
+
+    // First chunk is the real text delta; last must be the typed idle-timeout error.
+    assert!(
+        matches!(&chunks[0], ChatChunk::TextDelta(s) if s == "hi"),
+        "first chunk should be the real delta, got: {chunks:?}"
+    );
+    let last = chunks.last().unwrap();
+    assert!(
+        matches!(
+            last,
+            ChatChunk::Error {
+                kind: StreamErrorKind::IdleTimeout,
+                ..
+            }
+        ),
+        "expected terminal IdleTimeout error, got: {chunks:?}"
+    );
+
+    server_task.abort();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -277,6 +277,28 @@ async fn run_request_loop<P: Provider>(
                     // Tool calls happened — build continuation request and loop.
                     break;
                 }
+
+                ChatChunk::Error { kind, message } => {
+                    // Stream aborted under a provider-layer bound (line cap,
+                    // idle timeout, wall-clock timeout, transport error).
+                    // Finalise whatever assistant text we streamed so the UI
+                    // composer unwedges, then surface the failure.
+                    session
+                        .emit(Event::AssistantMessage {
+                            id: msg_id.clone(),
+                            provider: provider_id.clone(),
+                            model: model.clone(),
+                            at: Utc::now(),
+                            stream_finalised: true,
+                            text: assistant_text.clone(),
+                            branch_parent: None,
+                            branch_variant_index: 0,
+                        })
+                        .await?;
+                    return Err(anyhow::anyhow!(
+                        "provider stream aborted ({kind:?}): {message}"
+                    ));
+                }
             }
         }
 


### PR DESCRIPTION
Closes forge-ide/forge#87

## Summary

A local squatter on `127.0.0.1:11434` (Ollama crash, startup race, malicious binary) controls the bytes the session daemon consumes. The original decoder accumulated via `String::from_utf8_lossy` into an unbounded `String` and only drained on newline — one request with no newline was an RSS-unbounded OOM.

This PR replaces the hand-rolled loop with `FramedRead<StreamReader<_>, LinesCodec>` and wraps three independent bounds around it:

- **Per-line cap** (1 MiB) via `LinesCodec::new_with_max_length`. `MaxLineLengthExceeded` is translated into a terminal `ChatChunk::Error` — the decoder stops reading immediately rather than letting `FramedRead` resync-and-discard bytes from a hostile peer.
- **Inter-chunk idle timeout** (30 s) via `tokio::time::timeout` around each `framed.next()`.
- **Overall wall-clock deadline** (10 min) computed once when the stream is first polled; each iteration checks against it before the idle wait.

Any bound hit yields a terminal `ChatChunk::Error { kind: StreamErrorKind, message }` and closes the stream. The session orchestrator finalizes whatever assistant text has streamed so the UI composer unwedges, then propagates the failure to the caller.

## Delivered scope

Issue #87's DoD is three checkboxes (per-line cap + regression test + CI green). The task prompt expanded this to defend against slow-drip / half-open peers as well, so this PR ships:

| Item | Where |
|---|---|
| Per-line cap (1 MiB) | `LinesCodec::new_with_max_length(cfg.max_line_bytes)` in `ollama.rs` |
| Inter-chunk idle timeout (30 s) | `tokio::time::timeout(idle, framed.next())` in `decode_ndjson_stream` |
| Wall-clock timeout (10 min) | `deadline = Instant::now() + cfg.wall_clock_timeout`, checked each iteration |
| Structured error | `ChatChunk::Error { kind: StreamErrorKind, .. }` — new variant in `forge-providers::lib` |
| `StreamErrorKind` enum | `LineTooLong`, `IdleTimeout`, `WallClockTimeout`, `Transport` |
| Orchestrator propagation | New match arm in `orchestrator.rs`: finalize partial `AssistantMessage`, return `Err` |
| Regression test — oversized line | `chat_oversized_line_yields_typed_error_and_terminates` (wiremock, 10 MiB body vs 64 KiB cap) |
| Regression test — idle timeout | `chat_idle_timeout_yields_typed_error_and_terminates` (raw `TcpListener` that stalls after one line) |

## Bounds rationale

- **1 MiB per line**: real Ollama NDJSON chunks are <100 KB even with tool calls; 1 MiB has 10× headroom without enabling accumulation attacks.
- **30 s idle**: a stream that goes quiet for 30 s either lost the peer or is a slow-drip attacker. Interactive models stream sub-second tokens.
- **10 min wall-clock**: covers a 70B local model on CPU for practical prompts. Users chasing longer runs can request a per-request knob later.

## F-046 coordination

F-046 (#88) addresses `reqwest::Client` timeouts (`connect_timeout` / `read_timeout` / `timeout`). Those are constructor-side changes at `ollama.rs:64` (and the other `reqwest::Client::new()` sites). This PR leaves the client construction untouched; F-046 is a drop-in `ClientBuilder` swap with no decoder shape changes required.

## Known gap (follow-up, not this PR)

If a peer sends a partial line (e.g. `{"messa`) and closes the TCP connection cleanly, the decoder currently emits no error chunk — the stream just ends. Not the filed threat class (T8 is unbounded accumulation / slow-drip), but worth tracking as silent-truncation. Candidate follow-up for F-058 (M5).

## Test plan

- [x] `cargo test -p forge-providers --test ollama` — happy path, HTTP error, `list_models`, oversized-line, idle-timeout all pass
- [x] `cargo test --workspace` — all existing suites pass (incl. orchestrator)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>