### PR TITLE
docs(skills): parent-context handoff for DoD + code-review gates

### DIFF
--- a/.claude/agents/forge-task-orchestrator.md
+++ b/.claude/agents/forge-task-orchestrator.md
@@ -2,6 +2,18 @@
 name: "forge-task-orchestrator"
 description: "Use this agent when you need to orchestrate the forge-complete-task skill and coordinate all subagents that execute as part of that skill's workflow. This agent manages the full lifecycle of a Forge task — from intake through delegation, parallel subagent coordination, result aggregation, and final delivery.\\n\\n<example>\\nContext: The user wants to implement a new feature in the Forge IDE codebase.\\nuser: \"Add keyboard shortcut support to the quad canvas panel\"\\nassistant: \"I'll use the forge-task-orchestrator agent to coordinate this task through the forge-complete-task skill.\"\\n<commentary>\\nThis is a multi-step feature implementation that spans exploration, planning, and execution — exactly what the forge-task-orchestrator is designed to handle by orchestrating the forge-complete-task skill and its subagents.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user needs a complex refactor across multiple files.\\nuser: \"Refactor the credential resolution logic to support the new multi-provider config system\"\\nassistant: \"Let me launch the forge-task-orchestrator agent to handle this through the forge-complete-task skill.\"\\n<commentary>\\nCross-cutting refactors require coordinated exploration, planning, and targeted edits — the forge-task-orchestrator will spawn and coordinate the right subagents via the forge-complete-task skill.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user requests a debugging session on a broken feature.\\nuser: \"The bootstrap service isn't resolving credentials correctly for secondary providers\"\\nassistant: \"I'll use the forge-task-orchestrator agent to investigate and resolve this.\"\\n<commentary>\\nDebugging tasks require exploration subagents, root cause analysis, and targeted fixes — all orchestrated through the forge-complete-task skill.\\n</commentary>\\n</example>"
 model: inherit
+tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+  - Glob
+  - Grep
+  - TodoWrite
+  - WebFetch
+  - WebSearch
+  - Agent
+  - ToolSearch
 ---
 
 You are the Forge Task Orchestrator — an elite coordination agent responsible for driving the `forge-complete-task` skill and managing every subagent that executes within it. You operate as the central nervous system of Forge task execution: you receive a task, decompose it, delegate aggressively, synchronize results, and deliver a coherent outcome.
@@ -33,6 +45,8 @@ Your job is orchestration, not execution. You never do deep work inline. Every d
 - After implementation subagents complete, validate by running tests or builds in the main context.
 - If validation fails, spawn targeted debugging subagents — do not inline-debug.
 - Confirm final output meets the original task intent before reporting completion.
+- **Never spawn DoD-verifier or code-reviewer subagents from inside this orchestrator.** Per `forge-finish-task`, those gates run in the *parent* context (the context that invoked this orchestrator), so the verifier's context is independent of the implementer's. Spawning them here would collapse that independence and defeat the fresh-eyes invariant. Your job ends at emitting the `HANDOFF-REQUEST` that `forge-finish-task` produces; the parent takes it from there.
+- **Never auto-merge the PR.** Merging is a parent-context decision, gated on the parent's verifier and reviewer results. An auto-merge from inside the orchestrator bypasses both gates silently.
 
 ### 5. Forge-Specific Conventions
 - **Architecture**: Simple over clever. No over-engineering.

--- a/.claude/skills/forge-complete-task/SKILL.md
+++ b/.claude/skills/forge-complete-task/SKILL.md
@@ -53,18 +53,49 @@ Invoke `superpowers:test-driven-development` for every change. No exceptions.
 
 **Gate:** All tests pass and the DoD is fully addressed before proceeding.
 
-## Phase 3: Submit
+## Phase 3: Submit + hand off for gates
 
