### PR TITLE
[F-068] forge-shell: cap untyped-string fields on session commands

### DIFF
--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -33,6 +33,31 @@ use crate::bridge::{EventSink, SessionBridge, SessionConnections, SessionEventPa
 /// wire shape — never a panic.
 pub(crate) const LABEL_MISMATCH_ERROR: &str = "forbidden: window label mismatch";
 
+/// F-068 / L4 (T7): per-field byte caps on untyped-string inputs to session
+/// commands. `forge_ipc::write_frame` rejects frames above 4 MiB, but a
+/// compromised webview can still loop 4 MiB sends — each causes transient
+/// Rust-side allocation and, for `text`, billable model calls. These caps
+/// stop the allocation before serialization.
+///
+/// All caps are byte counts (`.len()` on `String`), not char counts — the
+/// resource being bounded is memory/wire cost.
+///
+/// A single command may bind additive validations in the future
+/// (e.g. F-069 typed-enum validation on `scope` will layer on top of the
+/// size check here).
+pub(crate) const MAX_MESSAGE_TEXT_BYTES: usize = 128 * 1024;
+pub(crate) const MAX_TOOL_CALL_ID_BYTES: usize = 64;
+pub(crate) const MAX_APPROVAL_SCOPE_BYTES: usize = 256;
+pub(crate) const MAX_REJECT_REASON_BYTES: usize = 1024;
+
+/// F-068 / L4 (T7): error returned when a session command's untyped-string
+/// input exceeds its byte cap. Tests assert against the literal fragments
+/// `"payload too large"` + the field name — keep both when evolving the
+/// message so existing tests and any UI handling stay stable.
+fn payload_too_large(field: &str, limit_bytes: usize) -> String {
+    format!("payload too large: {field} exceeds {limit_bytes}-byte limit")
+}
+
 /// Assert the calling webview's label equals `expected`. Used at the top of
 /// every session/dashboard `#[tauri::command]` to reject cross-window invokes
 /// before the bridge sees the frame.
@@ -44,6 +69,19 @@ pub(crate) fn require_window_label<R: Runtime>(
         Ok(())
     } else {
         Err(LABEL_MISMATCH_ERROR.to_string())
+    }
+}
+
+/// F-068 / L4 (T7): reject payloads whose byte length exceeds `limit_bytes`.
+/// Runs after `require_window_label` (so unauthorized windows don't learn
+/// about cap values) and before any bridge call (so the allocation/wire cost
+/// never materializes). Returns `Err` with a stable marker that tests and
+/// any UI-side handling can pattern-match on.
+pub(crate) fn require_size(field: &str, value: &str, limit_bytes: usize) -> Result<(), String> {
+    if value.len() <= limit_bytes {
+        Ok(())
+    } else {
+        Err(payload_too_large(field, limit_bytes))
     }
 }
 
