### PR TITLE
fix(web): narrow session:event payloads at Rust → TS boundary (F-064)

### DIFF
--- a/web/packages/app/src/ipc/events.test.ts
+++ b/web/packages/app/src/ipc/events.test.ts
@@ -275,3 +275,106 @@ describe('fromRustEvent — assistant_message', () => {
     expect(fromRustEvent(rust)).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// F-064 / M12 / T7 — Runtime narrowing regression tests.
+//
+// Before narrowing, required string/shape fields were type-asserted with
+// `as string` / `as { description: string }`, so malformed daemon payloads
+// (bug, version skew, compromised bridge writer) silently flowed into the
+// messages store as `undefined`. Downstream, `AssistantDelta` concatenated
+// the literal "undefined" into chat text, and `ApprovalPrompt` dereferenced
+// `preview.description` on an undefined object and threw at render time.
+//
+// fromRustEvent must now reject these payloads (return null) rather than
+// forwarding garbage. See docs/audits/phase-1/findings/M12.md.
+// ---------------------------------------------------------------------------
+
+describe('fromRustEvent — narrowing drops malformed required fields', () => {
+  it('drops user_message missing id', () => {
+    expect(fromRustEvent({ type: 'user_message', text: 'hi' })).toBeNull();
+  });
+
+  it('drops user_message missing text', () => {
+    expect(fromRustEvent({ type: 'user_message', id: 'm1' })).toBeNull();
+  });
+
+  it('drops user_message with non-string text', () => {
+    expect(fromRustEvent({ type: 'user_message', id: 'm1', text: 42 })).toBeNull();
+  });
+
+  it('drops tool_call_rejected missing id', () => {
+    expect(fromRustEvent({ type: 'tool_call_rejected', reason: 'x' })).toBeNull();
+  });
+
+  it('drops tool_call_completed missing id', () => {
+    expect(fromRustEvent({ type: 'tool_call_completed', result: {} })).toBeNull();
+  });
+
+  it('drops tool_call_approval_requested missing id', () => {
+    expect(
+      fromRustEvent({ type: 'tool_call_approval_requested', preview: { description: 'x' } }),
+    ).toBeNull();
+  });
+
+  it('drops tool_call_approval_requested missing preview (ApprovalPrompt crash repro)', () => {
+    expect(fromRustEvent({ type: 'tool_call_approval_requested', id: 'tc-x' })).toBeNull();
+  });
+
+  it('drops tool_call_approval_requested with preview missing description', () => {
+    expect(
+      fromRustEvent({ type: 'tool_call_approval_requested', id: 'tc-x', preview: {} }),
+    ).toBeNull();
+  });
+
+  it('drops tool_call_approval_requested with preview.description non-string', () => {
+    expect(
+      fromRustEvent({
+        type: 'tool_call_approval_requested',
+        id: 'tc-x',
+        preview: { description: 123 },
+      }),
+    ).toBeNull();
+  });
+
+  it('drops tool_call_started missing tool name', () => {
+    expect(
+      fromRustEvent({ type: 'tool_call_started', id: 'tc-1', args: {} }),
+    ).toBeNull();
+  });
+
+  it('drops tool_call_started missing id', () => {
+    expect(
+      fromRustEvent({ type: 'tool_call_started', tool: 'fs.read', args: {} }),
+    ).toBeNull();
+  });
+
+  it('drops assistant_delta missing delta (AssistantDelta undefined-concat repro)', () => {
+    expect(fromRustEvent({ type: 'assistant_delta', id: 'm1' })).toBeNull();
+  });
+
+  it('drops assistant_delta with non-string delta', () => {
+    expect(fromRustEvent({ type: 'assistant_delta', id: 'm1', delta: 42 })).toBeNull();
+  });
+
+  it('drops assistant_delta missing id', () => {
+    expect(fromRustEvent({ type: 'assistant_delta', delta: 'hi' })).toBeNull();
+  });
+
+  it('drops finalised assistant_message missing text', () => {
+    expect(
+      fromRustEvent({ type: 'assistant_message', id: 'm1', stream_finalised: true }),
+    ).toBeNull();
+  });
+
+  it('drops finalised assistant_message with non-string text', () => {
+    expect(
+      fromRustEvent({
+        type: 'assistant_message',
+        id: 'm1',
+        stream_finalised: true,
+        text: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/web/packages/app/src/ipc/events.ts
+++ b/web/packages/app/src/ipc/events.ts
@@ -6,8 +6,48 @@
 // `message_id` instead of `id`, `args_json` string instead of `args` value, etc.).
 // This adapter is the single conversion point — call it at the IPC boundary.
 // Returns `null` for variants that have no renderable effect.
+//
+// F-064 / M12 / T7 — Runtime narrowing. Every required field is checked with
+// `typeof` / shape predicates before the event crosses into the store. If a
+// malformed payload arrives (daemon bug, version skew, compromised bridge
+// writer), we drop the event (return `null`) rather than `as string`-casting
+// `undefined`/`number`/object values into fields downstream code assumes are
+// strings. A single `warn` per (type, missing field) keys the drift so it
+// surfaces in the console without flooding.
 
 import type { SessionEvent } from '../stores/messages';
+
+// ---------------------------------------------------------------------------
+// Narrowing helpers
+// ---------------------------------------------------------------------------
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string';
+}
+
+function isObjectWith<K extends string>(
+  v: unknown,
+  key: K,
+): v is Record<K, unknown> {
+  return typeof v === 'object' && v !== null && key in v;
+}
+
+// Warn once per (type, reason) so a malformed payload surfaces but doesn't
+// spam the console when the daemon is emitting the same bad shape repeatedly.
+const warnedDrops = new Set<string>();
+function warnDrop(type: string, reason: string): void {
+  const key = `${type}:${reason}`;
+  if (warnedDrops.has(key)) return;
+  warnedDrops.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[ipc/events] dropped malformed ${type} event: ${reason}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
 
 export function fromRustEvent(rustEvent: unknown): SessionEvent | null {
   if (typeof rustEvent !== 'object' || rustEvent === null) return null;
@@ -15,44 +55,83 @@ export function fromRustEvent(rustEvent: unknown): SessionEvent | null {
   const type = ev['type'];
 
   if (type === 'user_message') {
-    return {
-      kind: 'UserMessage',
-      message_id: ev['id'] as string,
-      text: ev['text'] as string,
-    };
+    const id = ev['id'];
+    const text = ev['text'];
+    if (!isString(id)) {
+      warnDrop('user_message', 'id missing or not a string');
+      return null;
+    }
+    if (!isString(text)) {
+      warnDrop('user_message', 'text missing or not a string');
+      return null;
+    }
+    return { kind: 'UserMessage', message_id: id, text };
   }
 
   if (type === 'tool_call_rejected') {
+    const id = ev['id'];
+    if (!isString(id)) {
+      warnDrop('tool_call_rejected', 'id missing or not a string');
+      return null;
+    }
     const reason = ev['reason'];
     return {
       kind: 'ToolCallFailed',
-      tool_call_id: ev['id'] as string,
-      error: typeof reason === 'string' && reason.length > 0 ? reason : 'rejected',
+      tool_call_id: id,
+      error: isString(reason) && reason.length > 0 ? reason : 'rejected',
     };
   }
 
   if (type === 'tool_call_completed') {
+    const id = ev['id'];
+    if (!isString(id)) {
+      warnDrop('tool_call_completed', 'id missing or not a string');
+      return null;
+    }
     return {
       kind: 'ToolCallCompleted',
-      tool_call_id: ev['id'] as string,
+      tool_call_id: id,
       result_summary: JSON.stringify(ev['result'] ?? null).slice(0, 200),
     };
   }
 
   if (type === 'tool_call_approval_requested') {
+    const id = ev['id'];
+    if (!isString(id)) {
+      warnDrop('tool_call_approval_requested', 'id missing or not a string');
+      return null;
+    }
+    const preview = ev['preview'];
+    if (!isObjectWith(preview, 'description') || !isString(preview.description)) {
+      warnDrop(
+        'tool_call_approval_requested',
+        'preview missing or preview.description not a string',
+      );
+      return null;
+    }
     return {
       kind: 'ToolCallApprovalRequested',
-      tool_call_id: ev['id'] as string,
-      preview: ev['preview'] as { description: string },
+      tool_call_id: id,
+      preview: { description: preview.description },
     };
   }
 
   if (type === 'tool_call_started') {
+    const id = ev['id'];
+    if (!isString(id)) {
+      warnDrop('tool_call_started', 'id missing or not a string');
+      return null;
+    }
+    const tool = ev['tool'];
+    if (!isString(tool)) {
+      warnDrop('tool_call_started', 'tool missing or not a string');
+      return null;
+    }
     const parallelGroup = ev['parallel_group'];
     const out: SessionEvent = {
       kind: 'ToolCallStarted',
-      tool_call_id: ev['id'] as string,
-      tool_name: ev['tool'] as string,
+      tool_call_id: id,
+      tool_name: tool,
       args_json: JSON.stringify(ev['args'] ?? null),
     };
     if (typeof parallelGroup === 'number') {
@@ -62,11 +141,17 @@ export function fromRustEvent(rustEvent: unknown): SessionEvent | null {
   }
 
   if (type === 'assistant_delta') {
-    return {
-      kind: 'AssistantDelta',
-      message_id: ev['id'] as string,
-      delta: ev['delta'] as string,
-    };
+    const id = ev['id'];
+    if (!isString(id)) {
+      warnDrop('assistant_delta', 'id missing or not a string');
+      return null;
+    }
+    const delta = ev['delta'];
+    if (!isString(delta)) {
+      warnDrop('assistant_delta', 'delta missing or not a string');
+      return null;
+    }
+    return { kind: 'AssistantDelta', message_id: id, delta };
   }
 
   if (type === 'assistant_message') {
@@ -77,11 +162,17 @@ export function fromRustEvent(rustEvent: unknown): SessionEvent | null {
     // empty, non-streaming assistant turn that intercepts subsequent deltas
     // and suppresses the streaming cursor. Drop stream-open.
     if (ev['stream_finalised'] !== true) return null;
-    return {
-      kind: 'AssistantMessage',
-      message_id: ev['id'] as string,
-      text: ev['text'] as string,
-    };
+    const id = ev['id'];
+    if (!isString(id)) {
+      warnDrop('assistant_message', 'id missing or not a string');
+      return null;
+    }
+    const text = ev['text'];
+    if (!isString(text)) {
+      warnDrop('assistant_message', 'text missing or not a string');
+      return null;
+    }
+    return { kind: 'AssistantMessage', message_id: id, text };
   }
 
   return null;


### PR DESCRIPTION
Closes forge-ide/forge#106

## Summary

- `fromRustEvent` in `web/packages/app/src/ipc/events.ts` now narrows every required field with `typeof` / shape checks (`isString`, `isObjectWith`) and returns `null` on mismatch, instead of silently `as string`-casting through `unknown`.
- Added a `warnDrop` helper that logs once per event-key + field-key pair when a payload is dropped — schema drift surfaces in the console without spam.
- 16 new regression tests cover every variant's required-field validation and missing/wrong-type rejection.

## Test plan

- [x] `events.test.ts`: 16 new tests pass (204 total in the suite)
- [x] Typecheck clean
- [x] No behavioral change on well-formed payloads — every existing variant test still passes

## Verification status

PR is open; DoD and code-review gates pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)