### PR TITLE
fix(forge-core): bound per-line reads in event log and transcript (F-060)

### DIFF
--- a/crates/forge-core/src/event_log.rs
+++ b/crates/forge-core/src/event_log.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::io::{AsyncBufRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
@@ -12,6 +13,14 @@ use crate::{ForgeError, Result};
 
 const SCHEMA_HEADER: &str = r#"{"schema_version":1}"#;
 const FLUSH_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Per-line byte cap for `events.jsonl` / transcript readers.
+///
+/// Legitimate events are far smaller than this (the orchestrator chunks
+/// assistant deltas). The cap exists so a malformed or adversarial log
+/// cannot force readers to buffer an unbounded line before parsing
+/// (see CWE-770 — Allocation of Resources Without Limits).
+pub const MAX_LINE_BYTES: usize = 4 * 1024 * 1024;
 
 pub struct EventLog {
     writer: Arc<Mutex<BufWriter<tokio::fs::File>>>,
@@ -102,18 +111,123 @@ impl EventLog {
     }
 }
 
+/// Outcome of a single bounded-line read.
+enum BoundedLine {
+    /// A full line was read; terminating `\n` has been consumed but is not
+    /// included in the caller's buffer.
+    Line,
+    /// EOF was hit before any bytes were read.
+    Eof,
+    /// EOF was hit mid-line (no trailing `\n`). Buffer holds the partial line.
+    EofNoNewline,
+    /// The per-line byte cap was exhausted before a `\n` was seen.
+    Exceeded,
+}
+
+/// Read one line into `buf` with a hard upper bound of `max` bytes.
+///
+/// Uses `fill_buf`/`consume` directly so memory use is bounded to at most
+/// `max` regardless of how the adversarial input is shaped. The terminating
+/// `\n` is consumed from the reader but is not appended to `buf`.
+/// Outcome of a single `poll_fill_buf` pass.
+enum PassOutcome {
+    /// Reader returned an empty slice — EOF.
+    Eof,
+    /// Chunk contained a newline and the preceding content fit under `max`.
+    LineReady,
+    /// The per-line cap was exhausted before a newline was reached.
+    Exceeded,
+    /// Chunk had no newline; content was appended. Loop again.
+    KeepReading,
+}
+
+async fn read_bounded_line<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+    max: usize,
+) -> std::io::Result<BoundedLine> {
+    use std::future::poll_fn;
+    use std::task::Poll;
+
+    buf.clear();
+    loop {
+        let outcome = poll_fn(|cx| {
+            let chunk = match Pin::new(&mut *reader).poll_fill_buf(cx) {
+                Poll::Ready(Ok(c)) => c,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            };
+            if chunk.is_empty() {
+                return Poll::Ready(Ok(PassOutcome::Eof));
+            }
+            match chunk.iter().position(|b| *b == b'\n') {
+                Some(pos) => {
+                    let consume = pos + 1;
+                    let outcome = if buf.len().saturating_add(pos) > max {
+                        PassOutcome::Exceeded
+                    } else {
+                        buf.extend_from_slice(&chunk[..pos]);
+                        PassOutcome::LineReady
+                    };
+                    Pin::new(&mut *reader).consume(consume);
+                    Poll::Ready(Ok(outcome))
+                }
+                None => {
+                    let len = chunk.len();
+                    let outcome = if buf.len().saturating_add(len) > max {
+                        PassOutcome::Exceeded
+                    } else {
+                        buf.extend_from_slice(chunk);
+                        PassOutcome::KeepReading
+                    };
+                    Pin::new(&mut *reader).consume(len);
+                    Poll::Ready(Ok(outcome))
+                }
+            }
+        })
+        .await?;
+
+        match outcome {
+            PassOutcome::Eof => {
+                return Ok(if buf.is_empty() {
+                    BoundedLine::Eof
+                } else {
+                    BoundedLine::EofNoNewline
+                });
+            }
+            PassOutcome::LineReady => return Ok(BoundedLine::Line),
+            PassOutcome::Exceeded => return Ok(BoundedLine::Exceeded),
+            PassOutcome::KeepReading => continue,
+        }
+    }
+}
+
 /// Reads events from the log at `path` that have sequence number greater than `since`.
 ///
 /// Events are 1-indexed: the first event in the file is seq 1. Sending `since: 0`
 /// returns all events; `since: N` returns events N+1 onward.
