### PR TITLE
docs(forge-providers): add rustdoc to ChatRequest, ChatMessage, ChatRole (F-099)

### DIFF
--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -10,21 +10,55 @@ pub mod ollama;
 
 // ── Chat domain types ─────────────────────────────────────────────────────────
 
+/// A single request to a chat [`Provider`]: an optional system prompt plus
+/// the conversation history the provider should respond to.
+///
+/// Sampling parameters (temperature, max-tokens, stop sequences) are not
+/// modelled here — providers either default them or read them from
+/// provider-specific configuration. Callers that need provider-specific
+/// knobs should wrap or extend this type at the provider boundary rather
+/// than overload it with optional fields that no provider honours.
 #[derive(Debug, Clone)]
 pub struct ChatRequest {
+    /// Optional system prompt. Providers handle it in role-specific ways:
+    /// e.g. Anthropic hoists it to a top-level `system` field, Ollama
+    /// prepends it to the message stream. `None` means "no system prompt".
     pub system: Option<String>,
+    /// Conversation history in chronological order. Typically alternates
+    /// [`ChatRole::User`] and [`ChatRole::Assistant`], though providers
+    /// vary in how strictly they enforce that.
     pub messages: Vec<ChatMessage>,
 }
 
+/// One message in a chat conversation, tagged with the role that produced
+/// it and carrying one or more content blocks.
+///
+/// Splitting content into a `Vec<ChatBlock>` (rather than a flat string)
+/// lets a single message interleave text, tool calls, and tool results
+/// — which matches how modern provider APIs frame multi-part turns.
 #[derive(Debug, Clone)]
 pub struct ChatMessage {
+    /// Who produced this message.
     pub role: ChatRole,
+    /// The message body, as an ordered sequence of content blocks.
+    /// See [`ChatBlock`] for the variants (text, tool calls, tool results).
     pub content: Vec<ChatBlock>,
 }
 
+/// The role a [`ChatMessage`] was produced by.
+///
+/// Only `User` and `Assistant` are modelled. System prompts live on
+/// [`ChatRequest::system`], not as a role. Tool interactions are not a
+/// distinct role either — they ride inside an assistant or user message
+/// as [`ChatBlock::ToolCall`] / [`ChatBlock::ToolResult`] content blocks.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChatRole {
+    /// A message authored by the human (or upstream caller acting on the
+    /// human's behalf). Carries the user's prompt and any tool results
+    /// being fed back into the conversation.
     User,
+    /// A message authored by the model. Carries the model's textual reply
+    /// and any tool calls it has decided to invoke.
     Assistant,
 }
 


### PR DESCRIPTION
Closes forge-ide/forge#172

## Summary
- Adds summary-sentence rustdoc to the three foundational public domain types in `forge-providers/src/lib.rs` — `ChatRequest`, `ChatMessage`, `ChatRole` — that callers must understand to use the `Provider` trait.
- Adds field-level rustdoc on `ChatRequest::system` (provider-specific handling: Anthropic hoists, Ollama prepends), `ChatRequest::messages` (chronological alternation), and `ChatMessage::role` / `content`.
- Documents two non-obvious modelling decisions the issue called out: sampling parameters (temperature/max_tokens/stop) are not modelled here, and tool interactions ride inside `ChatBlock::ToolCall` / `ChatBlock::ToolResult` content blocks rather than as a distinct role.
- Tone matches `forge-session` rustdoc — terse, intent-focused, explains why behaviour is what it is.

## Scope drift note
The issue's remediation example listed `temperature` / `max_tokens` / `stop` fields on `ChatRequest` and a `tool` `ChatRole` variant. The actual code has neither — `ChatRequest { system, messages }` and `ChatRole { User, Assistant }`. Per the DoD ("summary-sentence rustdoc on each of the three types"), this PR documents what exists rather than inventing fields to match the sketch.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets --all-features -- -D warnings` passes
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features -p forge-providers` passes (0 warnings, baseline was also 0 — no regression)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)