### PR TITLE
[F-074] Replace silent fallbacks in forge-session IPC handlers with explicit errors

### DIFF
--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -23,6 +23,22 @@ use crate::sandbox::ChildRegistry;
 use crate::session::Session;
 use forge_core::ApprovalScope;
 
+/// Static name for an `IpcMessage` discriminant — used for diagnostic logging
+/// when the dispatch loop encounters a frame that is structurally valid but
+/// not legal at the post-handshake stage of a session connection (F-074).
+/// Exhaustive over the variant set; adding a new variant is a compile error.
+fn ipc_message_kind(msg: &IpcMessage) -> &'static str {
+    match msg {
+        IpcMessage::Hello(_) => "Hello",
+        IpcMessage::HelloAck(_) => "HelloAck",
+        IpcMessage::Subscribe(_) => "Subscribe",
+        IpcMessage::Event(_) => "Event",
+        IpcMessage::SendUserMessage(_) => "SendUserMessage",
+        IpcMessage::ToolCallApproved(_) => "ToolCallApproved",
+        IpcMessage::ToolCallRejected(_) => "ToolCallRejected",
+    }
+}
+
 /// Compute the session's `allowed_paths` glob list from its workspace root.
 ///
 /// Returns `[format!("{}/**", canonical_ws)]` when `workspace` points at an
@@ -458,24 +474,33 @@ async fn handle_connection<P: Provider + 'static>(
                     }
 
                     Some(IpcMessage::ToolCallApproved(a)) => {
-                        // F-053: parse the client-supplied scope (wire format is still
-                        // a bare string, per forge_ipc::ToolCallApproved) into the typed
-                        // `ApprovalScope`. On parse failure, fall back to `Once` and
-                        // warn — the user did click approve, so we honour the approval
-                        // at the weakest scope rather than dropping it silently.
-                        let scope = serde_json::from_value::<ApprovalScope>(
+                        // F-053 / F-074: parse the client-supplied scope (wire
+                        // format is still a bare string, per
+                        // `forge_ipc::ToolCallApproved`) into the typed
+                        // `ApprovalScope`. On parse failure we now reject the
+                        // approval rather than silently downgrading to `Once`:
+                        // a user who granted "Always" must not have it
+                        // demoted without notice (audit M7-class finding).
+                        // The client receives the rejection via the same
+                        // approval channel it would for an explicit deny,
+                        // and downstream `ToolCallRejected` event surfaces
+                        // the outcome to the session log.
+                        let parsed = serde_json::from_value::<ApprovalScope>(
                             serde_json::Value::String(a.scope.clone()),
-                        )
-                        .unwrap_or_else(|_| {
-                            eprintln!(
-                                "ToolCallApproved: unknown scope {:?}, falling back to Once",
-                                a.scope
-                            );
-                            ApprovalScope::Once
-                        });
+                        );
                         let mut map = pending_approvals.lock().await;
                         if let Some(tx) = map.remove(&a.id) {
-                            let _ = tx.send(ApprovalDecision::Approved(scope));
+                            let decision = match parsed {
+                                Ok(scope) => ApprovalDecision::Approved(scope),
+                                Err(_) => {
+                                    eprintln!(
+                                        "ToolCallApproved: unknown scope {:?}, rejecting approval",
+                                        a.scope
+                                    );
+                                    ApprovalDecision::Rejected
+                                }
+                            };
+                            let _ = tx.send(decision);
                         }
                     }
 
@@ -486,7 +511,24 @@ async fn handle_connection<P: Provider + 'static>(
                         }
                     }
 
-                    Some(_) => {} // ignore other messages
+                    // F-074: exhaustive match over the remaining
+                    // `IpcMessage` variants — adding a new variant must be a
+                    // compile error here so an IPC handler is added
+                    // deliberately rather than silently swallowed at the
+                    // trust boundary. `Hello` / `HelloAck` are handshake
+                    // frames already consumed before the read loop;
+                    // `Subscribe` is reserved for future multi-subscriber
+                    // sessions; `Event` is server→client only and would
+                    // indicate a malformed/forged client frame.
+                    Some(other @ (IpcMessage::Hello(_)
+                        | IpcMessage::HelloAck(_)
+                        | IpcMessage::Subscribe(_)
+                        | IpcMessage::Event(_))) => {
+                        eprintln!(
+                            "session: ignoring unexpected client frame {}",
+                            ipc_message_kind(&other)
+                        );
+                    }
                     None => break,
                 }
             }

