### PR TITLE
fix(forge-shell): validate session id before building window label (F-063)

### DIFF
--- a/crates/forge-shell/src-tauri/capabilities/default.json
+++ b/crates/forge-shell/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capability for the Dashboard and Session windows. Grants Tauri's built-in core APIs. App-local commands (F-020 session bridge etc.) do not require capability entries — Tauri only gates plugin commands.",
+  "description": "Default capability for the Dashboard and Session windows. Grants Tauri's built-in core APIs via `core:default`.\n\nApp-local commands registered on this capability are not Tauri-gated in Tauri 2 today (only plugin commands are), but are enumerated here so that a future Tauri upgrade or capability refactor that changes gating semantics produces a reviewable diff against an explicit list:\n\n- provider_status (dashboard only)\n- session_list (dashboard only)\n- open_session (dashboard only; validates the session id before creating the window — see F-063 / M11)\n- session_hello (session-* only)\n- session_subscribe (session-* only)\n- session_send_message (session-* only)\n- session_approve_tool (session-* only)\n- session_reject_tool (session-* only)\n\nPer-window authorization is enforced in-process by `require_window_label` (F-051 / H10). Bare identifiers like `allow-open-session` are intentionally omitted from the `permissions` array: Tauri 2's ACL resolver rejects identifiers that do not correspond to a compiled permission file, and Forge does not yet ship app-local permission manifests.",
   "windows": ["dashboard", "session-*"],
   "permissions": ["core:default"]
 }

--- a/crates/forge-shell/src/dashboard_sessions.rs
+++ b/crates/forge-shell/src/dashboard_sessions.rs
@@ -254,6 +254,103 @@ pub fn default_workspaces_toml() -> PathBuf {
     base.join("forge").join("workspaces.toml")
 }
 
