### PR TITLE
fix(forge-providers): validate OLLAMA_BASE_URL scheme/host (F-058)

### DIFF
--- a/crates/forge-providers/src/ollama.rs
+++ b/crates/forge-providers/src/ollama.rs
@@ -26,8 +26,74 @@ use std::time::Duration;
 use crate::{ChatChunk, ChatMessage, ChatRequest, Provider, StreamErrorKind};
 use forge_core::Result;
 use futures::stream::{BoxStream, StreamExt};
+use reqwest::Url;
 
 pub const DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434";
+
+/// Opt-in env var that gates non-loopback `OLLAMA_BASE_URL` values. Strict
+/// literal match against `"1"` — no other spelling is accepted so typos
+/// don't accidentally enable remote dialing.
+pub const ALLOW_REMOTE_ENV: &str = "FORGE_ALLOW_REMOTE_OLLAMA";
+
+/// Validate a user-supplied Ollama base URL against the loopback policy.
+///
+/// F-058 / M5 (T7 — config injection / trust boundary). `OLLAMA_BASE_URL` is
+/// read from the process environment and sets where LLM traffic and every
+/// `ChatBlock::ToolResult` payload (including `fs.read` content) is sent.
+/// Because `reqwest` is built with `rustls-tls`, an unvalidated URL can
+/// TLS-dial any host — an attacker with env-var write access (shell-init,
+/// `terminal.integrated.env`, `.envrc`, PATH-hijacked launcher) turns the
+/// agent into a remote-controlled exfiltration channel.
+///
+/// Policy:
+/// - `raw` is `None` or empty → fall back to [`DEFAULT_BASE_URL`].
+/// - Scheme must be `http` (Ollama's loopback convention; `https` is rejected
+///   even under opt-in — the trust model is loopback, not TLS-anywhere).
+/// - Host must be exact-match `127.0.0.1`, `localhost`, or `::1` unless
+///   `allow_remote` is true. Exact-match — not `starts_with` — so
+///   `127.0.0.1.attacker.com` is rejected.
+pub fn validate_base_url(raw: Option<&str>, allow_remote: bool) -> Result<Url> {
+    let raw = raw.map(str::trim).filter(|s| !s.is_empty());
+    let input = raw.unwrap_or(DEFAULT_BASE_URL);
+
+    let url = Url::parse(input)
+        .map_err(|e| anyhow::anyhow!("OLLAMA_BASE_URL parse failed for {input:?}: {e}"))?;
+
+    if url.scheme() != "http" {
+        return Err(anyhow::anyhow!(
+            "OLLAMA_BASE_URL scheme {:?} is not allowed; only `http` is accepted \
+             (Ollama loopback convention)",
+            url.scheme()
+        )
+        .into());
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow::anyhow!("OLLAMA_BASE_URL {input:?} has no host"))?;
+
+    // `Url::host_str()` lowercases DNS names and, for IPv6 literals, returns
+    // the bracketed form (`"[::1]"`). Match both spellings defensively; a
+    // future `url` upgrade that switches to unbracketed will still pass.
+    let is_loopback = matches!(host, "127.0.0.1" | "localhost" | "::1" | "[::1]");
+
+    if !is_loopback && !allow_remote {
+        return Err(anyhow::anyhow!(
+            "OLLAMA_BASE_URL host {host:?} is not loopback; set \
+             {ALLOW_REMOTE_ENV}=1 to explicitly opt in to a remote Ollama endpoint"
+        )
+        .into());
+    }
+
+    Ok(url)
+}
+
+/// Parse the `FORGE_ALLOW_REMOTE_OLLAMA` env-var value. Strict: only literal
+/// `"1"` is accepted. Any other value (including `"true"`, `"yes"`, or empty)
+/// is treated as not-set so a typo cannot silently unlock remote dialing.
+pub fn parse_allow_remote(raw: Option<&str>) -> bool {
+    raw == Some("1")
+}
 
 /// Per-line NDJSON byte cap (1 MiB). Real Ollama chunks are <100 KB.
 pub const DEFAULT_MAX_LINE_BYTES: usize = 1 << 20;
@@ -606,5 +672,163 @@ mod tests {
                 args: serde_json::json!({"path": "/tmp/x"}),
             })
         );
