### PR TITLE
fix(forge-session): validate shell.exec cwd and surface it in preview (F-054)

### DIFF
--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -378,6 +378,144 @@ mod tests {
         );
     }
 
+    #[test]
+    fn shell_exec_preview_includes_cwd_when_provided() {
+        let tool = ShellExecTool;
+        let preview = tool.approval_preview(&json!({
+            "command": "ls",
+            "args": ["."],
+            "cwd": "/tmp/somewhere-specific"
+        }));
+        assert!(
+            preview.description.contains("/tmp/somewhere-specific"),
+            "cwd missing from preview: {}",
+            preview.description
+        );
+        assert!(
+            preview.description.contains("ls"),
+            "command missing from preview: {}",
+            preview.description
+        );
+    }
+
+    #[test]
+    fn shell_exec_preview_omits_cwd_when_absent() {
+        let tool = ShellExecTool;
+        let preview = tool.approval_preview(&json!({
+            "command": "ls",
+            "args": ["."]
+        }));
+        assert!(
+            !preview.description.to_lowercase().contains("cwd"),
+            "cwd should not appear when absent: {}",
+            preview.description
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn shell_exec_dispatch_rejects_cwd_outside_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(ShellExecTool)).unwrap();
+
+        let ctx = ToolCtx {
+            allowed_paths: vec![],
+            workspace_root: Some(dir.path().to_path_buf()),
+            child_registry: Some(crate::sandbox::ChildRegistry::new()),
+        };
+        let result = d
+            .dispatch(
+                "shell.exec",
+                &json!({
+                    "command": "/bin/sh",
+                    "args": ["-c", "echo should-not-run"],
+                    "cwd": "/etc",
+                    "timeout_ms": 5000
+                }),
+                &ctx,
+            )
+            .unwrap();
+
+        assert!(
+            result.get("error").is_some(),
+            "expected error when cwd is outside workspace; got: {result}"
+        );
+        assert!(
+            result.get("exit_code").is_none(),
+            "command must not execute when cwd is rejected; got: {result}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn shell_exec_dispatch_accepts_cwd_inside_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(ShellExecTool)).unwrap();
+
+        let ctx = ToolCtx {
+            allowed_paths: vec![],
+            workspace_root: Some(dir.path().to_path_buf()),
+            child_registry: Some(crate::sandbox::ChildRegistry::new()),
+        };
+        let result = d
+            .dispatch(
+                "shell.exec",
+                &json!({
+                    "command": "/bin/sh",
+                    "args": ["-c", "pwd"],
+                    "cwd": sub.to_str().unwrap(),
+                    "timeout_ms": 5000
+                }),
+                &ctx,
+            )
+            .unwrap();
+
+        assert_eq!(result["exit_code"].as_i64(), Some(0), "result: {result}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn shell_exec_dispatch_rejects_cwd_via_symlink_escape() {
+        // Symlink inside the workspace pointing outside must be rejected:
+        // canonicalize() resolves the symlink, and the post-canonical
+        // prefix check catches the escape.
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("escape");
+        std::os::unix::fs::symlink("/etc", &link).unwrap();
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(ShellExecTool)).unwrap();
+
+        let ctx = ToolCtx {
+            allowed_paths: vec![],
+            workspace_root: Some(dir.path().to_path_buf()),
+            child_registry: Some(crate::sandbox::ChildRegistry::new()),
+        };
+        let result = d
+            .dispatch(
+                "shell.exec",
+                &json!({
+                    "command": "/bin/sh",
+                    "args": ["-c", "echo should-not-run"],
+                    "cwd": link.to_str().unwrap(),
+                    "timeout_ms": 5000
+                }),
+                &ctx,
+            )
+            .unwrap();
+
+        assert!(
+            result.get("error").is_some(),
+            "symlink escape must be rejected; got: {result}"
+        );
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn shell_exec_dispatch_clears_daemon_env_by_default() {

--- a/crates/forge-session/src/tools/shell_exec.rs
+++ b/crates/forge-session/src/tools/shell_exec.rs
@@ -44,11 +44,21 @@ impl Tool for ShellExecTool {
                     .join(" ")
             })
             .unwrap_or_default();
+        // Surface `cwd` in the preview whenever it is supplied. When absent,
+        // `run_linux` defaults to `ctx.workspace_root` — there is nothing for
+        // the user to distinguish, so no `cwd` line is shown. When present,
+        // the directory context is load-bearing and must appear in consent
+        // (F-054 / audit finding M8).
+        let cwd = args.get("cwd").and_then(|v| v.as_str());
+        let head = if argv.is_empty() {
+            format!("Run command: {command}")
+        } else {
+            format!("Run command: {command} {argv}")
+        };
         ApprovalPreview {
-            description: if argv.is_empty() {
-                format!("Run command: {command}")
-            } else {
-                format!("Run command: {command} {argv}")
+            description: match cwd {
+                Some(p) => format!("{head} (cwd: {p})"),
+                None => head,
             },
         }
     }
@@ -85,14 +95,52 @@ fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
         })
         .unwrap_or_default();
 
