### PR TITLE
fix(forge-fs): cap read/write/edit byte sizes (F-061)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,6 @@ dependencies = [
 name = "forge-fs"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "glob",
  "hex",
  "sha2",

--- a/crates/forge-fs/Cargo.toml
+++ b/crates/forge-fs/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
 glob = "0.3"
 hex = "0.4"
 sha2 = "0.10"

--- a/crates/forge-fs/src/lib.rs
+++ b/crates/forge-fs/src/lib.rs
@@ -1,9 +1,10 @@
-use anyhow::{bail, Context, Result};
 use glob::Pattern;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
+mod limits;
 mod mutate;
+pub use limits::Limits;
 pub use mutate::{edit, edit_preview, write, write_preview, ApprovalPreview, FsError};
 
 /// Result of a successful `fs.read` operation.
@@ -14,16 +15,39 @@ pub struct ReadResult {
     pub sha256: String,
 }
 
-/// Read a file at `path`, validating it against the `allowed_paths` glob patterns.
+/// Read a file at `path`, validating it against `allowed_paths` glob patterns
+/// and rejecting files larger than `limits.max_read_bytes` *before* allocating
+/// the read buffer.
 ///
-/// The path is canonicalized before glob matching to prevent `..` traversal attacks.
-/// Returns `Err` if no pattern matches or the file cannot be read.
-pub fn read_file(path: &str, allowed_paths: &[String]) -> Result<ReadResult> {
-    // Canonicalize first so `..` components can't bypass glob patterns.
-    let canonical =
-        std::fs::canonicalize(path).with_context(|| format!("cannot resolve path '{path}'"))?;
-    validate_against_globs(&canonical, allowed_paths)?;
-    let raw = std::fs::read(&canonical)?;
+/// The path is canonicalized before glob matching to prevent `..` traversal.
+pub fn read_file(
+    path: &str,
+    allowed_paths: &[String],
+    limits: &Limits,
+) -> Result<ReadResult, FsError> {
+    let canonical = std::fs::canonicalize(path).map_err(|e| FsError::Io {
+        path: PathBuf::from(path),
+        source: e,
+    })?;
+    enforce_allowed(&canonical, allowed_paths)?;
+
+    let metadata = std::fs::metadata(&canonical).map_err(|e| FsError::Io {
+        path: canonical.clone(),
+        source: e,
+    })?;
+    let actual = metadata.len();
+    if actual > limits.max_read_bytes {
+        return Err(FsError::TooLarge {
+            path: canonical,
+            actual,
+            limit: limits.max_read_bytes,
+        });
+    }
+
+    let raw = std::fs::read(&canonical).map_err(|e| FsError::Io {
+        path: canonical.clone(),
+        source: e,
+    })?;
     let bytes = raw.len();
     let content = String::from_utf8_lossy(&raw).into_owned();
     let sha256 = hex::encode(Sha256::digest(&raw));
@@ -34,23 +58,10 @@ pub fn read_file(path: &str, allowed_paths: &[String]) -> Result<ReadResult> {
     })
 }
 
-fn validate_against_globs(path: &Path, allowed_paths: &[String]) -> Result<()> {
-    for pattern in allowed_paths {
-        if let Ok(pat) = Pattern::new(pattern) {
-            if pat.matches_path(path) {
-                return Ok(());
-            }
-        }
-    }
-    bail!("path '{}' is not allowed by allowed_paths", path.display());
-}
-
 /// Shared helper: return the canonical form of `path` only if every component is
 /// symlink-free. Used by both write and edit to enforce symlink rejection even
 /// when the enclosing directory is allowed.
 pub(crate) fn canonicalize_no_symlink(path: &Path) -> std::result::Result<PathBuf, FsError> {
-    // Walk each ancestor; if any ancestor is a symlink, reject.
-    // The target itself may or may not exist yet (write creates it).
     let mut cursor = PathBuf::new();
     for comp in path.components() {
         cursor.push(comp);
@@ -62,9 +73,6 @@ pub(crate) fn canonicalize_no_symlink(path: &Path) -> std::result::Result<PathBu
             }
         }
     }
