### PR TITLE
fix(forge-session): refuse /tmp UDS fallback and chmod socket to 0o600 (F-044)

### DIFF
--- a/crates/forge-cli/src/main.rs
+++ b/crates/forge-cli/src/main.rs
@@ -29,8 +29,8 @@ async fn session_new(kind: SessionNewKind) -> Result<()> {
     };
 
     let session_id = forge_core::SessionId::new();
-    let sock = forge_cli::socket::socket_path(&session_id.to_string());
-    let pid_file = forge_cli::socket::pid_path(&session_id.to_string());
+    let sock = forge_cli::socket::socket_path(&session_id.to_string())?;
+    let pid_file = forge_cli::socket::pid_path(&session_id.to_string())?;
 
     if let Some(parent) = sock.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -79,7 +79,7 @@ async fn session_list() -> Result<()> {
     use forge_ipc::{ClientInfo, FramedStream, Hello, IpcMessage, PROTO_VERSION};
     use tokio::net::UnixStream;
 
-    let dir = forge_cli::socket::sessions_socket_dir();
+    let dir = forge_cli::socket::sessions_socket_dir()?;
     let mut read_dir = match tokio::fs::read_dir(&dir).await {
         Ok(d) => d,
         Err(_) => {
@@ -139,7 +139,7 @@ async fn session_tail(id: &str) -> Result<()> {
     use forge_ipc::{ClientInfo, FramedStream, Hello, IpcMessage, Subscribe, PROTO_VERSION};
     use tokio::net::UnixStream;
 
-    let sock = forge_cli::socket::socket_path(id);
+    let sock = forge_cli::socket::socket_path(id)?;
     let stream = UnixStream::connect(&sock)
         .await
         .map_err(|e| anyhow::anyhow!("cannot connect to session {id}: {e}"))?;
@@ -185,7 +185,7 @@ async fn session_tail(id: &str) -> Result<()> {
 }
 
 async fn session_kill(id: &str) -> Result<()> {
-    let pid_file = forge_cli::socket::pid_path(id);
+    let pid_file = forge_cli::socket::pid_path(id)?;
     // F-049: race-free kill via start-time verification + pidfd_send_signal.
     // `kill_session_from_pid_file` reads the two-line record (pid + start-time),
     // re-reads `/proc/<pid>/stat` to confirm the PID hasn't been recycled,
@@ -218,7 +218,7 @@ async fn run_agent(name: &str, input_source: &str) -> Result<()> {
     };
 
     let session_id = forge_core::SessionId::new();
-    let sock = forge_cli::socket::socket_path(&session_id.to_string());
+    let sock = forge_cli::socket::socket_path(&session_id.to_string())?;
 
     if let Some(parent) = sock.parent() {
         tokio::fs::create_dir_all(parent).await?;

--- a/crates/forge-cli/src/socket.rs
+++ b/crates/forge-cli/src/socket.rs
@@ -13,8 +13,37 @@ pub fn session_id_is_valid(s: &str) -> bool {
     s.len() == 16 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
 }
 
+/// Error message shared by all path resolvers when `XDG_RUNTIME_DIR` is
+/// unset. Keeping a single message means any caller that surfaces this error
+/// (CLI, shell, daemon startup) advertises the same fix to the operator.
+fn xdg_runtime_dir_missing() -> anyhow::Error {
+    anyhow::anyhow!(
+        "XDG_RUNTIME_DIR is unset: forge refuses to fall back to a \
+         shared /tmp directory because the socket there would be \
+         world-connectable. Set XDG_RUNTIME_DIR to a per-user 0o700 \
+         directory (systemd sets it to /run/user/<uid> automatically). \
+         (F-044 / H8)"
+    )
+}
+
+/// Read `XDG_RUNTIME_DIR` or error. We deliberately do not consult `$UID`
+/// (an unreliable shell-only variable that F-044 removed) nor fall back to
+/// `/tmp/forge-<uid>` — that fallback was the defect H8 closed.
+fn xdg_runtime_dir() -> anyhow::Result<PathBuf> {
+    std::env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(xdg_runtime_dir_missing)
+}
+
 /// Resolve the Unix socket path for a session, using the same logic as `forged`.
-pub fn socket_path(session_id: &str) -> PathBuf {
+///
+/// Returns an error when `XDG_RUNTIME_DIR` is unset. `forged` refuses to
+/// start without it (see `forge_session::socket_path::resolve_socket_path`),
+/// so any CLI resolution without the env var would be pointing at a socket
+/// that can't exist.
+pub fn socket_path(session_id: &str) -> anyhow::Result<PathBuf> {
     // Defense-in-depth for F-057 (T12a): the CLI's clap `value_parser`
     // already rejects malformed ids, but any future caller that constructs
     // a session id from a non-CLI source (env var, IPC message, disk) must
@@ -25,29 +54,18 @@ pub fn socket_path(session_id: &str) -> PathBuf {
         session_id_is_valid(session_id),
         "socket_path: session_id_is_valid({session_id:?}) == false"
     );
-    let base = std::env::var("XDG_RUNTIME_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let uid = std::env::var("UID").unwrap_or_else(|_| "0".to_string());
-            PathBuf::from(format!("/tmp/forge-{uid}"))
-        });
-    base.join("forge/sessions")
-        .join(format!("{session_id}.sock"))
+    Ok(xdg_runtime_dir()?
+        .join("forge/sessions")
+        .join(format!("{session_id}.sock")))
 }
 
 /// Return the directory containing all session sockets.
-pub fn sessions_socket_dir() -> PathBuf {
-    let base = std::env::var("XDG_RUNTIME_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let uid = std::env::var("UID").unwrap_or_else(|_| "0".to_string());
-            PathBuf::from(format!("/tmp/forge-{uid}"))
-        });
-    base.join("forge/sessions")
+pub fn sessions_socket_dir() -> anyhow::Result<PathBuf> {
+    Ok(xdg_runtime_dir()?.join("forge/sessions"))
 }
 
 /// Resolve the PID file path for a session.
-pub fn pid_path(session_id: &str) -> PathBuf {
+pub fn pid_path(session_id: &str) -> anyhow::Result<PathBuf> {
     // Defense-in-depth for F-057 (T12a): same rationale as `socket_path`.
     // `socket_path` below will also debug-assert, but stating the invariant
     // explicitly here keeps the failure message attached to the function
@@ -56,7 +74,7 @@ pub fn pid_path(session_id: &str) -> PathBuf {
         session_id_is_valid(session_id),
         "pid_path: session_id_is_valid({session_id:?}) == false"
     );
-    socket_path(session_id).with_extension("pid")
+    Ok(socket_path(session_id)?.with_extension("pid"))
 }
 
 /// Parse and validate the contents of a session pid file.
@@ -398,32 +416,65 @@ mod tests {
         }
     }
 
+    /// F-044: cover both the success (XDG_RUNTIME_DIR set) and failure
+    /// (unset) branches of every path resolver in a single `#[test]` so
+    /// env-mutation can't race parallel readers in this binary.
     #[test]
-    fn socket_path_uses_xdg_runtime_dir() {
-        // Temporarily set XDG_RUNTIME_DIR to a known value.
-        // Use a fixed path so the test is deterministic.
-        // We can't really set env vars safely in parallel tests, so just verify
-        // the path structure with the fallback UID approach.
-        let path = socket_path("deadbeefcafebabe");
-        let path_str = path.to_string_lossy();
-        assert!(
-            path_str.contains("forge/sessions"),
-            "expected forge/sessions in path: {path_str}"
-        );
-        assert!(
-            path_str.ends_with("deadbeefcafebabe.sock"),
-            "expected .sock extension: {path_str}"
-        );
-    }
+    fn path_resolvers_require_xdg_runtime_dir() {
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        let prev_uid = std::env::var("UID").ok();
 
-    #[test]
-    fn pid_path_has_pid_extension() {
-        let path = pid_path("abc123def4560000");
-        assert!(
-            path.to_string_lossy().ends_with("abc123def4560000.pid"),
-            "expected .pid extension: {}",
-            path.display()
+        // --- Happy path: XDG_RUNTIME_DIR set ---
+        // SAFETY: this is the only test in this binary mutating env vars at
+        // this point; the session_id_is_valid / parse_session_pid tests are
+        // pure and do not read XDG_RUNTIME_DIR / UID.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", "/run/user/4242");
+        }
+
+        let sock = socket_path("deadbeefcafebabe").expect("should resolve");
+        assert_eq!(
+            sock.to_string_lossy(),
+            "/run/user/4242/forge/sessions/deadbeefcafebabe.sock"
         );
+        let pid = pid_path("abc123def4560000").expect("should resolve");
+        assert!(
+            pid.to_string_lossy().ends_with("abc123def4560000.pid"),
+            "expected .pid extension: {}",
+            pid.display()
+        );
+        let dir = sessions_socket_dir().expect("should resolve");
+        assert_eq!(dir.to_string_lossy(), "/run/user/4242/forge/sessions");
+
+        // --- Failure path: XDG_RUNTIME_DIR unset, no /tmp fallback ---
+        unsafe {
+            std::env::remove_var("XDG_RUNTIME_DIR");
+            std::env::remove_var("UID");
+        }
+        let err = socket_path("deadbeefcafebabe").expect_err("no xdg -> err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("XDG_RUNTIME_DIR"),
+            "error must name XDG_RUNTIME_DIR, got: {msg}"
+        );
+        assert!(
+            !msg.contains("/tmp/forge-"),
+            "error must not advertise /tmp fallback, got: {msg}"
+        );
+        assert!(sessions_socket_dir().is_err());
+        assert!(pid_path("abc123def4560000").is_err());
+
+        // Restore
+        unsafe {
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+            match prev_uid {
+                Some(v) => std::env::set_var("UID", v),
+                None => std::env::remove_var("UID"),
+            }
+        }
     }
 
     /// Defense-in-depth: if clap's `value_parser` is ever bypassed (e.g. a
@@ -441,16 +492,6 @@ mod tests {
     #[cfg(debug_assertions)]
     fn socket_path_debug_asserts_valid_session_id() {
         let _ = socket_path("../../tmp/x");
-    }
-
-    #[test]
-    fn sessions_socket_dir_contains_forge_sessions() {
-        let dir = sessions_socket_dir();
-        assert!(
-            dir.to_string_lossy().contains("forge/sessions"),
-            "got: {}",
-            dir.display()
-        );
     }
 
     #[test]

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -55,3 +55,11 @@ path = "tests/provider_selection.rs"
 [[test]]
 name = "pid_file_lifecycle"
 path = "tests/pid_file_lifecycle.rs"
+
+[[test]]
+name = "uds_socket_permissions"
+path = "tests/uds_socket_permissions.rs"
+
+[[test]]
+name = "socket_path_fallback"
+path = "tests/socket_path_fallback.rs"

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -5,4 +5,5 @@ pub mod provider_spec;
 pub mod sandbox;
 pub mod server;
 pub mod session;
+pub mod socket_path;
 pub mod tools;

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -5,6 +5,7 @@ use forge_session::{
     provider_spec::{parse_provider_spec, ProviderKind},
     server::{event_log_path, serve_with_session},
     session::Session,
+    socket_path::resolve_socket_path,
 };
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -24,9 +25,14 @@ async fn main() -> Result<()> {
     // print the path before forged starts and can track it for `session kill`.
     let session_id = std::env::var("FORGE_SESSION_ID")
         .unwrap_or_else(|_| forge_core::SessionId::new().to_string());
-    let socket_path = std::env::var("FORGE_SOCKET_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| resolve_socket_path(&session_id));
+    // F-044 (H8): `resolve_socket_path` now refuses to return a path when
+    // `XDG_RUNTIME_DIR` is unset rather than falling back to `/tmp/forge-0`.
+    // Tests always set `FORGE_SOCKET_PATH` explicitly, so this resolver runs
+    // only on the production path where systemd provides `XDG_RUNTIME_DIR`.
+    let socket_path = match std::env::var("FORGE_SOCKET_PATH") {
+        Ok(p) if !p.is_empty() => PathBuf::from(p),
+        _ => resolve_socket_path(&session_id)?,
+    };
     // Normalize FORGE_WORKSPACE to an absolute path so HelloAck.workspace is
     // portable for clients (which may have a different CWD than the daemon).
     // std::path::absolute does not require the path to exist, unlike canonicalize.
@@ -156,13 +162,3 @@ async fn build_mock_provider() -> Result<Arc<MockProvider>> {
     }
 }
 
-fn resolve_socket_path(session_id: &str) -> PathBuf {
-    let base = std::env::var("XDG_RUNTIME_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let uid = std::env::var("UID").unwrap_or_else(|_| "0".to_string());
-            PathBuf::from(format!("/tmp/forge-{uid}"))
-        });
-    base.join("forge/sessions")
-        .join(format!("{session_id}.sock"))
-}

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -161,4 +161,3 @@ async fn build_mock_provider() -> Result<Arc<MockProvider>> {
         Ok(Arc::new(MockProvider::with_default_path()))
     }
 }
-

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -82,11 +83,30 @@ pub async fn serve_with_session<P: Provider + 'static>(
 ) -> Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
+        // F-044 (H8): tighten the socket's parent dir to 0o700 regardless of
+        // whether we created it or found it pre-existing. `XDG_RUNTIME_DIR`
+        // itself is 0o700 per systemd.exec(5), but the `forge/sessions`
+        // subdir sits inside and inherits `0o777 & ~umask` (typically 0o755)
+        // on first creation. Applying 0o700 explicitly closes the tiny window
+        // where the subdir is created loose and means the defense-in-depth
+        // survives if a future operator runs forged with `XDG_RUNTIME_DIR`
+        // pointed somewhere with a permissive parent. Best-effort: if the
+        // chmod fails (e.g. parent owned by another user under FORGE_SOCKET_PATH
+        // in a test), the 0o600 mode on the socket itself is the real defense.
+        let _ = tokio::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).await;
     }
     if path.exists() {
         tokio::fs::remove_file(path).await?;
     }
     let listener = UnixListener::bind(path)?;
+    // F-044 (H8): chmod the socket to 0o600 the moment it exists. bind(2)
+    // creates the socket file with `0o777 & ~umask`, typically 0o755 —
+    // world-connectable, which in Phase 1 means any local user can drive the
+    // session. There is a brief TOCTOU window between bind and the chmod
+    // here (tracked by F-056); this call closes the steady-state exposure
+    // without widening that window. We refuse to proceed if the chmod fails
+    // rather than serve on a permissive socket.
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
     let workspace_path: Option<PathBuf> = workspace.clone();
     // F-043: Derive `allowed_paths` from the workspace root so `fs.*` tools can
     // only touch files inside the session's workspace. Fail-closed — if no

--- a/crates/forge-session/src/socket_path.rs
+++ b/crates/forge-session/src/socket_path.rs
@@ -1,0 +1,49 @@
+//! UDS socket-path resolution for `forged`.
+//!
+//! # F-044 (H8): rejecting the `/tmp` fallback
+//!
+//! Phase 1's IPC trust boundary is a Unix domain socket; anyone who can
+//! connect to it can drive the session, approve tool calls, and exfiltrate
+//! events. Prior to F-044 this resolver fell back to `/tmp/forge-{uid}` when
+//! `XDG_RUNTIME_DIR` was unset, and read the UID from `std::env::var("UID")`
+//! — a shell variable that child processes don't generally inherit — with a
+//! fallback of `"0"`. That combination let multiple local users share a
+//! world-accessible `/tmp/forge-0/forge/sessions/` directory.
+//!
+//! The remediation (option 4 of the H8 finding) is to refuse to resolve a
+//! path at all when `XDG_RUNTIME_DIR` is unset. `forged` will fail to start
+//! with a clear error naming the missing env var. On Linux with systemd
+//! `XDG_RUNTIME_DIR` is always set to a per-user `0o700` tmpfs mount, so the
+//! only production path is through `$XDG_RUNTIME_DIR/forge/sessions/<id>.sock`;
+//! anything else is a misconfiguration that we surface loudly rather than
+//! mask with a shared-tmp fallback.
+//!
+//! See `server.rs` for the post-bind `chmod` defense-in-depth that runs
+//! irrespective of this resolver's input.
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+
+/// Resolve the UDS socket path for a session under `$XDG_RUNTIME_DIR`.
+///
+/// Returns `Err` when `XDG_RUNTIME_DIR` is unset or empty. The error message
+/// names the missing env var so operators reading `forged`'s stderr know the
+/// fix. No `/tmp` fallback is attempted.
+pub fn resolve_socket_path(session_id: &str) -> Result<PathBuf> {
+    let base = std::env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "forged refuses to start: XDG_RUNTIME_DIR is unset. \
+                 This env var must point to a per-user 0o700 directory \
+                 (systemd sets it to /run/user/<uid> automatically). \
+                 Set it explicitly or use FORGE_SOCKET_PATH to override \
+                 the socket location. (F-044 / H8)"
+            )
+        })?;
+    Ok(PathBuf::from(base)
+        .join("forge/sessions")
+        .join(format!("{session_id}.sock")))
+}

--- a/crates/forge-session/tests/socket_path_fallback.rs
+++ b/crates/forge-session/tests/socket_path_fallback.rs
@@ -1,0 +1,66 @@
+//! F-044 (H8) regression: `resolve_socket_path` rejects the `/tmp` fallback.
+//!
+//! Before F-044, `resolve_socket_path` fell back to `/tmp/forge-{uid}` when
+//! `XDG_RUNTIME_DIR` was unset, and read the UID from `std::env::var("UID")`
+//! (a shell variable not generally exported to child processes) with a
+//! fallback of `"0"`. The result: multiple local users all binding under
+//! `/tmp/forge-0/forge/sessions/`, world-connectable.
+//!
+//! Remediation (option 4 from H8): require `XDG_RUNTIME_DIR` and refuse to
+//! start otherwise. Tests cover:
+//!   - success when XDG_RUNTIME_DIR is set
+//!   - error when XDG_RUNTIME_DIR is unset (no silent /tmp fallback)
+//!   - the error message names `XDG_RUNTIME_DIR` so operators see the fix
+//!
+//! Both cases run in a single `#[test]` so env mutation can't race another
+//! parallel reader in this same test binary.
+
+use forge_session::socket_path::resolve_socket_path;
+
+#[test]
+fn resolve_socket_path_requires_xdg_runtime_dir() {
+    let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+    let prev_uid = std::env::var("UID").ok();
+
+    // --- Case 1: XDG_RUNTIME_DIR set -> Ok(path under that dir) ---
+    // SAFETY: single-threaded test binary; only this test file exists in
+    // this crate target, so no other tokio task concurrently reads env.
+    unsafe {
+        std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1234");
+    }
+    let path = resolve_socket_path("abc123").expect("should resolve");
+    assert_eq!(
+        path.to_str().unwrap(),
+        "/run/user/1234/forge/sessions/abc123.sock"
+    );
+
+    // --- Case 2: XDG_RUNTIME_DIR unset (and UID unset too) -> Err ---
+    // Clear UID so no caller can smuggle a uid through the old fallback.
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+        std::env::remove_var("UID");
+    }
+    let err = resolve_socket_path("abc123").expect_err("must refuse without XDG_RUNTIME_DIR");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("XDG_RUNTIME_DIR"),
+        "error must name XDG_RUNTIME_DIR so operators see the fix, got: {msg}"
+    );
+    // Defense-in-depth: never silently resolve to /tmp.
+    assert!(
+        !msg.contains("/tmp"),
+        "error must not advertise a /tmp fallback, got: {msg}"
+    );
+
+    // Restore
+    unsafe {
+        match prev_xdg {
+            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
+        match prev_uid {
+            Some(v) => std::env::set_var("UID", v),
+            None => std::env::remove_var("UID"),
+        }
+    }
+}

