### PR TITLE
[F-073] Unify TS IPC invoke imports through mockable wrapper

### DIFF
--- a/web/packages/app/src/ipc/session.test.ts
+++ b/web/packages/app/src/ipc/session.test.ts
@@ -1,18 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { invokeMock, listenMock } = vi.hoisted(() => ({
-  invokeMock: vi.fn(),
+const { listenMock } = vi.hoisted(() => ({
   listenMock: vi.fn(),
-}));
-
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: invokeMock,
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({
   listen: listenMock,
 }));
 
+import { setInvokeForTesting } from '../lib/tauri';
 import {
   sessionHello,
   sessionSubscribe,
@@ -24,9 +20,16 @@ import {
 } from './session';
 
 describe('session ipc wrappers', () => {
+  let invokeMock: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
-    invokeMock.mockReset();
+    invokeMock = vi.fn();
+    setInvokeForTesting(invokeMock as never);
     listenMock.mockReset();
+  });
+
+  afterEach(() => {
+    setInvokeForTesting(null);
   });
 
   it('sessionHello invokes `session_hello` with sessionId only', async () => {
@@ -119,5 +122,81 @@ describe('session ipc wrappers', () => {
 
     expect(handler).toHaveBeenCalledWith(payload);
     expect(off).toBe(unlisten);
+  });
+});
+
+// F-073: the test seam contract — `setInvokeForTesting()` must intercept
+// commands routed through the typed helpers in `ipc/session.ts`. This guards
+// against regressions where a helper bypasses the wrapper by importing
+// `invoke` directly from the underlying Tauri API.
+describe('setInvokeForTesting intercepts ipc/session commands', () => {
+  afterEach(() => {
+    setInvokeForTesting(null);
+  });
+
+  it('routes sessionHello through the wrapper seam', async () => {
+    const spy = vi.fn().mockResolvedValue({
+      session_id: 'seam',
+      workspace: '/ws',
+      started_at: '2026-04-19T00:00:00Z',
+      event_seq: 0,
+      schema_version: 1,
+    });
+    setInvokeForTesting(spy as never);
+
+    await sessionHello('seam');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('session_hello', { sessionId: 'seam' });
+  });
+
+  it('routes sessionSubscribe through the wrapper seam', async () => {
+    const spy = vi.fn().mockResolvedValue(undefined);
+    setInvokeForTesting(spy as never);
+
+    await sessionSubscribe('seam', 7);
+
+    expect(spy).toHaveBeenCalledWith('session_subscribe', {
+      sessionId: 'seam',
+      since: 7,
+    });
+  });
+
+  it('routes sessionSendMessage through the wrapper seam', async () => {
+    const spy = vi.fn().mockResolvedValue(undefined);
+    setInvokeForTesting(spy as never);
+
+    await sessionSendMessage('seam', 'hi');
+
+    expect(spy).toHaveBeenCalledWith('session_send_message', {
+      sessionId: 'seam',
+      text: 'hi',
+    });
+  });
+
+  it('routes sessionApproveTool through the wrapper seam', async () => {
+    const spy = vi.fn().mockResolvedValue(undefined);
+    setInvokeForTesting(spy as never);
+
+    await sessionApproveTool('seam', 'tc-1', 'ThisFile');
+
+    expect(spy).toHaveBeenCalledWith('session_approve_tool', {
+      sessionId: 'seam',
+      toolCallId: 'tc-1',
+      scope: 'ThisFile',
+    });
+  });
+
+  it('routes sessionRejectTool through the wrapper seam', async () => {
+    const spy = vi.fn().mockResolvedValue(undefined);
+    setInvokeForTesting(spy as never);
+
+    await sessionRejectTool('seam', 'tc-2', 'no');
+
+    expect(spy).toHaveBeenCalledWith('session_reject_tool', {
+      sessionId: 'seam',
+      toolCallId: 'tc-2',
+      reason: 'no',
+    });
   });
 });

--- a/web/packages/app/src/ipc/session.ts
+++ b/web/packages/app/src/ipc/session.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { invoke } from '../lib/tauri';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type { SessionId, ToolCallId, ApprovalScope } from '@forge/ipc';
 

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -1,14 +1,8 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@solidjs/testing-library';
 import type { SessionId } from '@forge/ipc';
 
-// --- Mocks (hoisted so vi.mock works) ---
-const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
-
-vi.mock('../../lib/tauri', () => ({ invoke: invokeMock }));
-vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
-
-// --- Store imports (after mocks) ---
+// --- Store imports ---
 import {
   pushEvent,
   setAwaitingResponse,
@@ -16,16 +10,23 @@ import {
 } from '../../stores/messages';
 import { setActiveSessionId } from '../../stores/session';
 import { resetApprovalsStore } from '../../stores/approvals';
+import { setInvokeForTesting } from '../../lib/tauri';
 import { ChatPane } from './ChatPane';
 
 const SID = 'session-chat-test' as SessionId;
+const invokeMock = vi.fn();
 
 beforeEach(() => {
   invokeMock.mockReset();
   invokeMock.mockResolvedValue(undefined);
+  setInvokeForTesting(invokeMock as never);
   resetMessagesStore();
   resetApprovalsStore();
   setActiveSessionId(SID);
+});
+
+afterEach(() => {
+  setInvokeForTesting(null);
 });
 
 describe('ChatPane rendering', () => {

--- a/web/packages/app/src/routes/Session/SessionWindow.test.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.test.tsx
@@ -8,10 +8,6 @@ const { invokeMock, listenMock, unlistenMock, closeMock } = vi.hoisted(() => ({
   closeMock: vi.fn(),
 }));
 
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: invokeMock,
-}));
-
 vi.mock('@tauri-apps/api/event', () => ({
   listen: listenMock,
 }));
@@ -24,6 +20,7 @@ import { MemoryRouter, Route, createMemoryHistory } from '@solidjs/router';
 import { SessionWindow } from './SessionWindow';
 import { resetSessionEventStore } from '../../stores/session';
 import { resetMessagesStore } from '../../stores/messages';
+import { setInvokeForTesting } from '../../lib/tauri';
 
 const helloAck = {
   session_id: 'abc123',
@@ -55,10 +52,12 @@ describe('SessionWindow', () => {
       if (cmd === 'session_hello') return helloAck;
       return undefined;
     });
+    setInvokeForTesting(invokeMock as never);
     listenMock.mockResolvedValue(unlistenMock);
   });
 
   afterEach(() => {
+    setInvokeForTesting(null);
     cleanup();
   });
 

--- a/web/packages/app/src/stores/session.event.test.ts
+++ b/web/packages/app/src/stores/session.event.test.ts
@@ -8,9 +8,6 @@ const { listenMock, unlistenMock } = vi.hoisted(() => ({
 vi.mock('@tauri-apps/api/event', () => ({
   listen: listenMock,
 }));
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(),
-}));
 
 import type { SessionId } from '@forge/ipc';
 import {


### PR DESCRIPTION
Closes forge-ide/forge#146

## Summary
- Refactor `web/packages/app/src/ipc/session.ts` to import `invoke` from the local `../lib/tauri` mockable wrapper instead of the underlying Tauri core API. Every `session_*` typed helper now flows through the same single seam used by `SessionsPanel`, `ProviderPanel`, and `ChatPane`, restoring uniform error semantics across the surface.
- Audit the rest of `web/packages/app/src/` for direct invoke imports — none remain. The only direct Tauri API touchpoints in `src/` are now the event listener (`listen`) and the window helper (`getCurrentWindow`), both of which are out of the wrapper's scope.
- Add a regression-guard `setInvokeForTesting intercepts ipc/session commands` describe block to `ipc/session.test.ts` that verifies the seam intercepts every typed helper. This block fails the moment any helper bypasses the wrapper again.
- Convert `ipc/session.test.ts`, `stores/session.event.test.ts`, `routes/Session/SessionWindow.test.tsx`, and `routes/Session/ChatPane.test.tsx` from hand-rolled module mocks of the underlying Tauri core API to the wrapper's `setInvokeForTesting()` seam — matching the house style already used elsewhere.

## Test plan
- `pnpm -r typecheck` passes
- `pnpm -r test` passes (211 tests, 17 files)
- New `setInvokeForTesting` seam tests fail on the pre-refactor `ipc/session.ts` (verified RED) and pass after the import swap (verified GREEN)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Note: this PR is foundational — F-079 depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)