### PR TITLE
fix(forge-session): clamp shell.exec timeout_ms to 10-minute ceiling (F-066)

### DIFF
--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -518,6 +518,49 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn shell_exec_clamps_timeout_ms_to_documented_ceiling() {
+        // Regression for F-066: a provider may pass an arbitrarily large
+        // timeout_ms (up to u64::MAX). Without the clamp, tokio::time::timeout
+        // receives a far-future deadline and a shell backgrounding sleeps can
+        // hold the tool-call future open indefinitely. With the clamp, the
+        // deadline is capped at MAX_TIMEOUT_MS (10 minutes) so the tool call
+        // always resolves within the ceiling. We drive a fast-exiting command
+        // here so the test runs quickly — the assertion is that the dispatch
+        // returns successfully (proving u64::MAX does not overflow or hang)
+        // and completes well under the ceiling.
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(ShellExecTool)).unwrap();
+
+        let ctx = ToolCtx {
+            allowed_paths: vec![],
+            workspace_root: Some(dir.path().to_path_buf()),
+            child_registry: Some(crate::sandbox::ChildRegistry::new()),
+        };
+
+        let started = std::time::Instant::now();
+        let result = d
+            .dispatch(
+                "shell.exec",
+                &json!({"command": "/bin/true", "timeout_ms": u64::MAX}),
+                &ctx,
+            )
+            .unwrap();
+        let elapsed = started.elapsed();
+
+        assert_eq!(result["exit_code"].as_i64(), Some(0), "result: {result}");
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "u64::MAX timeout caused dispatch to hang for {elapsed:?}"
+        );
+        // Compile-time guard: ceiling exists and stays within the documented
+        // 10-minute budget.
+        const _: () = assert!(shell_exec::MAX_TIMEOUT_MS <= 10 * 60 * 1000);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn shell_exec_dispatch_clears_daemon_env_by_default() {
         let dir = tempfile::tempdir().unwrap();
         std::env::set_var("FORGE_SHELL_EXEC_CANARY", "nope");

--- a/crates/forge-session/src/tools/shell_exec.rs
+++ b/crates/forge-session/src/tools/shell_exec.rs
@@ -8,7 +8,8 @@
 //!   "args": ["FOO"],                // optional
 //!   "cwd": "/path/to/workspace",    // optional; defaults to ctx.workspace_root
 //!   "env": { "FOO": "bar" },        // optional caller-scoped env allow-list
-//!   "timeout_ms": 30000             // optional wall-clock guard
+//!   "timeout_ms": 30000             // optional wall-clock guard; silently
+//!                                   // clamped to `MAX_TIMEOUT_MS` (10 min)
 //! }
 //! ```
 //!
@@ -20,6 +21,14 @@ use crate::sandbox::SandboxedCommand;
 use forge_core::ApprovalPreview;
 #[cfg(target_os = "linux")]
 use std::time::Duration;
+
+/// Upper bound for `shell.exec` `timeout_ms`. A provider-supplied value larger
+/// than this is silently clamped. Prevents a runaway tool call from holding
+/// the future open indefinitely (F-066 / CWE-400).
+pub(crate) const MAX_TIMEOUT_MS: u64 = 10 * 60 * 1000;
+
+/// Default `timeout_ms` when the caller does not supply one.
+pub(crate) const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
 pub struct ShellExecTool;
 
@@ -145,7 +154,8 @@ fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
     let timeout_ms = args
         .get("timeout_ms")
         .and_then(|v| v.as_u64())
-        .unwrap_or(30_000);
+        .unwrap_or(DEFAULT_TIMEOUT_MS)
+        .min(MAX_TIMEOUT_MS);
 
     let mut sb = SandboxedCommand::new(command, &cwd);
     sb.command_mut().args(&argv);


### PR DESCRIPTION
Closes forge-ide/forge#108

## Summary
- Introduce `pub(crate) const MAX_TIMEOUT_MS = 10 * 60 * 1000` (10 minutes) in `crates/forge-session/src/tools/shell_exec.rs` and clamp the caller-supplied `timeout_ms` via `.min(MAX_TIMEOUT_MS)`. A provider passing `u64::MAX` (or any value above the ceiling) is silently capped, preventing runaway tool calls from holding the future open indefinitely (CWE-400).
- Update the module doc comment to document the ceiling on the `timeout_ms` field.
- Add a regression test `shell_exec_clamps_timeout_ms_to_documented_ceiling` that dispatches `shell.exec` with `timeout_ms: u64::MAX` and asserts the call resolves under 5 s, plus a `const _: () = assert!(...)` compile-time guard that the ceiling stays within the documented 10-minute budget.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)