-Invoke `forge-finish-task`. That skill already spawns fresh-context subagents for DoD verification and code review — let it do so. Do not inline those checks.
+Invoke `forge-finish-task`. That skill verifies the build, pushes the branch, opens the PR, sets `status: code-review`, and emits a **`HANDOFF-REQUEST`** — but it does **not** run DoD verification or code review. Those gates run in the parent context so the verifier's context stays independent of the implementer's.
 
 Steps delegated inside `forge-finish-task`:
-- Fresh-context general-purpose subagent verifies every DoD checkbox independently
 - Build verification (`cargo fmt --check && cargo check && cargo test && cargo clippy`)
-- Fresh-context `feature-dev:code-reviewer` subagent reviews changed files
+- Branch push to `origin` (fork)
 - PR opened to `forge-ide/forge`
 - Issue label updated to `status: code-review`
+- HANDOFF-REQUEST returned to parent (PR URL, issue number, branch, changed files, DoD, design note)
 
-**If forge-finish-task finds gaps:** fix them (return to Phase 2), then re-run Phase 3. Do not re-run Phase 1.
+### Parent's responsibility after receiving HANDOFF-REQUEST
+
+The parent (the surrounding context that invoked `forge-complete-task`) must run both gates before merging. **A PR without completed gates must not be merged** — the whole point of the handoff is that the gates actually run.
+
+1. **Dispatch a fresh-context DoD-verifier agent** (general-purpose subagent). Prompt template:
+   > Verify the following Definition of Done checkboxes for the forge repo at `/home/jeroche/repos/forge`. For each item, find concrete code evidence (grep result, file read, or test run). Do NOT accept "it compiles" as evidence — find the actual symbol, method, or file.
+   >
+   > Definition of Done:
+   > `<paste DoD from HANDOFF-REQUEST>`
+   >
+   > Changed files:
+   > `<paste changed_files from HANDOFF-REQUEST>`
+   >
+   > For each checkbox report `VERIFIED: <what you found and where>` or `NOT FOUND: <what is missing>`. Do not guess.
+
+2. **Dispatch a fresh-context code-reviewer agent** (`pr-review-toolkit:code-reviewer` or equivalent). Prompt template:
+   > Review PR `<pr_url from HANDOFF-REQUEST>` for forge-ide/forge issue #`<issue_number>`.
+   >
+   > Definition of Done:
+   > `<paste DoD>`
+   >
+   > Verify: (1) every DoD item is behaviorally correct, not just structurally present; (2) no regressions in existing tests or public APIs; (3) Rust-specific issues — missing derives, incorrect serde attributes, clippy violations; (4) report only HIGH-confidence findings, skip style nitpicks.
+
+3. **If either gate surfaces issues:** re-engage the orchestrator (new Agent invocation with the findings embedded). The orchestrator returns to Phase 2, fixes, amends the branch, re-pushes, and re-emits HANDOFF-REQUEST. Parent re-runs the gates. Loop until both clean.
+
+4. **If both gates are clean:** merge the PR. Only then is the task complete.
+
+### Failure modes to watch for
+
+- `forge-finish-task` exits without a HANDOFF-REQUEST — the orchestrator aborted early. Do not merge blindly; investigate.
+- A gate fails but the orchestrator "fixed" it inline without re-emitting HANDOFF-REQUEST — that means the fix was never re-verified. Re-run the gates against the amended branch.
+- Merging on a timer / auto-merge without waiting for gates — the gates exist precisely to prevent this. Merge manually after gates confirm clean.
 
 ## Delegation Rules
 

--- a/.claude/skills/forge-finish-task/SKILL.md
+++ b/.claude/skills/forge-finish-task/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: forge-finish-task
-description: Use when implementation is complete and you are ready to submit a Forge GitHub Issue for review — verifies the Definition of Done, pushes the feature branch, and opens a PR to upstream.
+description: Use when implementation is complete and you are ready to submit a Forge GitHub Issue for review — verifies the build, pushes the feature branch, opens a PR, and hands DoD verification and code review OFF to the parent context via a HANDOFF-REQUEST.
 ---
 
 # forge-finish-task
 
 ## Overview
 
