### PR TITLE
[F-042] fix(forge-fs): stop write_preview from leaking target file contents

### DIFF
--- a/crates/forge-fs/src/mutate.rs
+++ b/crates/forge-fs/src/mutate.rs
@@ -8,8 +8,6 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use similar::TextDiff;
-
 use crate::{canonicalize_no_symlink, enforce_allowed};
 
 /// Error variants for mutation operations. Matches the DoD vocabulary.
@@ -105,19 +103,18 @@ pub fn edit(path: &str, patch: &str, allowed_paths: &[String]) -> Result<(), FsE
     write(canonical_str, &updated, allowed_paths)
 }
 
-/// `ApprovalPreview` for a prospective write. Compares on-disk contents (or
-/// empty for new files) against the proposed content and returns a unified
-/// diff.
+/// `ApprovalPreview` for a prospective write. Returns a content-only preview
+/// of the proposed new bytes — does **not** read the existing file.
+///
+/// Reading the target file here would run before `allowed_paths` enforcement
+/// (which happens in [`write`]) and leak attacker-chosen file contents into
+/// the approval event (see F-042 / audit finding H3). The proposed `content`
+/// is already supplied by the caller, so echoing it back does not expand the
+/// trust surface. If a before/after diff is needed for UX, compute it via an
+/// explicit `fs.read` call that goes through the same approval gate.
 pub fn write_preview(path: &str, content: &str) -> ApprovalPreview {
-    let old = std::fs::read_to_string(path).unwrap_or_default();
-    let diff = TextDiff::from_lines(old.as_str(), content);
-    let file_label = path;
-    let body = diff
-        .unified_diff()
-        .header(file_label, file_label)
-        .to_string();
     ApprovalPreview {
-        description: format!("Write file {path} ({} bytes)\n{body}", content.len()),
+        description: format!("Write file {path} ({} bytes)\n{content}", content.len()),
     }
 }
 
@@ -286,6 +283,7 @@ fn parse_hunk_old_start(rest: &str) -> Result<usize, FsError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use similar::TextDiff;
 
     #[test]
     fn split_preserves_trailing_newlines() {

--- a/crates/forge-fs/tests/fs_write.rs
+++ b/crates/forge-fs/tests/fs_write.rs
@@ -75,11 +75,33 @@ fn write_refuses_to_create_parent_directories() {
 }
 
 #[test]
-fn write_preview_returns_unified_diff_for_new_file() {
+fn write_preview_does_not_leak_existing_file_contents() {
+    // Regression for F-042 (H3): write_preview used to read the target file
+    // from disk and embed its contents in the approval description, leaking
+    // arbitrary files (e.g. /etc/passwd, ~/.ssh/id_rsa) onto the event bus
+    // before the user could approve or reject.
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("secret.txt");
+    let secret = "SECRETMARKER-f042-do-not-leak";
+    let mut f = std::fs::File::create(&target).unwrap();
+    f.write_all(secret.as_bytes()).unwrap();
+
+    let preview = write_preview(target.to_str().unwrap(), "replacement\n");
+
+    assert!(
+        !preview.description.contains(secret),
+        "preview description leaked existing file contents: {}",
+        preview.description
+    );
+}
+
+#[test]
+fn write_preview_describes_path_byte_count_and_proposed_content() {
     let dir = tempdir().unwrap();
     let target = dir.path().join("new.txt");
+    let content = "line1\nline2\n";
 
-    let preview = write_preview(target.to_str().unwrap(), "line1\nline2\n");
+    let preview = write_preview(target.to_str().unwrap(), content);
 
     assert!(
         preview.description.contains("new.txt"),
@@ -87,29 +109,15 @@ fn write_preview_returns_unified_diff_for_new_file() {
         preview.description
     );
     assert!(
-        preview.description.contains("+line1"),
-        "expected added line in diff: {}",
-        preview.description
-    );
-}
-
-#[test]
-fn write_preview_returns_unified_diff_for_overwrite() {
-    let dir = tempdir().unwrap();
-    let target = dir.path().join("existing.txt");
-    let mut f = std::fs::File::create(&target).unwrap();
-    f.write_all(b"old_line\n").unwrap();
-
-    let preview = write_preview(target.to_str().unwrap(), "new_line\n");
-
-    assert!(
-        preview.description.contains("-old_line"),
-        "expected removed line: {}",
+        preview
+            .description
+            .contains(&format!("({} bytes)", content.len())),
+        "description missing byte count: {}",
         preview.description
     );
     assert!(
-        preview.description.contains("+new_line"),
-        "expected added line: {}",
+        preview.description.contains(content),
+        "description missing proposed content: {}",
         preview.description
     );
 }


### PR DESCRIPTION
Closes forge-ide/forge#84

## Summary
- `forge_fs::write_preview` no longer reads arbitrary paths. Dropped the "diff against existing" behavior; it now emits a content-only preview: `Write file {path} ({N} bytes)\n{proposed_content}`.
- The proposed content is already caller-supplied, so echoing it does not expand the trust surface. Existing on-disk bytes — which could be `/etc/passwd`, `~/.ssh/id_rsa`, `~/.aws/credentials`, `.env` — are no longer read or embedded in `ApprovalPreview.description` before the user approves or rejects.
- Adds a regression test (`write_preview_does_not_leak_existing_file_contents`) that fails without the fix. The previous unified-diff-shape preview tests were replaced with `write_preview_describes_path_byte_count_and_proposed_content`, which encodes the new contract.
- Addresses audit finding **H3** (threat class **T2** — `allowed_paths` bypass with confidentiality side-channel; CWE-200 + CWE-22).

### Why primary remediation (drop the diff) over the minimal fallback
The finding's preferred remediation is to remove the "diff against existing" behavior entirely rather than add `allowed_paths` + canonicalization to `write_preview`. Going with the preferred path because (1) `ApprovalPreview.description` is rendered as an opaque string by the web approval UI — no layer depends on the diff format (verified in `web/packages/app/tests/phase1/uat-07-four-scope-approval.spec.ts`), so no UX breakage; (2) any real before/after diff needed in the future should be computed via an explicit `fs.read` that goes through the same approval gate; (3) it closes the side-channel permanently instead of duplicating path-validation logic that already lives in `write()` / `edit()`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` — all suites pass, including new regression test
- [x] `cargo clippy --all-targets -- -D warnings`

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)