### PR TITLE
fix(forge-session): keep SandboxedChild live across shell.exec timeout (F-047)

### DIFF
--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -454,13 +454,13 @@ mod tests {
     // `vec![]` is only safe if the enforcement layer it feeds actually denies
     // on empty. Likewise a workspace of `/tmp/ws` must not match `/etc/passwd`.
     //
-    // `forge_fs::read_file` returns `anyhow::Result`, so we assert on the
-    // error message produced by `validate_against_globs`'s `bail!` rather than
-    // on a typed variant.
+    // `forge_fs::read_file` returns `Result<_, FsError>` (F-061); we assert
+    // on the `Display` rendering of the typed `NotAllowed` variant, which
+    // still formats as "…not allowed by allowed_paths".
     #[test]
     fn fs_read_etc_passwd_denied_when_no_workspace() {
         let allowed = compute_allowed_paths(None);
-        let err = forge_fs::read_file("/etc/passwd", &allowed)
+        let err = forge_fs::read_file("/etc/passwd", &allowed, &forge_fs::Limits::default())
             .expect_err("reading /etc/passwd without a workspace must fail");
         let msg = format!("{err:#}");
         assert!(
@@ -479,7 +479,7 @@ mod tests {
             !allowed.is_empty(),
             "workspace present → allow-list should not be empty"
         );
-        let err = forge_fs::read_file("/etc/passwd", &allowed)
+        let err = forge_fs::read_file("/etc/passwd", &allowed, &forge_fs::Limits::default())
             .expect_err("reading /etc/passwd with a scoped workspace must fail");
         let msg = format!("{err:#}");
         assert!(

--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -291,6 +291,94 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shell_exec_timeout_kills_sandboxed_grandchild() {
+        // F-047 / H6: after `shell.exec` returns a timeout error, the
+        // sandboxed process group (including detached grandchildren) must
+        // be dead. Before the fix, `run_linux` called `.into_child()` which
+        // detached the `SandboxedChild` from the registry and disabled the
+        // Drop-based `killpg`, so the grandchild leaked past both the
+        // tool call and daemon shutdown.
+
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("grandchild.pid");
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(ShellExecTool)).unwrap();
+
+        let registry = crate::sandbox::ChildRegistry::new();
+        let ctx = ToolCtx {
+            allowed_paths: vec![],
+            workspace_root: Some(dir.path().to_path_buf()),
+            child_registry: Some(registry.clone()),
+        };
+
+        // Background a long sleep, write its pid, detach its stdio from
+        // the parent shell so that when the shell exits the wait_fut may
+        // complete but the grandchild stays alive. The parent shell needs
+        // to keep running long enough for the timeout to fire, so we also
+        // sleep in the foreground.
+        let script = format!(
+            "sleep 30 </dev/null >/dev/null 2>&1 & echo $! > {}; sleep 30",
+            pid_file.display()
+        );
+
+        let ctx_clone_args = serde_json::json!({
+            "command": "/bin/sh",
+            "args": ["-c", script],
+            "timeout_ms": 200,
+        });
+
+        let result = tokio::task::spawn_blocking(move || {
+            d.dispatch("shell.exec", &ctx_clone_args, &ctx).unwrap()
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            result.get("error").is_some(),
+            "expected timeout error, got: {result}"
+        );
+
+        // Read grandchild pid written by the script.
+        let mut grandchild_pid: Option<i32> = None;
+        for _ in 0..50 {
+            if let Ok(s) = std::fs::read_to_string(&pid_file) {
+                if let Ok(pid) = s.trim().parse::<i32>() {
+                    grandchild_pid = Some(pid);
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        let grandchild_pid = grandchild_pid.expect("script never wrote grandchild pid");
+
+        // Poll for the grandchild to be reaped — killpg delivery plus shell
+        // teardown can take a few ms on loaded CI.
+        let mut alive = true;
+        for _ in 0..100 {
+            let rc = unsafe { libc::kill(grandchild_pid, 0) };
+            if rc != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+                alive = false;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(
+            !alive,
+            "grandchild {grandchild_pid} survived shell.exec timeout \
+             (sandbox escape — pgid was not killed)"
+        );
+
+        // Secondary assertion: the registry entry was cleared. If Drop
+        // on `SandboxedChild` ran, `registry.remove(pgid)` executed.
+        assert!(
+            registry.is_empty(),
+            "ChildRegistry still tracks pgid after timeout — Drop did not run"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
     #[test]
     fn shell_exec_dispatch_clears_daemon_env_by_default() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/forge-session/src/tools/shell_exec.rs
+++ b/crates/forge-session/src/tools/shell_exec.rs
@@ -120,15 +120,24 @@ fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
     // `Tool::invoke` is synchronous but is called from inside an async
     // context in `run_turn`. If we are on a multi-threaded runtime we can
     // block_in_place; otherwise fall back to a fresh current-thread runtime.
+    //
+    // F-047 / H6: the `SandboxedChild` wrapper MUST stay live across the
+    // timeout. Calling `.into_child()` here would set `released = true` and
+    // remove the pgid from the session's `ChildRegistry`, so a timeout (or
+    // task cancellation / panic) drop of the `tokio::process::Child` alone
+    // would orphan the process group — the whole point of Level-1 isolation
+    // defeated. Keeping `sandboxed` in scope guarantees `Drop::killpg` runs
+    // on every exit path and the registry entry is cleaned up.
     let fut = async move {
-        let sandboxed = match sb.spawn() {
+        let mut sandboxed = match sb.spawn() {
             Ok(c) => c,
             Err(e) => return serde_json::json!({ "error": format!("spawn: {e}") }),
         };
-        let mut child = sandboxed.into_child();
 
-        let stdout = child.stdout.take();
-        let stderr = child.stderr.take();
+        // Take the stdout / stderr pipes by value so the concurrent reader
+        // futures can own them; we only need `&mut Child` for `wait()`.
+        let stdout = sandboxed.as_child_mut().stdout.take();
+        let stderr = sandboxed.as_child_mut().stderr.take();
 
         let stdout_fut = async move {
             match stdout {
@@ -153,8 +162,11 @@ fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
             }
         };
 
-        let wait_fut = async move { child.wait().await };
-        let combined = async move { tokio::join!(wait_fut, stdout_fut, stderr_fut) };
+        // Run wait + stdout + stderr concurrently so the child cannot block
+        // on full pipe buffers while we wait on exit. `sandboxed` stays
+        // borrowed by `as_child_mut()` only for the duration of the join.
+        let combined =
+            async { tokio::join!(sandboxed.as_child_mut().wait(), stdout_fut, stderr_fut,) };
 
         match tokio::time::timeout(Duration::from_millis(timeout_ms), combined).await {
             Ok((Ok(status), stdout, stderr)) => {
@@ -172,6 +184,9 @@ fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
             Ok((Err(e), _, _)) => serde_json::json!({ "error": format!("wait: {e}") }),
             Err(_) => serde_json::json!({ "error": format!("timeout after {timeout_ms}ms") }),
         }
+        // `sandboxed` drops here — on both success (drop is idempotent;
+        // killpg on an already-reaped pgid returns ESRCH) and on timeout
+        // (drop sends SIGKILL to the pgid and removes it from the registry).
     };
 
     match tokio::runtime::Handle::try_current() {


### PR DESCRIPTION
## Summary

Fixes #89 (F-047, H6 — forge-session shell.exec timeout orphans sandboxed child). Threat class **T4 — sandbox escape**.

Before this fix, `run_linux` in `crates/forge-session/src/tools/shell_exec.rs` immediately called `sandboxed.into_child()` after spawn. That does two load-bearing things:

1. Sets `released = true` so `SandboxedChild::drop` becomes a no-op (no `killpg`).
2. Removes the pgid from the session-scoped `ChildRegistry` so `kill_all()` on daemon shutdown cannot clean it up either.

The returned `tokio::process::Child` was then moved into a future passed to `tokio::time::timeout`. `kill_on_drop` was never set. On timeout, the `Child` was dropped without any signal — the sandbox pgid (and any detached grandchildren) survived past both the tool call and daemon shutdown. The whole point of Level-1 isolation defeated by a single orphan.

### Remediation — preferred path (per audit)

Keep the `SandboxedChild` wrapper live for the whole wait. Use `.as_child_mut()` to borrow the underlying `Child` for:
- `.stdout.take()` / `.stderr.take()` before kicking off the reader futures
- `.wait()` inside `tokio::join!(...)` alongside the reader futures

On every exit path — success, timeout, panic, task cancellation — `SandboxedChild::drop` then runs, sending `SIGKILL` to the pgid and removing the registry entry. Drop is idempotent on a reaped pgid (killpg returns ESRCH harmlessly), so the success path pays only one extra syscall.

This is strictly stronger than the minimal alternative (`killpg` in the timeout error branch only), which would still leak on panics and task cancellations.

### Regression test

`shell_exec_timeout_kills_sandboxed_grandchild` in `crates/forge-session/src/tools/mod.rs`:

- Spawns `/bin/sh -c 'sleep 30 </dev/null >/dev/null 2>&1 & echo $! > pid_file; sleep 30'` with `timeout_ms=200`
- Confirms the tool returns a timeout error
- Reads the captured grandchild pid
- Polls `kill(pid, 0)` until `ESRCH` (grandchild was reaped)
- Secondary assert: `ChildRegistry::is_empty()` (Drop ran through `registry.remove(pgid)` + `killpg`)

### Side-fix disclosure

`crates/forge-session/src/server.rs` tests added in F-043 used the pre-F-061 `forge_fs::read_file(path, allowed)` signature. F-061 (merged just before F-043) added a required `&Limits` parameter, so `upstream/main` does not compile `cargo test -p forge-session --lib`. The DoD requires tests to pass in CI; without this 2-line change, no test binary could even build. Applied the trivial fix:

```diff
-        let err = forge_fs::read_file("/etc/passwd", &allowed)
+        let err = forge_fs::read_file("/etc/passwd", &allowed, &forge_fs::Limits::default())
```

Aware that an in-flight branch `fix/server-test-read_file-args` in the local main worktree is doing the same trivial fix. Merge conflict resolution is trivial if both land.

## Test plan

- [x] RED confirmed on pristine upstream/main: regression test fails (`grandchild <pid> survived shell.exec timeout`)
- [x] GREEN after fix applied: regression test passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green (all forge-session and all workspace tests)
- [ ] CI on this PR green

## Definition of Done

- [x] `shell_exec` no longer releases the `SandboxedChild` before timeout completes (preferred path — wrapper stays live through wait)
- [x] Regression test on Linux: a tool call with `timeout_ms=200` running `/bin/sh -c 'sleep 30 & echo hi'` (extended to capture grandchild pid) — after the tool returns timeout, `kill -0 <grandchild_pid>` returns ESRCH (child is gone)
- [x] Tests pass locally; CI gate TBD on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)