### PR TITLE
fix(forge-providers): bound ollama reqwest client against slow-drip DoS (F-046)

### DIFF
--- a/crates/forge-providers/src/ollama.rs
+++ b/crates/forge-providers/src/ollama.rs
@@ -9,6 +9,17 @@
 //! three independent bounds — per-line byte cap, inter-chunk idle timeout, and
 //! overall wall-clock timeout — any of which terminates the stream with a
 //! typed [`ChatChunk::Error`] rather than panicking or growing unbounded.
+//!
+//! # Client bounds
+//!
+//! Below the decoder, the reqwest client itself is built with explicit
+//! `connect_timeout`, `read_timeout`, and `tcp_keepalive` settings (see
+//! [`ClientConfig`]). Two clients live on the provider: `stream_client` for
+//! `/api/chat` omits a total `.timeout()` so long generations are not cut,
+//! while `request_client` for short-lived `/api/tags` applies one. These
+//! HTTP-layer bounds fire on half-open connects and stalled header reads —
+//! conditions that occur *before* the NDJSON decoder starts and therefore
+//! cannot be caught by its stream-level timers.
 
 use std::time::Duration;
 
@@ -26,6 +37,20 @@ pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 /// Wall-clock cap on the entire stream. 10 min accommodates slow local
 /// inference; pathological runs can be re-attempted by the user.
 pub const DEFAULT_WALL_CLOCK_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Cap on the TCP-connect handshake.
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Per-read idle cap at the HTTP layer (reqwest ≥ 0.12.5). Applies to header
+/// reads and between-chunk gaps on streaming responses. Aligns numerically
+/// with `DEFAULT_IDLE_TIMEOUT` but fires on a different condition (HTTP
+/// transport vs NDJSON line gap); both are intentionally kept.
+pub const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
+/// Total-request cap for buffered (non-streaming) endpoints only. Streaming
+/// clients omit this so long generations are not cut mid-stream.
+pub const DEFAULT_TOTAL_TIMEOUT: Duration = Duration::from_secs(120);
+/// TCP keepalive probe interval; helps detect dead peers on long-lived
+/// streaming connections that might otherwise linger at the OS layer.
+pub const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(30);
 
 /// Bounds that make the NDJSON decoder DoS-resistant against a hostile peer.
 #[derive(Debug, Clone, Copy)]
@@ -49,21 +74,73 @@ impl Default for StreamConfig {
     }
 }
 
