### PR TITLE
fix(forge-core): deny unknown fields in on-disk meta and workspaces (F-065)

### DIFF
--- a/crates/forge-core/src/meta.rs
+++ b/crates/forge-core/src/meta.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SessionMeta {
     pub id: SessionId,
     pub workspace_id: WorkspaceId,

--- a/crates/forge-core/src/workspaces.rs
+++ b/crates/forge-core/src/workspaces.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceEntry {
     pub id: WorkspaceId,
     pub path: PathBuf,
@@ -13,6 +14,7 @@ pub struct WorkspaceEntry {
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct WorkspacesFile {
     #[serde(default)]
     workspaces: Vec<WorkspaceEntry>,

--- a/crates/forge-core/tests/meta_toml.rs
+++ b/crates/forge-core/tests/meta_toml.rs
@@ -87,6 +87,48 @@ async fn meta_toml_round_trip_bare_provider() {
 }
 
 #[tokio::test]
+async fn meta_toml_rejects_unknown_field() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("meta.toml");
+
+    let meta = SessionMeta {
+        id: SessionId::new(),
+        workspace_id: WorkspaceId::new(),
+        name: "unknown-field-probe".to_string(),
+        agent: None,
+        provider_id: None,
+        model: None,
+        state: SessionState::Active,
+        persistence: SessionPersistence::Persist,
+        started_at: Utc::now().with_nanosecond(0).unwrap(),
+        ended_at: None,
+        tokens_in: 0,
+        tokens_out: 0,
+        cost_usd: 0.0,
+        pid: 1,
+        socket_path: PathBuf::from("/tmp/test.sock"),
+    };
+
+    write_meta(&path, &meta).await.unwrap();
+
+    // Append a forward-looking trust-bearing field that this version of the
+    // daemon does not know about. An older daemon must refuse the file rather
+    // than silently drop the field — see audit finding L1 (F-065).
+    let mut contents = tokio::fs::read_to_string(&path).await.unwrap();
+    contents.push_str("\nallowed_paths = [\"/etc\"]\n");
+    tokio::fs::write(&path, contents).await.unwrap();
+
+    let err = read_meta(&path)
+        .await
+        .expect_err("unknown field must error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("allowed_paths") || msg.contains("unknown field"),
+        "expected unknown-field error, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn meta_toml_creates_parent_dirs() {
     let dir = TempDir::new().unwrap();
     let path = dir

--- a/crates/forge-core/tests/workspaces_toml.rs
+++ b/crates/forge-core/tests/workspaces_toml.rs
@@ -76,6 +76,55 @@ async fn workspaces_toml_creates_parent_dirs() {
 }
 
 #[tokio::test]
+async fn workspaces_toml_rejects_unknown_field_on_entry() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("workspaces.toml");
+
+    // Hand-written TOML: a valid entry plus a forward-looking field (e.g. a
+    // trust-bearing `trusted` flag) that this daemon does not recognize.
+    // Must error rather than silently drop the field — audit L1 (F-065).
+    let toml_contents = r#"
+[[workspaces]]
+id = "01J9X0000000000000000WENTR"
+path = "/home/alice/code/acme-api"
+name = "acme-api"
+last_opened = "2025-01-01T00:00:00Z"
+pinned = false
+trusted = true
+"#;
+    tokio::fs::write(&path, toml_contents).await.unwrap();
+
+    let err = read_workspaces(&path)
+        .await
+        .expect_err("unknown field on WorkspaceEntry must error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("trusted") || msg.contains("unknown field"),
+        "expected unknown-field error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn workspaces_toml_rejects_unknown_field_on_file() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("workspaces.toml");
+
+    // Top-level unknown key on WorkspacesFile (e.g. a future `version` field
+    // that an older daemon should not silently ignore).
+    let toml_contents = "workspaces = []\nversion = 2\n";
+    tokio::fs::write(&path, toml_contents).await.unwrap();
+
+    let err = read_workspaces(&path)
+        .await
+        .expect_err("unknown field on WorkspacesFile must error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("version") || msg.contains("unknown field"),
+        "expected unknown-field error, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn workspaces_toml_empty_list() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("workspaces.toml");


### PR DESCRIPTION
Closes forge-ide/forge#107

## Summary

- Adds `#[serde(deny_unknown_fields)]` to `SessionMeta` (`crates/forge-core/src/meta.rs`), `WorkspaceEntry`, and `WorkspacesFile` (`crates/forge-core/src/workspaces.rs`).
- Regression tests assert that appending an unknown key to a valid `meta.toml` or `workspaces.toml` surfaces a typed deserializer error instead of being silently dropped.
- Threat class: T1 (forward-looking). Today the structs are benign, but the first trust-relevant field (allowed_paths, sandbox_profile, credential_ref) added later would otherwise be silently lost on rollback. With this attribute, the field must be added intentionally — migrations become explicit.

## Deliberate deferral

The finding body suggests coupling this with a `schema: u32` field (`#[serde(default = "schema_v1")]`). The Definition of Done does not mandate that, and introducing a new `schema` field changes the serialized on-disk shape. Deferring to a future task keeps this PR scoped to the DoD.

## Test plan

- `cargo fmt --check` clean
- `cargo check --workspace` clean
- `cargo test --workspace` — all tests pass, including new regression tests:
  - `meta_toml_rejects_unknown_field`
  - `workspaces_toml_rejects_unknown_field_on_entry`
  - `workspaces_toml_rejects_unknown_field_on_file`
- `cargo clippy --all-targets -- -D warnings` clean

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)