### PR TITLE
[F-095] Correct forge-core external deps list in crate-architecture.md

### DIFF
--- a/docs/architecture/crate-architecture.md
+++ b/docs/architecture/crate-architecture.md
@@ -75,7 +75,9 @@ pub trait Credentials: Send + Sync {
 }
 ```
 
-**External deps.** `serde`, `serde_json`, `tokio`, `chrono`, `thiserror`, `anyhow`, `ts-rs` (for TS type generation), `secrecy` (for `Secret<T>`), `toml`, `gray_matter` (YAML frontmatter parsing).
+**External deps.** `serde`, `serde_json`, `tokio`, `chrono`, `thiserror`, `anyhow`, `ts-rs` (for TS type generation), `toml`, `rand`.
+
+**Planned (later phases).** `gray_matter` for `.agents/*.md` YAML frontmatter parsing arrives with `forge-agents` in Phase 2. `secrecy` (for `Secret<T>` in the `Credentials` trait above) arrives with credential management in Phase 3. See [`docs/build/roadmap.md`](../build/roadmap.md) §12 (Phase 2 — Full layout, MCP, agents; Phase 3 — Breadth).
 
 ---
 


### PR DESCRIPTION
Closes forge-ide/forge#168

## Summary
- §3.1 of `docs/architecture/crate-architecture.md` listed `secrecy` and `gray_matter` as forge-core deps, but neither appears in `crates/forge-core/Cargo.toml`.
- Updated the external deps line to match Cargo.toml exactly: `serde, serde_json, tokio, chrono, thiserror, anyhow, ts-rs, toml, rand`.
- Added a "Planned (later phases)" line documenting `gray_matter` (Phase 2 — `forge-agents` YAML frontmatter parsing) and `secrecy` (Phase 3 — credential management with `Secret<T>`), cross-referencing `docs/build/roadmap.md` §12.
- Edits scoped to §3.1 only to avoid conflicting with F-096 (§3.5 session-state drift), which is a separate dispatched task.

## Test plan
- `cargo fmt --all -- --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)