### PR TITLE
[F-085] Add active-state translateY(1px) transform to ApprovalPrompt buttons

### DIFF
--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.active-transform.test.ts
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.active-transform.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ApprovalPrompt button :active transform (F-085):
+// component-principles.md "Buttons" — "Active state always includes
+// `transform: translateY(1px)`." F-027 shipped two button variants without
+// this rule. Both must declare it on their `:active` selector. JSDOM cannot
+// reliably compute pseudo-class styles, so assert the source-string contract
+// on the CSS rule blocks themselves (matches the F-084 pattern in
+// ApprovalPrompt.css.test.ts).
+
+const cssPath = resolve(__dirname, 'ApprovalPrompt.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+/**
+ * Extract the declarations inside the first rule block matching `selector`.
+ * Matches the helper in ApprovalPrompt.css.test.ts.
+ */
+function ruleBody(selector: string): string {
+  const at = css.indexOf(selector);
+  if (at < 0) throw new Error(`selector not found in ApprovalPrompt.css: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  if (open < 0 || close < 0) {
+    throw new Error(`malformed rule block for selector: ${selector}`);
+  }
+  return css.slice(open + 1, close).trim();
+}
+
+function hasDecl(body: string, name: string, value: string): boolean {
+  const normalised = body.replace(/\s+/g, ' ');
+  return normalised.includes(`${name}: ${value};`);
+}
+
+describe.each([
+  '.approval-prompt__btn--primary:active',
+  '.approval-prompt__btn--ghost:active',
+])('ApprovalPrompt active state — %s', (selector) => {
+  it(`declares transform: translateY(1px)`, () => {
+    const body = ruleBody(selector);
+    expect(hasDecl(body, 'transform', 'translateY(1px)')).toBe(true);
+  });
+});

--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
@@ -139,6 +139,11 @@
   color: var(--color-text-primary);
 }
 
+.approval-prompt__btn--ghost:active {
+  background: var(--color-surface-3);
+  transform: translateY(1px);
+}
+
 .approval-prompt__btn--primary {
   background: var(--color-ember-400);
   border: 1px solid var(--color-ember-400);
@@ -153,6 +158,7 @@
 .approval-prompt__btn--primary:active {
   background: var(--color-ember-500);
   border-color: var(--color-ember-500);
+  transform: translateY(1px);
 }
 
 /* Split-button seam between Approve and ▾ */


### PR DESCRIPTION
Closes forge-ide/forge#158

## Summary
- `.approval-prompt__btn--primary:active` now includes `transform: translateY(1px)` alongside the existing color shift.
- New `.approval-prompt__btn--ghost:active { background: var(--color-surface-3); transform: translateY(1px); }` rule (variant had no `:active` rule before).
- Adds `ApprovalPrompt.active-transform.test.ts` — source-string vitest assertions on both selectors, matching the F-084 typography test pattern (jsdom cannot compute `:active` styles reliably).

Brings ApprovalPrompt buttons into compliance with `component-principles.md` "Buttons": "Active state always includes `transform: translateY(1px)`."

## Test plan
- `pnpm -r typecheck` clean
- `pnpm -r test` — all 253 app tests pass, including the 2 new assertions
- `node scripts/check-tokens.mjs` — ok
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` — all pass

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)