-When implementation is done, verify every DoD checkbox, push the feature branch, and open a PR to `forge-ide/forge`. **Do not close the issue** — it closes automatically when the PR merges.
+When implementation is done, verify the build locally, push the feature branch, open a PR, and then **hand control back to the parent context** for DoD verification and code review.
+
+**Do not spawn verifier or code-reviewer subagents from inside this skill.** The parent context owns those gates so the verifier's context is guaranteed fresh — independent of the implementer's context. Running them here would collapse that independence and defeat the whole point of fresh-eyes review.
+
+**Do not close the issue** — it closes automatically when the PR merges. **Do not auto-merge the PR** — the parent decides to merge after its gates pass.
 
 ## Steps
 
@@ -17,62 +21,17 @@ When implementation is done, verify every DoD checkbox, push the feature branch,
 gh issue view <number> --repo forge-ide/forge
 ```
 
-Extract every `- [ ]` item. You will verify each one in the next step.
+Extract every `- [ ]` item verbatim. Do not verify them yet — the parent context will. Record them for the handoff in step 6.
 
-2. **Verify each DoD item via a fresh-context subagent**
-
-Spawn a general-purpose subagent. Give it the DoD checkboxes and nothing else — no implementation context, no file names, no hints. It must find evidence independently.
-
-```
-Prompt template:
-  Verify the following Definition of Done checkboxes for forge repo at /home/jeroche/repos/github/jeff-roche/forge.
-  For each item, find concrete code evidence (grep result, file read, or test run).
-  Do NOT accept "it compiles" as evidence for a specific item — find the actual symbol, method, or file.
-
-  Definition of Done:
-  <paste DoD checkboxes>
-
-  For each checkbox report:
-  - VERIFIED: <what you found and where>
-  - NOT FOUND: <what is missing>
-
-  If any item is NOT FOUND, stop and report — do not guess.
-```
-
-**If any item comes back NOT FOUND:** implement the missing items, re-run the build verification from step 3, then spawn a fresh-context DoD subagent and repeat this step. Loop until every checkbox comes back VERIFIED. Each iteration must use a new subagent with no memory of prior runs.
-
-3. **Verify the build**
+2. **Verify the build locally**
 
 ```bash
 cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings
 ```
 
-All must pass before continuing.
+All must pass before continuing. This is the only verification that happens locally; behavioral DoD verification and code review run in the parent context after handoff (step 6).
 
-4. **Code review with a fresh-context subagent**
-
-Spawn a `feature-dev:code-reviewer` subagent. Give it the issue number, the DoD, and the list of changed files — nothing else. It must derive its own understanding from the code.
-
-```
-Prompt template:
-  Review the implementation for forge-ide/forge issue #<N>: "<issue title>"
-
-  Definition of Done:
-  <paste DoD checkboxes>
-
-  Changed files (git diff --name-only upstream/main):
-  <paste list>
-
-  Verify:
-  1. Every DoD item is fully implemented — not just structurally present but behaviorally correct.
-  2. No regressions in existing tests or public APIs.
-  3. Rust-specific issues: missing derives, incorrect serde attributes, unused imports, clippy violations.
-  4. Report only HIGH-confidence findings. Skip style nitpicks.
-```
-
-**If the reviewer raises any HIGH-confidence finding:** fix all findings, re-run the build verification from step 3, then spawn a fresh-context code-reviewer subagent and repeat this step. Loop until the reviewer reports no HIGH-confidence findings. Each iteration must use a new subagent with no memory of prior runs. Do not push code with known issues.
-
-5. **Create and push the feature branch**
+3. **Create and push the feature branch**
 
 If not already on a feature branch, create one now:
 
@@ -89,7 +48,7 @@ Commit all changes, then push to `origin` (your fork):
 git push -u origin <branch-name>
 ```
 
