### PR TITLE
fix(forge-shell): scope session:event to owning webview (F-062)

### DIFF
--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -2,7 +2,8 @@
 //!
 //! Every command is a thin wrapper over [`crate::bridge::SessionBridge`],
 //! plus an [`EventSink`] implementation that forwards payloads to the
-//! webview via `AppHandle::emit("session:event", …)`.
+//! owning session's webview via `AppHandle::emit_to(EventTarget::webview_window(
+//! "session-{session_id}"), "session:event", …)`.
 //!
 //! **Authorization (F-051 / H10):** each session command requires the
 //! calling webview's label to equal `format!("session-{session_id}")`.
@@ -10,11 +11,19 @@
 //! be forged from webview JS, so they serve as the per-window authenticator
 //! binding a session's control channel to its review channel. Mismatches
 //! return [`LABEL_MISMATCH_ERROR`] and never reach the daemon.
+//!
+//! **Webview isolation (F-062 / M10 / T5):** the event sink targets a single
+//! webview (`session-{session_id}`) instead of broadcasting app-wide. Prior
+//! to this fix, every session window (and the dashboard) received every
+//! session's events; the trust boundary was enforced client-side in the
+//! Solid store. The per-sink `session_id` is bound at construction in
+//! `session_subscribe` (already label-authenticated), not re-read from the
+//! event payload.
 
 use std::sync::Arc;
 
 use forge_ipc::HelloAck;
-use tauri::{AppHandle, Emitter, Manager, Runtime, State, Webview};
+use tauri::{AppHandle, Emitter, EventTarget, Manager, Runtime, State, Webview};
 
 use crate::bridge::{EventSink, SessionBridge, SessionConnections, SessionEventPayload};
 
@@ -78,18 +87,43 @@ impl BridgeState {
     }
 }
 
