### PR TITLE
[F-086] Replace composer textarea opacity disabled-state with token-based darkening

### DIFF
--- a/web/packages/app/src/routes/Session/ChatPane.css
+++ b/web/packages/app/src/routes/Session/ChatPane.css
@@ -225,8 +225,13 @@
   color: var(--color-text-tertiary);
 }
 
+/* F-086: token-based locked state during streaming. Per
+   `component-principles.md` ("Buttons"): never use `opacity` to signal
+   disabled — opacity makes elements appear interactive. Mirror the
+   `iron-600`-style button-disabled precedent with surface + text tokens. */
 .composer__textarea:disabled {
-  opacity: 0.5;
+  background: var(--color-surface-2);
+  color: var(--color-text-disabled);
   cursor: not-allowed;
 }
 

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@solidjs/testing-library';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { SessionId } from '@forge/ipc';
 
 // --- Store imports ---
@@ -236,6 +238,53 @@ describe('Composer disabled state', () => {
     setAwaitingResponse(SID, true);
     const { getByTestId } = render(() => <ChatPane />);
     expect(getByTestId('streaming-indicator')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-086: composer disabled-state CSS contract
+// ---------------------------------------------------------------------------
+//
+// `component-principles.md` ("Buttons"): "Disabled buttons use iron-600
+// background and text. Never reduce opacity on a button to show disabled
+// state — opacity makes elements appear interactive." The rule applies to
+// any interactive control, including the composer textarea while a stream
+// is locked. jsdom does not resolve external stylesheets at render time, so
+// the CSS source itself is the contract — assert against the source the
+// way `check-tokens.test.ts` asserts against `tokens.css`.
+describe('Composer disabled state CSS (F-086)', () => {
+  const cssSource = readFileSync(
+    resolve(__dirname, 'ChatPane.css'),
+    'utf-8',
+  );
+
+  // Match `.composer__textarea:disabled { ... }` and capture the rule body.
+  const ruleMatch = cssSource.match(
+    /\.composer__textarea:disabled\s*\{([^}]*)\}/,
+  );
+
+  it('declares a `:disabled` rule for the composer textarea', () => {
+    expect(ruleMatch).not.toBeNull();
+  });
+
+  it('does not reduce opacity to signal disabled (component-principles.md)', () => {
+    const body = ruleMatch?.[1] ?? '';
+    expect(body).not.toMatch(/\bopacity\s*:/);
+  });
+
+  it('uses --color-surface-2 for the locked background', () => {
+    const body = ruleMatch?.[1] ?? '';
+    expect(body).toMatch(/background\s*:\s*var\(--color-surface-2\)/);
+  });
+
+  it('uses --color-text-disabled for the locked text color', () => {
+    const body = ruleMatch?.[1] ?? '';
+    expect(body).toMatch(/color\s*:\s*var\(--color-text-disabled\)/);
+  });
+
+  it('keeps `cursor: not-allowed` to signal the locked state', () => {
+    const body = ruleMatch?.[1] ?? '';
+    expect(body).toMatch(/cursor\s*:\s*not-allowed/);
   });
 });
 


### PR DESCRIPTION
Closes forge-ide/forge#159

## Summary
- `.composer__textarea:disabled` no longer uses `opacity` — it now uses `background: var(--color-surface-2)` and `color: var(--color-text-disabled)`, matching the `iron-600` button-disabled precedent in `component-principles.md`.
- `cursor: not-allowed` is preserved.
- Added a CSS-source contract suite (`Composer disabled state CSS (F-086)`) in `ChatPane.test.tsx` that reads `ChatPane.css` and asserts the `:disabled` rule contains the two tokens, keeps `cursor: not-allowed`, and contains no `opacity` declaration. This is the snapshot/visual-regression equivalent in this jsdom-only suite (mirroring the pattern in `check-tokens.test.ts`).

## Test plan
- `pnpm -r typecheck` — clean across `@forge/design`, `@forge/ipc`, `app`.
- `pnpm -r test` — 216/216 pass (37 in ChatPane.test.tsx, including the 5 new F-086 cases).
- `node scripts/check-tokens.mjs` — `ok: 56 tokens match`.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code.