+    }
+
+    // ── validate_base_url: scheme/host policy ─────────────────────────────────
+    //
+    // F-058 / M5 (T7): `OLLAMA_BASE_URL` is a single-user trust boundary. An
+    // attacker who can plant shell-init env vars otherwise redirects LLM and
+    // tool-result traffic off-box. Policy: `http` only, loopback host only,
+    // remote hosts gated by an explicit opt-in (`FORGE_ALLOW_REMOTE_OLLAMA=1`).
+
+    #[test]
+    fn validate_base_url_accepts_default_when_raw_is_none() {
+        let url = validate_base_url(None, false).expect("default must pass");
+        assert_eq!(url.scheme(), "http");
+        assert_eq!(url.host_str(), Some("127.0.0.1"));
+    }
+
+    #[test]
+    fn validate_base_url_accepts_default_when_raw_is_empty() {
+        // Empty string (unset-but-present env var shape) is treated as unset
+        // so operators can't accidentally zero the URL to ""
+        let url = validate_base_url(Some(""), false).expect("empty must fall back");
+        assert_eq!(url.host_str(), Some("127.0.0.1"));
+    }
+
+    #[test]
+    fn validate_base_url_accepts_loopback_ipv4() {
+        let url = validate_base_url(Some("http://127.0.0.1:11434"), false).expect("loopback v4");
+        assert_eq!(url.host_str(), Some("127.0.0.1"));
+    }
+
+    #[test]
+    fn validate_base_url_accepts_localhost() {
+        validate_base_url(Some("http://localhost:11434"), false).expect("localhost");
+    }
+
+    #[test]
+    fn validate_base_url_accepts_localhost_uppercase() {
+        // `Url::parse` lowercases host; lock that assumption so a future
+        // upgrade that changes it doesn't silently reject valid input.
+        validate_base_url(Some("http://LOCALHOST:11434"), false).expect("LOCALHOST");
+    }
+
+    #[test]
+    fn validate_base_url_accepts_loopback_ipv6() {
+        // `Url::host_str()` strips the brackets; assert the normalized form.
+        let url = validate_base_url(Some("http://[::1]:11434"), false).expect("loopback v6");
+        assert_eq!(url.host_str(), Some("[::1]"));
+    }
+
+    #[test]
+    fn validate_base_url_rejects_https_even_loopback() {
+        let err = validate_base_url(Some("https://127.0.0.1:11434"), false)
+            .expect_err("https must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("scheme"),
+            "error must name the scheme policy, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_base_url_rejects_remote_host_without_opt_in() {
+        let err = validate_base_url(Some("http://example.com"), false)
+            .expect_err("non-loopback must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("FORGE_ALLOW_REMOTE_OLLAMA"),
+            "error must name the opt-in env var, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_base_url_rejects_https_remote_even_with_opt_in() {
+        // Scheme policy is independent of the host opt-in — `https` is always
+        // rejected because our trust model is for the Ollama loopback
+        // convention, not for TLS-dialing arbitrary servers.
+        let err = validate_base_url(Some("https://example.com"), true)
+            .expect_err("https must still be rejected under opt-in");
+        let msg = format!("{err}");
+        assert!(msg.contains("scheme"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_base_url_rejects_prefix_spoof_of_loopback() {
+        // A host like `127.0.0.1.attacker.com` must be rejected — the policy
+        // is exact host match, not a `starts_with` check.
+        let err = validate_base_url(Some("http://127.0.0.1.attacker.com"), false)
+            .expect_err("prefix-spoof must be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("FORGE_ALLOW_REMOTE_OLLAMA"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_base_url_accepts_remote_with_opt_in() {
+        let url = validate_base_url(Some("http://example.com"), true).expect("opt-in remote");
+        assert_eq!(url.host_str(), Some("example.com"));
+    }
+
+    #[test]
+    fn validate_base_url_rejects_non_http_scheme() {
+        let err =
+            validate_base_url(Some("ftp://127.0.0.1"), false).expect_err("ftp must be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("scheme"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_base_url_rejects_file_scheme() {
+        let err = validate_base_url(Some("file:///etc/passwd"), false)
+            .expect_err("file must be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("scheme"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_base_url_rejects_malformed_url() {
+        let err =
+            validate_base_url(Some("not a url"), false).expect_err("malformed must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("parse") || msg.contains("OLLAMA_BASE_URL"),
+            "error should name the input or parse failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_base_url_rejects_url_without_host() {
+        // `http:///foo` parses but has no host — treat as invalid.
+        let err =
+            validate_base_url(Some("http:///foo"), false).expect_err("no-host must be rejected");
+        let msg = format!("{err}");
+        // Message should reach the user; exact wording is not asserted, just
+        // that we fail rather than dial an empty host.
+        assert!(!msg.is_empty());
+    }
+
+    // ── opt-in env-var parsing ────────────────────────────────────────────────
+    //
+    // `FORGE_ALLOW_REMOTE_OLLAMA` is strict: only literal `"1"` counts.
+    // Anything else (including common truthy spellings) is not opt-in so
+    // typos don't accidentally unlock remote dialing.
+
+    #[test]
+    fn allow_remote_parses_one_as_true() {
+        assert!(parse_allow_remote(Some("1")));
+    }
+
+    #[test]
+    fn allow_remote_parses_unset_as_false() {
+        assert!(!parse_allow_remote(None));
+    }
+
+    #[test]
+    fn allow_remote_rejects_true_spelling() {
+        assert!(!parse_allow_remote(Some("true")));
+        assert!(!parse_allow_remote(Some("yes")));
+        assert!(!parse_allow_remote(Some("0")));
+        assert!(!parse_allow_remote(Some("")));
     }
 }

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -79,9 +79,34 @@ async fn main() -> Result<()> {
                 .await
             }
             ProviderKind::Ollama { model } => {
-                let base_url = std::env::var("OLLAMA_BASE_URL")
-                    .unwrap_or_else(|_| forge_providers::ollama::DEFAULT_BASE_URL.to_string());
-                let provider = Arc::new(OllamaProvider::new(base_url, model));
+                // F-058 / M5 (T7): validate `OLLAMA_BASE_URL` before handing
+                // it to reqwest. An unvalidated URL (the old `env::var` +
+                // `unwrap_or_else` pattern) TLS-dials arbitrary hosts and
+                // exfiltrates every chat transcript + tool-result payload.
+                // Policy is enforced by `validate_base_url`; see its docs.
+                let raw = std::env::var("OLLAMA_BASE_URL").ok();
+                let allow_remote_raw =
+                    std::env::var(forge_providers::ollama::ALLOW_REMOTE_ENV).ok();
+                let allow_remote =
+                    forge_providers::ollama::parse_allow_remote(allow_remote_raw.as_deref());
+                let url = forge_providers::ollama::validate_base_url(raw.as_deref(), allow_remote)?;
+                // Loudly surface the resolved URL so env-var redirection is
+                // visible in logs. Remote-opt-in is called out explicitly.
+                if allow_remote
+                    && !matches!(
+                        url.host_str(),
+                        Some("127.0.0.1") | Some("localhost") | Some("::1") | Some("[::1]")
+                    )
+                {
+                    eprintln!(
+                        "forged: WARN ollama base_url = {} (remote endpoint enabled via {}=1)",
+                        url,
+                        forge_providers::ollama::ALLOW_REMOTE_ENV
+                    );
+                } else {
+                    eprintln!("forged: ollama base_url = {}", url);
+                }
+                let provider = Arc::new(OllamaProvider::new(url.as_str(), model));
                 serve_with_session(
                     &socket_path,
                     session,

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -454,13 +454,13 @@ mod tests {
     // `vec![]` is only safe if the enforcement layer it feeds actually denies
     // on empty. Likewise a workspace of `/tmp/ws` must not match `/etc/passwd`.
     //
-    // `forge_fs::read_file` returns `anyhow::Result`, so we assert on the
-    // error message produced by `validate_against_globs`'s `bail!` rather than
-    // on a typed variant.
+    // `forge_fs::read_file` returns `Result<_, FsError>` (F-061); we assert
+    // on the `Display` rendering of the typed `NotAllowed` variant, which
+    // still formats as "…not allowed by allowed_paths".
     #[test]
     fn fs_read_etc_passwd_denied_when_no_workspace() {
         let allowed = compute_allowed_paths(None);
-        let err = forge_fs::read_file("/etc/passwd", &allowed)
+        let err = forge_fs::read_file("/etc/passwd", &allowed, &forge_fs::Limits::default())
             .expect_err("reading /etc/passwd without a workspace must fail");
         let msg = format!("{err:#}");
         assert!(
@@ -479,7 +479,7 @@ mod tests {
             !allowed.is_empty(),
             "workspace present → allow-list should not be empty"
         );
-        let err = forge_fs::read_file("/etc/passwd", &allowed)
+        let err = forge_fs::read_file("/etc/passwd", &allowed, &forge_fs::Limits::default())
             .expect_err("reading /etc/passwd with a scoped workspace must fail");
         let msg = format!("{err:#}");
         assert!(

--- a/crates/forge-session/tests/ollama_url_validation.rs
+++ b/crates/forge-session/tests/ollama_url_validation.rs
@@ -1,0 +1,181 @@
+//! Startup-level regression for F-058 / M5 (T7 — config injection).
+//!
+//! The `OLLAMA_BASE_URL` env var controls where LLM traffic and tool-result
+//! payloads (including `fs.read` content) are sent. These tests exercise the
+//! actual forged binary entry path to make sure the validator's error
+//! surfaces out to the user on stderr and aborts startup — a future refactor
+//! that accidentally swallowed the error in `main.rs` would slip past a
+//! pure-function-only test.
+
+use std::process::Stdio;
+use std::time::Duration;
+use tempfile::TempDir;
+
+const FORGED: &str = env!("CARGO_BIN_EXE_forged");
+
+/// Spawn `forged` with a given `OLLAMA_BASE_URL` and return (exit_status,
+/// merged_stderr). Uses `--ephemeral` so no pid-file plumbing is required
+/// and `--provider ollama:<model>` so the validator is actually reached
+/// (the default path stays on MockProvider).
+fn run_with_ollama_url(
+    base_url: &str,
+    allow_remote: Option<&str>,
+) -> (std::process::ExitStatus, String) {
+    let dir = TempDir::new().unwrap();
+    let workspace = dir.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let sock_path = dir.path().join("session.sock");
+
+    let mut cmd = std::process::Command::new(FORGED);
+    cmd.arg("--ephemeral")
+        .arg("--provider")
+        .arg("ollama:nonexistent-model")
+        .env("FORGE_SESSION_ID", "ollama-url-validation")
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .env("FORGE_WORKSPACE", &workspace)
+        .env("OLLAMA_BASE_URL", base_url)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    if let Some(v) = allow_remote {
+        cmd.env("FORGE_ALLOW_REMOTE_OLLAMA", v);
+    } else {
+        cmd.env_remove("FORGE_ALLOW_REMOTE_OLLAMA");
+    }
+
+    let mut child = cmd.spawn().expect("spawn forged");
+
+    // The validator fires synchronously on the startup path before the socket
+    // is bound, so the process should exit quickly. If it doesn't (because a
+    // regression silently accepted the URL), fail the test rather than hang.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait") {
+            let out = child.wait_with_output().expect("wait_with_output");
+            let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+            return (status, stderr);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let out = child.wait_with_output().expect("wait_with_output");
+            let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+            panic!("forged did not exit on invalid OLLAMA_BASE_URL={base_url}; stderr={stderr}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn https_url_without_opt_in_fails_startup_with_clear_error() {
+    let (status, stderr) = run_with_ollama_url("https://example.com", None);
+    assert!(
+        !status.success(),
+        "forged must reject https OLLAMA_BASE_URL; stderr={stderr}"
+    );
+    // Error must reach the user and explain what failed. Match on both the
+    // scheme word and the policy guidance so a lazy future refactor that
+    // demotes the message to "invalid url" doesn't slip through.
+    assert!(
+        stderr.contains("scheme"),
+        "stderr must describe the scheme policy, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("OLLAMA_BASE_URL"),
+        "stderr must name the offending env var, got: {stderr}"
+    );
+}
+
+#[test]
+fn remote_http_without_opt_in_fails_startup() {
+    let (status, stderr) = run_with_ollama_url("http://attacker.example", None);
+    assert!(
+        !status.success(),
+        "forged must reject non-loopback OLLAMA_BASE_URL; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("FORGE_ALLOW_REMOTE_OLLAMA"),
+        "stderr must name the opt-in env var, got: {stderr}"
+    );
+}
+
+#[test]
+fn loopback_http_logs_resolved_url_to_stderr() {
+    // Loopback URL is accepted and the resolved form is surfaced on stderr
+    // (F-058 DoD: "Startup log surfaces the resolved URL"). Point at port 1
+    // so the daemon gets past validation but doesn't actually need an Ollama
+    // instance; the startup log line is emitted before any chat happens.
+    let dir = TempDir::new().unwrap();
+    let workspace = dir.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let sock_path = dir.path().join("session.sock");
+
+    let mut child = std::process::Command::new(FORGED)
+        .arg("--ephemeral")
+        .arg("--provider")
+        .arg("ollama:nonexistent-model")
+        .env("FORGE_SESSION_ID", "ollama-url-log")
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .env("FORGE_WORKSPACE", &workspace)
+        .env("OLLAMA_BASE_URL", "http://127.0.0.1:1")
+        .env_remove("FORGE_ALLOW_REMOTE_OLLAMA")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn forged");
+
+    // Give forged enough time to emit the startup log before we kill it.
+    std::thread::sleep(Duration::from_millis(500));
+    let _ = child.kill();
+    let out = child.wait_with_output().expect("wait_with_output");
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+
+    assert!(
+        stderr.contains("ollama base_url"),
+        "startup log must surface the resolved ollama URL, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("127.0.0.1"),
+        "startup log must include the resolved host, got: {stderr}"
+    );
+}
+
+#[test]
+fn remote_http_with_opt_in_is_accepted_and_logged_as_warn() {
+    // With `FORGE_ALLOW_REMOTE_OLLAMA=1`, a non-loopback `http` URL is
+    // accepted but the startup log must call out the remote endpoint so
+    // operators grepping logs see why traffic is leaving the box.
+    let dir = TempDir::new().unwrap();
+    let workspace = dir.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let sock_path = dir.path().join("session.sock");
+
+    let mut child = std::process::Command::new(FORGED)
+        .arg("--ephemeral")
+        .arg("--provider")
+        .arg("ollama:nonexistent-model")
+        .env("FORGE_SESSION_ID", "ollama-url-remote")
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .env("FORGE_WORKSPACE", &workspace)
+        // Loopback port so reqwest can't actually dial anything — the log
+        // line fires before any network I/O.
+        .env("OLLAMA_BASE_URL", "http://198.51.100.1:1")
+        .env("FORGE_ALLOW_REMOTE_OLLAMA", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn forged");
+
+    std::thread::sleep(Duration::from_millis(500));
+    let _ = child.kill();
+    let out = child.wait_with_output().expect("wait_with_output");
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+
+    assert!(
+        stderr.contains("WARN"),
+        "remote-accepted startup log must be WARN-flavored, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("FORGE_ALLOW_REMOTE_OLLAMA"),
+        "WARN log must name the opt-in env var, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#100

## Summary

- `OLLAMA_BASE_URL` is now parsed with `reqwest::Url` and validated against a loopback-first policy in `forge_providers::ollama::validate_base_url`: scheme must be `http`, host must be an exact match against `127.0.0.1` / `localhost` / `::1` unless `FORGE_ALLOW_REMOTE_OLLAMA=1` is set. `https` is rejected even under opt-in (trust model is Ollama's loopback convention, not TLS-anywhere). Prefix-spoof hosts like `127.0.0.1.attacker.com` are rejected because the comparison is exact, not `starts_with`.
- The opt-in env var is strict literal `"1"`; `"true"`, `"yes"`, etc. are rejected so typos cannot silently unlock remote dialing.
- `forged` surfaces the resolved URL on stderr at startup. When `FORGE_ALLOW_REMOTE_OLLAMA=1` is in effect for a non-loopback host, the log line is WARN-flavored and names the env var so operators grepping logs see why traffic is leaving the box.
- Regression suite: 13 new unit tests for `validate_base_url` (scheme/host matrix, IPv6 bracket form, prefix-spoof, malformed/no-host input), 3 for the opt-in parser, and 4 startup-level integration tests that spawn `forged` and assert the validator's error surfaces on stderr + aborts startup for `https://example.com` and `http://attacker.example` without opt-in.

## Drive-by fix

`crates/forge-session/src/server.rs` had two F-043 tests calling the pre-F-061 two-arg `forge_fs::read_file`; F-061 added a `Limits` parameter, and upstream/main has been uncompilable for `cargo test -p forge-session` since both landed. Added `&forge_fs::Limits::default()` to the two call sites so CI's test job can actually run against this branch. Two-line mechanical change, called out explicitly here to avoid surprising a reviewer.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo check --all` passes
- [x] `cargo test --all` passes (full workspace, incl. the 4 new startup-level integration tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

References: `docs/audits/phase-1/findings/M5.md`, CWE-20, CWE-918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)