### PR TITLE
[F-082] ProviderPanel must handle probe-failure error state

### DIFF
--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.css
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.css
@@ -158,3 +158,23 @@
   font-size: 13px;
   color: var(--color-text-secondary);
 }
+
+.provider-panel__error {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  padding: var(--sp-3);
+  background: var(--color-error-bg);
+  border-left: 3px solid var(--color-ember-400);
+  border-radius: var(--r-sm);
+}
+
+.provider-panel__error-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  color: var(--color-ember-300);
+}

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.test.tsx
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.test.tsx
@@ -90,4 +90,35 @@ describe('ProviderPanel', () => {
     });
     expect(await findByText(/3\s+models/i)).toBeInTheDocument();
   });
+
+  it('renders the error state when provider_status rejects, showing the detail verbatim', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('authz denied: dashboard'));
+    setInvokeForTesting(invoke as never);
+
+    const { findByText } = render(() => <ProviderPanel />);
+
+    // Noun-state heading per voice-terminology.md
+    expect(await findByText('PROVIDER UNAVAILABLE')).toBeInTheDocument();
+    // Verbatim technical detail — String(new Error('x')) is "Error: x"
+    expect(await findByText(/Error: authz denied: dashboard/)).toBeInTheDocument();
+  });
+
+  it('retry button on the error state re-invokes provider_status and recovers', async () => {
+    const invoke = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('authz denied: dashboard'))
+      .mockResolvedValueOnce(reachable);
+    setInvokeForTesting(invoke as never);
+
+    const { findByRole, findByText } = render(() => <ProviderPanel />);
+
+    const retry = await findByRole('button', { name: /^retry$/i });
+    fireEvent.click(retry);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledTimes(2);
+    });
+    // After recovery, the success render replaces the error state.
+    expect(await findByText('http://127.0.0.1:11434')).toBeInTheDocument();
+  });
 });

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.tsx
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.tsx
@@ -23,32 +23,47 @@ export const ProviderPanel: Component = () => {
         <span class="provider-panel__name">ollama</span>
       </header>
 
-      <Show when={status()} fallback={<p class="provider-panel__loading">PROBING</p>}>
-        {(s) => (
-          <>
-            <div class="provider-panel__row">
-              <HealthIndicator reachable={s().reachable} />
-              <code class="provider-panel__url">{s().base_url}</code>
-            </div>
-
-            <Show
-              when={s().reachable}
-              fallback={<UnreachableHint baseUrl={s().base_url} errorKind={s().error_kind} />}
-            >
-              <ModelSection
-                models={s().models}
-                expanded={expanded()}
-                onToggle={() => setExpanded((v) => !v)}
-              />
-            </Show>
-
+      <Show
+        when={!status.error}
+        fallback={
+          <div class="provider-panel__error" role="alert">
+            <p class="provider-panel__error-title">PROVIDER UNAVAILABLE</p>
+            <p class="provider-panel__error-detail">{String(status.error)}</p>
             <div class="provider-panel__actions">
               <button type="button" class="provider-panel__btn" onClick={() => refetch()}>
-                REFRESH
+                RETRY
               </button>
             </div>
-          </>
-        )}
+          </div>
+        }
+      >
+        <Show when={status()} fallback={<p class="provider-panel__loading">PROBING</p>}>
+          {(s) => (
+            <>
+              <div class="provider-panel__row">
+                <HealthIndicator reachable={s().reachable} />
+                <code class="provider-panel__url">{s().base_url}</code>
+              </div>
+
+              <Show
+                when={s().reachable}
+                fallback={<UnreachableHint baseUrl={s().base_url} errorKind={s().error_kind} />}
+              >
+                <ModelSection
+                  models={s().models}
+                  expanded={expanded()}
+                  onToggle={() => setExpanded((v) => !v)}
+                />
+              </Show>
+
+              <div class="provider-panel__actions">
+                <button type="button" class="provider-panel__btn" onClick={() => refetch()}>
+                  REFRESH
+                </button>
+              </div>
+            </>
+          )}
+        </Show>
       </Show>
     </section>
   );


### PR DESCRIPTION
Closes forge-ide/forge#155

## Summary
- `ProviderPanel` now renders a dedicated error state when `status.error` is truthy (the probe rejected), with a `RETRY` button wired to `refetch()`.
- Copy follows `docs/design/voice-terminology.md`: noun-state heading (`PROVIDER UNAVAILABLE`), verbatim error detail (`String(status.error)`), and the single-verb `RETRY` (acceptable per the issue rationale — no destructive alternative).
- Added two regression tests covering the `createResource` rejection path: error state renders with the verbatim detail, and the retry button re-invokes `provider_status` to recover into the success render.
- Wraps the new error branch *outside* the existing `<Show when={status()}>` so a late rejection cannot flicker through the loading state.
- New CSS classes `.provider-panel__error` and `.provider-panel__error-title` mirror the existing `.provider-panel__unreachable` treatment (ember border-left, error-bg surface, display-caps title).

## Test plan
- `pnpm -r typecheck` passes
- `pnpm -r test` passes (206/206, including 2 new ProviderPanel tests)
- Targeted run: `pnpm --filter app test -- ProviderPanel` → 7/7

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)