### PR TITLE
[F-057] forge-cli validate session id format at clap parse time

### DIFF
--- a/crates/forge-cli/src/lib.rs
+++ b/crates/forge-cli/src/lib.rs
@@ -4,6 +4,28 @@ pub mod socket;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+/// Clap `value_parser` for `<session-id>` arguments.
+///
+/// Enforces the canonical `SessionId` wire format (`^[0-9a-f]{16}$`) *at
+/// parse time* — before any command body runs — so attacker-controlled ids
+/// like `../../tmp/evil` can never reach `socket::pid_path` or
+/// `socket::socket_path`. See F-057 (T12a, path-traversal vector for raw-PID
+/// SIGTERM).
+///
+/// Returning `Err(String)` here produces a typed clap error message of the
+/// form `invalid value '<id>' for '<session-id>': ...`, which is what the
+/// DoD calls a "typed validation error".
+fn parse_session_id(raw: &str) -> Result<String, String> {
+    if socket::session_id_is_valid(raw) {
+        Ok(raw.to_string())
+    } else {
+        Err(format!(
+            "session id must be 16 lowercase hex characters (got {:?})",
+            raw
+        ))
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "forge", about = "Forge IDE command-line interface")]
 pub struct Cli {
@@ -36,12 +58,14 @@ pub enum SessionCommands {
     List,
     /// Stream events from a session to stdout.
     Tail {
-        /// Session ID to tail.
+        /// Session ID to tail (16 lowercase hex characters).
+        #[arg(value_parser = parse_session_id)]
         id: String,
     },
     /// Send SIGTERM to a session process.
     Kill {
-        /// Session ID to kill.
+        /// Session ID to kill (16 lowercase hex characters).
+        #[arg(value_parser = parse_session_id)]
         id: String,
     },
 }

--- a/crates/forge-cli/src/socket.rs
+++ b/crates/forge-cli/src/socket.rs
@@ -1,7 +1,30 @@
 use std::path::PathBuf;
 
+/// Return `true` iff `s` matches the canonical `SessionId` wire format:
+/// exactly 16 lowercase hex characters (8 random bytes rendered as `{:02x}`
+/// in `forge_core::SessionId::new`).
+///
+/// This is the single chokepoint the CLI uses to refuse attacker-controlled
+/// session ids before they reach path-building functions. A canonical id
+/// cannot contain `/`, `.`, `..`, NUL, whitespace, or any character with
+/// filesystem meaning, so validation here is sufficient to block the
+/// `../../tmp/evil` style path-traversal identified in F-057 (T12a).
+pub fn session_id_is_valid(s: &str) -> bool {
+    s.len() == 16 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
 /// Resolve the Unix socket path for a session, using the same logic as `forged`.
 pub fn socket_path(session_id: &str) -> PathBuf {
+    // Defense-in-depth for F-057 (T12a): the CLI's clap `value_parser`
+    // already rejects malformed ids, but any future caller that constructs
+    // a session id from a non-CLI source (env var, IPC message, disk) must
+    // not be able to smuggle path-traversal through here silently. Debug
+    // builds panic loudly; release builds still honour the upstream
+    // `value_parser` contract.
+    debug_assert!(
+        session_id_is_valid(session_id),
+        "socket_path: session_id_is_valid({session_id:?}) == false"
+    );
     let base = std::env::var("XDG_RUNTIME_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
@@ -25,6 +48,14 @@ pub fn sessions_socket_dir() -> PathBuf {
 
 /// Resolve the PID file path for a session.
 pub fn pid_path(session_id: &str) -> PathBuf {
+    // Defense-in-depth for F-057 (T12a): same rationale as `socket_path`.
+    // `socket_path` below will also debug-assert, but stating the invariant
+    // explicitly here keeps the failure message attached to the function
+    // the caller actually invoked.
+    debug_assert!(
+        session_id_is_valid(session_id),
+        "pid_path: session_id_is_valid({session_id:?}) == false"
+    );
     socket_path(session_id).with_extension("pid")
 }
 
@@ -309,6 +340,65 @@ mod tests {
     use super::*;
 
     #[test]
+    fn session_id_is_valid_accepts_canonical_16_char_lowercase_hex() {
+        assert!(session_id_is_valid("deadbeefcafebabe"));
+        assert!(session_id_is_valid("0123456789abcdef"));
+    }
+
+    #[test]
+    fn session_id_is_valid_rejects_path_traversal() {
+        assert!(!session_id_is_valid("../../tmp/x"));
+        assert!(!session_id_is_valid("../etc/passwd"));
+        assert!(!session_id_is_valid("."));
+        assert!(!session_id_is_valid(".."));
+        assert!(!session_id_is_valid("/absolute/path"));
+    }
+
+    #[test]
+    fn session_id_is_valid_rejects_uppercase() {
+        // SessionId::new() emits lowercase hex via {:02x}; any uppercase id
+        // cannot have come from the canonical generator and must be refused
+        // so the validator has a single normal form.
+        assert!(!session_id_is_valid("DEADBEEFCAFEBABE"));
+        assert!(!session_id_is_valid("DeadBeefCafeBabe"));
+    }
+
+    #[test]
+    fn session_id_is_valid_rejects_wrong_length() {
+        assert!(!session_id_is_valid(""));
+        assert!(!session_id_is_valid("abc"));
+        // 15 chars
+        assert!(!session_id_is_valid("deadbeefcafebab"));
+        // 17 chars
+        assert!(!session_id_is_valid("deadbeefcafebabe0"));
+        // 32 chars (uuid-like length)
+        assert!(!session_id_is_valid("deadbeefcafebabedeadbeefcafebabe"));
+    }
+
+    #[test]
+    fn session_id_is_valid_rejects_non_hex() {
+        assert!(!session_id_is_valid("deadbeefcafebabg")); // 'g'
+        assert!(!session_id_is_valid("deadbeef cafebabe")); // space
+        assert!(!session_id_is_valid("deadbeef-cafebabe")); // dash
+        assert!(!session_id_is_valid("deadbeef.cafebabe")); // dot
+        assert!(!session_id_is_valid("deadbeef\u{00}bedbabe")); // NUL
+    }
+
+    #[test]
+    fn session_id_is_valid_accepts_all_freshly_generated_ids() {
+        // Round-trip property: whatever SessionId::new() emits must pass the
+        // validator. If we ever widen the generator to, say, 32 hex chars,
+        // this test will fail loudly and force the validator to be updated.
+        for _ in 0..32 {
+            let id = forge_core::SessionId::new().to_string();
+            assert!(
+                session_id_is_valid(&id),
+                "freshly-generated SessionId must be valid: {id:?}"
+            );
+        }
+    }
+
+    #[test]
     fn socket_path_uses_xdg_runtime_dir() {
         // Temporarily set XDG_RUNTIME_DIR to a known value.
         // Use a fixed path so the test is deterministic.
@@ -328,12 +418,29 @@ mod tests {
 
     #[test]
     fn pid_path_has_pid_extension() {
-        let path = pid_path("abc123");
+        let path = pid_path("abc123def4560000");
         assert!(
-            path.to_string_lossy().ends_with("abc123.pid"),
+            path.to_string_lossy().ends_with("abc123def4560000.pid"),
             "expected .pid extension: {}",
             path.display()
         );
+    }
+
+    /// Defense-in-depth: if clap's `value_parser` is ever bypassed (e.g. a
+    /// future caller constructs a session id from a different source and
+    /// forgets to validate), the path-builders must still refuse.
+    #[test]
+    #[should_panic(expected = "session_id_is_valid")]
+    #[cfg(debug_assertions)]
+    fn pid_path_debug_asserts_valid_session_id() {
+        let _ = pid_path("../../tmp/x");
+    }
+
+    #[test]
+    #[should_panic(expected = "session_id_is_valid")]
+    #[cfg(debug_assertions)]
+    fn socket_path_debug_asserts_valid_session_id() {
+        let _ = socket_path("../../tmp/x");
     }
 
     #[test]

--- a/crates/forge-cli/tests/cli_args.rs
+++ b/crates/forge-cli/tests/cli_args.rs
@@ -115,15 +115,15 @@ fn parse_session_list() {
 
 #[test]
 fn parse_session_tail() {
-    let cli =
-        Cli::try_parse_from(["forge", "session", "tail", "abc123def456"]).expect("should parse");
+    let cli = Cli::try_parse_from(["forge", "session", "tail", "abc123def4560000"])
+        .expect("should parse");
     let Commands::Session {
         cmd: SessionCommands::Tail { id },
     } = cli.command
     else {
         panic!("wrong command shape");
     };
-    assert_eq!(id, "abc123def456");
+    assert_eq!(id, "abc123def4560000");
 }
 
 #[test]
@@ -137,6 +137,55 @@ fn parse_session_kill() {
         panic!("wrong command shape");
     };
     assert_eq!(id, "deadbeefcafe0000");
+}
+
+/// F-057 (T12a): clap must reject a path-traversal session id during
+/// argument parsing — before any command body runs — so the filesystem
+/// is never touched with an attacker-controlled path component.
+#[test]
+fn parse_session_kill_rejects_path_traversal() {
+    let result = Cli::try_parse_from(["forge", "session", "kill", "../../tmp/x"]);
+    assert!(
+        result.is_err(),
+        "path-traversal session id must be rejected at parse time"
+    );
+}
+
+#[test]
+fn parse_session_tail_rejects_path_traversal() {
+    let result = Cli::try_parse_from(["forge", "session", "tail", "../../tmp/x"]);
+    assert!(
+        result.is_err(),
+        "path-traversal session id must be rejected at parse time"
+    );
+}
+
+#[test]
+fn parse_session_kill_rejects_absolute_path() {
+    let result = Cli::try_parse_from(["forge", "session", "kill", "/etc/passwd"]);
+    assert!(result.is_err(), "absolute path id must be rejected");
+}
+
+#[test]
+fn parse_session_kill_rejects_uppercase_hex() {
+    // SessionId::new() emits lowercase hex only; uppercase cannot have
+    // come from the canonical generator.
+    let result = Cli::try_parse_from(["forge", "session", "kill", "DEADBEEFCAFEBABE"]);
+    assert!(result.is_err(), "uppercase hex id must be rejected");
+}
+
+#[test]
+fn parse_session_kill_rejects_wrong_length() {
+    // 15 chars — one short of the canonical 16.
+    let result = Cli::try_parse_from(["forge", "session", "kill", "deadbeefcafebab"]);
+    assert!(result.is_err(), "15-char id must be rejected");
+}
+
+#[test]
+fn parse_session_kill_rejects_non_hex() {
+    // 16 chars but contains 'g'.
+    let result = Cli::try_parse_from(["forge", "session", "kill", "deadbeefcafebabg"]);
+    assert!(result.is_err(), "non-hex id must be rejected");
 }
 
 #[test]


### PR DESCRIPTION
Closes forge-ide/forge#99

## Summary
- F-057 (T12a): `forge session kill <id>` and `forge session tail <id>` piped the raw id string straight into `socket::pid_path` / `socket::socket_path`, which does `base.join(format!("{id}.sock"))`. An id like `../../tmp/evil` resolves outside the sessions dir, letting `session_kill` read an attacker-chosen `.pid`-extensioned file and feed its first line to `libc::kill` as a pid.
- Adds `forge_cli::socket::session_id_is_valid(&str) -> bool` enforcing the canonical `SessionId` wire format (16 lowercase hex — matches `forge_core::SessionId::new()` output via `{:02x}`).
- Gates `SessionCommands::Kill.id` and `SessionCommands::Tail.id` on a clap `value_parser` (`parse_session_id`). Validation runs before any command body, so `forge session kill '../../tmp/x'` exits with a typed clap error and never touches the filesystem.
- Defense-in-depth: `pid_path` and `socket_path` `debug_assert!` the invariant so future non-CLI callers that forget to validate fail loudly.
- Does not modify `parse_session_pid` (F-048) or `OwnedPidFile` / `kill_session_from_pid_file` (F-049); this validation lands upstream of both.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- New regression tests in `crates/forge-cli/tests/cli_args.rs`:
  - `parse_session_kill_rejects_path_traversal` (the canonical DoD test)
  - `parse_session_tail_rejects_path_traversal`
  - `parse_session_kill_rejects_absolute_path`
  - `parse_session_kill_rejects_uppercase_hex`
  - `parse_session_kill_rejects_wrong_length`
  - `parse_session_kill_rejects_non_hex`
- New unit tests in `crates/forge-cli/src/socket.rs`:
  - Positive, rejection (path traversal / uppercase / wrong length / non-hex), and round-trip property tests for `session_id_is_valid`
  - `debug_assert!` guard tests for `pid_path` and `socket_path`

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

## Note on branch name
Branch is `feat/task-057-worktree` rather than the conventional `feat/task-057` because `feat/task-057` was already checked out in a sibling worktree at the time this agent started. Same F-number, same issue — the suffix is a worktree artifact only.

Generated with [Claude Code](https://claude.com/claude-code)