### PR TITLE
fix(forge-shell): type session_approve_tool scope as enum (F-069)

### DIFF
--- a/crates/forge-shell/src/bridge.rs
+++ b/crates/forge-shell/src/bridge.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
+use forge_core::ApprovalScope;
 use forge_ipc::{
     read_frame, write_frame, ClientInfo, Hello, HelloAck, IpcMessage, SendUserMessage, Subscribe,
     ToolCallApproved, ToolCallRejected, PROTO_VERSION,
@@ -197,9 +198,20 @@ impl SessionBridge {
         write_frame(&mut *writer, &frame).await
     }
 
-    pub async fn approve_tool(&self, session_id: &str, id: String, scope: String) -> Result<()> {
+    pub async fn approve_tool(
+        &self,
+        session_id: &str,
+        id: String,
+        scope: ApprovalScope,
+    ) -> Result<()> {
         let writer = self.writer_for(session_id).await?;
         let mut writer = writer.lock().await;
+        // F-069 / L5 (T7): the Tauri command layer is the trust boundary — it
+        // accepts a typed `ApprovalScope` only. The wire shape in
+        // `forge_ipc::ToolCallApproved` still carries `scope: String` so the
+        // forge-session daemon's deserializer keeps working unchanged while
+        // F-053 (M7) — the complementary server-side fix — is still pending.
+        let scope = scope_to_wire(&scope);
         let frame = IpcMessage::ToolCallApproved(ToolCallApproved { id, scope });
         write_frame(&mut *writer, &frame).await
     }
@@ -223,6 +235,21 @@ impl SessionBridge {
             .ok_or_else(|| anyhow!("no active connection for session {session_id}"))?;
         Ok(Arc::clone(&conn.writer))
     }
+}
+
+/// F-069 / L5 (T7): map a typed [`ApprovalScope`] to the short PascalCase
+/// string that `forge_ipc::ToolCallApproved.scope` (and the existing daemon
+/// parser via F-053) expects. Kept explicit — not derived through
+/// `serde_json::to_value` — so the wire strings stay grep-able and any
+/// future variant addition forces a compile error here.
+fn scope_to_wire(scope: &ApprovalScope) -> String {
+    match scope {
+        ApprovalScope::Once => "Once",
+        ApprovalScope::ThisFile => "ThisFile",
+        ApprovalScope::ThisPattern => "ThisPattern",
+        ApprovalScope::ThisTool => "ThisTool",
+    }
+    .to_string()
 }
 
 async fn pump_events(mut reader: OwnedReadHalf, session_id: String, sink: Arc<dyn EventSink>) {

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -22,6 +22,7 @@
 
 use std::sync::Arc;
 
+use forge_core::ApprovalScope;
 use forge_ipc::HelloAck;
 use tauri::{AppHandle, Emitter, EventTarget, Manager, Runtime, State, Webview};
 
@@ -42,12 +43,13 @@ pub(crate) const LABEL_MISMATCH_ERROR: &str = "forbidden: window label mismatch"
 /// All caps are byte counts (`.len()` on `String`), not char counts — the
 /// resource being bounded is memory/wire cost.
 ///
-/// A single command may bind additive validations in the future
-/// (e.g. F-069 typed-enum validation on `scope` will layer on top of the
-/// size check here).
+/// F-069 / L5 (T7) superseded the byte cap on `session_approve_tool`'s `scope`
+/// with a typed-enum (`forge_core::ApprovalScope`) whose variants are all
+/// short; any oversize or non-variant input is rejected by serde at the Tauri
+/// arg-deserialization layer — earlier than this check. No `MAX_SCOPE_BYTES`
+/// constant is defined for that reason.
 pub(crate) const MAX_MESSAGE_TEXT_BYTES: usize = 128 * 1024;
 pub(crate) const MAX_TOOL_CALL_ID_BYTES: usize = 64;
-pub(crate) const MAX_APPROVAL_SCOPE_BYTES: usize = 256;
 pub(crate) const MAX_REJECT_REASON_BYTES: usize = 1024;
 
 /// F-068 / L4 (T7): error returned when a session command's untyped-string
@@ -229,16 +231,17 @@ pub async fn session_send_message<R: Runtime>(
 pub async fn session_approve_tool<R: Runtime>(
     session_id: String,
     tool_call_id: String,
-    scope: String,
+    scope: ApprovalScope,
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
     require_window_label(&webview, &format!("session-{session_id}"))?;
-    // F-068 / L4 (T7): tool_call_id is a short opaque handle; scope is a
-    // short enum-ish string. Both are bounded here before F-069's typed-enum
-    // validation lands on `scope`.
+    // F-068 / L4 (T7): tool_call_id is a short opaque handle; bound it here.
+    // F-069 / L5 (T7): `scope` is typed as `forge_core::ApprovalScope` — serde
+    // rejects any non-variant string at Tauri arg-deserialization (before this
+    // body runs), so no explicit scope validation is needed and no byte cap
+    // is useful (the longest variant is 11 bytes).
     require_size("tool_call_id", &tool_call_id, MAX_TOOL_CALL_ID_BYTES)?;
-    require_size("scope", &scope, MAX_APPROVAL_SCOPE_BYTES)?;
     state
         .bridge
         .approve_tool(&session_id, tool_call_id, scope)

--- a/crates/forge-shell/tests/bridge_e2e.rs
+++ b/crates/forge-shell/tests/bridge_e2e.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use forge_core::Event;
+use forge_core::{ApprovalScope, Event};
 use forge_providers::MockProvider;
 use forge_session::server::serve_with_session;
 use forge_session::session::Session;
@@ -139,7 +139,7 @@ async fn approve_tool_proxies_to_daemon() {
         .expect("subscribe");
 
     bridge
-        .approve_tool("approve-session", "call-123".into(), "Once".into())
+        .approve_tool("approve-session", "call-123".into(), ApprovalScope::Once)
         .await
         .expect("approve_tool writes frame");
 

--- a/crates/forge-shell/tests/ipc_commands.rs
+++ b/crates/forge-shell/tests/ipc_commands.rs
@@ -319,31 +319,11 @@ fn session_approve_tool_rejects_tool_call_id_above_cap_at_command_layer() {
     );
 }
 
-#[test]
-fn session_approve_tool_rejects_scope_above_cap_at_command_layer() {
-    let app = make_app();
-    app.manage(BridgeState::new(SessionConnections::new()));
-    let window = make_session_window(&app, "scope");
-
-    let err = invoke_err(
-        &window,
-        "session_approve_tool",
-        serde_json::json!({
-            "sessionId": "scope",
-            "toolCallId": "tc-1",
-            "scope": "x".repeat(257),
-        }),
-    );
-
-    assert!(
-        err.contains("payload too large") && err.contains("scope"),
-        "expected size-cap error mentioning scope, got: {err}"
-    );
-    assert!(
-        !err.contains("no active connection"),
-        "size check must fire before the bridge, got: {err}"
-    );
-}
+// F-069 / L5 (T7) removed the byte-cap test for `scope` above — `scope` is
+// now typed as `forge_core::ApprovalScope`, so any oversize/non-variant input
+// is rejected by serde at the Tauri arg-deserialization layer. The
+// positive/negative coverage lives in `session_approve_tool_rejects_garbage_scope_at_command_layer`
+// and `session_approve_tool_accepts_valid_scope_variants` below.
 
 #[test]
 fn session_reject_tool_rejects_tool_call_id_above_cap_at_command_layer() {
@@ -422,4 +402,69 @@ fn session_reject_tool_accepts_absent_reason() {
         !err.contains("payload too large"),
         "None reason must not be rejected by the size cap, got: {err}"
     );
+}
+
+// F-069 / L5 (T7): typed-enum validation on `scope`.
+//
+// `scope` is declared as `forge_core::ApprovalScope` on the Tauri command, so
+// Tauri's arg-deserialization layer rejects any non-variant string before the
+// command body runs — earlier than `require_window_label`, earlier than the
+// F-068 byte caps, earlier than the bridge. A garbage string ("not-a-scope")
+// cannot reach the bridge, which defends against type-confusion widening of
+// approvals by a compromised webview.
+
+#[test]
+fn session_approve_tool_rejects_garbage_scope_at_command_layer() {
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "garbage-scope");
+
+    let err = invoke_err(
+        &window,
+        "session_approve_tool",
+        serde_json::json!({
+            "sessionId": "garbage-scope",
+            "toolCallId": "tc-1",
+            "scope": "garbage",
+        }),
+    );
+
+    // The load-bearing assertions: rejection must be serde-level (typed-enum
+    // validation fires before the bridge is consulted). If the call reached
+    // the bridge, we would see "no active connection" instead.
+    assert!(
+        !err.contains("no active connection"),
+        "typed-enum validation must fire before the bridge, got: {err}"
+    );
+    assert!(
+        err.contains("scope"),
+        "error must surface the offending field `scope`, got: {err}"
+    );
+}
+
+#[test]
+fn session_approve_tool_accepts_valid_scope_variants() {
+    // Every TS-side ApprovalScope variant must round-trip through
+    // Tauri arg-deserialization and reach the bridge (which will then error
+    // with "no active connection" — the security-relevant evidence that the
+    // typed enum accepted the value).
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "valid-scope");
+
+    for variant in ["Once", "ThisFile", "ThisPattern", "ThisTool"] {
+        let err = invoke_err(
+            &window,
+            "session_approve_tool",
+            serde_json::json!({
+                "sessionId": "valid-scope",
+                "toolCallId": "tc-1",
+                "scope": variant,
+            }),
+        );
+        assert!(
+            err.contains("no active connection"),
+            "variant {variant:?} must pass enum validation and reach the bridge, got: {err}"
+        );
+    }
 }


### PR DESCRIPTION
Closes forge-ide/forge#111

## Summary

- **Finding (L5 / T7):** `session_approve_tool` accepted `scope: String` at the Tauri command layer, so a compromised webview could pass any value — silently treated as "no persistent approval" by the session's catch-all, and a crafted scope that happened to satisfy a future `starts_with`/`contains` check could widen approval beyond what the UI rendered.
- **Fix:** changed the shell-side DTO to the typed `forge_core::ApprovalScope` enum (`Once | ThisFile | ThisPattern | ThisTool`). Tauri's arg-deserialization layer now rejects any non-variant string at invoke dispatch — before `require_window_label`, before the F-068 byte caps, before the bridge.
- **Stacking on F-068:** serde runs first, so a 257-byte garbage scope fails as a typed-enum error (not as a byte-cap error). The scope-specific `MAX_APPROVAL_SCOPE_BYTES` and its regression test are removed — no valid variant exceeds 11 bytes, so the cap is dead. The F-068 caps on `text`, `tool_call_id`, and `reason` are unaffected.
- **Bridge contract:** `SessionBridge::approve_tool(..., scope: ApprovalScope)` now takes the typed enum and serializes to the short PascalCase string at the wire boundary via `scope_to_wire`. `forge_ipc::ToolCallApproved.scope: String` is intentionally unchanged — F-053 (M7) will tighten the server-side parser independently.

## Definition of Done

- [x] Shell-side `ApprovalScope` is a typed enum; invalid values reject at the Tauri command layer
- [x] Regression test: `session_approve_tool` with `scope: "garbage"` returns a deserialization error
- [x] Tests pass in CI

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (63 forge-shell tests across unit + integration including the new F-069 tests)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)