+/// HTTP-layer timeouts applied at `reqwest::ClientBuilder` construction.
+///
+/// `total_timeout` is enforced on the buffered `list_models()` path only; the
+/// streaming `chat()` path relies on `read_timeout` (per-read) so long
+/// generations are not cut by a wall-clock cap.
+#[derive(Debug, Clone, Copy)]
+pub struct ClientConfig {
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+    pub total_timeout: Duration,
+    pub tcp_keepalive: Duration,
+}
+
+impl ClientConfig {
+    pub const DEFAULT: ClientConfig = ClientConfig {
+        connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+        read_timeout: DEFAULT_READ_TIMEOUT,
+        total_timeout: DEFAULT_TOTAL_TIMEOUT,
+        tcp_keepalive: DEFAULT_TCP_KEEPALIVE,
+    };
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Build the streaming client (no total `.timeout()`; long generations must
+/// not be cut by a wall-clock cap — `read_timeout` is the per-read guard).
+fn build_stream_client(cfg: &ClientConfig) -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(cfg.connect_timeout)
+        .read_timeout(cfg.read_timeout)
+        .tcp_keepalive(Some(cfg.tcp_keepalive))
+        .build()
+        .expect("reqwest stream client builder — only fails if no TLS backend is available")
+}
+
+/// Build the buffered request client (short-lived endpoints; total timeout
+/// bounds every call end-to-end in addition to the per-read guard).
+fn build_request_client(cfg: &ClientConfig) -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(cfg.connect_timeout)
+        .read_timeout(cfg.read_timeout)
+        .timeout(cfg.total_timeout)
+        .tcp_keepalive(Some(cfg.tcp_keepalive))
+        .build()
+        .expect("reqwest request client builder — only fails if no TLS backend is available")
+}
+
 pub struct OllamaProvider {
     base_url: String,
     model: String,
-    client: reqwest::Client,
+    stream_client: reqwest::Client,
+    request_client: reqwest::Client,
     stream_cfg: StreamConfig,
 }
 
 impl OllamaProvider {
     pub fn new(base_url: impl Into<String>, model: impl Into<String>) -> Self {
-        Self {
-            base_url: base_url.into(),
-            model: model.into(),
-            client: reqwest::Client::new(),
-            stream_cfg: StreamConfig::DEFAULT,
-        }
+        Self::with_config_full(
+            base_url,
+            model,
+            ClientConfig::DEFAULT,
+            StreamConfig::DEFAULT,
+        )
     }
 
     pub fn with_default_url(model: impl Into<String>) -> Self {
@@ -78,10 +155,25 @@ impl OllamaProvider {
         model: impl Into<String>,
         stream_cfg: StreamConfig,
     ) -> Self {
+        Self::with_config_full(base_url, model, ClientConfig::DEFAULT, stream_cfg)
+    }
+
+    /// Construct a provider with explicit HTTP-client and decoder bounds.
+    /// Primarily a test affordance for regression tests that need fast
+    /// `read_timeout` windows; production code should use
+    /// [`OllamaProvider::new`].
+    #[doc(hidden)]
+    pub fn with_config_full(
+        base_url: impl Into<String>,
+        model: impl Into<String>,
+        client_cfg: ClientConfig,
+        stream_cfg: StreamConfig,
+    ) -> Self {
         Self {
             base_url: base_url.into(),
             model: model.into(),
-            client: reqwest::Client::new(),
+            stream_client: build_stream_client(&client_cfg),
+            request_client: build_request_client(&client_cfg),
             stream_cfg,
         }
     }
@@ -89,7 +181,7 @@ impl OllamaProvider {
     pub async fn list_models(&self) -> Result<Vec<String>> {
         let url = format!("{}/api/tags", self.base_url.trim_end_matches('/'));
         let resp = self
-            .client
+            .request_client
             .get(&url)
             .send()
             .await
@@ -135,7 +227,7 @@ impl Provider for OllamaProvider {
             "messages": to_ollama_messages(&req.system, &req.messages),
             "stream": true,
         });
-        let client = self.client.clone();
+        let client = self.stream_client.clone();
         let cfg = self.stream_cfg;
 
         async move {
@@ -161,10 +253,10 @@ impl Provider for OllamaProvider {
 
 /// Decode a byte stream of NDJSON into [`ChatChunk`]s under the configured
 /// bounds. Terminal failures (cap exceeded, idle/wall-clock elapsed, transport
-/// error) surface as a single [`ChatChunk::Error`] and close the stream. This
-/// helper is factored out to keep the `chat()` body readable and to give
-/// future changes (e.g. F-046's reqwest client timeouts) a single seam to
-/// extend without reshaping the decoder.
+/// error) surface as a single [`ChatChunk::Error`] and close the stream.
+/// Transport errors here include reqwest's client-level `read_timeout` firing
+/// mid-stream (see [`ClientConfig`]), which surfaces as
+/// [`StreamErrorKind::Transport`].
 fn decode_ndjson_stream<S, E>(byte_stream: S, cfg: StreamConfig) -> BoxStream<'static, ChatChunk>
 where
     S: futures::Stream<Item = std::result::Result<bytes::Bytes, E>> + Send + 'static,

--- a/crates/forge-providers/tests/ollama.rs
+++ b/crates/forge-providers/tests/ollama.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use forge_providers::ollama::{OllamaProvider, StreamConfig};
+use forge_providers::ollama::{ClientConfig, OllamaProvider, StreamConfig};
 use forge_providers::{
     ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider, StreamErrorKind,
 };
@@ -247,6 +247,68 @@ async fn chat_idle_timeout_yields_typed_error_and_terminates() {
             }
         ),
         "expected terminal IdleTimeout error, got: {chunks:?}"
+    );
+
+    server_task.abort();
+}
+
+/// A peer that accepts the TCP connect but never writes a single byte of the
+/// HTTP response must be cut by the client-level `read_timeout`. This is the
+/// layer *below* F-045's decoder idle timer — the decoder is never reached,
+/// because headers never arrive. `provider.chat().await` must return `Err`
+/// within `read_timeout + small_margin`, not hang.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_half_open_connect_times_out_within_read_timeout() {
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Accept one connection and hold the socket open without ever writing a
+    // byte (no status line, no headers). Drop only after the client has
+    // already timed out.
+    let server_task = tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        drop(sock);
+    });
+
+    let read_timeout = Duration::from_millis(200);
+    let client_cfg = ClientConfig {
+        connect_timeout: Duration::from_secs(2),
+        read_timeout,
+        total_timeout: Duration::from_secs(5),
+        tcp_keepalive: Duration::from_secs(30),
+    };
+    let provider = OllamaProvider::with_config_full(
+        format!("http://{addr}"),
+        "llama3",
+        client_cfg,
+        StreamConfig::DEFAULT,
+    );
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+    };
+
+    let start = std::time::Instant::now();
+    let result = tokio::time::timeout(
+        read_timeout + Duration::from_millis(800),
+        provider.chat(req),
+    )
+    .await
+    .expect("chat() must return within read_timeout + margin, not hang");
+    let elapsed = start.elapsed();
+
+    assert!(result.is_err(), "half-open connect must surface as Err");
+    assert!(
+        elapsed >= read_timeout,
+        "chat() returned in {elapsed:?}, before read_timeout ({read_timeout:?}) — \
+         the read_timeout did not fire; another code path produced the error"
+    );
+    assert!(
+        elapsed < read_timeout + Duration::from_millis(800),
+        "chat() took {elapsed:?}, exceeds read_timeout ({read_timeout:?}) + margin"
     );
 
     server_task.abort();


