### PR TITLE
[F-083] Add :focus-visible indicator to all buttons missing one

### DIFF
--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
@@ -120,6 +120,11 @@
   line-height: 1;
 }
 
+.approval-prompt__btn:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}
+
 .approval-prompt__btn--ghost {
   background: transparent;
   border: 1px solid var(--color-border-2);
@@ -213,4 +218,9 @@
 .approval-prompt__menu-item:hover {
   background: var(--color-surface-3);
   color: var(--color-ember-300);
+}
+
+.approval-prompt__menu-item:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
 }

--- a/web/packages/app/src/focus-visible.test.tsx
+++ b/web/packages/app/src/focus-visible.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@solidjs/testing-library';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ApprovalPrompt } from './components/ApprovalPrompt/ApprovalPrompt';
+import { ProviderPanel } from './routes/Dashboard/ProviderPanel';
+import { PaneHeader } from './routes/Session/PaneHeader';
+import { setInvokeForTesting } from './lib/tauri';
+
+// ---------------------------------------------------------------------------
+// Regression for F-083: every interactive button in ApprovalPrompt,
+// ProviderPanel, and PaneHeader must (a) carry a `:focus-visible` rule
+// using the ember-400 outline pattern, and (b) be reachable via keyboard
+// focus. JSDOM cannot compute `:focus-visible` styles, so we assert the
+// rule on disk and confirm focusability against the live DOM.
+// ---------------------------------------------------------------------------
+
+const cssDir = resolve(__dirname);
+
+const FOCUS_RULE = /:focus-visible\s*\{[^}]*outline:\s*2px\s+solid\s+var\(--color-ember-400\)[^}]*outline-offset:\s*2px/;
+
+function readCss(relPath: string): string {
+  return readFileSync(resolve(cssDir, relPath), 'utf-8');
+}
+
+function expectFocusVisibleRule(css: string, selector: string) {
+  // Find a rule that targets `selector:focus-visible` (selector may share
+  // the rule with siblings via comma; just require the selector and the
+  // ember-400 outline pattern in the same rule body).
+  const re = new RegExp(
+    `${selector.replace(/[.\-]/g, (c) => `\\${c}`)}:focus-visible\\s*[,\\{]`,
+  );
+  expect(css, `expected ${selector}:focus-visible rule`).toMatch(re);
+  expect(css, 'expected ember-400 outline pattern somewhere in file').toMatch(FOCUS_RULE);
+}
+
+afterEach(() => {
+  cleanup();
+  setInvokeForTesting(null);
+});
+
+// ---------------------------------------------------------------------------
+// CSS rules on disk
+// ---------------------------------------------------------------------------
+
+describe('F-083 :focus-visible rules in CSS', () => {
+  it('ApprovalPrompt.css covers .approval-prompt__btn and .approval-prompt__menu-item', () => {
+    const css = readCss('components/ApprovalPrompt/ApprovalPrompt.css');
+    expectFocusVisibleRule(css, '.approval-prompt__btn');
+    expectFocusVisibleRule(css, '.approval-prompt__menu-item');
+  });
+
+  it('ProviderPanel.css covers .provider-panel__btn', () => {
+    const css = readCss('routes/Dashboard/ProviderPanel.css');
+    expectFocusVisibleRule(css, '.provider-panel__btn');
+  });
+
+  it('PaneHeader.css covers .pane-header__close', () => {
+    const css = readCss('routes/Session/PaneHeader.css');
+    expectFocusVisibleRule(css, '.pane-header__close');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Buttons are reachable via keyboard focus
+// ---------------------------------------------------------------------------
+
+describe('F-083 buttons are keyboard-focusable', () => {
+  it('ApprovalPrompt buttons accept focus (reject, approve, dropdown, menu items)', () => {
+    const container = document.createElement('div');
+    container.tabIndex = 0;
+    document.body.appendChild(container);
+
+    const { getByTestId } = render(
+      () => (
+        <ApprovalPrompt
+          toolCallId="tc-test"
+          toolName="fs.edit"
+          argsJson={JSON.stringify({ path: '/src/foo.ts', patch: '...' })}
+          preview={{ description: 'Edit /src/foo.ts' }}
+          containerRef={container}
+          onApprove={vi.fn()}
+          onReject={vi.fn()}
+        />
+      ),
+      { container },
+    );
+
+    for (const id of ['reject-btn', 'approve-once-btn', 'approve-dropdown-btn']) {
+      const btn = getByTestId(id) as HTMLButtonElement;
+      btn.focus();
+      expect(document.activeElement, `${id} should accept focus`).toBe(btn);
+    }
+
+    // Open dropdown to expose menu items, then verify each menu item is focusable.
+    const toggle = getByTestId('approve-dropdown-btn') as HTMLButtonElement;
+    toggle.click();
+    for (const id of ['scope-once-btn', 'scope-file-btn', 'scope-pattern-btn', 'scope-tool-btn']) {
+      const item = getByTestId(id) as HTMLButtonElement;
+      item.focus();
+      expect(document.activeElement, `${id} should accept focus`).toBe(item);
+    }
+  });
+
+  it('ProviderPanel refresh button accepts focus', async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      reachable: true,
+      base_url: 'http://127.0.0.1:11434',
+      models: ['llama3'],
+      last_checked: '2026-04-19T00:00:00Z',
+    });
+    setInvokeForTesting(invoke as never);
+
+    const { findByRole } = render(() => <ProviderPanel />);
+    const refresh = (await findByRole('button', { name: /refresh/i })) as HTMLButtonElement;
+    refresh.focus();
+    expect(document.activeElement).toBe(refresh);
+  });
+
+  it('PaneHeader close button accepts focus', () => {
+    const { getByRole } = render(() => (
+      <PaneHeader
+        subject="hello"
+        providerLabel="ollama"
+        costLabel="0.00"
+        onClose={vi.fn()}
+      />
+    ));
+    const close = getByRole('button', { name: /close session window/i }) as HTMLButtonElement;
+    close.focus();
+    expect(document.activeElement).toBe(close);
+  });
+});

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.css
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.css
@@ -125,6 +125,11 @@
   transform: translateY(1px);
 }
 
+.provider-panel__btn:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}
+
 .provider-panel__btn--ghost {
   border-color: var(--color-border-1);
   text-align: left;

--- a/web/packages/app/src/routes/Session/PaneHeader.css
+++ b/web/packages/app/src/routes/Session/PaneHeader.css
@@ -61,3 +61,8 @@
   border-color: var(--color-border-2);
   border-radius: var(--r-sm);
 }
+
+.pane-header__close:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
Closes forge-ide/forge#156

## Summary
- Adds the canonical ember-400 `:focus-visible` outline (`outline: 2px solid var(--color-ember-400); outline-offset: 2px`) to every button class in `ApprovalPrompt.css`, `ProviderPanel.css`, and `PaneHeader.css`.
- Covers `.approval-prompt__btn` *and* the separately-classed `.approval-prompt__menu-item` in the scope dropdown — they're sibling selectors, not modifier variants, so a single base rule isn't enough.
- New regression test `web/packages/app/src/focus-visible.test.tsx` reads each CSS file from disk and asserts the rule body (JSDOM cannot compute `:focus-visible` styles), then renders each component and asserts every button is keyboard-focusable.

## Test plan
- `pnpm -r typecheck` passes
- `pnpm -r test` passes (225 vitest tests, including the 6 new focus-visible regressions)
- `node scripts/check-tokens.mjs` passes (no raw hex introduced; uses existing `--color-ember-400` token)
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)