### PR TITLE
fix(web/app): align button typography and copy with component-principles (F-084)

### DIFF
--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
@@ -113,7 +113,10 @@
   gap: var(--sp-2);
   padding: var(--sp-1) var(--sp-3);
   border-radius: var(--r-sm);
-  font-family: var(--font-mono);
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
   font-size: 11px;
   cursor: pointer;
   transition: var(--ease);
@@ -207,7 +210,10 @@
   padding: var(--sp-2) var(--sp-3);
   background: transparent;
   border: none;
-  font-family: var(--font-mono);
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
   font-size: 11px;
   color: var(--color-text-primary);
   cursor: pointer;

--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css.test.ts
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ApprovalPrompt button typography (F-084):
+// component-principles.md "Buttons" — "All buttons use Barlow Condensed 700,
+// uppercase, letter-spacing: 0.1em." Both `.approval-prompt__btn` and
+// `.approval-prompt__menu-item` were declared with `--font-mono` and no
+// weight/transform/letter-spacing. Assert source-string remediation in the
+// CSS rule blocks; jsdom computed-style assertions are unreliable.
+
+const cssPath = resolve(__dirname, 'ApprovalPrompt.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+/**
+ * Extract the declarations inside the first rule block matching `selector`.
+ * Returns the body string (between `{` and `}`), trimmed.
+ *
+ * We split on the literal selector text rather than building a regex; CSS
+ * selectors contain dots and dashes that are awkward to escape and we don't
+ * need any regex matching here — a literal substring locates the rule.
+ */
+function ruleBody(selector: string): string {
+  const at = css.indexOf(selector);
+  if (at < 0) throw new Error(`selector not found in ApprovalPrompt.css: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  if (open < 0 || close < 0) {
+    throw new Error(`malformed rule block for selector: ${selector}`);
+  }
+  return css.slice(open + 1, close).trim();
+}
+
+const REQUIRED_DECLS: Array<{ name: string; value: string }> = [
+  { name: 'font-family', value: 'var(--font-display)' },
+  { name: 'font-weight', value: '700' },
+  { name: 'text-transform', value: 'uppercase' },
+  { name: 'letter-spacing', value: '0.1em' },
+];
+
+/** Returns true if `body` contains a declaration matching `name: value;`
+ *  (whitespace-tolerant). Substring match avoids regex-escape pitfalls. */
+function hasDecl(body: string, name: string, value: string): boolean {
+  // Normalise: collapse runs of whitespace, then look for "name: value;".
+  const normalised = body.replace(/\s+/g, ' ');
+  return normalised.includes(`${name}: ${value};`);
+}
+
+describe.each(['.approval-prompt__btn', '.approval-prompt__menu-item'])(
+  'ApprovalPrompt button typography — %s',
+  (selector) => {
+    const body = ruleBody(selector);
+
+    for (const decl of REQUIRED_DECLS) {
+      it(`declares ${decl.name}: ${decl.value}`, () => {
+        expect(hasDecl(body, decl.name, decl.value)).toBe(true);
+      });
+    }
+
+    it('no longer uses --font-mono (would re-introduce the F-084 regression)', () => {
+      expect(hasDecl(body, 'font-family', 'var(--font-mono)')).toBe(false);
+    });
+  },
+);

--- a/web/packages/app/src/routes/Session/PaneHeader.test.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@solidjs/testing-library';
+import { PaneHeader } from './PaneHeader';
+
+// PaneHeader close button (F-084): per voice-terminology.md §8 "Button labels:
+// verb + noun in display caps." The close button's visible text must read
+// `CLOSE SESSION` literally — the aria-label remains a sentence for AT users.
+
+describe('PaneHeader close button — voice & terminology (F-084)', () => {
+  it('renders close button text as `CLOSE SESSION` (verb + noun, display caps)', () => {
+    const { getByRole } = render(() => (
+      <PaneHeader
+        subject="example"
+        providerLabel="local"
+        costLabel="$0.00"
+        onClose={vi.fn()}
+      />
+    ));
+    const btn = getByRole('button', { name: 'Close session window' });
+    // Literal match — case matters; this is the source-of-truth string,
+    // not a CSS uppercase transform.
+    expect(btn.textContent).toBe('CLOSE SESSION');
+  });
+
+  it('keeps the existing aria-label as a sentence for screen readers', () => {
+    const { getByRole } = render(() => (
+      <PaneHeader
+        subject="example"
+        providerLabel="local"
+        costLabel="$0.00"
+        onClose={vi.fn()}
+      />
+    ));
+    const btn = getByRole('button', { name: 'Close session window' });
+    expect(btn.getAttribute('aria-label')).toBe('Close session window');
+  });
+});

--- a/web/packages/app/src/routes/Session/PaneHeader.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.tsx
@@ -32,7 +32,7 @@ export const PaneHeader: Component<PaneHeaderProps> = (props) => {
         aria-label="Close session window"
         onClick={props.onClose}
       >
-        close
+        CLOSE SESSION
       </button>
     </header>
   );


### PR DESCRIPTION
Closes forge-ide/forge#157

## Summary
- `.approval-prompt__btn` and `.approval-prompt__menu-item` now use `--font-display`, `font-weight: 700`, `text-transform: uppercase`, `letter-spacing: 0.1em` (per component-principles.md "Buttons").
- `PaneHeader` close-button text reads `CLOSE SESSION` (per voice-terminology.md §8 and the F-087 pane-header.md spec). The `aria-label="Close session window"` is unchanged for screen readers.
- New Vitest coverage:
  - `ApprovalPrompt.css.test.ts` — asserts both selectors carry the four required declarations and no longer reference `--font-mono`.
  - `PaneHeader.test.tsx` — asserts the close button's literal text is `CLOSE SESSION` and the aria-label remains a sentence.

## Test plan
- `pnpm -r typecheck` passes
- `pnpm -r test` passes (241 tests in `app`, including the 12 new assertions)
- `node scripts/check-tokens.mjs` passes (no token changes)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code