--- a/crates/forge-session/tests/uds_socket_permissions.rs
+++ b/crates/forge-session/tests/uds_socket_permissions.rs
@@ -1,0 +1,73 @@
+//! F-044 (H8) regression: post-bind UDS socket permissions.
+//!
+//! Phase 1's IPC trust boundary is the Unix domain socket — anyone who can
+//! connect to it can drive the session, approve tool calls, and exfiltrate
+//! events. Before F-044 the socket was created with `0777 & ~umask` (typically
+//! `0755`, world-connectable). This test spawns `forged` with an explicit
+//! `FORGE_SOCKET_PATH` and asserts that after the listener has bound, the
+//! socket file's mode is exactly `0o600` — owner read/write, no one else.
+//!
+//! The test is Linux-gated because the audit target is Linux/systemd and CI
+//! only runs Linux runners. macOS/Windows get the same `set_permissions` call
+//! in `server.rs` but their semantics around Unix-socket permissions differ
+//! and are intentionally out of scope for this finding.
+
+#![cfg(target_os = "linux")]
+
+use std::os::unix::fs::PermissionsExt;
+use std::process::Stdio;
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+const FORGED: &str = env!("CARGO_BIN_EXE_forged");
+
+async fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..100 {
+        if let Ok(stream) = UnixStream::connect(path).await {
+            drop(stream);
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    panic!(
+        "forged did not create socket {} within deadline",
+        path.display()
+    );
+}
+
+#[tokio::test]
+async fn bound_socket_has_mode_0600() {
+    let dir = TempDir::new().expect("tempdir");
+    let sock_path = dir.path().join("session.sock");
+
+    // Relax the caller's umask so any accidental reliance on the caller's
+    // umask to mask bits would be exposed by this test. If `server.rs` still
+    // depended on umask, the bound socket would come out `0o666`; with the
+    // F-044 chmod, it must be `0o600` regardless.
+    // SAFETY: umask(2) is async-signal-safe; single-threaded test process at
+    // this point (tokio runtime hasn't spawned workers yet for this task).
+    let _prev = unsafe { libc::umask(0) };
+
+    let mut child = tokio::process::Command::new(FORGED)
+        .arg("--auto-approve-unsafe")
+        .env("FORGE_SESSION_ID", "permtest00000001")
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to spawn forged");
+
+    wait_for_socket(&sock_path).await;
+
+    let meta = std::fs::metadata(&sock_path).expect("stat socket");
+    let mode = meta.permissions().mode() & 0o777;
+
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+
+    assert_eq!(
+        mode, 0o600,
+        "socket mode must be 0o600 after bind (got {mode:o}) — anyone else on the host can \
+         otherwise connect and drive this session"
+    );
+}

--- a/crates/forge-shell/src/bridge.rs
+++ b/crates/forge-shell/src/bridge.rs
@@ -71,17 +71,31 @@ impl SessionConnections {
 }
 
 /// Resolve the default socket path for a session id, following the same
-/// rules as `forge-session::main`. Exposed so the Tauri command layer and
-/// tests agree on the convention.
-pub fn default_socket_path(session_id: &str) -> PathBuf {
+/// rules as `forge-session::socket_path::resolve_socket_path`. Exposed so
+/// the Tauri command layer and tests agree on the convention.
+///
+/// Returns `Err` when `XDG_RUNTIME_DIR` is unset. F-044 (H8) closed the
+/// pre-existing `/tmp/forge-<uid>` fallback; `forged` itself refuses to
+/// start without `XDG_RUNTIME_DIR`, so a shell that silently resolved to
+/// `/tmp/...` would only ever hit `ENOENT`. Surfacing the missing env var
+/// here gives the operator a clearer error than "no such file".
+pub fn default_socket_path(session_id: &str) -> Result<PathBuf> {
     let base = std::env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
         .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let uid = std::env::var("UID").unwrap_or_else(|_| "0".to_string());
-            PathBuf::from(format!("/tmp/forge-{uid}"))
-        });
-    base.join("forge/sessions")
-        .join(format!("{session_id}.sock"))
+        .ok_or_else(|| {
+            anyhow!(
+                "XDG_RUNTIME_DIR is unset: forge-shell refuses to fall \
+                 back to /tmp because the socket there would be \
+                 world-connectable. Set XDG_RUNTIME_DIR to a per-user \
+                 0o700 directory (systemd sets /run/user/<uid> \
+                 automatically). (F-044 / H8)"
+            )
+        })?;
+    Ok(base
+        .join("forge/sessions")
+        .join(format!("{session_id}.sock")))
 }
 
 /// Top-level bridge operations invoked by Tauri commands. Keyed on
