### PR TITLE
fix(app): handle invoke() rejections in ChatPane + SessionsPanel (F-079)

### DIFF
--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.css
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.css
@@ -75,6 +75,18 @@
   margin: var(--sp-6) 0;
 }
 
+/* F-079: inline error surface for failed open_session invokes. */
+.sessions__error {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-warning);
+  margin: 0;
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--color-warning);
+  border-radius: var(--r-sm);
+  background: rgba(255, 74, 18, 0.04);
+}
+
 .sessions__grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.test.tsx
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.test.tsx
@@ -24,6 +24,10 @@ async function waitForFetch() {
 
 beforeEach(() => {
   invokeMock.mockReset();
+  // Default any unstubbed invoke to a resolved promise so fire-and-fix call
+  // sites (e.g., open_session in SessionsPanel) don't throw on `.catch(...)`
+  // when a test only stubs the initial session_list call.
+  invokeMock.mockResolvedValue(undefined);
   setInvokeForTesting(invokeMock as never);
 });
 
@@ -110,5 +114,25 @@ describe('SessionsPanel', () => {
     const { findByText } = render(() => <SessionsPanel />);
     await waitForFetch();
     expect(await findByText('// no active sessions')).toBeTruthy();
+  });
+
+  // F-079: open_session was previously a fire-and-forget `void invoke(...)`. A
+  // rejection (IPC auth failure, validation error, etc.) must surface
+  // user-visible feedback rather than silently dropping the click.
+  it('surfaces an inline error when open_session rejects', async () => {
+    invokeMock
+      .mockResolvedValueOnce([sample({ id: 'xyz', subject: 'click me', state: 'active' })])
+      .mockRejectedValueOnce(new Error('open denied'));
+
+    const { findByLabelText, findByRole } = render(() => <SessionsPanel />);
+    await waitForFetch();
+
+    const card = await findByLabelText(/open session click me/i);
+    fireEvent.click(card);
+
+    // After microtasks drain, an inline error region must be visible to the user.
+    await waitForFetch();
+    const alert = await findByRole('alert');
+    expect(alert.textContent ?? '').toMatch(/open denied/);
   });
 });

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.tsx
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.tsx
@@ -45,11 +45,19 @@ function count(n: number): string {
 export const SessionsPanel: Component = () => {
   const [sessions] = createResource(fetchSessions, { initialValue: [] });
   const [tab, setTab] = createSignal<Tab>('active');
+  // F-079: inline error surface when `open_session` rejects (IPC auth fail,
+  // missing window, validation error, etc.). Previously a fire-and-forget
+  // `void invoke(...)` swallowed all rejections silently.
+  const [openError, setOpenError] = createSignal<string | null>(null);
   const groups = () => partition(sessions() ?? []);
   const current = () => groups()[tab()];
 
   const handleOpen = (id: string) => {
-    void invoke('open_session', { id });
+    setOpenError(null);
+    invoke('open_session', { id }).catch((err) => {
+      const detail = err instanceof Error ? err.message : String(err);
+      setOpenError(`open_session failed: ${detail}`);
+    });
   };
 
   return (
@@ -58,6 +66,13 @@ export const SessionsPanel: Component = () => {
         <TabButton tab="active" current={tab()} onSelect={setTab} count={groups().active.length} />
         <TabButton tab="archived" current={tab()} onSelect={setTab} count={groups().archived.length} />
       </div>
+      <Show when={openError()}>
+        {(msg) => (
+          <p class="sessions__error" role="alert">
+            {msg()}
+          </p>
+        )}
+      </Show>
       <Show
         when={current().length > 0}
         fallback={

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -465,3 +465,73 @@ describe('Whitelist auto-approve', () => {
     expect(pills).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// F-079: error handling on invoke rejection
+// ---------------------------------------------------------------------------
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('invoke rejection handling (F-079)', () => {
+  it('clears awaitingResponse and surfaces an error turn when session_send_message rejects', async () => {
+    invokeMock.mockReset();
+    invokeMock.mockRejectedValueOnce(new Error('send failed'));
+
+    const { getByTestId, findByText } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.input(textarea, { target: { value: 'hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: false });
+
+    // Composer flips to disabled synchronously when handleSend sets awaitingResponse(true).
+    expect(textarea).toBeDisabled();
+
+    // After the rejected invoke promise resolves, awaitingResponse must be cleared
+    // (composer re-enabled) AND an error turn must surface the failure.
+    await flushMicrotasks();
+    expect(textarea).not.toBeDisabled();
+    expect(await findByText(/send failed/)).toBeInTheDocument();
+  });
+
+  it('surfaces an error turn when session_approve_tool rejects from the inline prompt', async () => {
+    invokeMock.mockReset();
+    invokeMock.mockRejectedValueOnce(new Error('approve boom'));
+
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-rej-approve',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/x.ts', patch: '...' }),
+      preview: { description: 'Edit /src/x.ts' },
+    });
+
+    const { getByTestId, findByText } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('approve-once-btn'));
+
+    await flushMicrotasks();
+    expect(await findByText(/approve boom/)).toBeInTheDocument();
+  });
+
+  it('surfaces an error turn when session_reject_tool rejects', async () => {
+    invokeMock.mockReset();
+    invokeMock.mockRejectedValueOnce(new Error('reject boom'));
+
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-rej-reject',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/x.ts', patch: '...' }),
+      preview: { description: 'Edit /src/x.ts' },
+    });
+
+    const { getByTestId, findByText } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('reject-btn'));
+
+    await flushMicrotasks();
+    expect(await findByText(/reject boom/)).toBeInTheDocument();
+  });
+});

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -10,9 +10,11 @@ import { invoke } from '../../lib/tauri';
 import { activeSessionId } from '../../stores/session';
 import {
   getMessagesState,
+  pushEvent,
   setAwaitingResponse,
   type ChatTurn,
 } from '../../stores/messages';