-/// Event sink that forwards session events to the webview under the
-/// `session:event` event name.
-struct AppHandleSink<R: Runtime> {
-    app: AppHandle<R>,
+/// Event sink that forwards session events to the owning session's webview
+/// under the `session:event` event name.
+///
+/// **F-062 (M10 / T5):** `session_id` is bound at construction from the
+/// authenticated `session_subscribe` argument (already gated by
+/// [`require_window_label`]). It is *not* re-read from the payload, so a
+/// forged payload field cannot redirect delivery to another window.
+pub(crate) struct AppHandleSink<R: Runtime> {
+    pub(crate) app: AppHandle<R>,
+    pub(crate) session_id: String,
 }
 
 impl<R: Runtime> EventSink for AppHandleSink<R> {
     fn emit(&self, payload: SessionEventPayload) {
-        if let Err(e) = self.app.emit("session:event", payload) {
+        // F-062 (M10 / T5): target the session's own webview window instead
+        // of broadcasting app-wide. Prior to this, every `session-*` window
+        // (and the dashboard) received every session's events; filtering
+        // happened client-side in the Solid store — exactly the wrong place
+        // for a trust boundary. Target label uses `self.session_id` (bound
+        // at construction from the authenticated `session_subscribe`
+        // argument), not a payload field, so a forged payload cannot
+        // redirect delivery.
+        let target = EventTarget::webview_window(format!("session-{}", self.session_id));
+        if let Err(e) = self.app.emit_to(target, "session:event", payload) {
             eprintln!("session:event emit failed: {e}");
         }
     }
+}
+
+/// Test-only constructor for [`AppHandleSink`]. Gated behind the
+/// `webview-test` feature so production builds cannot reach into the sink.
+#[cfg(feature = "webview-test")]
+pub fn make_app_handle_sink<R: Runtime>(
+    app: AppHandle<R>,
+    session_id: String,
+) -> std::sync::Arc<dyn EventSink> {
+    std::sync::Arc::new(AppHandleSink { app, session_id })
 }
 
 #[tauri::command]
@@ -123,7 +157,10 @@ pub async fn session_subscribe<R: Runtime>(
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
     require_window_label(&webview, &format!("session-{session_id}"))?;
-    let sink: Arc<dyn EventSink> = Arc::new(AppHandleSink { app });
+    let sink: Arc<dyn EventSink> = Arc::new(AppHandleSink {
+        app,
+        session_id: session_id.clone(),
+    });
     state
         .bridge
         .subscribe(&session_id, since.unwrap_or(0), sink)

--- a/crates/forge-shell/tests/ipc_emit_target.rs
+++ b/crates/forge-shell/tests/ipc_emit_target.rs
@@ -1,0 +1,85 @@
+//! F-062 / M10 / T5: webview isolation for `session:event`.
+//!
+//! `AppHandleSink::emit` must deliver `session:event` only to the owning
+//! session's webview window. Under the pre-fix broadcast behavior, a
+//! listener registered on Window B would observe Session A's full event
+//! stream (tool-call args, assistant turns, content excerpts). These tests
+//! assert the trust boundary is enforced in Rust, not in the Solid store.
+//!
+//! Strategy: build a `mock_builder()` app with two `WebviewWindow`s labeled
+//! `session-A` and `session-B`. Construct an `AppHandleSink` bound to
+//! `session_id = "A"` via the `webview-test`-gated
+//! [`forge_shell::ipc::make_app_handle_sink`]. Emit one payload with
+//! `session_id = "A"`. Assert:
+//!   - Window A's `session:event` listener fires exactly once.
+//!   - Window B's `session:event` listener does not fire.
+
+#![cfg(feature = "webview-test")]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use forge_shell::bridge::{EventSink, SessionEventPayload};
+use forge_shell::ipc::make_app_handle_sink;
+use tauri::test::{mock_builder, mock_context, noop_assets};
+use tauri::Listener;
+
+fn make_app() -> tauri::App<tauri::test::MockRuntime> {
+    mock_builder()
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app")
+}
+
+fn build_window(
+    app: &tauri::App<tauri::test::MockRuntime>,
+    label: &str,
+) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
+    tauri::WebviewWindowBuilder::new(app, label, tauri::WebviewUrl::App("index.html".into()))
+        .build()
+        .expect("mock window")
+}
+
+#[test]
+fn session_event_reaches_only_the_owning_window() {
+    let app = make_app();
+    let win_a = build_window(&app, "session-A");
+    let win_b = build_window(&app, "session-B");
+
+    let hits_a = Arc::new(AtomicUsize::new(0));
+    let hits_b = Arc::new(AtomicUsize::new(0));
+
+    let hits_a_cb = Arc::clone(&hits_a);
+    win_a.listen("session:event", move |_event| {
+        hits_a_cb.fetch_add(1, Ordering::SeqCst);
+    });
+    let hits_b_cb = Arc::clone(&hits_b);
+    win_b.listen("session:event", move |_event| {
+        hits_b_cb.fetch_add(1, Ordering::SeqCst);
+    });
+
+    // Sink bound to session A (mirrors production `session_subscribe` for
+    // Window A's authenticated session).
+    let sink: Arc<dyn EventSink> = make_app_handle_sink(app.handle().clone(), "A".to_string());
+
+    sink.emit(SessionEventPayload {
+        session_id: "A".to_string(),
+        seq: 1,
+        event: serde_json::json!({ "type": "test" }),
+    });
+
+    // Listener dispatch is asynchronous on MockRuntime; give the event loop
+    // a moment to drain before asserting.
+    std::thread::sleep(Duration::from_millis(50));
+
+    assert_eq!(
+        hits_a.load(Ordering::SeqCst),
+        1,
+        "Window A must receive its own session's event",
+    );
+    assert_eq!(
+        hits_b.load(Ordering::SeqCst),
+        0,
+        "Window B must NOT receive Session A's events (cross-session disclosure)",
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#104

## Summary

- `AppHandleSink::emit` now calls `AppHandle::emit_to(EventTarget::webview_window("session-{session_id}"), ...)` instead of broadcasting app-wide. Previously every `session-*` window (and the dashboard) received every session's events; the trust boundary was enforced only by a client-side `session_id` check in the Solid store — exactly the wrong place for a boundary.
- `session_id` is bound into `AppHandleSink` at construction from the authenticated `session_subscribe` argument (already gated by `require_window_label`), not re-read from the event payload. A forged payload field cannot redirect delivery.
- Kept the web-side `session_id` check at `web/packages/app/src/routes/Session/SessionWindow.tsx:47` as defense-in-depth.
- Added a `webview-test`-gated regression test (`tests/ipc_emit_target.rs`) that builds two mock webview windows (`session-A`, `session-B`), emits a Session A payload through the sink, and asserts only Window A's `session:event` listener fires. Verified RED against the broadcast implementation, then GREEN after the fix.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` passes
- [x] `cargo test -p forge-shell --features webview-test` passes (includes new `ipc_emit_target` test)
- [x] `cargo clippy --all-targets -- -D warnings` passes

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)