### PR TITLE
fix(forge-shell): drop webview-supplied socket_path from session_hello (F-052)

### DIFF
--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -11,7 +11,6 @@
 //! binding a session's control channel to its review channel. Mismatches
 //! return [`LABEL_MISMATCH_ERROR`] and never reach the daemon.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use forge_ipc::HelloAck;
@@ -41,14 +40,40 @@ pub(crate) fn require_window_label<R: Runtime>(
 
 /// Tauri-managed bridge state. One per App; commands resolve it via
 /// `State<BridgeState>`.
+///
+/// **F-052 (H11 / T7):** the production `session_hello` command never
+/// accepts a webview-supplied socket path; the path is always derived via
+/// [`crate::bridge::default_socket_path`]. Integration tests (which run
+/// against ephemeral tempdir sockets) wire an override through the
+/// `webview-test`-gated [`Self::test_socket_override`] field. The field is
+/// absent from production builds entirely.
 pub struct BridgeState {
     pub bridge: SessionBridge,
+    #[cfg(feature = "webview-test")]
+    pub test_socket_override: Option<std::path::PathBuf>,
 }
 
 impl BridgeState {
     pub fn new(connections: SessionConnections) -> Self {
         Self {
             bridge: SessionBridge::new(connections),
+            #[cfg(feature = "webview-test")]
+            test_socket_override: None,
+        }
+    }
+
+    /// Test-only constructor: wires a fixed socket path that `session_hello`
+    /// will use instead of [`crate::bridge::default_socket_path`]. Gated
+    /// behind the `webview-test` feature so production builds cannot
+    /// construct a `BridgeState` that bypasses the default path.
+    #[cfg(feature = "webview-test")]
+    pub fn with_test_socket_override(
+        connections: SessionConnections,
+        socket_path: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            bridge: SessionBridge::new(connections),
+            test_socket_override: Some(socket_path),
         }
     }
 }
