### PR TITLE
[F-089] Implement focus trap and focus restoration for ApprovalPrompt

### DIFF
--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.test.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.test.tsx
@@ -346,4 +346,118 @@ describe('Keyboard shortcuts', () => {
     fireEvent.keyDown(container, { key: 'a' }); // should not approve
     expect(onApprove).not.toHaveBeenCalled();
   });
+
+  it('Escape calls onReject when pattern editor is closed', () => {
+    const onReject = vi.fn();
+    const { container } = renderPrompt({ onReject });
+    fireEvent.keyDown(container, { key: 'Escape' });
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape does NOT call onReject while the pattern editor is open', () => {
+    const onReject = vi.fn();
+    const { container, getByTestId, queryByTestId } = renderPrompt({ onReject });
+    fireEvent.keyDown(container, { key: 'p' });
+    expect(getByTestId('pattern-editor')).toBeInTheDocument();
+    fireEvent.keyDown(container, { key: 'Escape' });
+    // First Escape only closes the editor
+    expect(onReject).not.toHaveBeenCalled();
+    expect(queryByTestId('pattern-editor')).not.toBeInTheDocument();
+    // Second Escape now cancels the prompt
+    fireEvent.keyDown(container, { key: 'Escape' });
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Focus management — initial focus, focus trap, focus restoration (F-089)
+// ---------------------------------------------------------------------------
+
+describe('Focus management — initial focus (F-089)', () => {
+  it('focuses the primary Approve button on mount', () => {
+    const { getByTestId } = renderPrompt();
+    expect(document.activeElement).toBe(getByTestId('approve-once-btn'));
+  });
+});
+
+describe('Focus management — focus trap (F-089)', () => {
+  function focusableInPrompt(root: HTMLElement): HTMLElement[] {
+    return Array.from(
+      root.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+  }
+
+  it('Tab from the last focusable element wraps to the first', () => {
+    const { getByTestId } = renderPrompt();
+    const root = getByTestId('approval-prompt');
+    const focusables = focusableInPrompt(root);
+    expect(focusables.length).toBeGreaterThan(1);
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(last, { key: 'Tab' });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('Shift+Tab from the first focusable element wraps to the last', () => {
+    const { getByTestId } = renderPrompt();
+    const root = getByTestId('approval-prompt');
+    const focusables = focusableInPrompt(root);
+    expect(focusables.length).toBeGreaterThan(1);
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+
+    first.focus();
+    expect(document.activeElement).toBe(first);
+    fireEvent.keyDown(first, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('Tab in the middle of the focusable set does not interfere', () => {
+    const { getByTestId } = renderPrompt();
+    const root = getByTestId('approval-prompt');
+    const focusables = focusableInPrompt(root);
+    expect(focusables.length).toBeGreaterThan(2);
+    const middle = focusables[1]!;
+    middle.focus();
+    // No preventDefault or programmatic focus when not at a boundary —
+    // we simulate the keydown but the browser's default tab order takes over.
+    // The trap handler must NOT relocate focus mid-list.
+    fireEvent.keyDown(middle, { key: 'Tab' });
+    expect(document.activeElement).toBe(middle);
+  });
+});
+
+describe('Focus management — focus restoration (F-089)', () => {
+  it('restores focus to the previously focused element when the prompt unmounts', () => {
+    // Trigger element lives outside the prompt's container.
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open approval';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { unmount } = renderPrompt();
+    // Initial focus is captured by the prompt
+    expect(document.activeElement).not.toBe(trigger);
+
+    unmount();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('does not throw when the previously focused element is gone on unmount', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = renderPrompt();
+    // Remove the trigger before unmount — restoration must be defensive
+    trigger.remove();
+
+    expect(() => unmount()).not.toThrow();
+  });
 });

--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tsx
@@ -51,6 +51,17 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
   const [patternMode, setPatternMode] = createSignal(false);
   const [pattern, setPattern] = createSignal('');
 
+  // Capture the element that had focus before this prompt mounted so we can
+  // restore focus to it on dismiss. Read synchronously during component setup,
+  // before onMount runs and steals focus into the prompt.
+  const previouslyFocused =
+    typeof document !== 'undefined'
+      ? (document.activeElement as HTMLElement | null)
+      : null;
+
+  // Root element of the prompt — used as the focus-trap boundary.
+  let rootRef: HTMLDivElement | undefined;
+
   const path = () => extractPath(props.argsJson);
   const showFileScopes = () => isFileTool(props.toolName) && path() !== '';
 
@@ -66,8 +77,36 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
     props.onApprove(scope, pat);
   };
 
+  // Focusable elements within the prompt root, in DOM order. Used by the
+  // focus trap to compute boundaries.
+  const focusableElements = (): HTMLElement[] => {
+    if (!rootRef) return [];
+    return Array.from(
+      rootRef.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+  };
+
   const handleKeyDown = (e: KeyboardEvent) => {
-    // Don't intercept if user is editing pattern input
+    // Focus trap — keep Tab navigation within the prompt regardless of mode.
+    if (e.key === 'Tab') {
+      const focusables = focusableElements();
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!first || !last) return;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+      return;
+    }
+
+    // Don't intercept other shortcuts if user is editing pattern input
     if (patternMode()) {
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -75,7 +114,10 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
       }
       return;
     }
-    if (e.key === 'r' || e.key === 'R') {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      props.onReject();
+    } else if (e.key === 'r' || e.key === 'R') {
       e.preventDefault();
       props.onReject();
     } else if (e.key === 'a' || e.key === 'A' || e.key === 'Enter') {
@@ -95,16 +137,28 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
 
   onMount(() => {
     props.containerRef.addEventListener('keydown', handleKeyDown);
+    // Initial focus → primary Approve button (default action per spec §10.2).
+    const primary = rootRef?.querySelector<HTMLElement>(
+      '[data-testid="approve-once-btn"]',
+    );
+    primary?.focus();
   });
 
   onCleanup(() => {
     props.containerRef.removeEventListener('keydown', handleKeyDown);
+    // Restore focus to the element that had it before the prompt opened.
+    // Defensive: the previous element may have been removed from the DOM.
+    const prev = previouslyFocused;
+    if (prev && typeof prev.focus === 'function' && prev.isConnected) {
+      prev.focus();
+    }
   });
 
   const titleId = () => `approval-prompt-title-${props.toolCallId}`;
 
   return (
     <div
+      ref={rootRef}
       class="approval-prompt"
       data-testid="approval-prompt"
       role="alertdialog"


### PR DESCRIPTION
Closes forge-ide/forge#162

## Summary

The `ApprovalPrompt` is an interruptive `alertdialog` that gates agent
progress on every approval-required tool call. Until now it managed no
focus at all — keyboard users opening the prompt had no way to know
where focus was, could Tab out of it into the rest of the UI, and lost
focus context entirely on dismiss. This change adds the standard
`alertdialog` focus contract:

- **Initial focus** lands on the primary `Approve` button on mount
  (default action per spec §10.2)
- **Focus trap**: `Tab` from the last focusable element wraps to the
  first; `Shift+Tab` from the first wraps to the last
- **Focus restoration**: on unmount, focus returns to whichever element
  held focus before the prompt appeared. Captured synchronously at
  component setup so the value isn't lost when `onMount` steals focus
- **Escape → cancel** when the pattern editor isn't open (standard
  `alertdialog` dismissal — the existing pattern-editor Escape that
  closes the editor takes precedence when active)

The implementation is self-contained — no new dependency, no separate
hook, just `onMount`/`onCleanup` and a small Tab handler that recomputes
focusable boundaries on each keypress (so the dynamic dropdown menu's
focusable items participate correctly when open).

## Test plan

- `pnpm -r typecheck` passes
- `pnpm -r test` passes (239 tests, 6 new for F-089)
- New vitest cases:
  - initial focus → `approve-once-btn`
  - `Tab` from last → first; `Shift+Tab` from first → last
  - mid-list `Tab` left to native handling (no relocation)
  - focus restoration to the triggering element on unmount
  - defensive restoration when the previous element was removed
  - `Escape` → `onReject` (and Escape-while-pattern-editor-open still
    only closes the editor)
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` all pass (no Rust changes)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)