### PR TITLE
fix(forge-session): record client-supplied ApprovalScope faithfully (F-053)

### DIFF
--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -18,8 +18,18 @@ use crate::tools::{
     FsEditTool, FsReadTool, FsWriteTool, ShellExecTool, ToolCtx, ToolDispatcher, ToolError,
 };
 
+/// Client decision for a pending tool call approval. Carries the
+/// client-supplied `ApprovalScope` on approval so the event log records
+/// the scope faithfully (F-053); `Rejected` collapses scope since there's
+/// nothing to carry forward.
+#[derive(Debug, Clone)]
+pub enum ApprovalDecision {
+    Approved(ApprovalScope),
+    Rejected,
+}
+
 /// Pending tool call approvals: maps ToolCallId → sender for the approval result.
-pub type PendingApprovals = Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>;
+pub type PendingApprovals = Arc<Mutex<HashMap<String, oneshot::Sender<ApprovalDecision>>>>;
 
 /// Run a complete turn for the given user text. Emits all session events for:
 /// UserMessage → AssistantMessage(open) → AssistantDelta* →
@@ -178,7 +188,7 @@ async fn run_request_loop<P: Provider>(
                                     })
                                     .await?;
                             } else {
-                                let (tx, rx) = oneshot::channel::<bool>();
+                                let (tx, rx) = oneshot::channel::<ApprovalDecision>();
                                 pending_approvals
                                     .lock()
                                     .await
@@ -191,35 +201,40 @@ async fn run_request_loop<P: Provider>(
                                     })
                                     .await?;
 
-                                let approved = rx.await.unwrap_or(false);
+                                // If the client drops the channel we treat it as a
+                                // rejection — matches the pre-F-053 default.
+                                let decision = rx.await.unwrap_or(ApprovalDecision::Rejected);
 
-                                if !approved {
-                                    session
-                                        .emit(Event::ToolCallRejected {
-                                            id: call_id,
-                                            reason: Some("rejected by client".to_string()),
-                                        })
-                                        .await?;
-                                    session
-                                        .emit(Event::AssistantMessage {
-                                            id: msg_id.clone(),
-                                            provider: provider_id.clone(),
-                                            model: model.clone(),
-                                            at: Utc::now(),
-                                            stream_finalised: true,
-                                            text: assistant_text.clone(),
-                                            branch_parent: None,
-                                            branch_variant_index: 0,
-                                        })
-                                        .await?;
-                                    return Ok(());
-                                }
+                                let scope = match decision {
+                                    ApprovalDecision::Approved(scope) => scope,
+                                    ApprovalDecision::Rejected => {
+                                        session
+                                            .emit(Event::ToolCallRejected {
+                                                id: call_id,
+                                                reason: Some("rejected by client".to_string()),
+                                            })
+                                            .await?;
+                                        session
+                                            .emit(Event::AssistantMessage {
+                                                id: msg_id.clone(),
+                                                provider: provider_id.clone(),
+                                                model: model.clone(),
+                                                at: Utc::now(),
+                                                stream_finalised: true,
+                                                text: assistant_text.clone(),
+                                                branch_parent: None,
+                                                branch_variant_index: 0,
+                                            })
+                                            .await?;
+                                        return Ok(());
+                                    }
+                                };
 
                                 session
                                     .emit(Event::ToolCallApproved {
                                         id: call_id.clone(),
                                         by: ApprovalSource::User,
-                                        scope: ApprovalScope::Once,
+                                        scope,
                                         at: Utc::now(),
                                     })
                                     .await?;

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -16,9 +16,10 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::{broadcast, Mutex};
 
 use crate::archive::archive_or_purge;
-use crate::orchestrator::{run_turn, PendingApprovals};
+use crate::orchestrator::{run_turn, ApprovalDecision, PendingApprovals};
 use crate::sandbox::ChildRegistry;
 use crate::session::Session;
+use forge_core::ApprovalScope;
 
 /// Compute the session's `allowed_paths` glob list from its workspace root.
 ///