+///
+/// Every line is bounded to [`MAX_LINE_BYTES`]. An `events.jsonl` with a line that
+/// exceeds the cap is rejected with an error rather than buffered into memory.
 pub async fn read_since(path: &Path, since: u64) -> Result<Vec<(u64, Event)>> {
     let file = tokio::fs::File::open(path).await?;
-    let mut lines = BufReader::new(file).lines();
+    let mut reader = BufReader::new(file);
+    let mut line_buf: Vec<u8> = Vec::new();
 
-    let header = lines
-        .next_line()
-        .await?
-        .ok_or_else(|| ForgeError::Other(anyhow::anyhow!("event log is empty")))?;
+    match read_bounded_line(&mut reader, &mut line_buf, MAX_LINE_BYTES).await? {
+        BoundedLine::Eof => {
+            return Err(ForgeError::Other(anyhow::anyhow!("event log is empty")));
+        }
+        BoundedLine::Exceeded => {
+            return Err(ForgeError::Other(anyhow::anyhow!(
+                "events.jsonl header line exceeds {MAX_LINE_BYTES} bytes"
+            )));
+        }
+        BoundedLine::Line | BoundedLine::EofNoNewline => {}
+    }
+    let header = std::str::from_utf8(&line_buf).map_err(|_| {
+        ForgeError::Other(anyhow::anyhow!("events.jsonl header is not valid UTF-8"))
+    })?;
     if header != SCHEMA_HEADER {
         return Err(ForgeError::Other(anyhow::anyhow!(
             "schema header mismatch: expected {SCHEMA_HEADER:?}, got {header:?}"
@@ -122,12 +236,29 @@ pub async fn read_since(path: &Path, since: u64) -> Result<Vec<(u64, Event)>> {
 
     let mut events = Vec::new();
     let mut seq = 0u64;
-    while let Some(line) = lines.next_line().await? {
-        seq += 1;
-        if seq > since {
-            let event: Event = serde_json::from_str(&line)
-                .map_err(|e| ForgeError::Other(anyhow::anyhow!("bad event at seq {seq}: {e}")))?;
-            events.push((seq, event));
+    loop {
+        match read_bounded_line(&mut reader, &mut line_buf, MAX_LINE_BYTES).await? {
+            BoundedLine::Eof => break,
+            BoundedLine::Exceeded => {
+                return Err(ForgeError::Other(anyhow::anyhow!(
+                    "events.jsonl line at seq {next} exceeds {MAX_LINE_BYTES} bytes",
+                    next = seq + 1
+                )));
+            }
+            BoundedLine::Line | BoundedLine::EofNoNewline => {
+                seq += 1;
+                if seq > since {
+                    let line = std::str::from_utf8(&line_buf).map_err(|_| {
+                        ForgeError::Other(anyhow::anyhow!(
+                            "events.jsonl line at seq {seq} is not valid UTF-8"
+                        ))
+                    })?;
+                    let event: Event = serde_json::from_str(line).map_err(|e| {
+                        ForgeError::Other(anyhow::anyhow!("bad event at seq {seq}: {e}"))
+                    })?;
+                    events.push((seq, event));
+                }
+            }
         }
     }
     Ok(events)

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -10,7 +10,7 @@ pub mod workspaces;
 
 pub use error::{ForgeError, Result};
 pub use event::{ApprovalPreview, ApprovalSource, ContextRef, EndReason, Event};
-pub use event_log::{read_since, EventLog};
+pub use event_log::{read_since, EventLog, MAX_LINE_BYTES};
 pub use ids::{
     AgentId, AgentInstanceId, MessageId, ProviderId, SessionId, ToolCallId, WorkspaceId,
 };

--- a/crates/forge-core/src/transcript.rs
+++ b/crates/forge-core/src/transcript.rs
@@ -1,8 +1,9 @@
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 
 use crate::event::Event;
-use crate::Result;
+use crate::event_log::MAX_LINE_BYTES;
+use crate::{ForgeError, Result};
 
 #[derive(Debug, Default)]
 pub struct Transcript {
@@ -33,11 +34,41 @@ impl Transcript {
 
     pub fn from_file(path: &Path) -> Result<Self> {
         let file = std::fs::File::open(path)?;
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
         let mut events = Vec::new();
-        for line in reader.lines() {
-            let line = line?;
-            let event: Event = serde_json::from_str(&line)?;
+        let mut line_num: u64 = 0;
+        let mut buf: Vec<u8> = Vec::new();
+        loop {
+            buf.clear();
+            // Cap per-line reads at MAX_LINE_BYTES. `std::io::Take<R: BufRead>`
+            // implements `BufRead`, so `read_until` reuses the standard code path
+            // while hard-limiting how many bytes the reader will hand back.
+            let mut handle = reader.by_ref().take((MAX_LINE_BYTES as u64) + 1);
+            let n = handle.read_until(b'\n', &mut buf)?;
+            if n == 0 {
+                break; // EOF
+            }
+            line_num += 1;
+            // If we read MAX+1 bytes and the last byte is not '\n', the cap was
+            // hit mid-line. Anything that stopped at the cap *with* a trailing
+            // newline is exactly MAX content bytes — allowed.
+            let ended_with_newline = buf.last() == Some(&b'\n');
+            if n > MAX_LINE_BYTES && !ended_with_newline {
+                return Err(ForgeError::Other(anyhow::anyhow!(
+                    "transcript line {line_num} exceeds {MAX_LINE_BYTES} bytes"
+                )));
+            }
+            let content = if ended_with_newline {
+                &buf[..buf.len() - 1]
+            } else {
+                &buf[..]
+            };
+            let line = std::str::from_utf8(content).map_err(|_| {
+                ForgeError::Other(anyhow::anyhow!(
+                    "transcript line {line_num} is not valid UTF-8"
+                ))
+            })?;
+            let event: Event = serde_json::from_str(line)?;
             events.push(event);
         }
         Ok(Self { events })

--- a/crates/forge-core/tests/event_log_bounded_read.rs
+++ b/crates/forge-core/tests/event_log_bounded_read.rs
@@ -1,0 +1,95 @@
+use forge_core::{read_since, MAX_LINE_BYTES};
+use std::io::Write;
+use tempfile::TempDir;
+
+/// Write a crafted events.jsonl with a valid schema header plus one event line
+/// whose serialized JSON exceeds MAX_LINE_BYTES. Streams the oversize content
+/// byte-by-byte so the test itself doesn't need the entire line resident in RAM.
+fn write_oversize_events_jsonl(path: &std::path::Path, oversize_bytes: usize) {
+    let mut f = std::fs::File::create(path).unwrap();
+    // schema header
+    f.write_all(br#"{"schema_version":1}"#).unwrap();
+    f.write_all(b"\n").unwrap();
+    // one oversized event line: well-formed JSON prefix, then a huge run of 'a'
+    // inside a string field, then closing. No newline char is ever emitted
+    // until the very end — the reader must refuse before reaching it.
+    f.write_all(br#"{"type":"assistant_delta","id":"m","at":"1970-01-01T00:00:00Z","delta":""#)
+        .unwrap();
+    // Stream garbage content in chunks; total content size = oversize_bytes.
+    let chunk = vec![b'a'; 64 * 1024];
+    let mut remaining = oversize_bytes;
+    while remaining > 0 {
+        let take = remaining.min(chunk.len());
+        f.write_all(&chunk[..take]).unwrap();
+        remaining -= take;
+    }
+    f.write_all(br#""}"#).unwrap();
+    f.write_all(b"\n").unwrap();
+}
+
+#[tokio::test]
+async fn read_since_rejects_line_exceeding_max_line_bytes() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("events.jsonl");
+    // Oversized line content by 1 KiB above the cap — enough to trigger rejection.
+    write_oversize_events_jsonl(&path, MAX_LINE_BYTES + 1024);
+
+    let result = read_since(&path, 0).await;
+
+    let err = result.expect_err("read_since must reject oversized line");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("exceeds"),
+        "error must mention the cap, got: {msg}"
+    );
+}
+
+/// Attacker crafts a file whose header is valid but the first event line has
+/// no trailing newline *at all* — the original OOM primitive described in the
+/// finding. The reader must refuse the file instead of buffering it whole.
+#[tokio::test]
+async fn read_since_rejects_oversized_line_with_no_trailing_newline() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("events.jsonl");
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(br#"{"schema_version":1}"#).unwrap();
+    f.write_all(b"\n").unwrap();
+    let chunk = vec![b'x'; 64 * 1024];
+    // Write (MAX + 256 KiB) raw bytes — no newline anywhere after the header.
+    let mut remaining = MAX_LINE_BYTES + 256 * 1024;
+    while remaining > 0 {
+        let take = remaining.min(chunk.len());
+        f.write_all(&chunk[..take]).unwrap();
+        remaining -= take;
+    }
+    drop(f);
+
+    let result = read_since(&path, 0).await;
+
+    let err = result.expect_err("read_since must reject unterminated oversize line");
+    assert!(err.to_string().contains("exceeds"));
+}
+
+#[tokio::test]
+async fn read_since_accepts_legitimate_small_line() {
+    use chrono::Utc;
+    use forge_core::{Event, EventLog, MessageId};
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("events.jsonl");
+    let mut log = EventLog::create(&path).await.unwrap();
+
+    // A legitimate delta well under the cap must still round-trip through read_since.
+    let event = Event::AssistantDelta {
+        id: MessageId::new(),
+        at: Utc::now(),
+        delta: "hello".to_string(),
+    };
+    log.append(&event).await.unwrap();
+    log.close().await.unwrap();
+
+    let events = read_since(&path, 0)
+        .await
+        .expect("legitimate line must read");
+    assert_eq!(events.len(), 1);
+}

--- a/crates/forge-core/tests/transcript_bounded_read.rs
+++ b/crates/forge-core/tests/transcript_bounded_read.rs
@@ -1,0 +1,36 @@
+use forge_core::{Transcript, MAX_LINE_BYTES};
+use std::io::Write;
+use tempfile::TempDir;
+
+/// Write a transcript-style jsonl file containing one line whose total serialized
+/// size exceeds MAX_LINE_BYTES (no schema header — Transcript::from_file reads raw).
+fn write_oversize_transcript(path: &std::path::Path, oversize_bytes: usize) {
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(br#"{"type":"assistant_delta","id":"m","at":"1970-01-01T00:00:00Z","delta":""#)
+        .unwrap();
+    let chunk = vec![b'a'; 64 * 1024];
+    let mut remaining = oversize_bytes;
+    while remaining > 0 {
+        let take = remaining.min(chunk.len());
+        f.write_all(&chunk[..take]).unwrap();
+        remaining -= take;
+    }
+    f.write_all(br#""}"#).unwrap();
+    f.write_all(b"\n").unwrap();
+}
+
+#[test]
+fn from_file_rejects_line_exceeding_max_line_bytes() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("transcript.jsonl");
+    write_oversize_transcript(&path, MAX_LINE_BYTES + 1024);
+
+    let result = Transcript::from_file(&path);
+
+    let err = result.expect_err("Transcript::from_file must reject oversized line");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("exceeds"),
+        "error must mention the cap, got: {msg}"
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#102

## Summary

- Add `MAX_LINE_BYTES = 4 MiB` ceiling applied symmetrically in `event_log::read_since` and `Transcript::from_file`. Oversized lines return a typed error instead of buffering the entire run (original OOM primitive in the finding).
- Async reader (`event_log`) uses a custom `BoundedLine` helper driven by `poll_fill_buf` / `consume` so memory stays bounded regardless of adversarial input shape. Sync reader (`Transcript`) uses `Take<R: BufRead>` with `read_until(b'\n', ...)` and distinguishes cap-hit-mid-line (reject) from EOF-after-partial-line (accept).
- Both error messages include the line/seq number for diagnostic value.

## Test plan

- `cargo test -p forge-core` passes (55 tests, including pre-existing `transcript_roundtrip` and `event_log_persistence`)
- `cargo clippy -p forge-core --all-targets -- -D warnings` passes
- New regression tests (3 in `event_log_bounded_read.rs`, 1 in `transcript_bounded_read.rs`):
  - Oversize line inside well-formed JSON string → rejected
  - Unterminated oversize run (original finding's OOM primitive) → rejected
  - Happy-path legitimate line → parses cleanly
  - `Transcript::from_file` rejects oversize line

## Follow-up (explicitly out of scope)

The issue body suggested an optional depth cap on `args: Value` / `result: Value` via a serde visitor. Skipped here per the task brief — the cap is a broader surface that warrants its own issue. Recommend filing as a follow-up if the depth primitive is reachable through the event log.

## Verification status

PR is open; DoD and code-review gates pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)