### PR TITLE
fix(forge-shell): require dashboard label on provider_status (F-072)

### DIFF
--- a/crates/forge-shell/src/dashboard.rs
+++ b/crates/forge-shell/src/dashboard.rs
@@ -151,9 +151,11 @@ pub const CACHE_TTL: Duration = Duration::from_secs(10);
 
 #[cfg(feature = "webview")]
 #[tauri::command]
-pub async fn provider_status(
+pub async fn provider_status<R: tauri::Runtime>(
+    webview: tauri::Webview<R>,
     cache: tauri::State<'_, ProviderStatusCache>,
 ) -> std::result::Result<ProviderStatus, String> {
+    crate::ipc::require_window_label(&webview, "dashboard")?;
     Ok(cache.get_or_probe(DEFAULT_OLLAMA_URL, PROBE_TIMEOUT).await)
 }
 

--- a/crates/forge-shell/tests/ipc_authz.rs
+++ b/crates/forge-shell/tests/ipc_authz.rs
@@ -16,6 +16,7 @@
 #![cfg(feature = "webview-test")]
 
 use forge_shell::bridge::SessionConnections;
+use forge_shell::dashboard::{ProviderStatusCache, CACHE_TTL};
 use forge_shell::ipc::{build_invoke_handler, BridgeState};
 use tauri::test::{get_ipc_response, mock_builder, mock_context, noop_assets, INVOKE_KEY};
 use tauri::Manager;
@@ -211,6 +212,32 @@ fn non_dashboard_window_invoking_session_list_is_rejected() {
 
     let err = invoke(&window, "session_list", serde_json::json!({}))
         .expect_err("non-dashboard window must not call session_list");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}
+
+/// F-072: `provider_status` must enforce the `"dashboard"` label like every
+/// other dashboard-scoped Tauri command. Without authz, any `session-*` window
+/// could probe provider state — a low-blast-radius leak today, but it breaks
+/// the invariant that every command authenticates its caller window before
+/// executing, which is what makes per-window capability differentiation safe
+/// to add later.
+#[test]
+fn non_dashboard_window_invoking_provider_status_is_rejected() {
+    let app = mock_builder()
+        .invoke_handler(tauri::generate_handler![
+            forge_shell::dashboard::provider_status,
+        ])
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    app.manage(ProviderStatusCache::new(CACHE_TTL));
+    let window = build_window(&app, "session-A");
+
+    let err = invoke(&window, "provider_status", serde_json::json!({}))
+        .expect_err("non-dashboard window must not call provider_status");
 
     assert!(
         err.contains(LABEL_MISMATCH),

--- a/crates/forge-shell/tests/ipc_commands.rs
+++ b/crates/forge-shell/tests/ipc_commands.rs
@@ -204,7 +204,7 @@ fn make_session_window(
 ) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
     tauri::WebviewWindowBuilder::new(
         app,
-        &format!("session-{session_id}"),
+        format!("session-{session_id}"),
         tauri::WebviewUrl::App("index.html".into()),
     )
     .build()


### PR DESCRIPTION
## Summary

- `provider_status` (`crates/forge-shell/src/dashboard.rs`) now calls `crate::ipc::require_window_label(&webview, "dashboard")?` at the top of the handler, mirroring `session_list` and every other `#[tauri::command]` in the crate. Webview arg `tauri::Webview<R>` injected; the function gains an `<R: tauri::Runtime>` generic to match the existing dashboard pattern.
- Regression test added in `crates/forge-shell/tests/ipc_authz.rs`: `non_dashboard_window_invoking_provider_status_is_rejected` builds a `session-A` mock window via `mock_builder` + `WebviewWindowBuilder`, calls `provider_status`, and asserts the rejection is the standard `forbidden: window label mismatch` `Err(String)`. Without the new authz check this test surfaces a real `ProviderStatus` JSON payload — confirmed RED before GREEN.
- Drive-by: silenced a pre-existing `clippy::needless_borrows_for_generic_args` lint at `crates/forge-shell/tests/ipc_commands.rs:207` (`&format!(...)` -> `format!(...)`). Authored in F-068 (commit `41256d0c8eb`) and unrelated to this fix, but it blocks the same `cargo clippy --all-targets --all-features -- -D warnings` gate F-072 has to pass under rust 1.95.

Closes #145.

## Definition of Done

- [x] `provider_status` handler in `crates/forge-shell/src/dashboard.rs` calls `require_window_label(&window, "dashboard")`
- [x] Regression test added asserting non-dashboard windows are rejected with the consistent `Err(String)` shape
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Tests pass in CI

## Test plan

- [x] `cargo test -p forge-shell --features webview-test --test ipc_authz` — 10 tests pass, including the new regression
- [x] `cargo test -p forge-shell --features webview-test` — full forge-shell suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — workspace clean
- [x] `cargo fmt --all -- --check` — clean