@@ -70,16 +95,21 @@ impl<R: Runtime> EventSink for AppHandleSink<R> {
 #[tauri::command]
 pub async fn session_hello<R: Runtime>(
     session_id: String,
-    socket_path: Option<String>,
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<HelloAck, String> {
     require_window_label(&webview, &format!("session-{session_id}"))?;
-    // TODO(F-052): validate socket_path here — see issue #94.
-    let socket_path = socket_path.as_deref().map(PathBuf::from);
+    // F-052 (H11 / T7): the socket path is never taken from the invoke
+    // payload — a webview cannot redirect this connection to an arbitrary
+    // UDS. Production always resolves through `default_socket_path`; tests
+    // inject a tempdir path via the `webview-test` override field.
+    #[cfg(feature = "webview-test")]
+    let override_path = state.test_socket_override.as_deref();
+    #[cfg(not(feature = "webview-test"))]
+    let override_path: Option<&std::path::Path> = None;
     state
         .bridge
-        .hello(&session_id, socket_path.as_deref())
+        .hello(&session_id, override_path)
         .await
         .map_err(|e| e.to_string())
 }

--- a/crates/forge-shell/tests/ipc_authz.rs
+++ b/crates/forge-shell/tests/ipc_authz.rs
@@ -194,7 +194,6 @@ fn session_a_window_invoking_session_hello_for_session_b_is_rejected() {
         "session_hello",
         serde_json::json!({
             "sessionId": "B",
-            "socketPath": "/tmp/nonexistent.sock",
         }),
     )
     .expect_err("session-A must not perform hello for session B");

--- a/crates/forge-shell/tests/ipc_commands.rs
+++ b/crates/forge-shell/tests/ipc_commands.rs
@@ -1,12 +1,22 @@
-//! RED 3: The Tauri `ipc` module must expose the five commands required by
-//! F-020 and register them with `tauri::generate_handler!` without errors.
+//! Tauri `ipc` command surface tests for F-020 and F-052.
 //!
-//! These tests run under the `webview` feature so they can invoke real
-//! Tauri machinery via `tauri::test::mock_builder`.
+//! F-020: `build_invoke_handler()` and the five `#[tauri::command]` handlers
+//! compile and register together; `session_hello` round-trips against a real
+//! daemon via `tauri::test::get_ipc_response`.
+//!
+//! F-052 (H11 / T7): the production `session_hello` command does **not**
+//! accept an arbitrary `socketPath` — any value passed by a webview caller is
+//! ignored. The round-trip test uses a `webview-test`-gated
+//! [`BridgeState::with_test_socket_override`] constructor instead of a
+//! public parameter; the regression test spins up a rogue listener and
+//! asserts it never receives a connection even when its path is injected
+//! via the `socketPath` JSON field.
 
 #![cfg(feature = "webview-test")]
 
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use forge_providers::MockProvider;
 use forge_session::server::serve_with_session;
@@ -16,6 +26,7 @@ use forge_shell::ipc::{build_invoke_handler, BridgeState};
 use tauri::test::{mock_builder, mock_context, noop_assets, INVOKE_KEY};
 use tauri::Manager;
 use tempfile::TempDir;
+use tokio::net::UnixListener;
 
 fn make_app() -> tauri::App<tauri::test::MockRuntime> {
     mock_builder()
@@ -61,11 +72,17 @@ async fn session_hello_command_round_trips_via_tauri_invoke() {
         if sock.exists() {
             break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
     let app = make_app();
-    app.manage(BridgeState::new(SessionConnections::new()));
+    // F-052: production `session_hello` no longer accepts a `socketPath`
+    // parameter — the test daemon's path is wired through a test-only
+    // constructor on `BridgeState` gated behind the `webview-test` feature.
+    app.manage(BridgeState::with_test_socket_override(
+        SessionConnections::new(),
+        sock.clone(),
+    ));
 
     // F-051: window label must match `session-{session_id}` for the
     // session_hello authz check to pass.
@@ -77,10 +94,7 @@ async fn session_hello_command_round_trips_via_tauri_invoke() {
     .build()
     .expect("mock window");
 
-    let payload = serde_json::json!({
-        "sessionId": "tauri-hello",
-        "socketPath": sock.to_string_lossy(),
-    });
+    let payload = serde_json::json!({ "sessionId": "tauri-hello" });
     let res = tauri::test::get_ipc_response(
         &window,
         tauri::webview::InvokeRequest {
@@ -98,4 +112,75 @@ async fn session_hello_command_round_trips_via_tauri_invoke() {
     let obj = value.deserialize::<serde_json::Value>().unwrap();
     assert_eq!(obj["session_id"], "tauri-hello");
     assert_eq!(obj["schema_version"], 1);
+}
+
+/// F-052 regression: a webview that injects an attacker-controlled
+/// `socketPath` into the `session_hello` invoke payload must not cause the
+/// shell to connect to that path. We bind a rogue `UnixListener` at a
+/// tempdir path, invoke `session_hello` with `socketPath` set to that path,
+/// and assert the rogue listener never accepts a connection. The command
+/// should instead attempt the default path (which has no daemon) and fail.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_hello_ignores_attacker_supplied_socket_path() {
+    let rogue_dir = TempDir::new().unwrap();
+    let rogue_sock = rogue_dir.path().join("attacker.sock");
+    let rogue_listener = UnixListener::bind(&rogue_sock).expect("bind rogue UDS");
+
+    let accept_count = Arc::new(AtomicU32::new(0));
+    let accept_count_bg = Arc::clone(&accept_count);
+    let accept_task = tokio::spawn(async move {
+        // If the shell ever connects here, record it. The test must see 0.
+        if let Ok((_stream, _addr)) = rogue_listener.accept().await {
+            accept_count_bg.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+
+    let app = make_app();
+    // Production path: no test override → default_socket_path will be used.
+    app.manage(BridgeState::new(SessionConnections::new()));
+
+    let window = tauri::WebviewWindowBuilder::new(
+        &app,
+        "session-attacker",
+        tauri::WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("mock window");
+
+    let payload = serde_json::json!({
+        "sessionId": "attacker",
+        // Injected by a webview caller. With F-052 this field is unknown
+        // to the command and silently ignored by serde.
+        "socketPath": rogue_sock.to_string_lossy(),
+    });
+    let res = tauri::test::get_ipc_response(
+        &window,
+        tauri::webview::InvokeRequest {
+            cmd: "session_hello".into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+
+    // No daemon at the default path → the call fails. The security-meaningful
+    // assertion is that the rogue listener never accepted.
+    assert!(
+        res.is_err(),
+        "session_hello must not succeed when no daemon is listening at the default path"
+    );
+
+    // Give the accept task a brief window to (not) fire.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    accept_task.abort();
+    let _ = accept_task.await;
+
+    assert_eq!(
+        accept_count.load(Ordering::SeqCst),
+        0,
+        "rogue listener must not receive any connection from session_hello"
+    );
 }

--- a/web/packages/app/src/ipc/session.test.ts
+++ b/web/packages/app/src/ipc/session.test.ts
@@ -29,7 +29,7 @@ describe('session ipc wrappers', () => {
     listenMock.mockReset();
   });
 
-  it('sessionHello invokes `session_hello` with sessionId + socketPath', async () => {
+  it('sessionHello invokes `session_hello` with sessionId only', async () => {
     invokeMock.mockResolvedValue({
       session_id: 'abc',
       workspace: '/ws',
@@ -38,30 +38,14 @@ describe('session ipc wrappers', () => {
       schema_version: 1,
     });
 
-    const ack = await sessionHello('abc', '/tmp/forge.sock');
+    const ack = await sessionHello('abc');
 
+    // F-052: no `socketPath` in the payload — the shell always resolves
+    // the UDS via `default_socket_path(session_id)`.
     expect(invokeMock).toHaveBeenCalledWith('session_hello', {
       sessionId: 'abc',
-      socketPath: '/tmp/forge.sock',
     });
     expect(ack.session_id).toBe('abc');
-  });
-
-  it('sessionHello omits socketPath when unspecified', async () => {
-    invokeMock.mockResolvedValue({
-      session_id: 'abc',
-      workspace: '',
-      started_at: '',
-      event_seq: 0,
-      schema_version: 1,
-    });
-
-    await sessionHello('abc');
-
-    expect(invokeMock).toHaveBeenCalledWith('session_hello', {
-      sessionId: 'abc',
-      socketPath: undefined,
-    });
   });
 
   it('sessionSubscribe invokes `session_subscribe` with since', async () => {

--- a/web/packages/app/src/ipc/session.ts
+++ b/web/packages/app/src/ipc/session.ts
@@ -20,14 +20,16 @@ export interface SessionEventPayload {
   event: unknown;
 }
 
-export async function sessionHello(
-  sessionId: SessionId,
-  socketPath?: string,
-): Promise<HelloAck> {
-  return invoke<HelloAck>('session_hello', {
-    sessionId,
-    socketPath,
-  });
+/**
+ * F-052 (H11 / T7): `session_hello` takes no socket-path override. The Rust
+ * command has no `socketPath` parameter — any such field in the invoke
+ * payload is silently dropped by serde before the command runs, and the
+ * shell resolves the UDS exclusively via `default_socket_path(session_id)`.
+ * Do not add a second argument here; it would be unused at runtime and
+ * obscure the invariant that the webview cannot steer this connection.
+ */
+export async function sessionHello(sessionId: SessionId): Promise<HelloAck> {
+  return invoke<HelloAck>('session_hello', { sessionId });
 }
 
 export async function sessionSubscribe(

--- a/web/packages/app/src/routes/Session/SessionWindow.test.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.test.tsx
@@ -73,7 +73,6 @@ describe('SessionWindow', () => {
     await waitFor(() =>
       expect(invokeMock).toHaveBeenCalledWith('session_hello', {
         sessionId: 'abc123',
-        socketPath: undefined,
       }),
     );
   });


### PR DESCRIPTION
## Summary

Closes #94 (F-052, H11 / T7). The `#[tauri::command] session_hello` accepted an `Option<String>` `socket_path` and passed it straight to `UnixStream::connect`. A webview with code execution (the CSP-null threat model pre-F-050) could redirect the shell to connect to any UDS reachable by the user's uid — `$SSH_AUTH_SOCK`, docker.sock, a cross-workspace forged socket, or a trap listener returning a crafted `HelloAck`. That ack's `session_id` / `workspace` then flow back into the webview event stream.

### Remediation (Preferred path from issue body)

**Dropped the `socket_path` parameter from the public command.** `session_hello` now always resolves the UDS through `default_socket_path(session_id)`. Any `socketPath` field a webview injects into the invoke payload is silently dropped by serde before the command runs — the parameter doesn't exist on the Rust side.

### Key changes

- `crates/forge-shell/src/ipc.rs`
  - `session_hello` signature no longer has `socket_path: Option<String>`
  - The F-051 seam TODO at line 78 is removed
  - `BridgeState` gains a `#[cfg(feature = "webview-test")] test_socket_override: Option<PathBuf>` field and a matching `with_test_socket_override(...)` constructor. The field does not exist in production builds (production `cargo build` does not enable `webview-test`), so the code path that reads the override simply cannot be reached by a webview caller.
- `crates/forge-shell/tests/ipc_commands.rs`
  - Existing round-trip test now wires the daemon's tempdir path through `BridgeState::with_test_socket_override` instead of through the invoke payload.
  - **New regression test** `session_hello_ignores_attacker_supplied_socket_path`: binds a rogue `UnixListener` at a tempdir path, invokes `session_hello` with `{ sessionId, socketPath: <rogue path> }`, and asserts the rogue listener receives zero accepts. The load-bearing assertion is `accept_count == 0`.
- `crates/forge-shell/tests/ipc_authz.rs` — cleaned up the now-dead `socketPath` field in the label-mismatch payload for `session_hello`.
- `web/packages/app/src/ipc/session.ts` — `sessionHello(sessionId)` (the optional second arg is gone). Docstring pins the invariant.
- `web/packages/app/src/ipc/session.test.ts`, `web/packages/app/src/routes/Session/SessionWindow.test.tsx` — mock assertions updated to match the new payload shape.

### Design note

- **Remediation chosen:** preferred (drop the parameter). Alternative (canonicalize + allowlist under `<base>/forge/sessions/`) was not needed because the only production caller is `web/packages/app/src/routes/Session/SessionWindow.tsx:41`, which already calls `sessionHello(id)` with no path. Grep confirmed no other production consumer.
- **Test-only constructor:** `BridgeState::with_test_socket_override(connections, socket_path)`, gated on the existing `webview-test` feature. `#[cfg(test)]` would not have worked — `tests/ipc_commands.rs` is a separate integration-test crate and links against `forge-shell` compiled without `cfg(test)`. The `webview-test` feature is already the gate for `tests/ipc_commands.rs:7` and `tests/ipc_authz.rs:16`, so this matches existing convention.
- **DoD phrasing:** the DoD asks for "an error and no connection is opened." Both conditions are met: `res.is_err()` because no daemon listens at the default path for `attacker`, and `accept_count == 0`. The security-meaningful assertion is the accept count — in production, if a legitimate daemon happened to be listening at the default path for that session id the call would succeed, but the attacker's path was still ignored.
- **F-051 TODO removal:** the `// TODO(F-052): validate socket_path here — see issue #94.` seam at `crates/forge-shell/src/ipc.rs:78` is gone. The surrounding code was rewritten, so the comment no longer has any anchor.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo check --all-targets --features forge-shell/webview-test` clean
- [x] `cargo clippy --all-targets --features forge-shell/webview-test -- -D warnings` clean
- [x] `cargo test --workspace --features forge-shell/webview-test` — all tests pass (43 forge-shell tests including the new regression)
- [ ] **Web vitest could not be run locally** (sandbox blocked `pnpm install` and node-based execution). Changes are mechanical payload-shape updates in three files plus a TS type-signature narrowing; CI will validate.
- [x] Manual review: `SessionWindow.tsx` already calls `sessionHello(id)` with no path; grep confirms no other production consumer.

## Regression coverage

`cargo test -p forge-shell --features webview-test --test ipc_commands session_hello_ignores_attacker_supplied_socket_path` reproduces the original exploit scenario and asserts it is defanged.