### PR TITLE
docs(ui-specs): author dashboard and pane-header specs (F-087)

### DIFF
--- a/docs/ui-specs/dashboard.md
+++ b/docs/ui-specs/dashboard.md
@@ -1,0 +1,78 @@
+# Dashboard
+
+> Root window of the desktop app — surfaces the active provider and the session roster so the user can pick up where they left off or start something new.
+
+---
+
+## D. Dashboard
+
+**Purpose.** First view in the Dashboard window. Confirms the local environment is wired up (provider reachable, models discoverable) and lets the user re-enter an existing session or read what's been archived.
+
+**Where.** Root route (`/`) of the Dashboard window. There is exactly one Dashboard window per app instance.
+
+**Size.** Fills the window. Min-height `100vh`. Single-column layout, content-driven height.
+
+### D.1 Structure
+
+```
+┌───────────────────────────────────────────────┐
+│ Forge — Dashboard                             │ ← title, ember
+├───────────────────────────────────────────────┤
+│ ┌── PROVIDER · ollama ────────────────────┐   │
+│ │ ● http://localhost:11434                 │   │
+│ │ [SHOW MODELS — 4 models]   [REFRESH]     │   │
+│ └─────────────────────────────────────────┘   │
+├───────────────────────────────────────────────┤
+│ [active 03] [archived 12]                     │
+│ ┌─────────────┐ ┌─────────────┐ ┌──────────┐  │
+│ │ session     │ │ session     │ │ session  │  │
+│ │ specimen    │ │ specimen    │ │ specimen │  │
+│ └─────────────┘ └─────────────┘ └──────────┘  │
+└───────────────────────────────────────────────┘
+```
+
+Top-to-bottom: title → provider panel → sessions panel. No tab bar, no sidebar, no pane splits — the Dashboard is intentionally a single flat surface.
+
+### D.2 Title
+
+- Text: `Forge — Dashboard` (em dash, single space either side)
+- Font: `--font-display` (Barlow Condensed)
+- Size: 2rem
+- Color: `--color-text-ember`
+- Margin: `0 0 var(--sp-3) 0`
+
+### D.3 Spacing & background
+
+- Page padding: `var(--sp-8)` on all sides
+- Background: `--color-bg`
+- Body color: `--color-text-primary`
+- Body font: `--font-body`
+
+### D.4 Composition
+
+The Dashboard renders three children in order: `<h1>` title, `<ProviderPanel/>`, `<SessionsPanel/>`. Both panels self-source their data via Tauri commands (`provider_status`, `session_list`) and own their own loading and empty states.
+
+- **Provider panel** — see `web/packages/app/src/routes/Dashboard/ProviderPanel.tsx`. Shows the configured provider (Phase 1: ollama, hardcoded), reachability indicator, base URL, expandable model list, and a `REFRESH` action that re-probes. When unreachable, renders an `ECONNREFUSED <host>` line and a `START OLLAMA` CTA. Provider identity color follows `ai-patterns.md` — Ollama is `steel`.
+- **Sessions panel** — industrial-ledger specimen cards grouped by `active` / `archived` tabs. Card click dispatches `open_session` and reopens the Session window. Cards show subject, persistence badge, state pip, provider chip, and a relative `last event` timestamp.
+
+### D.5 States
+
+The Dashboard itself has no global loading or error state — it always renders the title and both panels. The panels each handle their own state:
+
+- **Provider panel — loading:** placeholder line `PROBING` while `provider_status` resolves.
+- **Provider panel — unreachable:** error line + remediation hint + `START OLLAMA` CTA.
+- **Sessions panel — empty (active tab):** `// no active sessions`.
+- **Sessions panel — empty (archived tab):** `// archive is empty`.
+- **Sessions panel — fetch failure:** treated as empty (the resource swallows errors and yields `[]`).
+
+### D.6 Cross-spec references
+
+- `session-roster.md` — the in-session roster of loaded assets. Different surface (Session window sidebar) but related vocabulary; the Dashboard's session cards link a user *into* a session whose roster lives there.
+- `ai-patterns.md` — provider accent colors used by the provider indicator and any future provider chips on session cards.
+- `provider-selector.md` — composer-time provider switching (Phase 2+). The Dashboard's provider panel is read-only status, not a switcher.
+- `layout-panes.md` — pane model used by the Session window. The Dashboard does not use the pane model.
+
+**Doesn't do.**
+- Does not start a new session inline — `forge run …` from a terminal still seeds new sessions in Phase 1; a `NEW SESSION` action arrives later.
+- Does not show usage, billing, or per-model cost — that surfaces in pane headers and the usage view.
+- Does not configure providers — provider config lives in `~/.config/forge/providers.toml`; the panel only reflects status.