-6. **Open a PR to upstream**
+4. **Open a PR to upstream**
 
 ```bash
 gh pr create \
@@ -107,31 +66,68 @@ Closes forge-ide/forge#<issue-number>
 - `cargo test --workspace` passes
 - `cargo clippy --all-targets -- -D warnings` passes
 
+## Verification status
+PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
 ```
 
-7. **Update the issue label**
+5. **Update the issue label**
 
 ```bash
 gh issue edit <number> --remove-label "status: in-progress" --add-label "status: code-review" --repo forge-ide/forge
 ```
 
-8. **Confirm**
+6. **Hand off to the parent context**
 
-```bash
-gh issue view <number> --repo forge-ide/forge --json state,labels --jq '{state,labels: .labels | map(.name)}'
+Return a structured `HANDOFF-REQUEST` as the final result of this skill. This is the contract the parent context reads to dispatch independent verifier + code-reviewer agents.
+
+**Do not spawn those agents from here.** The parent runs them. If you spawn them inside this skill, the verifier inherits your context (the implementer's context) and the independent-eyes invariant is destroyed silently.
+
+Return the following, verbatim, as the last thing this skill produces:
+
+```
+HANDOFF-REQUEST
+  pr_url:       https://github.com/forge-ide/forge/pull/<N>
+  issue_number: <GitHub issue number>
+  branch:       feat/task-<padded-number>
+  changed_files:
+    <output of `git diff --name-only upstream/main`, one per line>
+  dod:
+    <paste every DoD checkbox from step 1, verbatim>
+  design_note:
+    <one paragraph: what you changed and why — enough for a fresh reviewer
+     to orient without reading the diff>
 ```
 
-Expected: `"state": "OPEN"` with `status: code-review` label.
+### What the parent does with the HANDOFF-REQUEST
+
+Documented in `forge-complete-task` Phase 3. Summarized here:
+
+1. Dispatches a fresh-context DoD-verifier agent with the `dod` and `changed_files`.
+2. Dispatches a fresh-context `pr-review-toolkit:code-reviewer` (or equivalent) agent with the `pr_url` and `dod`.
+3. If either gate surfaces issues, re-engages this skill's parent orchestrator with the findings embedded. The orchestrator returns to Phase 2 (implement), amends the branch, re-pushes, and re-emits HANDOFF-REQUEST.
+4. If both gates are clean, merges the PR.
+
+## Protocol for re-engagement after gaps found
+
+If the parent context comes back with DoD or reviewer findings:
+
+1. Return to `forge-complete-task` Phase 2 (implement). Drive the fixes TDD-style: red (test the gap), green (fix), refactor.
+2. Re-run step 2 (build verification).
+3. Push amended commits to the same branch — do not force-push unless a rebase is genuinely required.
+4. Re-emit HANDOFF-REQUEST as the final result.
+
+Do not mark the task complete until the parent confirms the PR merged. Do not auto-merge from inside this skill under any circumstance — the gate results live in the parent context, and merging without them is a silent regression.
 
 ## Labels
 
 | Label | Meaning |
 |-------|---------|
 | `status: in-progress` | Actively being worked on |
-| `status: code-review` | PR open, awaiting review — set here |
+| `status: code-review` | PR open, gates running in parent — set here |
 | `status: blocked` | Waiting on a dependency |
 | `status: complete` | Done — added automatically when PR merges |
 | `type: feat` | New feature |
@@ -140,9 +136,14 @@ Expected: `"state": "OPEN"` with `status: code-review` label.
 
 ## Common Mistakes
 
-- Closing the issue manually — let the PR merge close it via "Closes #N"
-- Pushing to `upstream` instead of `origin` — always push to your fork (`origin`)
-- Skipping `cargo clippy` — CI enforces `-D warnings`
-- Using the GitHub issue number in the branch name instead of the F-number from the title
-- Checking a DoD box without verifying the code — a passing test or a `pub use` in `lib.rs` is evidence; memory is not
-- Assuming a prior issue is fully implemented without running the verification grep — always confirm types/methods exist before marking dependents as unblocked
+| Mistake | Correct |
+|---------|---------|
+| Closing the issue manually | Let the PR merge close it via `Closes #N` |
+| Pushing to `upstream` instead of `origin` | Always push to your fork (`origin`) |
+| Skipping `cargo clippy` | CI enforces `-D warnings` |
+| Using the GitHub issue number in the branch name | Use the F-number from the title, zero-padded to 3 digits |
+| Spawning a DoD-verifier or code-reviewer subagent from inside this skill | The parent runs those gates; spawning here breaks the independent-eyes invariant |
+| Auto-merging the PR from inside this skill | Only the parent merges, after its gates pass |
+| Running the DoD verification gate inline here | Document checkboxes in HANDOFF-REQUEST and let the parent verify |
+| Omitting the HANDOFF-REQUEST at the end | Without it, the parent can't run gates and the task stalls silently |
+| Marking complete before the parent confirms merge | A PR can still fail gates after push — wait for the parent's confirmation |