@@ -176,6 +214,10 @@ pub async fn session_send_message<R: Runtime>(
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
     require_window_label(&webview, &format!("session-{session_id}"))?;
+    // F-068 / L4 (T7): bound `text` before the bridge allocates a frame or
+    // the provider is billed. Runs after authz so unauthorized windows
+    // don't learn the cap value.
+    require_size("text", &text, MAX_MESSAGE_TEXT_BYTES)?;
     state
         .bridge
         .send_message(&session_id, text)
@@ -192,6 +234,11 @@ pub async fn session_approve_tool<R: Runtime>(
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
     require_window_label(&webview, &format!("session-{session_id}"))?;
+    // F-068 / L4 (T7): tool_call_id is a short opaque handle; scope is a
+    // short enum-ish string. Both are bounded here before F-069's typed-enum
+    // validation lands on `scope`.
+    require_size("tool_call_id", &tool_call_id, MAX_TOOL_CALL_ID_BYTES)?;
+    require_size("scope", &scope, MAX_APPROVAL_SCOPE_BYTES)?;
     state
         .bridge
         .approve_tool(&session_id, tool_call_id, scope)
@@ -208,6 +255,12 @@ pub async fn session_reject_tool<R: Runtime>(
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
     require_window_label(&webview, &format!("session-{session_id}"))?;
+    // F-068 / L4 (T7): bound tool_call_id and — only when present — reason.
+    // `None` reason is the common case and must skip the size check.
+    require_size("tool_call_id", &tool_call_id, MAX_TOOL_CALL_ID_BYTES)?;
+    if let Some(r) = reason.as_deref() {
+        require_size("reason", r, MAX_REJECT_REASON_BYTES)?;
+    }
     state
         .bridge
         .reject_tool(&session_id, tool_call_id, reason)

--- a/crates/forge-shell/tests/ipc_commands.rs
+++ b/crates/forge-shell/tests/ipc_commands.rs
@@ -184,3 +184,242 @@ async fn session_hello_ignores_attacker_supplied_socket_path() {
         "rogue listener must not receive any connection from session_hello"
     );
 }
+
+// F-068 / L4 (T7): size caps on untyped-string fields in session commands.
+//
+// These tests assert that oversize payloads are rejected by the *command*
+// layer (before the bridge is consulted), not by the `forge_ipc` 4 MiB wire
+// cap. The discriminator: with an empty `SessionConnections` registry, the
+// bridge layer would respond with "no active connection for session …".
+// If the size check fires first, we instead see our size-cap error marker.
+//
+// The at-cap tests invert the assertion: a payload sized exactly at the cap
+// must pass the size check (still error later with "no active connection"),
+// proving the boundary is inclusive and the size check alone is not swallowing
+// every call.
+
+fn make_session_window(
+    app: &tauri::App<tauri::test::MockRuntime>,
+    session_id: &str,
+) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
+    tauri::WebviewWindowBuilder::new(
+        app,
+        &format!("session-{session_id}"),
+        tauri::WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("mock window")
+}
+
+fn invoke_err(
+    window: &tauri::WebviewWindow<tauri::test::MockRuntime>,
+    cmd: &str,
+    payload: serde_json::Value,
+) -> String {
+    let res = tauri::test::get_ipc_response(
+        window,
+        tauri::webview::InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+    match res {
+        Ok(ok) => panic!("expected error, got Ok: {ok:?}"),
+        Err(serde_json::Value::String(s)) => s,
+        Err(other) => other.to_string(),
+    }
+}
+
+#[test]
+fn session_send_message_rejects_text_above_cap_at_command_layer() {
+    // 1 MiB is well under `forge_ipc`'s 4 MiB wire cap, so any rejection must
+    // originate from the command layer's size check, not the wire.
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "oversize");
+
+    let err = invoke_err(
+        &window,
+        "session_send_message",
+        serde_json::json!({
+            "sessionId": "oversize",
+            "text": "A".repeat(1024 * 1024),
+        }),
+    );
+
+    // The load-bearing assertion: rejection must be the size cap, not the
+    // bridge's "no active connection" — the latter would prove the size
+    // check was absent.
+    assert!(
+        err.contains("payload too large") && err.contains("text"),
+        "expected size-cap error mentioning text, got: {err}"
+    );
+    assert!(
+        !err.contains("no active connection"),
+        "size check must fire before the bridge, got: {err}"
+    );
+}
+
+#[test]
+fn session_send_message_accepts_text_exactly_at_cap() {
+    // 128 KiB — the inclusive boundary. The size check must let this through
+    // (the call will still fail, but at the bridge with "no active connection",
+    // proving the size gate didn't swallow it).
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "at-cap");
+
+    let err = invoke_err(
+        &window,
+        "session_send_message",
+        serde_json::json!({
+            "sessionId": "at-cap",
+            "text": "A".repeat(128 * 1024),
+        }),
+    );
+
+    assert!(
+        err.contains("no active connection"),
+        "128 KiB text must pass size check and reach the bridge, got: {err}"
+    );
+    assert!(
+        !err.contains("payload too large"),
+        "128 KiB must not be rejected by the size cap, got: {err}"
+    );
+}
+
+#[test]
+fn session_approve_tool_rejects_tool_call_id_above_cap_at_command_layer() {
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "tcid");
+
+    let err = invoke_err(
+        &window,
+        "session_approve_tool",
+        serde_json::json!({
+            "sessionId": "tcid",
+            "toolCallId": "x".repeat(65),
+            "scope": "ThisTool",
+        }),
+    );
+
+    assert!(
+        err.contains("payload too large") && err.contains("tool_call_id"),
+        "expected size-cap error mentioning tool_call_id, got: {err}"
+    );
+    assert!(
+        !err.contains("no active connection"),
+        "size check must fire before the bridge, got: {err}"
+    );
+}
+
+#[test]
+fn session_approve_tool_rejects_scope_above_cap_at_command_layer() {
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "scope");
+
+    let err = invoke_err(
+        &window,
+        "session_approve_tool",
+        serde_json::json!({
+            "sessionId": "scope",
+            "toolCallId": "tc-1",
+            "scope": "x".repeat(257),
+        }),
+    );
+
+    assert!(
+        err.contains("payload too large") && err.contains("scope"),
+        "expected size-cap error mentioning scope, got: {err}"
+    );
+    assert!(
+        !err.contains("no active connection"),
+        "size check must fire before the bridge, got: {err}"
+    );
+}
+
+#[test]
+fn session_reject_tool_rejects_tool_call_id_above_cap_at_command_layer() {
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "rej");
+
+    let err = invoke_err(
+        &window,
+        "session_reject_tool",
+        serde_json::json!({
+            "sessionId": "rej",
+            "toolCallId": "x".repeat(65),
+            "reason": null,
+        }),
+    );
+
+    assert!(
+        err.contains("payload too large") && err.contains("tool_call_id"),
+        "expected size-cap error mentioning tool_call_id, got: {err}"
+    );
+    assert!(
+        !err.contains("no active connection"),
+        "size check must fire before the bridge, got: {err}"
+    );
+}
+
+#[test]
+fn session_reject_tool_rejects_reason_above_cap_at_command_layer() {
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "rej-reason");
+
+    let err = invoke_err(
+        &window,
+        "session_reject_tool",
+        serde_json::json!({
+            "sessionId": "rej-reason",
+            "toolCallId": "tc-1",
+            "reason": "x".repeat(1025),
+        }),
+    );
+
+    assert!(
+        err.contains("payload too large") && err.contains("reason"),
+        "expected size-cap error mentioning reason, got: {err}"
+    );
+    assert!(
+        !err.contains("no active connection"),
+        "size check must fire before the bridge, got: {err}"
+    );
+}
+
+#[test]
+fn session_reject_tool_accepts_absent_reason() {
+    // `reason` is `Option<String>` — None must not trigger the size check.
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "rej-none");
+
+    let err = invoke_err(
+        &window,
+        "session_reject_tool",
+        serde_json::json!({
+            "sessionId": "rej-none",
+            "toolCallId": "tc-1",
+            "reason": null,
+        }),
+    );
+
+    assert!(
+        err.contains("no active connection"),
+        "None reason must skip size check and reach the bridge, got: {err}"
+    );
+    assert!(
+        !err.contains("payload too large"),
+        "None reason must not be rejected by the size cap, got: {err}"
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#110

## Summary
- Cap `session_send_message` text at 128 KiB; cap `tool_call_id` (64 B), `scope` (256 B), and `reason` (1 KiB) on `session_approve_tool` / `session_reject_tool`. Checks run after F-051 label authz and before the bridge so the allocation and provider call never fire.
- Oversize payloads return a stable `"payload too large: <field> exceeds <N>-byte limit"` marker — distinguishes command-layer rejection from wire/bridge errors for both UI handling and tests.
- Regression test: `session_send_message` with 1 MiB text (under the 4 MiB `forge_ipc` wire cap) is rejected at the command layer, not by `write_frame`. Plus at-cap (128 KiB exact) inclusive-boundary test and oversize tests for `tool_call_id` / `scope` / `reason`, plus a None-reason pass-through test.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo test -p forge-shell --features webview-test` passes (10 ipc_commands tests + 9 ipc_authz tests remain green)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)