+/// F-063 (M11 / T5): structured error returned when `open_session` is
+/// called with an id that does not match the canonical `SessionId` wire
+/// shape. Surfaced as a plain `String` so it matches the existing
+/// `Err(String)` wire shape of every `#[tauri::command]`.
+///
+/// Only consumed by the `webview`-gated `open_session`; the
+/// `cfg_attr(..., allow(dead_code))` keeps `--no-default-features` builds
+/// (which still compile the validator helper for its unit tests) clean.
+#[cfg_attr(not(feature = "webview"), allow(dead_code))]
+pub(crate) const INVALID_SESSION_ID_ERROR: &str = "invalid session id";
+
+/// Strict gate over the `id` argument to `open_session`. Matches exactly
+/// the output of `forge_core::SessionId::new()` — 16 lowercase hex chars,
+/// no separators — and rejects everything else.
+///
+/// F-063 (M11 / T5): the window label `session-{id}` is consumed by
+/// Tauri's capability matcher (`session-*` glob in
+/// `src-tauri/capabilities/default.json`). Without validation an id like
+/// `../foo` or one containing NUL / whitespace would still match the glob
+/// while producing a label with unexpected semantics. Keeping this helper
+/// in terms of the canonical `SessionId` wire shape means a future format
+/// change has exactly one place to update.
+///
+/// Under `--no-default-features` the webview command is not compiled, so
+/// the helper is only exercised by its own unit tests — the
+/// `cfg_attr(..., allow(dead_code))` silences the resulting dead-code
+/// warning without hiding real unused-code regressions under
+/// `--features webview`.
+#[cfg_attr(not(feature = "webview"), allow(dead_code))]
+fn is_valid_session_id(id: &str) -> bool {
+    id.len() == 16 && id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+#[cfg(test)]
+mod session_id_validation_tests {
+    use super::*;
+
+    #[test]
+    fn canonical_16_hex_lowercase_is_valid() {
+        assert!(is_valid_session_id("deadbeefcafebabe"));
+        assert!(is_valid_session_id("0123456789abcdef"));
+    }
+
+    #[test]
+    fn empty_is_invalid() {
+        assert!(!is_valid_session_id(""));
+    }
+
+    #[test]
+    fn shorter_than_16_is_invalid() {
+        assert!(!is_valid_session_id("deadbeefcafebab")); // 15
+    }
+
+    #[test]
+    fn longer_than_16_is_invalid() {
+        assert!(!is_valid_session_id("deadbeefcafebabe0")); // 17
+    }
+
+    #[test]
+    fn uppercase_hex_is_invalid() {
+        // SessionId::new() emits lowercase only; be strict.
+        assert!(!is_valid_session_id("DEADBEEFCAFEBABE"));
+    }
+
+    #[test]
+    fn dashes_are_invalid() {
+        // SessionId::new() never produces separators; reject to match the
+        // authoritative wire shape.
+        assert!(!is_valid_session_id("dead-beef-cafe-ba"));
+    }
+
+    #[test]
+    fn non_hex_chars_are_invalid() {
+        assert!(!is_valid_session_id("zzzzzzzzzzzzzzzz"));
+        assert!(!is_valid_session_id("deadbeefcafebabg"));
+    }
+
+    #[test]
+    fn path_traversal_is_invalid() {
+        assert!(!is_valid_session_id("../something"));
+        assert!(!is_valid_session_id("..cafebabe0000000"));
+    }
+
+    #[test]
+    fn whitespace_is_invalid() {
+        assert!(!is_valid_session_id("deadbeef cafebabe"));
+        assert!(!is_valid_session_id(" deadbeefcafebabe"));
+        assert!(!is_valid_session_id("deadbeefcafebabe "));
+        assert!(!is_valid_session_id("deadbeef\ncafebabe"));
+    }
+
+    #[test]
+    fn nul_byte_is_invalid() {
+        assert!(!is_valid_session_id("deadbeef\0cafebabe"));
+    }
+}
+
 /// Tauri command: return the sessions panel's data for the Dashboard.
 #[cfg(feature = "webview")]
 #[tauri::command]
@@ -268,6 +365,11 @@ pub async fn session_list<R: tauri::Runtime>(
 
 /// Tauri command: open (or focus) the Session window for `id`. Delegates to
 /// the F-019 `WindowManager`.
+///
+/// **F-063 (M11 / T5):** `id` is validated against the canonical
+/// `SessionId` wire shape *before* the label is built. The capability
+/// file's `session-*` glob would otherwise match labels such as
+/// `session-../foo` produced from a path-traversal id.
 #[cfg(feature = "webview")]
 #[tauri::command]
 pub async fn open_session<R: tauri::Runtime>(
@@ -276,6 +378,9 @@ pub async fn open_session<R: tauri::Runtime>(
     id: String,
 ) -> Result<(), String> {
     crate::ipc::require_window_label(&webview, "dashboard")?;
+    if !is_valid_session_id(&id) {
+        return Err(INVALID_SESSION_ID_ERROR.to_string());
+    }
     crate::window_manager::WindowManager::new(app)
         .open_session(&id)
         .map(|_| ())

--- a/crates/forge-shell/tests/ipc_authz.rs
+++ b/crates/forge-shell/tests/ipc_authz.rs
@@ -240,3 +240,46 @@ fn non_dashboard_window_invoking_open_session_is_rejected() {
         "expected label-mismatch error, got: {err}"
     );
 }
+
+/// F-063 (M11 / T5): `open_session` must reject any id that does not match
+/// the canonical `SessionId` wire shape *before* the window is created, so
+/// the capability file's `session-*` glob cannot be matched by a label
+/// containing path-traversal or control characters.
+#[test]
+fn dashboard_window_invoking_open_session_with_invalid_id_is_rejected_and_creates_no_window() {
+    const INVALID_ID: &str = "../foo";
+    let malicious_label = format!("session-{INVALID_ID}");
+
+    let app = mock_builder()
+        .invoke_handler(tauri::generate_handler![
+            forge_shell::dashboard_sessions::open_session,
+        ])
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    let window = build_window(&app, "dashboard");
+
+    // Sanity: the malicious window does not exist before the call.
+    assert!(
+        app.get_webview_window(&malicious_label).is_none(),
+        "precondition: no window with label `{malicious_label}`"
+    );
+
+    let err = invoke(
+        &window,
+        "open_session",
+        serde_json::json!({ "id": INVALID_ID }),
+    )
+    .expect_err("open_session must reject non-canonical session ids");
+
+    assert!(
+        err.contains("invalid session id"),
+        "expected invalid-session-id error, got: {err}"
+    );
+
+    // The security property: no window was ever created for the malicious
+    // label. Without validation the `session-*` capability glob would match.
+    assert!(
+        app.get_webview_window(&malicious_label).is_none(),
+        "no window with label `{malicious_label}` must exist after a rejected open_session"
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#105

## Summary

- Validate `id` in `dashboard_sessions::open_session` against the canonical `SessionId::new()` wire shape (16 lowercase hex chars, no separators) before handing it to `WindowManager`. A caller passing an id like `../foo` or one containing NUL / whitespace would otherwise produce a window label (`session-../foo`) that still matches the capability's `session-*` glob.
- Enumerate every app-local command (`provider_status`, `session_list`, `open_session` for dashboard; `session_hello`, `session_subscribe`, `session_send_message`, `session_approve_tool`, `session_reject_tool` for session-*) in `capabilities/default.json`'s `description` field, tagged with its window scope, so a future Tauri upgrade that changes gating semantics produces a reviewable diff rather than a silent widening.
- Regression test (under `webview-test`) invokes `open_session` with `id = "../foo"` from a mock dashboard window and asserts both the `invalid session id` error and that no `session-../foo` webview window exists after the call.

Threat class: T5 (capability scope).

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo test -p forge-shell --features webview-test` passes (runs the `webview-test`-gated regression test; confirmed the test ran by name: `dashboard_window_invoking_open_session_with_invalid_id_is_rejected_and_creates_no_window ... ok`)
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo clippy -p forge-shell --no-default-features --tests -- -D warnings` passes (validator helper and error const gated via `cfg_attr(not(feature = "webview"), allow(dead_code))` so the no-webview build stays clean)

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).