-    // Prefer canonicalizing the parent (always exists for write; target itself for edit).
-    // If canonicalize succeeds on the full path, use it; otherwise canonicalize parent and
-    // append the file name.
     match std::fs::canonicalize(path) {
         Ok(p) => Ok(p),
         Err(_) => {

--- a/crates/forge-fs/src/limits.rs
+++ b/crates/forge-fs/src/limits.rs
@@ -1,0 +1,24 @@
+//! Byte-size caps for filesystem operations. Enforcement lives in `forge-fs`
+//! so callers cannot forget to apply it; see F-061 / M3 audit finding.
+
+/// Maximum bytes to read or write in a single `forge-fs` operation.
+///
+/// Defaults to 10 MiB for each direction. Bump via a custom `Limits` if your
+/// workload is known-bounded; tighten it in tests to exercise the cap without
+/// generating large fixtures.
+#[derive(Debug, Clone, Copy)]
+pub struct Limits {
+    pub max_read_bytes: u64,
+    pub max_write_bytes: u64,
+}
+
+const DEFAULT_LIMIT: u64 = 10 * 1024 * 1024;
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_read_bytes: DEFAULT_LIMIT,
+            max_write_bytes: DEFAULT_LIMIT,
+        }
+    }
+}

--- a/crates/forge-fs/src/mutate.rs
+++ b/crates/forge-fs/src/mutate.rs
@@ -8,7 +8,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use crate::{canonicalize_no_symlink, enforce_allowed};
+use crate::{canonicalize_no_symlink, enforce_allowed, Limits};
 
 /// Error variants for mutation operations. Matches the DoD vocabulary.
 #[derive(Debug, thiserror::Error)]