--- a/crates/forge-session/src/tools/fs_edit.rs
+++ b/crates/forge-session/src/tools/fs_edit.rs
@@ -2,17 +2,23 @@
 //! returns `{ ok: true }` or `{ error }`. Preview delegates to
 //! [`forge_fs::edit_preview`].
 
-use super::{Tool, ToolCtx};
+use super::{get_required_str, Tool, ToolCtx};
 use forge_core::ApprovalPreview;
 
 pub struct FsEditTool;
 
+impl FsEditTool {
+    pub const NAME: &'static str = "fs.edit";
+}
+
 impl Tool for FsEditTool {
     fn name(&self) -> &str {
-        "fs.edit"
+        Self::NAME
     }
 
     fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
+        // Preview reflects whatever the client sent so the approval UI shows
+        // the literal request; `invoke` performs the required-arg check (F-074).
         let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
         let patch = args.get("patch").and_then(|v| v.as_str()).unwrap_or("");
         let fs_preview = forge_fs::edit_preview(path, patch);
@@ -22,8 +28,14 @@ impl Tool for FsEditTool {
     }
 
     fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
-        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
-        let patch = args.get("patch").and_then(|v| v.as_str()).unwrap_or("");
+        let path = match get_required_str(args, Self::NAME, "path") {
+            Ok(p) => p,
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
+        let patch = match get_required_str(args, Self::NAME, "patch") {
+            Ok(p) => p,
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
         match forge_fs::edit(
             path,
             patch,

--- a/crates/forge-session/src/tools/fs_read.rs
+++ b/crates/forge-session/src/tools/fs_read.rs
@@ -1,17 +1,25 @@
 //! `fs.read` tool: reads a file via [`forge_fs::read_file`] and returns
 //! `{ content, bytes, sha256 }` or `{ error }`.
 
-use super::{Tool, ToolCtx};
+use super::{get_required_str, Tool, ToolCtx};
 use forge_core::ApprovalPreview;
 
 pub struct FsReadTool;
 
+impl FsReadTool {
+    pub const NAME: &'static str = "fs.read";
+}
+
 impl Tool for FsReadTool {
     fn name(&self) -> &str {
-        "fs.read"
+        Self::NAME
     }
 
     fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
+        // Preview shows whatever the client sent (including blank) so the user
+        // sees exactly what was requested before approval. Required-argument
+        // validation runs in `invoke` only — no point rejecting a malformed
+        // call until the user has had a chance to refuse it. (F-074)
         let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
         ApprovalPreview {
             description: format!("Read file '{path}'"),
@@ -19,7 +27,10 @@ impl Tool for FsReadTool {
     }
 
     fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
-        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let path = match get_required_str(args, Self::NAME, "path") {
+            Ok(p) => p,
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
         match forge_fs::read_file(path, &ctx.allowed_paths, &forge_fs::Limits::default()) {
             Ok(r) => serde_json::json!({
                 "content": r.content,

--- a/crates/forge-session/src/tools/fs_write.rs
+++ b/crates/forge-session/src/tools/fs_write.rs
@@ -2,17 +2,23 @@
 //! `{ ok: true }` or `{ error }`. Preview delegates to
 //! [`forge_fs::write_preview`].
 
-use super::{Tool, ToolCtx};
+use super::{get_required_str, Tool, ToolCtx};
 use forge_core::ApprovalPreview;
 
 pub struct FsWriteTool;
 
+impl FsWriteTool {
+    pub const NAME: &'static str = "fs.write";
+}
+
 impl Tool for FsWriteTool {
     fn name(&self) -> &str {
-        "fs.write"
+        Self::NAME
     }
 
     fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
+        // Preview reflects whatever the client sent so the approval UI shows
+        // the literal request; `invoke` performs the required-arg check (F-074).
         let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
         let content = args.get("content").and_then(|v| v.as_str()).unwrap_or("");
         let fs_preview = forge_fs::write_preview(path, content);
@@ -22,8 +28,14 @@ impl Tool for FsWriteTool {
     }
 
     fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
-        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
-        let content = args.get("content").and_then(|v| v.as_str()).unwrap_or("");
+        let path = match get_required_str(args, Self::NAME, "path") {
+            Ok(p) => p,
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
+        let content = match get_required_str(args, Self::NAME, "content") {
+            Ok(c) => c,
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
         match forge_fs::write(
             path,
             content,

--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -35,6 +35,43 @@ pub enum ToolError {
     DuplicateName(String),
     #[error("unknown tool '{0}'")]
     UnknownTool(String),
+    /// A required string argument was absent or the value was not a JSON
+    /// string. Empty strings are accepted — see [`get_required_str`] for the
+    /// rationale. `Display` shape is
+    /// `tool.{tool}: missing required parameter '{arg}'` and is asserted by
+    /// IPC-level regression tests; treat it as contractual. F-075 will
+    /// broaden the extractor to cover optional / non-string arguments;
+    /// keep this variant minimal so that extension stays additive.
+    #[error("tool.{tool}: missing required parameter '{arg}'")]
+    MissingRequiredArg { tool: String, arg: String },
+}
+
+/// Extract a required string argument from a tool-call's JSON args object.
+///
+/// Returns `Err(ToolError::MissingRequiredArg { tool, arg: key })` when the
+/// key is absent or the value is not a JSON string. Empty strings are
+/// **accepted** — `fs.write` with `{"content": ""}` is a legitimate
+/// "truncate file to zero bytes" operation, and rejecting it here would
+/// regress that behaviour with a misleading "missing parameter" error
+/// (the parameter is supplied; it is just empty). Tools that need to
+/// additionally reject empty (e.g. `shell.exec` on `command`) layer that
+/// check on top of this helper.
+///
+/// F-075 will refactor this into a broader extractor (optional values,
+/// non-string types). Keep the signature narrow so that extension is purely
+/// additive — do not bake in a generic here.
+pub fn get_required_str<'a>(
+    args: &'a serde_json::Value,
+    tool: &str,
+    key: &str,
+) -> Result<&'a str, ToolError> {
+    match args.get(key).and_then(|v| v.as_str()) {
+        Some(s) => Ok(s),
+        None => Err(ToolError::MissingRequiredArg {
+            tool: tool.to_string(),
+            arg: key.to_string(),
+        }),
+    }
 }
 
 #[derive(Default)]
@@ -139,6 +176,206 @@ mod tests {
         let d = ToolDispatcher::new();
         let err = d.dispatch("nope", &json!({}), &empty_ctx()).unwrap_err();
         assert_eq!(err, ToolError::UnknownTool("nope".to_string()));
+    }
+
+    // ---- F-074: shared `get_required_str` helper ----
+
+    #[test]
+    fn get_required_str_returns_string_when_present() {
+        let v = json!({ "path": "/tmp/x" });
+        assert_eq!(get_required_str(&v, "fs.read", "path").unwrap(), "/tmp/x");
+    }
+
+    #[test]
+    fn get_required_str_accepts_empty_string() {
+        // F-074: empty is intentionally allowed so `fs.write` can truncate
+        // a file via `{"content": ""}`. Tools that need stricter checks
+        // (e.g. `shell.exec` rejecting `""` for `command`) layer the
+        // empty-guard on top of this helper.
+        let v = json!({ "content": "" });
+        assert_eq!(get_required_str(&v, "fs.write", "content").unwrap(), "");
+    }
+
+    #[test]
+    fn get_required_str_rejects_missing_key_with_unified_shape() {
+        let v = json!({});
+        let err = get_required_str(&v, "fs.read", "path").unwrap_err();
+        assert_eq!(
+            err,
+            ToolError::MissingRequiredArg {
+                tool: "fs.read".to_string(),
+                arg: "path".to_string()
+            }
+        );
+        assert_eq!(
+            err.to_string(),
+            "tool.fs.read: missing required parameter 'path'"
+        );
+    }
+
+    #[test]
+    fn get_required_str_rejects_non_string_value() {
+        let v = json!({ "path": 42 });
+        let err = get_required_str(&v, "fs.read", "path").unwrap_err();
+        assert_eq!(
+            err,
+            ToolError::MissingRequiredArg {
+                tool: "fs.read".to_string(),
+                arg: "path".to_string()
+            }
+        );
+    }
+
+    // ---- F-074: each tool surfaces the unified missing-arg error from
+    // `invoke` rather than coercing missing required args to "" and producing
+    // a confusing downstream error from `forge_fs` / sandbox. ----
+
+    #[test]
+    fn fs_read_invoke_errors_explicitly_on_missing_path() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(FsReadTool)).unwrap();
+        let result = d.dispatch("fs.read", &json!({}), &empty_ctx()).unwrap();
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.fs.read: missing required parameter 'path'"),
+            "result was: {result}"
+        );
+    }
+
+    #[test]
+    fn fs_write_invoke_errors_explicitly_on_missing_path() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(FsWriteTool)).unwrap();
+        let result = d
+            .dispatch("fs.write", &json!({ "content": "hi" }), &empty_ctx())
+            .unwrap();
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.fs.write: missing required parameter 'path'"),
+            "result was: {result}"
+        );
+    }
+
+    #[test]
+    fn fs_write_invoke_errors_explicitly_on_missing_content() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(FsWriteTool)).unwrap();
+        let result = d
+            .dispatch(
+                "fs.write",
+                &json!({ "path": "/tmp/forge-f074-noop" }),
+                &empty_ctx(),
+            )
+            .unwrap();
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.fs.write: missing required parameter 'content'"),
+            "result was: {result}"
+        );
+    }
+
+    #[test]
+    fn fs_write_invoke_allows_empty_content_to_truncate() {
+        // Empty content must remain a valid request — only missing keys
+        // should error. Otherwise the F-074 helper would silently break the
+        // legitimate "create empty file" / "truncate" use case.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("empty.txt");
+        std::fs::write(&target, "old contents").unwrap();
+        let canonical_parent = std::fs::canonicalize(dir.path()).unwrap();
+        let allowed = format!("{}/**", canonical_parent.to_str().unwrap());
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(FsWriteTool)).unwrap();
+        let ctx = ToolCtx {
+            allowed_paths: vec![allowed],
+            ..ToolCtx::default()
+        };
+        let result = d
+            .dispatch(
+                "fs.write",
+                &json!({ "path": target.to_str().unwrap(), "content": "" }),
+                &ctx,
+            )
+            .unwrap();
+        assert_eq!(result["ok"].as_bool(), Some(true), "result: {result}");
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "");
+    }
+
+    #[test]
+    fn fs_edit_invoke_errors_explicitly_on_missing_path() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(FsEditTool)).unwrap();
+        let result = d
+            .dispatch("fs.edit", &json!({ "patch": "@@ -1 +1 @@" }), &empty_ctx())
+            .unwrap();
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.fs.edit: missing required parameter 'path'"),
+            "result was: {result}"
+        );
+    }
+
+    #[test]
+    fn fs_edit_invoke_errors_explicitly_on_missing_patch() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(FsEditTool)).unwrap();
+        let result = d
+            .dispatch(
+                "fs.edit",
+                &json!({ "path": "/tmp/forge-f074-noop" }),
+                &empty_ctx(),
+            )
+            .unwrap();
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.fs.edit: missing required parameter 'patch'"),
+            "result was: {result}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn shell_exec_invoke_errors_explicitly_on_missing_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(ShellExecTool)).unwrap();
+        let ctx = ToolCtx {
+            allowed_paths: vec![],
+            workspace_root: Some(dir.path().to_path_buf()),
+            child_registry: Some(crate::sandbox::ChildRegistry::new()),
+        };
+        let result = d.dispatch("shell.exec", &json!({}), &ctx).unwrap();
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.shell.exec: missing required parameter 'command'"),
+            "result was: {result}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn shell_exec_invoke_errors_explicitly_on_empty_command() {
+        // shell.exec layers an empty-guard on top of `get_required_str`
+        // because spawning `""` is meaningless. The error shape stays
+        // unified ("tool.X: missing required parameter 'Y'") so the IPC
+        // surface is consistent across all four tools.
+        let dir = tempfile::tempdir().unwrap();
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(ShellExecTool)).unwrap();
+        let ctx = ToolCtx {
+            allowed_paths: vec![],
+            workspace_root: Some(dir.path().to_path_buf()),
+            child_registry: Some(crate::sandbox::ChildRegistry::new()),
+        };
+        let result = d
+            .dispatch("shell.exec", &json!({ "command": "" }), &ctx)
+            .unwrap();
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.shell.exec: missing required parameter 'command'"),
+            "result was: {result}"
+        );
     }
 
     #[test]

