### PR TITLE
fix(forge-session): bind UDS safely without pre-unlink TOCTOU (F-056)

### DIFF
--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -64,3 +64,7 @@ path = "tests/uds_socket_permissions.rs"
 [[test]]
 name = "socket_path_fallback"
 path = "tests/socket_path_fallback.rs"
+
+[[test]]
+name = "uds_bind_symlink_race"
+path = "tests/uds_bind_symlink_race.rs"

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
-use std::os::unix::fs::PermissionsExt;
+use std::io::ErrorKind;
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::Utc;
 use forge_core::{
     meta::{write_meta, SessionMeta},
@@ -66,6 +68,76 @@ pub async fn serve(path: &Path, auto_approve: bool, ephemeral: bool) -> Result<(
     serve_with_session(path, session, provider, auto_approve, ephemeral, None, None).await
 }
 
+/// Timeout for the post-`EADDRINUSE` liveness probe. Short enough that a
+/// genuinely orphaned socket doesn't stall daemon startup, long enough to let
+/// a slow local daemon reply. The probe is `connect(2)` only — no handshake —
+/// so the common-case round-trip is a few hundred microseconds.
+const LIVENESS_PROBE_TIMEOUT: Duration = Duration::from_millis(200);
+
+/// Bind a `UnixListener` at `path` without the classic pre-unlink TOCTOU.
+///
+/// F-056 (T6): the previous `if path.exists() { remove_file } ; bind` sequence
+/// let an attacker with write access to the parent directory plant a symlink
+/// and watch the daemon blindly unlink it. F-044 (H8) already closed the
+/// practical `/tmp/forge-0/` window by refusing the shared-directory fallback
+/// and chmod'ing the parent to 0o700, but the TOCTOU remains relevant as
+/// defense-in-depth for any future path configuration (e.g. an operator
+/// pointing `FORGE_SOCKET_PATH` into a shared location).
+///
+/// Protocol:
+/// 1. Try `bind` first — never pre-unlink.
+/// 2. On `EADDRINUSE`, probe with a short `UnixStream::connect`. If the probe
+///    succeeds, another live daemon is listening: bail out. **Do not** unlink
+///    another daemon's socket out from under it.
+/// 3. On probe failure (connection refused or timeout), the entry is likely
+///    an orphan. Confirm via `symlink_metadata` — which does **not** follow
+///    symlinks — that the entry is a real socket file. Symlinks and regular
+///    files are rejected outright: neither is a legitimate orphan, and
+///    unlinking either would be the exact exploit path this fix closes.
+/// 4. Unlink the confirmed orphan and retry `bind` exactly once.
+async fn bind_uds_safely(path: &Path) -> Result<UnixListener> {
+    match UnixListener::bind(path) {
+        Ok(listener) => Ok(listener),
+        Err(e) if e.kind() == ErrorKind::AddrInUse => {
+            // Address in use — either a live daemon is already serving or a
+            // prior daemon crashed leaving an orphan socket behind.
+            let probe =
+                tokio::time::timeout(LIVENESS_PROBE_TIMEOUT, UnixStream::connect(path)).await;
+            if let Ok(Ok(_stream)) = probe {
+                anyhow::bail!(
+                    "refusing to bind at {}: another daemon is already listening",
+                    path.display()
+                );
+            }
+
+            // Probe failed (refused or timed out). Check the entry type
+            // without following symlinks — `metadata()` would follow, which
+            // is itself exploitable.
+            let meta = tokio::fs::symlink_metadata(path).await.with_context(|| {
+                format!(
+                    "failed to stat {} while recovering from EADDRINUSE",
+                    path.display()
+                )
+            })?;
+            if !meta.file_type().is_socket() {
+                anyhow::bail!(
+                    "refusing to unlink {}: entry is not a socket (type={:?}). Remove it \
+                     manually after verifying it is not attacker-planted.",
+                    path.display(),
+                    meta.file_type()
+                );
+            }
+
+            tokio::fs::remove_file(path)
+                .await
+                .with_context(|| format!("failed to unlink orphan socket at {}", path.display()))?;
+            UnixListener::bind(path)
+                .with_context(|| format!("retry bind failed at {}", path.display()))
+        }
+        Err(e) => Err(e).with_context(|| format!("bind failed at {}", path.display())),
+    }
+}
+
 /// Start a session server with an explicit provider.
 ///
 /// `workspace` is reported back to clients via `HelloAck.workspace` (empty when `None`).
@@ -95,17 +167,15 @@ pub async fn serve_with_session<P: Provider + 'static>(
         // in a test), the 0o600 mode on the socket itself is the real defense.
         let _ = tokio::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).await;
     }