### PR DESCRIPTION
## Summary

Rewrites `forge-finish-task` so DoD verification and code review gates no longer run as subagents spawned from inside the orchestrator. Those gates now live in the parent context (the context that invoked `forge-complete-task`) and consume a `HANDOFF-REQUEST` emitted by `forge-finish-task`. Independent-eyes invariant is preserved by construction — the verifier's context is fresh because it was never in the orchestrator's loop.

## Why

The old skill said "spawn a general-purpose subagent" (DoD) and "spawn a `feature-dev:code-reviewer` subagent" (review), but the orchestrator's runtime doesn't expose a subagent-dispatch tool for those patterns — so both gates were silently no-op with an inline substitution. Observed during Phase 1 security-fix orchestration: F-045, F-046, F-049 each shipped with a self-noted "Task tool unavailable, inline substitution used" caveat in the PR body. Documenting a gate the skill isn't running is worse than not having the gate at all.

## Parts

1. **`forge-finish-task`** — removed verifier + code-reviewer subagent steps; added `HANDOFF-REQUEST` (PR URL, issue #, branch, changed files, DoD, design note) as the skill's final output. Explicit guardrails against auto-merge or inline verification.
2. **`forge-complete-task`** — rewrote Phase 3 to document the parent's responsibility: dispatch a fresh-context DoD verifier + a fresh-context code-reviewer after `HANDOFF-REQUEST`; loop back to Phase 2 on gaps; never merge without both gates clean.
3. **`forge-task-orchestrator` agent** — added explicit `tools:` frontmatter (so future runtimes can't silently strip tools) and a Section 4 body guardrail forbidding verifier/reviewer subagent spawning and auto-merges from inside the orchestrator.

The orchestrator keeps the `Agent` tool because Phase 2 of `forge-complete-task` still requires `Explore`-subagent delegation. The defensive invariant is enforced in skill prose rather than tool restriction — swapping the contract is the fix, not revoking the tool.

## Pilot plan (post-merge)

The next resumed cluster fix (likely F-062) will exercise the new flow end-to-end:
- Orchestrator completes, emits `HANDOFF-REQUEST`
- Parent context dispatches verifier + reviewer
- Parent merges only after both clean
- **Negative test**: inject a DoD failure into the pilot to confirm it surfaces as a parent-visible blocker, not a silent pass — the whole point of the rewrite depends on this property holding.

## Test plan

- [ ] Skill prose reads cleanly and describes the full handoff loop
- [ ] Orchestrator frontmatter lists tools explicitly
- [ ] Manual pilot on F-062 after merge exercises HANDOFF-REQUEST + parent dispatch
- [ ] Negative test: a DoD failure blocks merge and routes back to Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)