@@ -23,6 +23,12 @@ pub enum FsError {
     TargetMissing { path: PathBuf },
     #[error("malformed unified-diff patch: {reason}")]
     MalformedPatch { reason: String },
+    #[error("'{}' is {actual} bytes, exceeds limit of {limit}", path.display())]
+    TooLarge {
+        path: PathBuf,
+        actual: u64,
+        limit: u64,
+    },
     #[error("io error on '{}': {source}", path.display())]
     Io {
         path: PathBuf,
@@ -38,13 +44,27 @@ pub struct ApprovalPreview {
     pub description: String,
 }
 
-/// Atomically write `content` to `path` after validating the path.
+/// Atomically write `content` to `path` after validating the path and
+/// rejecting payloads larger than `limits.max_write_bytes`.
 ///
-/// Steps: reject symlinks → canonicalize → enforce `allowed_paths` glob →
-/// refuse if the parent dir is missing → write `content` to a sibling
+/// Steps: size cap → reject symlinks → canonicalize → enforce `allowed_paths`
+/// glob → refuse if the parent dir is missing → write `content` to a sibling
 /// `NamedTempFile` → `persist` (atomic rename on the same filesystem).
-pub fn write(path: &str, content: &str, allowed_paths: &[String]) -> Result<(), FsError> {
+pub fn write(
+    path: &str,
+    content: &str,
+    allowed_paths: &[String],
+    limits: &Limits,
+) -> Result<(), FsError> {
     let input = Path::new(path);
+    let actual = content.len() as u64;
+    if actual > limits.max_write_bytes {
+        return Err(FsError::TooLarge {
+            path: input.to_path_buf(),
+            actual,
+            limit: limits.max_write_bytes,
+        });
+    }
     let canonical = canonicalize_no_symlink(input)?;
     enforce_allowed(&canonical, allowed_paths)?;
 
@@ -77,8 +97,15 @@ pub fn write(path: &str, content: &str, allowed_paths: &[String]) -> Result<(), 
 }
 
 /// Apply a unified-diff `patch` to the file at `path` after validating the
-/// path. Writes atomically via [`write`]. Requires the target to exist.
-pub fn edit(path: &str, patch: &str, allowed_paths: &[String]) -> Result<(), FsError> {
+/// path. Rejects source files larger than `limits.max_read_bytes` before
+/// reading them into RAM, and delegates post-patch size enforcement to
+/// [`write`]. Writes atomically. Requires the target to exist.
+pub fn edit(
+    path: &str,
+    patch: &str,
+    allowed_paths: &[String],
+    limits: &Limits,
+) -> Result<(), FsError> {
     let input = Path::new(path);
     let canonical = canonicalize_no_symlink(input)?;
     enforce_allowed(&canonical, allowed_paths)?;
@@ -86,6 +113,19 @@ pub fn edit(path: &str, patch: &str, allowed_paths: &[String]) -> Result<(), FsE
     if !canonical.is_file() {
         return Err(FsError::TargetMissing {
             path: canonical.clone(),
+        });
+    }
+
+    let metadata = std::fs::metadata(&canonical).map_err(|e| FsError::Io {
+        path: canonical.clone(),
+        source: e,
+    })?;
+    let actual = metadata.len();
+    if actual > limits.max_read_bytes {
+        return Err(FsError::TooLarge {
+            path: canonical,
+            actual,
+            limit: limits.max_read_bytes,
         });
     }
 
@@ -100,7 +140,7 @@ pub fn edit(path: &str, patch: &str, allowed_paths: &[String]) -> Result<(), FsE
         path: canonical.clone(),
         source: std::io::Error::new(std::io::ErrorKind::InvalidData, "non-utf8 path"),
     })?;
-    write(canonical_str, &updated, allowed_paths)
+    write(canonical_str, &updated, allowed_paths, limits)
 }
 
 /// `ApprovalPreview` for a prospective write. Returns a content-only preview

--- a/crates/forge-fs/tests/fs_edit.rs
+++ b/crates/forge-fs/tests/fs_edit.rs
@@ -1,4 +1,4 @@
-use forge_fs::{edit, edit_preview, FsError};
+use forge_fs::{edit, edit_preview, FsError, Limits};
 use std::io::Write;
 use tempfile::tempdir;
 
@@ -23,7 +23,13 @@ fn edit_applies_unified_diff_patch() {
     let updated = "alpha\nBETA\ngamma\n";
     let patch = unified_diff(original, updated);
 
-    edit(target.to_str().unwrap(), &patch, &allowed).unwrap();
+    edit(
+        target.to_str().unwrap(),
+        &patch,
+        &allowed,
+        &Limits::default(),
+    )
+    .unwrap();
 
     let body = std::fs::read_to_string(&target).unwrap();
     assert_eq!(body, updated);
@@ -37,7 +43,13 @@ fn edit_rejects_malformed_patch() {
     let allowed = vec![canonical_glob(dir.path())];
     let bogus = "this is not a unified diff at all\n";
 
-    let err = edit(target.to_str().unwrap(), bogus, &allowed).unwrap_err();
+    let err = edit(
+        target.to_str().unwrap(),
+        bogus,
+        &allowed,
+        &Limits::default(),
+    )
+    .unwrap_err();
 
     assert!(
         matches!(err, FsError::MalformedPatch { .. }),
@@ -53,7 +65,13 @@ fn edit_rejects_path_outside_allowed_paths_with_path_denied() {
     let allowed = vec!["/nonexistent/allow/**".to_string()];
     let patch = unified_diff("a\n", "b\n");
 
-    let err = edit(target.to_str().unwrap(), &patch, &allowed).unwrap_err();
+    let err = edit(
+        target.to_str().unwrap(),
+        &patch,
+        &allowed,
+        &Limits::default(),
+    )
+    .unwrap_err();
 
     assert!(matches!(err, FsError::PathDenied { .. }), "got: {err:?}");
 }
@@ -72,7 +90,7 @@ fn edit_rejects_symlink_target() {
     let allowed = vec![canonical_glob(dir.path())];
     let patch = unified_diff("a\n", "b\n");
 
-    let err = edit(link.to_str().unwrap(), &patch, &allowed).unwrap_err();
+    let err = edit(link.to_str().unwrap(), &patch, &allowed, &Limits::default()).unwrap_err();
 
     assert!(matches!(err, FsError::SymlinkDenied { .. }), "got: {err:?}");
 }
@@ -84,7 +102,13 @@ fn edit_requires_target_file_to_exist() {
     let allowed = vec![canonical_glob(dir.path())];
     let patch = unified_diff("a\n", "b\n");
 
-    let err = edit(missing.to_str().unwrap(), &patch, &allowed).unwrap_err();
+    let err = edit(
+        missing.to_str().unwrap(),
+        &patch,
+        &allowed,
+        &Limits::default(),
+    )
+    .unwrap_err();
 
     assert!(matches!(err, FsError::TargetMissing { .. }), "got: {err:?}");
 }

--- a/crates/forge-fs/tests/fs_read.rs
+++ b/crates/forge-fs/tests/fs_read.rs
@@ -1,4 +1,4 @@
-use forge_fs::read_file;
+use forge_fs::{read_file, Limits};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -21,7 +21,7 @@ fn read_file_returns_content_bytes_sha256() {
     let path = f.path().to_str().unwrap();
     let allowed = vec![parent_glob(&f)];
 
-    let result = read_file(path, &allowed).unwrap();
+    let result = read_file(path, &allowed, &Limits::default()).unwrap();
 
     assert_eq!(result.content, "hello world");
     assert_eq!(result.bytes, 11);
@@ -35,8 +35,18 @@ fn read_file_sha256_differs_for_different_content() {
     let f1 = make_temp_file("hello world");
     let f2 = make_temp_file("different content");
 
-    let r1 = read_file(f1.path().to_str().unwrap(), &[parent_glob(&f1)]).unwrap();
-    let r2 = read_file(f2.path().to_str().unwrap(), &[parent_glob(&f2)]).unwrap();
+    let r1 = read_file(
+        f1.path().to_str().unwrap(),
+        &[parent_glob(&f1)],
+        &Limits::default(),
+    )
+    .unwrap();
+    let r2 = read_file(
+        f2.path().to_str().unwrap(),
+        &[parent_glob(&f2)],
+        &Limits::default(),
+    )
+    .unwrap();
 
     assert_ne!(r1.sha256, r2.sha256);
 }
@@ -49,7 +59,7 @@ fn read_file_rejects_path_not_in_allowed_globs() {
     // No matching glob
     let allowed = vec!["/nonexistent/**".to_string()];
 
-    let err = read_file(path, &allowed).unwrap_err();
+    let err = read_file(path, &allowed, &Limits::default()).unwrap_err();
     let msg = err.to_string();
     assert!(
         msg.contains("not allowed") || msg.contains("denied"),
@@ -62,7 +72,7 @@ fn read_file_rejects_empty_allowed_paths() {
     let f = make_temp_file("data");
     let path = f.path().to_str().unwrap();
 
-    let err = read_file(path, &[]).unwrap_err();
+    let err = read_file(path, &[], &Limits::default()).unwrap_err();
     let msg = err.to_string();
     assert!(
         msg.contains("not allowed") || msg.contains("denied"),
@@ -73,7 +83,12 @@ fn read_file_rejects_empty_allowed_paths() {
 #[test]
 fn read_file_errors_on_missing_file() {
     let allowed = vec!["/**".to_string()];
-    let err = read_file("/nonexistent/path/to/missing.txt", &allowed).unwrap_err();
+    let err = read_file(
+        "/nonexistent/path/to/missing.txt",
+        &allowed,
+        &Limits::default(),
+    )
+    .unwrap_err();
     let msg = err.to_string();
     assert!(
         msg.contains("No such file")
@@ -92,7 +107,7 @@ fn read_file_allows_exact_path_glob() {
     let canonical_str = canonical_path.to_str().unwrap();
     let allowed = vec![canonical_str.to_string()];
 
-    let result = read_file(f.path().to_str().unwrap(), &allowed).unwrap();
+    let result = read_file(f.path().to_str().unwrap(), &allowed, &Limits::default()).unwrap();
     assert_eq!(result.content, "exact");
 }
 
@@ -106,7 +121,7 @@ fn read_file_blocks_path_traversal() {
     // (Only allow paths under "/allowed/**" — never the actual temp location)
     let allowed = vec!["/allowed/**".to_string()];
 
-    let err = read_file(f.path().to_str().unwrap(), &allowed).unwrap_err();
+    let err = read_file(f.path().to_str().unwrap(), &allowed, &Limits::default()).unwrap_err();
     let msg = err.to_string();
     // After canonicalization, the real path (not under /allowed) must be rejected.
     assert!(

--- a/crates/forge-fs/tests/fs_size_limits.rs
+++ b/crates/forge-fs/tests/fs_size_limits.rs
@@ -1,0 +1,187 @@
+//! Regression tests for F-061 / M3: byte-size caps on forge-fs read/write/edit.
+//! Uses small explicit `Limits` so tests stay fast and don't write 10 MiB files.
+
+use forge_fs::{edit, read_file, write, FsError, Limits};
+use std::io::Write;
+use tempfile::{tempdir, NamedTempFile};
+
+fn make_temp_file(content: &str) -> NamedTempFile {
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+    f
+}
+
+fn parent_glob(f: &NamedTempFile) -> String {
+    let canonical = std::fs::canonicalize(f.path()).unwrap();
+    let parent = canonical.parent().unwrap().to_str().unwrap();
+    format!("{}/**", parent)
+}
+
+fn canonical_glob(dir: &std::path::Path) -> String {
+    let canonical = std::fs::canonicalize(dir).unwrap();
+    format!("{}/**", canonical.to_str().unwrap())
+}
+
+fn unified_diff(old: &str, new: &str) -> String {
+    similar::TextDiff::from_lines(old, new)
+        .unified_diff()
+        .to_string()
+}
+
+#[test]
+fn read_file_rejects_file_larger_than_cap_with_typed_error() {
+    let f = make_temp_file(&"x".repeat(1024));
+    let allowed = vec![parent_glob(&f)];
+    let limits = Limits {
+        max_read_bytes: 64,
+        max_write_bytes: 64,
+    };
+
+    let err = read_file(f.path().to_str().unwrap(), &allowed, &limits).unwrap_err();
+
+    match err {
+        FsError::TooLarge { actual, limit, .. } => {
+            assert_eq!(actual, 1024);
+            assert_eq!(limit, 64);
+        }
+        other => panic!("expected FsError::TooLarge, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_file_accepts_file_at_or_below_cap() {
+    let f = make_temp_file("small");
+    let allowed = vec![parent_glob(&f)];
+    let limits = Limits {
+        max_read_bytes: 64,
+        max_write_bytes: 64,
+    };
+
+    let result = read_file(f.path().to_str().unwrap(), &allowed, &limits).unwrap();
+    assert_eq!(result.content, "small");
+}
+
+#[test]
+fn read_file_default_limits_accept_small_files() {
+    let f = make_temp_file("hello");
+    let allowed = vec![parent_glob(&f)];
+
+    let result = read_file(f.path().to_str().unwrap(), &allowed, &Limits::default()).unwrap();
+    assert_eq!(result.content, "hello");
+}
+
+#[test]
+fn write_rejects_content_larger_than_cap_with_typed_error() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("out.txt");
+    let allowed = vec![canonical_glob(dir.path())];
+    let limits = Limits {
+        max_read_bytes: 64,
+        max_write_bytes: 64,
+    };
+    let payload = "y".repeat(1024);
+
+    let err = write(target.to_str().unwrap(), &payload, &allowed, &limits).unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            FsError::TooLarge {
+                actual: 1024,
+                limit: 64,
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+    assert!(!target.exists(), "oversized write must not touch disk");
+}
+
+#[test]
+fn write_accepts_content_at_or_below_cap() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("out.txt");
+    let allowed = vec![canonical_glob(dir.path())];
+    let limits = Limits {
+        max_read_bytes: 64,
+        max_write_bytes: 64,
+    };
+
+    write(target.to_str().unwrap(), "small", &allowed, &limits).unwrap();
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "small");
+}
+
+#[test]
+fn edit_rejects_source_file_larger_than_read_cap() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("src.txt");
+    std::fs::write(&target, "x".repeat(1024)).unwrap();
+    let allowed = vec![canonical_glob(dir.path())];
+    let limits = Limits {
+        max_read_bytes: 64,
+        max_write_bytes: 10 * 1024 * 1024,
+    };
+    let patch = "@@ -1,1 +1,1 @@\n-x\n+y\n";
+
+    let err = edit(target.to_str().unwrap(), patch, &allowed, &limits).unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            FsError::TooLarge {
+                actual: 1024,
+                limit: 64,
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn edit_rejects_post_patch_output_larger_than_write_cap() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("src.txt");
+    let original = "alpha\n";
+    std::fs::write(&target, original).unwrap();
+    let allowed = vec![canonical_glob(dir.path())];
+    // Read cap is large so we get past stat; write cap is tiny so post-patch fails.
+    let limits = Limits {
+        max_read_bytes: 10 * 1024 * 1024,
+        max_write_bytes: 4,
+    };
+    // Diff that expands one short line into a much larger line.
+    let expanded = "alpha plus much more content here\n";
+    let patch = unified_diff(original, expanded);
+
+    let err = edit(target.to_str().unwrap(), &patch, &allowed, &limits).unwrap_err();
+
+    assert!(matches!(err, FsError::TooLarge { .. }), "got: {err:?}");
+    // File must be unchanged.
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), original);
+}
+
+#[test]
+fn edit_accepts_when_both_caps_honored() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("src.txt");
+    let original = "alpha\nbeta\ngamma\n";
+    std::fs::write(&target, original).unwrap();
+    let allowed = vec![canonical_glob(dir.path())];
+    let limits = Limits {
+        max_read_bytes: 1024,
+        max_write_bytes: 1024,
+    };
+    let updated = "alpha\nBETA\ngamma\n";
+    let patch = unified_diff(original, updated);
+
+    edit(target.to_str().unwrap(), &patch, &allowed, &limits).unwrap();
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), updated);
+}
+
+#[test]
+fn limits_default_is_ten_mebibytes_each() {
+    let d = Limits::default();
+    assert_eq!(d.max_read_bytes, 10 * 1024 * 1024);
+    assert_eq!(d.max_write_bytes, 10 * 1024 * 1024);
+}

--- a/crates/forge-fs/tests/fs_write.rs
+++ b/crates/forge-fs/tests/fs_write.rs
@@ -1,4 +1,4 @@
-use forge_fs::{write, write_preview, FsError};
+use forge_fs::{write, write_preview, FsError, Limits};
 use std::io::Write;
 use tempfile::tempdir;
 
@@ -13,7 +13,13 @@ fn write_creates_file_atomically_when_path_allowed() {
     let target = dir.path().join("hello.txt");
     let allowed = vec![canonical_glob(dir.path())];
 
-    write(target.to_str().unwrap(), "hello world", &allowed).unwrap();
+    write(
+        target.to_str().unwrap(),
+        "hello world",
+        &allowed,
+        &Limits::default(),
+    )
+    .unwrap();
 
     let body = std::fs::read_to_string(&target).unwrap();
     assert_eq!(body, "hello world");
@@ -26,7 +32,13 @@ fn write_overwrites_existing_file_atomically() {
     std::fs::write(&target, "old").unwrap();
     let allowed = vec![canonical_glob(dir.path())];
 
-    write(target.to_str().unwrap(), "new", &allowed).unwrap();
+    write(
+        target.to_str().unwrap(),
+        "new",
+        &allowed,
+        &Limits::default(),
+    )
+    .unwrap();
 
     let body = std::fs::read_to_string(&target).unwrap();
     assert_eq!(body, "new");
@@ -38,7 +50,13 @@ fn write_rejects_path_outside_allowed_paths_with_path_denied() {
     let target = dir.path().join("blocked.txt");
     let allowed = vec!["/nonexistent/allow/**".to_string()];
 
-    let err = write(target.to_str().unwrap(), "nope", &allowed).unwrap_err();
+    let err = write(
+        target.to_str().unwrap(),
+        "nope",
+        &allowed,
+        &Limits::default(),
+    )
+    .unwrap_err();
 
     assert!(matches!(err, FsError::PathDenied { .. }), "got: {err:?}");
 }
@@ -58,7 +76,13 @@ fn write_rejects_symlink_parent() {
     // allow the real directory; symlinked path must still be rejected
     let allowed = vec![canonical_glob(dir.path())];
 
-    let err = write(target.to_str().unwrap(), "payload", &allowed).unwrap_err();
+    let err = write(
+        target.to_str().unwrap(),
+        "payload",
+        &allowed,
+        &Limits::default(),
+    )
+    .unwrap_err();
 
     assert!(matches!(err, FsError::SymlinkDenied { .. }), "got: {err:?}");
 }
@@ -69,7 +93,7 @@ fn write_refuses_to_create_parent_directories() {
     let target = dir.path().join("missing_parent").join("file.txt");
     let allowed = vec![canonical_glob(dir.path())];
 
-    let err = write(target.to_str().unwrap(), "x", &allowed).unwrap_err();
+    let err = write(target.to_str().unwrap(), "x", &allowed, &Limits::default()).unwrap_err();
 
     assert!(matches!(err, FsError::ParentMissing { .. }), "got: {err:?}");
 }

--- a/crates/forge-session/src/tools/fs_edit.rs
+++ b/crates/forge-session/src/tools/fs_edit.rs
@@ -24,7 +24,12 @@ impl Tool for FsEditTool {
     fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
         let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
         let patch = args.get("patch").and_then(|v| v.as_str()).unwrap_or("");
-        match forge_fs::edit(path, patch, &ctx.allowed_paths) {
+        match forge_fs::edit(
+            path,
+            patch,
+            &ctx.allowed_paths,
+            &forge_fs::Limits::default(),
+        ) {
             Ok(()) => serde_json::json!({ "ok": true }),
             Err(e) => serde_json::json!({ "error": e.to_string() }),
         }

--- a/crates/forge-session/src/tools/fs_read.rs
+++ b/crates/forge-session/src/tools/fs_read.rs
@@ -20,7 +20,7 @@ impl Tool for FsReadTool {
 
     fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
         let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
-        match forge_fs::read_file(path, &ctx.allowed_paths) {
+        match forge_fs::read_file(path, &ctx.allowed_paths, &forge_fs::Limits::default()) {
             Ok(r) => serde_json::json!({
                 "content": r.content,
                 "bytes": r.bytes,

--- a/crates/forge-session/src/tools/fs_write.rs
+++ b/crates/forge-session/src/tools/fs_write.rs
@@ -24,7 +24,12 @@ impl Tool for FsWriteTool {
     fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
         let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
         let content = args.get("content").and_then(|v| v.as_str()).unwrap_or("");
-        match forge_fs::write(path, content, &ctx.allowed_paths) {
+        match forge_fs::write(
+            path,
+            content,
+            &ctx.allowed_paths,
+            &forge_fs::Limits::default(),
+        ) {
             Ok(()) => serde_json::json!({ "ok": true }),
             Err(e) => serde_json::json!({ "error": e.to_string() }),
         }


### PR DESCRIPTION
Closes forge-ide/forge#103

## Summary
- forge-fs exposes configurable byte-size caps for read and write/edit paths; defaults enforced (10 MiB each via `Limits::default`).
- `read_file` stats via `fs::metadata` before allocating, rejecting oversized inputs with the new typed `FsError::TooLarge` variant.
- `write` rejects oversized content before touching disk; `edit` stats the source file against `max_read_bytes` pre-read and delegates post-patch size enforcement to `write`.
- Callers in `forge-session` pass `&Limits::default()`; `ToolCtx` is unchanged.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)