### PR TITLE
fix(forge-providers): cap ollama list_models response body at 1 MiB (F-059)

### DIFF
--- a/crates/forge-providers/src/ollama.rs
+++ b/crates/forge-providers/src/ollama.rs
@@ -31,6 +31,11 @@ pub const DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434";
 
 /// Per-line NDJSON byte cap (1 MiB). Real Ollama chunks are <100 KB.
 pub const DEFAULT_MAX_LINE_BYTES: usize = 1 << 20;
+/// Cap on the buffered response body for `list_models()` (1 MiB). Real
+/// `/api/tags` responses are a few kilobytes; a multi-megabyte body is
+/// pathological and is rejected before `serde_json::from_slice` to bound
+/// peak allocation against a hostile peer on the loopback interface.
+pub const DEFAULT_MAX_BODY_BYTES: usize = 1 << 20;
 /// Wall-clock gap between consecutive chunks. 30 s is generous for local
 /// models but still bounds half-open and slow-drip peers.
 pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -197,9 +202,25 @@ impl OllamaProvider {
             .into());
         }
 
-        let value: serde_json::Value = resp
-            .json()
+        // Buffer the body and enforce a size cap before `serde_json::from_slice`.
+        // A hostile local peer can advertise any `Content-Length` and stream
+        // gigabytes into memory; the cap bounds peak allocation on the
+        // dashboard-refresh path. `resp.bytes()` still buffers, so this guards
+        // deserialization cost — transport-layer bounds (see `ClientConfig`)
+        // handle the wall-clock side.
+        let bytes = resp
+            .bytes()
             .await
+            .map_err(|e| anyhow::anyhow!("ollama list_models read failed: {e}"))?;
+        if bytes.len() > DEFAULT_MAX_BODY_BYTES {
+            return Err(anyhow::anyhow!(
+                "ollama list_models body too large: {} bytes exceeds cap of {} bytes",
+                bytes.len(),
+                DEFAULT_MAX_BODY_BYTES
+            )
+            .into());
+        }
+        let value: serde_json::Value = serde_json::from_slice(&bytes)
             .map_err(|e| anyhow::anyhow!("ollama list_models decode failed: {e}"))?;
 
         let models = value

--- a/crates/forge-providers/tests/ollama.rs
+++ b/crates/forge-providers/tests/ollama.rs
@@ -333,3 +333,41 @@ async fn list_models_returns_tag_names() {
     let models = provider.list_models().await.expect("list_models succeeds");
     assert_eq!(models, vec!["llama3", "mistral"]);
 }
+
+/// A malicious Ollama substitute that returns a multi-megabyte 200 OK body
+/// must not OOM the dashboard refresh. `list_models()` enforces a size cap
+/// before `serde_json::from_slice` and surfaces the overflow as a clean error.
+#[tokio::test(flavor = "multi_thread")]
+async fn list_models_rejects_oversized_body() {
+    let server = MockServer::start().await;
+
+    // 10 MiB of body (matches the DoD reproduction). Default cap is 1 MiB
+    // (see `DEFAULT_MAX_BODY_BYTES`), so this must error out — not OOM and
+    // not hang. Content is a large opaque string; the size check fires
+    // before deserialization, so the payload's JSON validity is irrelevant.
+    let oversized = "A".repeat(10 * 1024 * 1024);
+
+    Mock::given(method("GET"))
+        .and(path("/api/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(oversized))
+        .mount(&server)
+        .await;
+
+    let provider = OllamaProvider::new(server.uri(), "llama3");
+
+    let err = match provider.list_models().await {
+        Ok(_) => panic!("oversized body must map to an error"),
+        Err(e) => e,
+    };
+    let msg = format!("{err}");
+    // Must surface as an explicit size-cap error (not a generic JSON decode
+    // failure). The message should name the cap so operators can diagnose.
+    assert!(
+        msg.contains("cap") || msg.contains("too large"),
+        "error should describe the size cap, got: {msg}"
+    );
+    assert!(
+        msg.contains("1048576") || msg.contains("1 MiB") || msg.contains("1MiB"),
+        "error should name the cap value, got: {msg}"
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#101

## Summary
- `list_models()` buffered `resp.json()` with no size cap — a hostile peer on `127.0.0.1:11434` could stream multi-GB into memory on dashboard refresh.
- Added `DEFAULT_MAX_BODY_BYTES` (1 MiB) and rewrote `list_models()` to read bytes, enforce the cap, then `serde_json::from_slice`. The overflow surfaces as a typed anyhow error naming both the cap and the observed size.
- Added regression test `list_models_rejects_oversized_body` — wiremock `/api/tags` returns 10 MiB body; `list_models()` errors with the cap-specific message.
- Complements F-046 (transport-layer `total_timeout` on the `request_client`).

## Test plan
- `cargo test -p forge-providers` passes (7 integration tests, including the new one)
- `cargo test --workspace --exclude forge-shell` passes
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Scope note
`resp.bytes()` still fully buffers before the size check fires. This is the remediation the issue prescribes: it bounds deserialization cost. A stricter fix using `bytes_stream()` + cumulative accumulator would also bound peak network buffering but is a separate finding; transport-layer bounds from F-046 already cap wall-clock exposure on this path.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)