### PR TITLE
[F-098] Add rustdoc to forge-agents public API

### DIFF
--- a/crates/forge-agents/src/lib.rs
+++ b/crates/forge-agents/src/lib.rs
@@ -3,6 +3,11 @@ use gray_matter::{engine::YAML, Matter, ParsedEntity};
 use serde::Deserialize;
 use std::{fs, path::Path};
 
+/// Canonical agent definition parsed from a Markdown file with YAML frontmatter.
+///
+/// `name` defaults to the file stem when frontmatter is absent or omits it,
+/// `body` holds the prompt content with the frontmatter stripped, and
+/// `allowed_paths` scopes filesystem access for tools the agent may invoke.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AgentDef {
     pub name: String,
@@ -69,14 +74,22 @@ fn load_from_dir(dir: &Path) -> Result<Vec<AgentDef>> {
     paths.iter().map(|p| parse_agent_file(p)).collect()
 }
 
+/// Load agents from `<workspace_root>/.agents/*.md`, returning an empty vec if the directory is absent.
 pub fn load_workspace_agents(workspace_root: &Path) -> Result<Vec<AgentDef>> {
     load_from_dir(&workspace_root.join(".agents"))
 }
 
+/// Load agents from `<user_home>/.agents/*.md`, returning an empty vec if the directory is absent.
 pub fn load_user_agents(user_home: &Path) -> Result<Vec<AgentDef>> {
     load_from_dir(&user_home.join(".agents"))
 }
 
+/// Load and merge user-home and workspace-local agent definitions.
+///
+/// User agents are loaded first; workspace agents are then layered on top so
+/// that on a name collision the workspace definition replaces the user one,
+/// and workspace-only agents are appended. This lets a project pin or override
+/// agents without editing the user's home directory.
 pub fn load_agents(workspace_root: &Path, user_home: &Path) -> Result<Vec<AgentDef>> {
     let workspace = load_workspace_agents(workspace_root)?;
     let mut merged = load_user_agents(user_home)?;
@@ -90,6 +103,7 @@ pub fn load_agents(workspace_root: &Path, user_home: &Path) -> Result<Vec<AgentD
     Ok(merged)
 }
 
+/// Read `<workspace_root>/AGENTS.md` if present, returning `Ok(None)` when the file is absent.
 pub fn load_agents_md(workspace_root: &Path) -> Result<Option<String>> {
     let path = workspace_root.join("AGENTS.md");
     if path.exists() {
@@ -99,12 +113,17 @@ pub fn load_agents_md(workspace_root: &Path) -> Result<Option<String>> {
     }
 }
 
+/// Bundle of merged agent definitions plus the optional workspace-level `AGENTS.md` preamble.
+///
+/// Constructed once per session via [`AgentLoader::load`] and then queried
+/// through [`AgentLoader::agents`] and [`AgentLoader::agents_md`].
 pub struct AgentLoader {
     agents: Vec<AgentDef>,
     agents_md: Option<String>,
 }
 
 impl AgentLoader {
+    /// Load workspace + user agents and the workspace `AGENTS.md` in one pass.
     pub fn load(workspace_root: &Path, user_home: &Path) -> Result<Self> {
         Ok(Self {
             agents: load_agents(workspace_root, user_home)?,
@@ -112,10 +131,12 @@ impl AgentLoader {
         })
     }
 
+    /// Borrow the merged agent definitions, ordered user-first then workspace-only appended.
     pub fn agents(&self) -> &[AgentDef] {
         &self.agents
     }
 
+    /// Borrow the workspace `AGENTS.md` contents, or `None` if the file was absent.
     pub fn agents_md(&self) -> Option<&str> {
         self.agents_md.as_deref()
     }


### PR DESCRIPTION
Closes forge-ide/forge#171

## Summary
- Adds summary-sentence rustdoc to every `pub` item in `crates/forge-agents/src/lib.rs` — `AgentDef`, `load_workspace_agents`, `load_user_agents`, `load_agents`, `load_agents_md`, `AgentLoader`, and the three `AgentLoader` methods (`load`, `agents`, `agents_md`).
- Calls out the non-obvious `load_agents` precedence (user-first, workspace overrides on name collision) and the `AgentDef` field semantics in an extra paragraph each.
- Tone matches the existing rustdoc in `forge-core` (`workspace.rs`) and `forge-session` (`socket_path.rs`): terse summary, optional paragraph for non-obvious behavior.

## Test plan
- `cargo doc --no-deps -p forge-agents` emits 0 warnings
- `cargo doc --no-deps --all-features` adds no new warnings (the two pre-existing `forge-shell` warnings are unrelated and present on `main`)
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)