-    if path.exists() {
-        tokio::fs::remove_file(path).await?;
-    }
-    let listener = UnixListener::bind(path)?;
+    let listener = bind_uds_safely(path).await?;
     // F-044 (H8): chmod the socket to 0o600 the moment it exists. bind(2)
     // creates the socket file with `0o777 & ~umask`, typically 0o755 —
     // world-connectable, which in Phase 1 means any local user can drive the
-    // session. There is a brief TOCTOU window between bind and the chmod
-    // here (tracked by F-056); this call closes the steady-state exposure
-    // without widening that window. We refuse to proceed if the chmod fails
-    // rather than serve on a permissive socket.
+    // session. There is a brief post-bind TOCTOU window between `bind` and
+    // this chmod; it is a distinct concern from F-056 (which closed the
+    // *pre-bind* `remove_file`→`bind` race via `bind_uds_safely`) and remains
+    // bounded by the 0o700 parent-dir mode set above. We refuse to proceed if
+    // the chmod fails rather than serve on a permissive socket.
     tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
     let workspace_path: Option<PathBuf> = workspace.clone();
     // F-043: Derive `allowed_paths` from the workspace root so `fs.*` tools can

--- a/crates/forge-session/tests/uds_bind_symlink_race.rs
+++ b/crates/forge-session/tests/uds_bind_symlink_race.rs
@@ -1,0 +1,184 @@
+//! F-056 (T6) regression: UDS pre-bind `remove_file` is a TOCTOU race.
+//!
+//! Before F-056, `serve_with_session` did:
+//!
+//! ```text
+//! if path.exists() { remove_file(path).await?; }
+//! listener.bind(path)
+//! ```
+//!
+//! An attacker with write access to the parent directory could pre-create the
+//! socket path as a symlink (or a regular file) and watch the daemon blindly
+//! unlink whatever was there. Under H8's shared-`/tmp/forge-0/` fallback this
+//! was a full exploit; F-044 removed that fallback, but the TOCTOU still
+//! matters as defense-in-depth for any future path configuration (e.g.
+//! operators pointing `FORGE_SOCKET_PATH` into a shared location themselves).
+//!
+//! The fix: try `bind` first. On `EADDRINUSE`, probe with a short
+//! `UnixStream::connect` — only unlink-and-retry when the probe confirms the
+//! entry is an orphan socket. Critically, we never unlink a symlink or a
+//! regular file; both are signs of an attack or misconfiguration.
+//!
+//! These tests spawn `forged` with an explicit `FORGE_SOCKET_PATH` pointing at
+//! a symlink and assert that the daemon fails to start without mutating the
+//! symlink or its target.
+//!
+//! Linux-gated to match the rest of the UDS regression suite — the threat
+//! model is Linux/systemd and CI only runs Linux runners.
+
+#![cfg(target_os = "linux")]
+
+use std::os::unix::fs::PermissionsExt;
+use std::process::Stdio;
+use std::time::Duration;
+use tempfile::TempDir;
+
+const FORGED: &str = env!("CARGO_BIN_EXE_forged");
+
+/// Waits up to ~2s for `forged` to exit on its own (we expect it to bail out
+/// fast when the bind path is a symlink). Returns the exit status if the
+/// process exited, or kills it and returns `None` if it's still running — a
+/// `None` here is the regression signal: the old buggy code would have happily
+/// unlinked the symlink and proceeded to serve.
+async fn wait_for_exit(child: &mut tokio::process::Child) -> Option<std::process::ExitStatus> {
+    match tokio::time::timeout(Duration::from_secs(2), child.wait()).await {
+        Ok(Ok(status)) => Some(status),
+        _ => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            None
+        }
+    }
+}
+
+#[tokio::test]
+async fn symlink_at_bind_path_is_not_unlinked_and_rebound() {
+    let dir = TempDir::new().expect("tempdir");
+    let target = dir.path().join("attacker-target.txt");
+    let sock_path = dir.path().join("session.sock");
+
+    // Victim's bind path is a symlink pointing at a regular file the attacker
+    // already owned. Under the old code, `remove_file(&sock_path)` would have
+    // unlinked the symlink, and `bind(&sock_path)` would then have created a
+    // real socket at that name — quietly letting the daemon start. The fix
+    // must refuse, leaving both the symlink and the target untouched.
+    std::fs::write(&target, b"do not touch").expect("write target");
+    std::os::unix::fs::symlink(&target, &sock_path).expect("create symlink");
+
+    let mut child = tokio::process::Command::new(FORGED)
+        .arg("--auto-approve-unsafe")
+        .env("FORGE_SESSION_ID", "f056symlink00001")
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn forged");
+
+    let status = wait_for_exit(&mut child).await;
+
+    // After forged has exited (or we killed it), the symlink MUST still be a
+    // symlink and the target MUST still exist with its original contents. Any
+    // path that went through the old `remove_file + bind` sequence would have
+    // replaced `session.sock` with a real socket and left `target` orphaned.
+    let meta = std::fs::symlink_metadata(&sock_path).expect("stat sock_path");
+    assert!(
+        meta.file_type().is_symlink(),
+        "F-056: daemon must not replace a symlink at the bind path with a fresh socket"
+    );
+    assert!(
+        target.exists(),
+        "F-056: attacker target file must still exist — daemon should have refused to bind"
+    );
+    let contents = std::fs::read(&target).expect("read target");
+    assert_eq!(
+        contents, b"do not touch",
+        "F-056: attacker target contents must be untouched"
+    );
+
+    // Forged must have exited non-zero, not continued to serve. `None` means
+    // it was still running after 2s, which is the exact failure mode the old
+    // code exhibited.
+    let status = status.expect("forged should exit fast when bind path is a symlink");
+    assert!(
+        !status.success(),
+        "F-056: forged must exit non-zero when it refuses to bind onto a symlink"
+    );
+}
+
+#[tokio::test]
+async fn dangling_symlink_at_bind_path_is_not_unlinked_and_rebound() {
+    // Variant: the symlink points at a nonexistent target. Bind still fails
+    // (EADDRINUSE-ish or ENOENT via symlink resolution), the liveness probe
+    // still fails, but `symlink_metadata` still reports a symlink — so the
+    // fix must still refuse to unlink.
+    let dir = TempDir::new().expect("tempdir");
+    let sock_path = dir.path().join("session.sock");
+    let nowhere = dir.path().join("does-not-exist");
+
+    std::os::unix::fs::symlink(&nowhere, &sock_path).expect("create dangling symlink");
+
+    let mut child = tokio::process::Command::new(FORGED)
+        .arg("--auto-approve-unsafe")
+        .env("FORGE_SESSION_ID", "f056dangling0001")
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn forged");
+
+    let status = wait_for_exit(&mut child).await;
+
+    let meta = std::fs::symlink_metadata(&sock_path).expect("stat sock_path");
+    assert!(
+        meta.file_type().is_symlink(),
+        "F-056: daemon must not replace a dangling symlink with a fresh socket"
+    );
+
+    let status = status.expect("forged should exit fast when bind path is a dangling symlink");
+    assert!(
+        !status.success(),
+        "F-056: forged must exit non-zero when it refuses to bind onto a dangling symlink"
+    );
+}
+
+#[tokio::test]
+async fn regular_file_at_bind_path_is_not_unlinked_and_rebound() {
+    // Third variant: an attacker (or stale leftover) plants a regular file at
+    // the bind path. The old code would unlink it; the fix must refuse
+    // because a regular file is never a legitimate orphan socket.
+    let dir = TempDir::new().expect("tempdir");
+    let sock_path = dir.path().join("session.sock");
+
+    std::fs::write(&sock_path, b"attacker-planted").expect("write regular file");
+    // Give it a unique mode so we can assert the inode is untouched.
+    std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o644))
+        .expect("chmod regular file");
+
+    let mut child = tokio::process::Command::new(FORGED)
+        .arg("--auto-approve-unsafe")
+        .env("FORGE_SESSION_ID", "f056regfile00001")
+        .env("FORGE_SOCKET_PATH", &sock_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn forged");
+
+    let status = wait_for_exit(&mut child).await;
+
+    let meta = std::fs::symlink_metadata(&sock_path).expect("stat sock_path");
+    assert!(
+        meta.file_type().is_file(),
+        "F-056: daemon must not replace a regular file with a fresh socket"
+    );
+    let contents = std::fs::read(&sock_path).expect("read regular file");
+    assert_eq!(
+        contents, b"attacker-planted",
+        "F-056: attacker-planted file contents must be untouched"
+    );
+
+    let status = status.expect("forged should exit fast when bind path is a regular file");
+    assert!(
+        !status.success(),
+        "F-056: forged must exit non-zero when it refuses to bind onto a regular file"
+    );
+}