+import type { SessionId } from '@forge/ipc';
 import {
   getApprovalWhitelist,
   addWhitelistEntry,
@@ -23,6 +25,23 @@ import { ApprovalPrompt } from '../../components/ApprovalPrompt/ApprovalPrompt';
 import { WhitelistedPill } from '../../components/ApprovalPrompt/WhitelistedPill';
 import type { ApprovalScope } from '@forge/ipc';
 import './ChatPane.css';
+
+// ---------------------------------------------------------------------------
+// invoke rejection helper (F-079)
+// ---------------------------------------------------------------------------
+
+/**
+ * Surface a rejected `invoke()` as an inline `error` turn in the chat. The
+ * `Error` event handler in the messages store (see `stores/messages.ts`) also
+ * clears `awaitingResponse` and `streamingMessageId`, which is what rolls back
+ * the optimistic disable performed by `handleSend` before the call. Routing
+ * every command-rejection through this single sink keeps the user-feedback
+ * shape consistent across approve/reject/send call sites.
+ */
+function reportInvokeError(sessionId: SessionId, command: string, err: unknown): void {
+  const detail = err instanceof Error ? err.message : String(err);
+  pushEvent(sessionId, { kind: 'Error', message: `${command} failed: ${detail}` });
+}
 
 // ---------------------------------------------------------------------------
 // ToolCallCard — inline tool call card with optional approval prompt (F-026/F-027)
@@ -89,7 +108,7 @@ const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholde
     const id = sessionId();
     const key = whitelistKey();
     if (!id || !key || props.turn.status !== 'awaiting-approval') return;
-    void invoke('session_approve_tool', {
+    invoke('session_approve_tool', {
       sessionId: id,
       toolCallId: props.turn.tool_call_id,
       // Derive scope from key prefix
@@ -98,7 +117,7 @@ const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholde
         : key.startsWith('pattern:')
           ? ('ThisPattern' as ApprovalScope)
           : ('ThisFile' as ApprovalScope),
-    });
+    }).catch((err) => reportInvokeError(id, 'session_approve_tool', err));
   });
 
   const handleApprove = (scope: ApprovalScope, pattern?: string) => {
@@ -117,20 +136,20 @@ const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholde
       addWhitelistEntry(id, scope, props.turn.tool_name, path, pattern);
     }
 
-    void invoke('session_approve_tool', {
+    invoke('session_approve_tool', {
       sessionId: id,
       toolCallId: props.turn.tool_call_id,
       scope,
-    });
+    }).catch((err) => reportInvokeError(id, 'session_approve_tool', err));
   };
 
   const handleReject = () => {
     const id = sessionId();
     if (!id) return;
-    void invoke('session_reject_tool', {
+    invoke('session_reject_tool', {
       sessionId: id,
       toolCallId: props.turn.tool_call_id,
-    });
+    }).catch((err) => reportInvokeError(id, 'session_reject_tool', err));
   };
 
   const handleRevoke = () => {
@@ -333,7 +352,12 @@ export const ChatPane: Component = () => {
     setAwaitingResponse(id, true);
     // Re-pin on new user message
     setUserScrolledUp(false);
-    void invoke('session_send_message', { sessionId: id, text });
+    // On rejection, the Error event handler in the messages store rolls back
+    // both `awaitingResponse` and `streamingMessageId`, re-enabling the
+    // composer and surfacing the failure as an inline error turn.
+    invoke('session_send_message', { sessionId: id, text }).catch((err) =>
+      reportInvokeError(id, 'session_send_message', err),
+    );
   };
 
   return (


### PR DESCRIPTION
Closes forge-ide/forge#152

## Summary
- Five fire-and-forget `void invoke(...)` sites in `ChatPane.tsx` (4) and `SessionsPanel.tsx` (1) silently dropped Tauri command rejections — including `session_send_message`, which left the composer permanently disabled if send failed (because `awaitingResponse` was set true before the call and never rolled back).
- ChatPane: `session_approve_tool`, `session_reject_tool`, and `session_send_message` rejections now flow through a small `reportInvokeError` helper that pushes an `Error` event into the messages store. The existing `Error` handler in `stores/messages.ts` already clears `awaitingResponse` and `streamingMessageId`, so the optimistic composer disable is rolled back cleanly and the failure surfaces as an inline error turn.
- SessionsPanel: `open_session` rejections now render an inline `role="alert"` banner inside the panel. No new global toast system was introduced — one site, one local signal, smallest viable surface.
- Tests: new RED-then-GREEN coverage that send failure (a) clears `awaitingResponse` (composer re-enables) and (b) renders the error message; plus parallel coverage for `session_approve_tool`, `session_reject_tool`, and `open_session` rejection paths.

## Test plan
- `pnpm -r typecheck` clean (3 packages)
- `pnpm -r test` clean (208/208 passing)
- New ChatPane tests assert composer re-enables and error turn renders on rejection
- New SessionsPanel test asserts inline alert renders with the failure message

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code