--- a/crates/forge-session/src/tools/shell_exec.rs
+++ b/crates/forge-session/src/tools/shell_exec.rs
@@ -15,6 +15,8 @@
 //!
 //! Result shape: `{ stdout, stderr, exit_code, signal? }` or `{ error }`.
 
+#[cfg(target_os = "linux")]
+use super::{get_required_str, ToolError};
 use super::{Tool, ToolCtx};
 #[cfg(target_os = "linux")]
 use crate::sandbox::SandboxedCommand;
@@ -89,9 +91,24 @@ impl Tool for ShellExecTool {
 
 #[cfg(target_os = "linux")]
 fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
-    let command = match args.get("command").and_then(|v| v.as_str()) {
-        Some(c) if !c.is_empty() => c,
-        _ => return serde_json::json!({ "error": "shell.exec: missing 'command'" }),
+    // F-074: route through the shared `get_required_str` helper so the
+    // missing-arg error shape matches the other tools (`tool.X: missing
+    // required parameter 'Y'`). An explicit empty-string guard sits on top
+    // because spawning `""` is meaningless — the helper itself accepts ""
+    // so callers like `fs.write` can legitimately truncate a file. Both
+    // the missing and empty cases surface the unified `MissingRequiredArg`
+    // error so the IPC error string is identical across all tools.
+    let command = match get_required_str(args, ShellExecTool::NAME, "command") {
+        Ok(c) if !c.is_empty() => c,
+        Ok(_) | Err(_) => {
+            return serde_json::json!({
+                "error": ToolError::MissingRequiredArg {
+                    tool: ShellExecTool::NAME.to_string(),
+                    arg: "command".to_string(),
+                }
+                .to_string()
+            });
+        }
     };
 
     let argv: Vec<String> = args

--- a/crates/forge-session/tests/orchestrator.rs
+++ b/crates/forge-session/tests/orchestrator.rs
@@ -644,3 +644,196 @@ async fn approval_with_this_tool_scope_is_recorded_faithfully() {
         "client-supplied ApprovalScope::ThisTool must be recorded faithfully"
     );
 }
+
+/// F-074 regression: when the client sends a `ToolCallApproved` whose
+/// `scope` does not deserialize into `ApprovalScope` (e.g. PascalCase typo
+/// "Always" or any other unknown variant), the session must NOT silently
+/// downgrade the approval to `Once`. Doing so would honour an approval the
+/// user did not actually grant. The new behaviour rejects the approval
+/// outright; the orchestrator emits `Event::ToolCallRejected` and the tool
+/// call is denied — observable to both client and session log.
+#[tokio::test]
+async fn malformed_approval_scope_rejects_instead_of_silently_downgrading_to_once() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("scope_reject.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider =
+        Arc::new(MockProvider::from_responses(vec![SCRIPT_INITIAL.to_string()]).unwrap());
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            server_session,
+            server_provider,
+            false,
+            false,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "hi".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    let (mut reader, mut writer) = stream.into_split();
+
+    // Read events, send a bogus scope when approval is requested, and
+    // assert we observe a ToolCallRejected (NOT a ToolCallApproved {Once}).
+    let mut saw_rejected = false;
+    let mut saw_approved = false;
+    for _ in 0..40 {
+        let frame = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            forge_ipc::read_frame(&mut reader),
+        )
+        .await
+        {
+            Ok(Ok(f)) => f,
+            Ok(Err(_)) | Err(_) => break,
+        };
+        match extract_event(&frame) {
+            Some(Event::ToolCallApprovalRequested { id, .. }) => {
+                forge_ipc::write_frame(
+                    &mut writer,
+                    &IpcMessage::ToolCallApproved(ToolCallApproved {
+                        id: id.to_string(),
+                        // Deliberately unknown variant — this used to be
+                        // silently downgraded to `ApprovalScope::Once`.
+                        scope: "Always".to_string(),
+                    }),
+                )
+                .await
+                .unwrap();
+            }
+            Some(Event::ToolCallRejected { .. }) => {
+                saw_rejected = true;
+                break;
+            }
+            Some(Event::ToolCallApproved { .. }) => {
+                saw_approved = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        !saw_approved,
+        "malformed scope must NOT produce ToolCallApproved (silent downgrade regression)"
+    );
+    assert!(
+        saw_rejected,
+        "malformed scope must produce ToolCallRejected"
+    );
+}
+
+/// F-074 regression: the dispatch loop's previous catch-all
+/// `Some(_) => {}` silently dropped unexpected `IpcMessage` variants. The
+/// new exhaustive match logs the discriminant and continues; the session
+/// must not panic, deadlock, or stop processing subsequent valid frames.
+///
+/// This test sends a duplicate `Hello` mid-session — structurally valid as
+/// an `IpcMessage`, never expected after handshake — then drives a normal
+/// `SendUserMessage` turn through the same connection. If the session
+/// survives and emits the expected events, the dispatch path correctly
+/// handles the unexpected frame.
+#[tokio::test]
+async fn unexpected_post_handshake_frame_is_logged_not_silently_dropped() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("ipc_unexpected.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider =
+        Arc::new(MockProvider::from_responses(vec![SCRIPT_INITIAL.to_string()]).unwrap());
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            server_session,
+            server_provider,
+            true, // auto_approve so we don't need an approval round-trip
+            false,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+
+    // Send a duplicate Hello after handshake — this is an unexpected frame.
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::Hello(Hello {
+            proto: PROTO_VERSION,
+            client: ClientInfo {
+                kind: "test-replay".into(),
+                pid: std::process::id(),
+                user: "tester".into(),
+            },
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Then issue a normal turn — the session must still be alive and
+    // responsive after the unexpected frame.
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "hi".to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    let (mut reader, _writer) = stream.into_split();
+    let mut saw_user_msg = false;
+    for _ in 0..40 {
+        let frame = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            forge_ipc::read_frame(&mut reader),
+        )
+        .await
+        {
+            Ok(Ok(f)) => f,
+            Ok(Err(_)) | Err(_) => break,
+        };
+        if let Some(Event::UserMessage { .. }) = extract_event(&frame) {
+            saw_user_msg = true;
+            break;
+        }
+    }
+
+    assert!(
+        saw_user_msg,
+        "session must keep processing valid frames after an unexpected one"
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#147

## Summary

Three distinct silent-fallback sites in `crates/forge-session` IPC handlers now reject explicitly instead of swallowing malformed frames or downgrading security-relevant fields:

- **Required tool params:** new shared `get_required_str(args, tool, key) -> Result<&str, ToolError>` helper plus `ToolError::MissingRequiredArg { tool, arg }` whose `Display` is `tool.{tool}: missing required parameter '{arg}'`. `fs.read` / `fs.write` / `fs.edit` / `shell.exec` all surface that unified shape from `invoke` rather than coercing missing args to `""` and failing downstream in `forge_fs` / sandbox. Empty strings remain valid so `fs.write { content: "" }` keeps working as a truncate. The helper is intentionally narrow so F-075 can extend it additively.
- **IPC dispatch catch-all:** `Some(_) => {}` replaced with an exhaustive match over the four unhandled variants (`Hello`, `HelloAck`, `Subscribe`, `Event`). New `IpcMessage` variants will now be a compile error here, and unexpected post-handshake frames are logged with their discriminant.
- **ApprovalScope parse:** a malformed `scope` (e.g. PascalCase typo `"Always"`) used to silently downgrade to `ApprovalScope::Once`, honouring an approval the user never granted. The session now rejects the approval outright on parse failure; the orchestrator emits `Event::ToolCallRejected` so the outcome is observable to both client and session log.

## Test plan

- `cargo test --workspace` passes (added: helper unit tests, per-tool missing-arg invoke tests, an `fs.write` empty-content test pinning preserved truncate behaviour, an orchestrator test asserting malformed scope produces `ToolCallRejected`, and a dispatch test confirming the session survives an unexpected post-handshake frame)
- `cargo clippy --all-targets --all-features -- -D warnings` passes
- `cargo fmt --all -- --check` clean

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)