### PR DESCRIPTION
Closes #98

## Summary

Close the pre-bind TOCTOU in `serve_with_session`. Before this change, the server did:

```rust
if path.exists() { remove_file(path).await?; }
let listener = UnixListener::bind(path)?;
```

which let an attacker with write access to the parent directory plant a symlink or regular file at the bind path and watch the daemon blindly unlink it. F-044 (H8) already closed the practical exploit window by refusing the `/tmp/forge-0/` shared-directory fallback and chmod'ing the parent to `0o700`, but the TOCTOU remained as a defense-in-depth gap for any future path configuration (e.g. operators pointing `FORGE_SOCKET_PATH` into a shared location themselves).

## Fix

New `bind_uds_safely` helper in `crates/forge-session/src/server.rs`:

1. Try `bind` first — never pre-unlink.
2. On `EADDRINUSE`, probe with a 200 ms `UnixStream::connect`. If the probe succeeds, another live daemon is serving — bail out rather than unlink someone else's socket.
3. On probe failure (refused or timed out), confirm the entry type with `symlink_metadata` (does **not** follow symlinks — `metadata` would itself be exploitable) and refuse unless `is_socket()`. Symlinks and regular files are rejected outright; they are the exact exploit shapes this fix closes.
4. Unlink the confirmed orphan and retry `bind` exactly once.

Also clarified the F-044 chmod comment to note that F-056 has closed the pre-bind race (the remaining post-bind chmod window is a distinct, bounded concern).

## Tests

New Linux-gated regression suite at `crates/forge-session/tests/uds_bind_symlink_race.rs`:

- `symlink_at_bind_path_is_not_unlinked_and_rebound` — plants a symlink to a regular file and asserts forged exits non-zero with both the symlink and target intact.
- `dangling_symlink_at_bind_path_is_not_unlinked_and_rebound` — symlink to a nonexistent target; still refused.
- `regular_file_at_bind_path_is_not_unlinked_and_rebound` — plants a regular file; contents must be untouched.

All three pass against the new code; the first and third fail against the old `remove_file + bind` sequence (confirmed by running them pre-change).

## Definition of Done

- [x] UDS bind avoids pre-unlink unless liveness probe confirms orphan
- [x] Regression test: a symlink at the bind path is not blindly unlinked-and-rebound
- [x] Tests pass in CI

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p forge-session` (35+ tests, all green)
- [x] `cargo test --workspace` (all green)

Refs CWE-367.