@@ -387,16 +388,31 @@ async fn handle_connection<P: Provider + 'static>(
                     }
 
                     Some(IpcMessage::ToolCallApproved(a)) => {
+                        // F-053: parse the client-supplied scope (wire format is still
+                        // a bare string, per forge_ipc::ToolCallApproved) into the typed
+                        // `ApprovalScope`. On parse failure, fall back to `Once` and
+                        // warn — the user did click approve, so we honour the approval
+                        // at the weakest scope rather than dropping it silently.
+                        let scope = serde_json::from_value::<ApprovalScope>(
+                            serde_json::Value::String(a.scope.clone()),
+                        )
+                        .unwrap_or_else(|_| {
+                            eprintln!(
+                                "ToolCallApproved: unknown scope {:?}, falling back to Once",
+                                a.scope
+                            );
+                            ApprovalScope::Once
+                        });
                         let mut map = pending_approvals.lock().await;
                         if let Some(tx) = map.remove(&a.id) {
-                            let _ = tx.send(true);
+                            let _ = tx.send(ApprovalDecision::Approved(scope));
                         }
                     }
 
                     Some(IpcMessage::ToolCallRejected(r)) => {
                         let mut map = pending_approvals.lock().await;
                         if let Some(tx) = map.remove(&r.id) {
-                            let _ = tx.send(false);
+                            let _ = tx.send(ApprovalDecision::Rejected);
                         }
                     }
 

--- a/crates/forge-session/tests/orchestrator.rs
+++ b/crates/forge-session/tests/orchestrator.rs
@@ -1,4 +1,4 @@
-use forge_core::Event;
+use forge_core::{ApprovalScope, Event};
 use forge_ipc::{
     ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, ToolCallApproved,
     PROTO_VERSION,
@@ -564,5 +564,83 @@ async fn tool_result_fed_back_to_provider_in_continuation() {
     assert!(
         has_tool_result,
         "second ChatRequest should contain a ToolResult block"
+    );
+}
+
+/// F-053 regression: the client-supplied ApprovalScope on `ToolCallApproved`
+/// must be recorded faithfully in the emitted `Event::ToolCallApproved`,
+/// rather than being hard-coded to `Once`.
+#[tokio::test]
+async fn approval_with_this_tool_scope_is_recorded_faithfully() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("scope_fidelity.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider =
+        Arc::new(MockProvider::from_responses(vec![SCRIPT_INITIAL.to_string()]).unwrap());
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            server_session,
+            server_provider,
+            false,
+            false,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "hi".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    let (mut reader, mut writer) = stream.into_split();
+
+    // Read events, approve with scope="ThisTool" when requested, and capture
+    // the emitted ToolCallApproved event so we can inspect its scope.
+    let mut approved_scope: Option<ApprovalScope> = None;
+    for _ in 0..20 {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        match extract_event(&frame) {
+            Some(Event::ToolCallApprovalRequested { id, .. }) => {
+                forge_ipc::write_frame(
+                    &mut writer,
+                    &IpcMessage::ToolCallApproved(ToolCallApproved {
+                        id: id.to_string(),
+                        scope: "ThisTool".to_string(),
+                    }),
+                )
+                .await
+                .unwrap();
+            }
+            Some(Event::ToolCallApproved { scope, .. }) => {
+                approved_scope = Some(scope);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        approved_scope,
+        Some(ApprovalScope::ThisTool),
+        "client-supplied ApprovalScope::ThisTool must be recorded faithfully"
     );
 }


### PR DESCRIPTION
Closes forge-ide/forge#95

## Summary

Threat class **T1 — tool-approval fidelity**. The daemon was collapsing every
client scope into `Once`, so "Approve for this tool" / "this pattern"
silently re-prompted every call — approval fatigue without bypass.

- `server.rs` parses `a.scope` into `forge_core::ApprovalScope` via `serde_json`.
  Unknown scope falls back to `Once` with a stderr warn — the user did click
  approve; we honour the decision at the weakest scope rather than dropping it.
  F-069 already validates the enum on the TS side, so this branch is defensive.
- Introduces `ApprovalDecision::Approved(ApprovalScope) | Rejected` for the
  pending-approval oneshot channel — single match site for the approve/reject
  fork and the scope carry.
- User-approve branch of `run_request_loop` emits the client-supplied scope.
  The auto-approve branch (no client input) stays `Once`.

**Out of scope by design:** scope-based approval caching/persistence. The
audit explicitly defers that to Phase 2 — "At minimum, record the scope
faithfully in the event log today." This PR does exactly that.

## Test plan

- New regression test `approval_with_this_tool_scope_is_recorded_faithfully`
  in `crates/forge-session/tests/orchestrator.rs`: approve with `scope: "ThisTool"`,
  assert the emitted `Event::ToolCallApproved.scope == ApprovalScope::ThisTool`.
  Confirmed RED before the fix (`left: Some(Once), right: Some(ThisTool)`), GREEN after.
- `cargo test --workspace` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo fmt --check` passes

## Notes for reviewers

- The audit spec references `server.rs:337-342`; actual approval handler now
  sits at ~389 after F-068 removed the length cap and F-069 typed the TS side.
  The change targets the correct code path — line drift only.
- IPC wire format (`forge_ipc::ToolCallApproved.scope: String`) is unchanged;
  parsing is a session-side concern.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context
(per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)