-    let cwd = args
-        .get("cwd")
-        .and_then(|v| v.as_str())
-        .map(std::path::PathBuf::from)
-        .or_else(|| ctx.workspace_root.clone())
-        .unwrap_or_else(|| {
+    // Resolve cwd. If the caller supplied one, validate it lives under
+    // `ctx.workspace_root` — canonicalize both sides so a symlink inside
+    // the workspace that points out is rejected by the post-canonical prefix
+    // check (F-054 / audit finding M8, symmetric with forge-fs root checks
+    // for F-043). If no cwd is supplied, fall back to the workspace root.
+    let cwd = match args.get("cwd").and_then(|v| v.as_str()) {
+        Some(requested) => {
+            let Some(root) = ctx.workspace_root.as_ref() else {
+                return serde_json::json!({
+                    "error": "shell.exec: cwd cannot be validated without workspace_root"
+                });
+            };
+            let canonical_cwd = match std::fs::canonicalize(requested) {
+                Ok(p) => p,
+                Err(e) => {
+                    return serde_json::json!({
+                        "error": format!("shell.exec: cannot resolve cwd {requested:?}: {e}")
+                    });
+                }
+            };
+            let canonical_root = match std::fs::canonicalize(root) {
+                Ok(p) => p,
+                Err(e) => {
+                    return serde_json::json!({
+                        "error": format!(
+                            "shell.exec: cannot resolve workspace_root {}: {e}",
+                            root.display()
+                        )
+                    });
+                }
+            };
+            if !canonical_cwd.starts_with(&canonical_root) {
+                return serde_json::json!({
+                    "error": format!(
+                        "shell.exec: cwd {} is outside workspace {}",
+                        canonical_cwd.display(),
+                        canonical_root.display()
+                    )
+                });
+            }
+            canonical_cwd
+        }
+        None => ctx.workspace_root.clone().unwrap_or_else(|| {
             std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
-        });
+        }),
+    };
 
     let timeout_ms = args
         .get("timeout_ms")


### PR DESCRIPTION
Closes forge-ide/forge#96

## Summary

Addresses audit finding **M8 / F-054** (threat classes T1 approval fidelity + T3 shell path confusion). `shell.exec` previously accepted `cwd` verbatim and omitted it from the approval preview, so a model could direct execution at `/etc` (or anywhere else) while the user's consent prompt said only `Run command: ls .`.

- **Preview fidelity:** `ApprovalPreview.description` now appends `(cwd: <path>)` whenever `args.cwd` is supplied. When absent, the effective cwd is `ctx.workspace_root` and the preview is unchanged.
- **cwd containment:** `run_linux` canonicalizes both `args.cwd` and `ctx.workspace_root` and enforces `starts_with`. Because `std::fs::canonicalize` resolves symlinks, a symlink inside the workspace pointing outside is caught by the post-canonical prefix check — symmetric with the root-enforcement pattern in `forge-fs` (F-043).
- **Error shape preserved:** rejection returns the existing `{ "error": "..." }` JSON — no trait / public-API changes.
- **Additive:** default cwd path (no `args.cwd`) is untouched, so F-066's queued `timeout_ms` work layers cleanly on top.

## Test plan

- 5 new tests in `crates/forge-session/src/tools/mod.rs`:
  - `shell_exec_preview_includes_cwd_when_provided`
  - `shell_exec_preview_omits_cwd_when_absent`
  - `shell_exec_dispatch_rejects_cwd_outside_workspace` (cwd: `/etc`)
  - `shell_exec_dispatch_accepts_cwd_inside_workspace`
  - `shell_exec_dispatch_rejects_cwd_via_symlink_escape`
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` passes

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)