@@ -114,9 +128,10 @@ impl SessionBridge {
             }
         }
 
-        let path: PathBuf = socket_path
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| default_socket_path(session_id));
+        let path: PathBuf = match socket_path {
+            Some(p) => p.to_path_buf(),
+            None => default_socket_path(session_id)?,
+        };
         let stream = UnixStream::connect(&path)
             .await
             .with_context(|| format!("connect UDS {}", path.display()))?;

--- a/docs/architecture/crate-architecture.md
+++ b/docs/architecture/crate-architecture.md
@@ -238,7 +238,7 @@ async fn main() -> Result<()> {
 - Write session metadata to `.forge/sessions/<id>/meta.toml`
 - Host the agent orchestrator
 - Host the tool dispatcher (fs, shell, agent.spawn, mcp.*)
-- Expose an IPC server over a Unix domain socket at `$XDG_RUNTIME_DIR/forge/sessions/<id>.sock` (macOS: `/tmp/forge-<uid>/sessions/<id>.sock`)
+- Expose an IPC server over a Unix domain socket at `$XDG_RUNTIME_DIR/forge/sessions/<id>.sock`. As of F-044 the daemon refuses to start without `XDG_RUNTIME_DIR` set — a shared-tmp fallback would be world-connectable and is no longer offered. macOS systems that want to host `forged` must set `XDG_RUNTIME_DIR` themselves (to a per-user `0o700` directory) or override the path via `FORGE_SOCKET_PATH`.
 - Handle approval prompts (by emitting an event and waiting for an `ApproveToolCall` command)
 - Track usage counters in-memory, flush to monthly aggregate on session end (strategy TBD per CONCEPT.md §13)
 - Execute parallel reads; serialize writes/exec


### PR DESCRIPTION
## Summary

Closes H8 (`docs/audits/phase-1/findings/H8.md`) — issue #86.

- `resolve_socket_path` refuses to start `forged` when `XDG_RUNTIME_DIR` is unset (option 4 from the finding). The old `/tmp/forge-{uid}` fallback, powered by a broken `std::env::var(\"UID\")` read that returned `\"0\"` for most spawn paths, is deleted entirely.
- `UnixListener::bind` is followed immediately by `set_permissions(path, 0o600)` so the socket is never world-connectable. The parent directory is also tightened to `0o700`.
- Mirror the change across `forge-cli` (`socket.rs`) and `forge-shell` (`bridge.rs`) so CLI/shell surface the same clear error rather than silently pointing at a socket that can't exist.

## Design notes

- **Option 4 taken (reject fallback)** over options 1-3 (hardened fallback). All integration tests set `FORGE_SOCKET_PATH` explicitly, so `resolve_socket_path` runs only in production — where systemd provides `XDG_RUNTIME_DIR` at `/run/user/<uid>` (0o700 tmpfs). No legitimate flow depends on the fallback.
- **Scope expansion into forge-cli/forge-shell**: chose the full \`Result\`-returning refactor (4 CLI call-sites + 1 shell call-site) over the minimal \`libc::getuid()\` swap. The daemon refuses to start without `XDG_RUNTIME_DIR`; a CLI that silently resolves to \`/tmp/forge-0/...\` and reports \"no such daemon\" would produce a confusing error chain.
- **macOS behavior change**: `docs/architecture/crate-architecture.md:241` previously documented a `/tmp/forge-<uid>` macOS path. That's removed — macOS hosts must set `XDG_RUNTIME_DIR` themselves or use `FORGE_SOCKET_PATH`. CI is Linux-only so this doesn't regress any green build.
- **F-056 adjacency**: the narrow window between `bind()` and `set_permissions(0o600)` is intentionally left for F-056 to close; comments in `server.rs` flag it explicitly.

## Definition of Done

- [x] `resolve_socket_path` uses `getuid()`; `/tmp` fallback either rejected at startup or given mode `0700` parent + `0600` socket
  - Fallback rejected at startup with error naming `XDG_RUNTIME_DIR` (H8 option 4). Defense-in-depth: parent 0o700, socket 0o600 post-bind.
- [x] Regression test: on Linux, verify post-bind socket mode is `0600`
  - \`crates/forge-session/tests/uds_socket_permissions.rs::bound_socket_has_mode_0600\` spawns forged, stats the socket, asserts \`mode & 0o777 == 0o600\`.
- [x] Tests pass in CI
  - `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace` all clean.

## Test plan

- [ ] `cargo test -p forge-session --test uds_socket_permissions` — new mode test
- [ ] `cargo test -p forge-session --test socket_path_fallback` — resolver Ok/Err branches
- [ ] `cargo test -p forge-cli --lib socket::tests::path_resolvers_require_xdg_runtime_dir` — CLI parity
- [ ] `cargo test --workspace` — no regressions
- [ ] Manual: `XDG_RUNTIME_DIR= forged` should exit with the new error; `FORGE_SOCKET_PATH=/run/user/$UID/forge/sessions/x.sock forged` should still work.