### PR TITLE
[F-094] Add Phase-1-vs-reserved disclaimers to ipc-contracts.md §4.1 and §5.3

### DIFF
--- a/docs/architecture/ipc-contracts.md
+++ b/docs/architecture/ipc-contracts.md
@@ -28,6 +28,8 @@ Forge has **two distinct IPC boundaries**. They must not be confused.
 
 ### 4.1 Boundary 1: Tauri ↔ webview
 
+> **Phase 1 coverage.** Phase 1 ships the following Tauri commands: `session_hello`, `session_subscribe`, `session_send_message`, `session_approve_tool`, `session_reject_tool`, `session_list`, `open_session`, `provider_status`. Every other command listed below is reserved for subsequent milestones and is not wired in Phase 1. See ADR-001 §4 for the corresponding subset note on the UDS boundary.
+
 **Pattern.** Tauri `command` handlers for request/response (webview → host) and Tauri `events` for push (host → webview).
 
 #### Commands (webview → host)
@@ -181,6 +183,8 @@ The client then sends either:
 ```
 
 ### 5.3 Message types
+
+> **Phase 1 coverage.** Phase 1 implements the following `IpcMessage` variants in `crates/forge-ipc`: `Hello`, `HelloAck`, `Subscribe`, `Event`, `SendUserMessage`, `ToolCallApproved`, `ToolCallRejected`. Every other variant listed below is reserved for subsequent milestones and is not wired in Phase 1. See ADR-001 §4 for the same subset note alongside its rationale.
 
 Full discriminated union, `t` is the tag.
 


### PR DESCRIPTION
Closes forge-ide/forge#167

## Summary
- §4.1 now opens with a Phase 1 coverage disclaimer enumerating the 8 shipped Tauri commands (`session_hello`, `session_subscribe`, `session_send_message`, `session_approve_tool`, `session_reject_tool`, `session_list`, `open_session`, `provider_status`) and flagging the rest as reserved.
- §5.3 now opens with a Phase 1 coverage disclaimer enumerating the 7 shipped `IpcMessage` variants (`Hello`, `HelloAck`, `Subscribe`, `Event`, `SendUserMessage`, `ToolCallApproved`, `ToolCallRejected`) and flagging the rest as reserved.
- Both disclaimers cross-reference ADR-001 §4, which already carries the parallel implementation note.
- Shipped names verified directly against `crates/forge-shell/src/ipc.rs`, `crates/forge-shell/src/dashboard.rs`, `crates/forge-shell/src/dashboard_sessions.rs`, and `crates/forge-ipc/src/lib.rs` before writing.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)