--- a/docs/ui-specs/pane-header.md
+++ b/docs/ui-specs/pane-header.md
@@ -1,0 +1,80 @@
+# Pane Header
+
+> Extracted from SPECS.md §3.3 and the F-024 Session-window shell — the 28px header strip that titles every pane and exposes pane-local actions.
+
+---
+
+## PH. Pane header
+
+**Purpose.** Identify the pane (type + subject), surface live cost for chat panes, and expose pane-local actions (close, future overflow). Always 28px tall, always present at the top of every pane.
+
+**Where.** Top edge of every pane in the Session window. One per pane.
+
+**Size.** Height `28px`, width fills the pane.
+
+### PH.1 Structure
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ CHAT  refactor session  [● anthropic]   in 1k · out 2k · $0.04   ⋯   CLOSE SESSION │
+└─────────────────────────────────────────────────────────────┘
+  └type └subject          └provider pill └cost meter           └overflow └close
+```
+
+Flex row, vertically centered, `gap: var(--sp-3)`, padding `0 var(--sp-4)`. Background `--color-surface-2`, 1px bottom border `--color-border-1`.
+
+### PH.2 Slots (left to right)
+
+| Slot | Content | Style |
+|---|---|---|
+| Type label | `CHAT`, `TERMINAL`, `EDITOR` | `--font-mono` 10px, uppercase, letter-spacing 0.12em, color `--color-text-tertiary` |
+| Subject | Agent name / filename / shell name | `--font-body` 13px, color `--color-text-primary` |
+| Provider pill | `● <provider>` | `--font-mono` 11px, `--color-surface-3` bg, 1px `--color-border-1`, radius `--r-sm`, padding `0 var(--sp-2)`, gap `var(--sp-1)` for the dot |
+| Cost meter | `in <n> · out <n> · $<cost>` | `--font-mono` 10px, letter-spacing 0.04em, color `--color-text-secondary`, `margin-left: auto` (right-pushes everything after the subject) |
+| Overflow | `⋯` button | placeholder in Phase 1; opens pane-local actions menu (rename, duplicate, move-to-window, etc.) when implemented |
+| Close | `CLOSE SESSION` (chat) | `--font-mono` 10px, uppercase, letter-spacing 0.12em, color `--color-text-secondary`; hover bumps to `--color-text-primary` and a 1px `--color-border-2` border with radius `--r-sm` |
+
+### PH.3 Provider pill
+
+The pill is the per-pane provider indicator. Color follows `ai-patterns.md` — anthropic = `ember-400`, openai = `amber`, local/ollama = `steel`, custom = `iron-200`. The accent applies to the dot and the pill text.
+
+In Phase 1 the pill text color is hardcoded to `--color-provider-local` (steel) as a placeholder while only the local Ollama provider is wired. The convention above is the target — once provider identity is plumbed through the pane state, the pill picks the accent from the active session's provider.
+
+### PH.4 Cost meter format
+
+Format: `in <input-tokens> · out <output-tokens> · $<dollar-cost>`. Tokens are abbreviated (`1.2k`, `34k`); the dollar value uses up to two decimals with no leading zero stripping (`$0.04`, not `$.04`).
+
+The cost meter sits at `margin-left: auto`, so the subject and provider pill cluster at the left and the cost + actions cluster at the right.
+
+**Narrow-width collapse.** Per `chat-pane.md §4` (Narrow-width adaptations), when the pane is below 480px wide, the cost meter collapses to `$<cost>` only and the per-token breakdown moves into a tooltip on hover. Below the 320px pane minimum (per `layout-panes.md §3.7`), the type label and subject also collapse — type label becomes an icon, subject truncates with ellipsis.
+
+### PH.5 Overflow `⋯` menu
+
+Placeholder slot to the left of the close button, holding pane-local actions that don't fit the header inline:
+
+- Rename pane subject
+- Duplicate pane (clones into a new split)
+- Move to window (detach into a fresh window — Phase 2+)
+- Pane-specific: `compact context` for chat panes at high context fill (see `chat-pane.md §4.1` Compact button)
+
+In Phase 1 the slot is reserved but not rendered. When implemented, it opens a small popover anchored to the `⋯` glyph; clicks outside dismiss.
+
+### PH.6 Close button
+
+Text: `CLOSE SESSION` for chat panes (per `voice-terminology.md §8` — verb + noun in display caps; tracked via F-084). The text varies by pane type once non-chat panes ship: `CLOSE TAB` for editor panes that hold a single tab, `CLOSE PANE` for terminal and editor panes generally.
+
+Behavior: clicking invokes the parent's `onClose` callback. For chat panes in the Session window, this resolves to the session-window-close path that confirms when the underlying session has unsaved scrollback.
+
+Accessibility: the rendered text is the convention; `aria-label="Close session window"` carries the screen-reader copy and stays in plain sentence case.
+
+### PH.7 Cross-spec references
+
+- `layout-panes.md §3.3` — defines the 28px slot; this spec details the contents.
+- `chat-pane.md §4` — pane header slot in chat-mode (cost meter, narrow-width rules).
+- `ai-patterns.md` — provider accent color rules used by the pill.
+- `voice-terminology.md §8` — display-caps verb-noun rule for the close button.
+
+**Doesn't do.**
+- Does not show usage history — only the running totals for the current pane.
+- Does not host pane-switching tabs — those live in the tab bar above the pane (see `layout-panes.md`).
+- Does not gate the close action behind a confirm dialog inside the header itself; confirmation, when needed, is owned by the close handler.


### PR DESCRIPTION
Closes forge-ide/forge#160

## Summary

Phase 1 shipped `Dashboard.tsx` and `PaneHeader.tsx` without paired specs in `docs/ui-specs/`. This PR adds both as documentation-only changes — the specs reflect the current implementation as ground truth, no code is touched.

- `docs/ui-specs/dashboard.md` — window purpose/placement, layout (title + ProviderPanel + SessionsPanel), spacing/typography sourced from `Dashboard.css`, per-panel state catalogue, cross-refs to `session-roster.md`, `ai-patterns.md`, `provider-selector.md`, and `layout-panes.md`.
- `docs/ui-specs/pane-header.md` — 28px flex layout, slot-by-slot table (type label, subject, provider pill, cost meter, overflow, close), provider-pill convention from `ai-patterns.md` with an honest note that the Phase 1 CSS hardcodes `--color-provider-local` as a placeholder, cost-meter format and the `chat-pane.md §4` narrow-width collapse, the `⋯` overflow placeholder, and the `CLOSE SESSION` voice convention tracked by F-084.

## Test plan

- [x] `docs/ui-specs/dashboard.md` exists and documents purpose/placement, layout, spacing/typography, states, and cross-refs
- [x] `docs/ui-specs/pane-header.md` exists and documents the 28px flex layout, provider pill, cost meter, overflow placeholder, and `CLOSE SESSION` close button
- [x] Both specs cross-reference related spec files
- [x] No code changes (verified via `git diff --stat`)
- [x] CI passes trivially (docs-only)

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)