### PR DESCRIPTION
Closes forge-ide/forge#88

## Summary

`OllamaProvider::new` built `reqwest::Client::new()` with no timeouts — a squatter at `127.0.0.1:11434` that accepts the TCP handshake but never writes a byte of HTTP response wedges the session daemon forever (threat class T8 — resource exhaustion). Both `/api/chat` and `/api/tags` were affected.

This PR builds the client via `ClientBuilder` with explicit `connect_timeout`, `read_timeout`, `tcp_keepalive`, and (where safe) a total `timeout`.

## Design

**(a) Two clients, not one.** The issue body's footnote carves out a constraint that a single client cannot satisfy: streaming `/api/chat` must *not* have a total `.timeout()` (it would cut long generations), while buffered `/api/tags` should. Two clients is the cleaner expression — `stream_client` omits the total cap, `request_client` includes it. Both share `connect_timeout`, `read_timeout`, and `tcp_keepalive`.

**(b) Timeout values (verbatim from issue #88):**

| | stream_client (`/api/chat`) | request_client (`/api/tags`) |
|---|---|---|
| `connect_timeout` | 5s | 5s |
| `read_timeout` | 30s | 30s |
| `timeout` (total) | *omitted* | 120s |
| `tcp_keepalive` | 30s | 30s |

The 30s `read_timeout` numerically aligns with F-045's `DEFAULT_IDLE_TIMEOUT` (30s), but the two fire at different layers:
- `read_timeout` (this PR) — reqwest HTTP layer; catches stalled header reads and between-byte gaps before the decoder starts, and post-chunk stalls at the transport level.
- `idle_timeout` (F-045) — NDJSON decoder layer; catches gaps between parsed lines after chunks are arriving.

Both are intentionally kept. The alignment is coincidence (both derived from "30s is generous for local models but still bounds a hostile peer").

**(c) Additive composition with F-058 / F-059.** F-058 (`OLLAMA_BASE_URL` scheme validation) layers as a pre-construction URL-parse gate and does not touch this PR's timeout plumbing. F-059 (`list_models()` body buffering) would swap `.json::<Value>()` for NDJSON streaming but keeps `request_client` untouched. No rework expected for either.

**Signature preservation.** `OllamaProvider::new` still returns `Self`; the `ClientBuilder::build()` `Result` is `.expect(...)` with a justifying message — it only fails when no TLS backend is available, and every caller (`forge-session`, `forge-shell`) has no recovery path for that. Avoids cascading signature churn across three crates for a security-only fix.

## Regression test

`chat_half_open_connect_times_out_within_read_timeout` (tests/ollama.rs): binds a raw `TcpListener`, accepts one TCP connection, never writes an HTTP response byte. The test drives `provider.chat().await` with `read_timeout = 200ms` and asserts:

1. `result.is_err()` — the call surfaces as a transport error, not hang.
2. `elapsed >= read_timeout` — the `read_timeout` timer is what fired (not some other instant failure).
3. `elapsed < read_timeout + 800ms` — no hang and no double-timeout.

## Notes on review process

This task's `forge-finish-task` skill normally spawns fresh-context subagents for DoD verification and code review. The Task tool was not available in this session, so I conducted direct evidence-based verification instead (grep for the specific builder methods, test-runs, full-workspace `cargo check` + `cargo test` + `cargo clippy`). Flagging so reviewers know why the usual subagent trace is absent.

## Test plan

- [x] `cargo test --workspace` — all tests pass (including 6/6 `forge-providers` integration tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --workspace` — clean (confirms `OllamaProvider::new` signature preserved; `forge-session` and `forge-shell` callers untouched)
- [x] New regression test passes in ~200ms (matches `read_timeout` window, not a generic timeout)

Generated with [Claude Code](https://claude.com/claude-code)