### PR TITLE
[F-091] PaneHeader provider pill colors by active provider id

### DIFF
--- a/web/packages/app/src/focus-visible.test.tsx
+++ b/web/packages/app/src/focus-visible.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from '@solidjs/testing-library';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import type { ProviderId } from '@forge/ipc';
 import { ApprovalPrompt } from './components/ApprovalPrompt/ApprovalPrompt';
 import { ProviderPanel } from './routes/Dashboard/ProviderPanel';
 import { PaneHeader } from './routes/Session/PaneHeader';
@@ -121,6 +122,7 @@ describe('F-083 buttons are keyboard-focusable', () => {
     const { getByRole } = render(() => (
       <PaneHeader
         subject="hello"
+        providerId={'ollama' as ProviderId}
         providerLabel="ollama"
         costLabel="0.00"
         onClose={vi.fn()}

--- a/web/packages/app/src/routes/Session/PaneHeader.css
+++ b/web/packages/app/src/routes/Session/PaneHeader.css
@@ -29,7 +29,10 @@
   padding: 0 var(--sp-2);
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--color-provider-local);
+  /* F-091: per-provider accent set via inline custom property; the steel
+   * `--color-provider-local` fallback is the Phase-1 default for callers
+   * that haven't plumbed a providerId yet. */
+  color: var(--pane-header-provider-accent, var(--color-provider-local));
   background: var(--color-surface-3);
   border: 1px solid var(--color-border-1);
   border-radius: var(--r-sm);

--- a/web/packages/app/src/routes/Session/PaneHeader.css.test.ts
+++ b/web/packages/app/src/routes/Session/PaneHeader.css.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// PaneHeader provider pill (F-091): per ai-patterns.md §7 the pill color must
+// vary by provider. The implementation plumbs an inline CSS custom property
+// (`--pane-header-provider-accent`) and the rule reads it with the steel
+// `--color-provider-local` token as a Phase-1 default. Source-string asserts
+// guard the contract — jsdom can't resolve var() against an external sheet,
+// and a regression to the old hardcoded value would silently un-color other
+// providers in production.
+
+const cssPath = resolve(__dirname, 'PaneHeader.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+function ruleBody(selector: string): string {
+  const at = css.indexOf(selector);
+  if (at < 0) throw new Error(`selector not found in PaneHeader.css: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  if (open < 0 || close < 0) {
+    throw new Error(`malformed rule block for selector: ${selector}`);
+  }
+  return css.slice(open + 1, close).trim();
+}
+
+describe('PaneHeader.css `.pane-header__provider` (F-091)', () => {
+  const body = ruleBody('.pane-header__provider');
+
+  it('reads the per-pane accent from a CSS custom property with a steel fallback', () => {
+    const normalised = body.replace(/\s+/g, ' ');
+    expect(normalised).toContain(
+      'color: var(--pane-header-provider-accent, var(--color-provider-local));',
+    );
+  });
+
+  it('no longer hardcodes `color: var(--color-provider-local)` (would re-introduce F-091)', () => {
+    const normalised = body.replace(/\s+/g, ' ');
+    // Bare `color: var(--color-provider-local);` (without the custom-property
+    // fallback wrapper) is the pre-F-091 regression shape — block it.
+    expect(normalised).not.toMatch(/color: var\(--color-provider-local\);/);
+  });
+});

--- a/web/packages/app/src/routes/Session/PaneHeader.test.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render } from '@solidjs/testing-library';
+import type { ProviderId } from '@forge/ipc';
 import { PaneHeader } from './PaneHeader';
 
 // PaneHeader close button (F-084): per voice-terminology.md §8 "Button labels:
@@ -11,6 +12,7 @@ describe('PaneHeader close button — voice & terminology (F-084)', () => {
     const { getByRole } = render(() => (
       <PaneHeader
         subject="example"
+        providerId={'ollama' as ProviderId}
         providerLabel="local"
         costLabel="$0.00"
         onClose={vi.fn()}
@@ -26,6 +28,7 @@ describe('PaneHeader close button — voice & terminology (F-084)', () => {
     const { getByRole } = render(() => (
       <PaneHeader
         subject="example"
+        providerId={'ollama' as ProviderId}
         providerLabel="local"
         costLabel="$0.00"
         onClose={vi.fn()}
@@ -33,5 +36,54 @@ describe('PaneHeader close button — voice & terminology (F-084)', () => {
     ));
     const btn = getByRole('button', { name: 'Close session window' });
     expect(btn.getAttribute('aria-label')).toBe('Close session window');
+  });
+});
+
+// PaneHeader provider pill (F-091): per ai-patterns.md §7, the provider pill
+// color must follow the active provider — anthropic/ember, openai/amber,
+// ollama/lm-studio/local/steel, otherwise iron-200. The component plumbs the
+// active provider's accent into a CSS custom property on the provider pill so
+// the existing class-driven CSS picks it up without per-provider rules.
+
+describe('PaneHeader provider pill accent (F-091)', () => {
+  it.each<[ProviderId, string]>([
+    ['anthropic' as ProviderId, 'var(--color-provider-anthropic)'],
+    ['openai' as ProviderId, 'var(--color-provider-openai)'],
+    ['ollama' as ProviderId, 'var(--color-provider-local)'],
+    ['local' as ProviderId, 'var(--color-provider-local)'],
+    ['lm-studio' as ProviderId, 'var(--color-provider-local)'],
+    ['custom' as ProviderId, 'var(--color-provider-custom)'],
+  ])('binds the pill accent to %s → %s', (providerId, expectedAccent) => {
+    const { getByTestId } = render(() => (
+      <PaneHeader
+        subject="example"
+        providerId={providerId}
+        providerLabel={String(providerId)}
+        costLabel="$0.00"
+        onClose={vi.fn()}
+      />
+    ));
+    const pill = getByTestId('pane-header-provider');
+    // Inline style carries the CSS variable so the rule stays generic.
+    // jsdom's getPropertyValue is reliable for inline custom properties.
+    expect(pill.style.getPropertyValue('--pane-header-provider-accent')).toBe(
+      expectedAccent,
+    );
+  });
+
+  it('falls back to the custom accent for an unknown provider id', () => {
+    const { getByTestId } = render(() => (
+      <PaneHeader
+        subject="example"
+        providerId={'made-up-provider' as ProviderId}
+        providerLabel="custom"
+        costLabel="$0.00"
+        onClose={vi.fn()}
+      />
+    ));
+    const pill = getByTestId('pane-header-provider');
+    expect(pill.style.getPropertyValue('--pane-header-provider-accent')).toBe(
+      'var(--color-provider-custom)',
+    );
   });
 });

--- a/web/packages/app/src/routes/Session/PaneHeader.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.tsx
@@ -1,8 +1,16 @@
-import type { Component } from 'solid-js';
+import type { Component, JSX } from 'solid-js';
+import type { ProviderId } from '@forge/ipc';
+import { providerAccent } from './providerAccent';
 import './PaneHeader.css';
 
 export interface PaneHeaderProps {
   subject: string;
+  /**
+   * Active provider id (F-091). Drives the pill accent color via the
+   * `--pane-header-provider-accent` custom property; the display text remains
+   * the caller-supplied `providerLabel`.
+   */
+  providerId: ProviderId;
   providerLabel: string;
   costLabel: string;
   onClose: () => void;
@@ -12,15 +20,29 @@ export interface PaneHeaderProps {
  * Pane header (28px) per docs/ui-specs/layout-panes.md §3.3. Shows the
  * session subject, provider label, and a cost meter placeholder, with a
  * close action on the right.
+ *
+ * The provider pill color follows `ai-patterns.md §7` — anthropic→ember,
+ * openai→amber, ollama/lm-studio/local→steel, otherwise custom (iron-200).
+ * The accent is plumbed through an inline CSS custom property so adding a
+ * new provider requires only a `providerAccent` mapping update — no CSS edit.
  */
 export const PaneHeader: Component<PaneHeaderProps> = (props) => {
+  // Inline custom property keeps `.pane-header__provider` rule generic; the
+  // rule reads `var(--pane-header-provider-accent, var(--color-provider-local))`.
+  const pillStyle = (): JSX.CSSProperties => ({
+    '--pane-header-provider-accent': providerAccent(props.providerId),
+  });
   return (
     <header class="pane-header" role="banner">
       <span class="pane-header__type-label">CHAT</span>
       <span class="pane-header__subject" data-testid="pane-header-subject">
         {props.subject}
       </span>
-      <span class="pane-header__provider" data-testid="pane-header-provider">
+      <span
+        class="pane-header__provider"
+        data-testid="pane-header-provider"
+        style={pillStyle()}
+      >
         {props.providerLabel}
       </span>
       <span class="pane-header__cost" data-testid="pane-header-cost">

--- a/web/packages/app/src/routes/Session/SessionWindow.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.tsx
@@ -1,7 +1,7 @@
 import { type Component, onCleanup, onMount } from 'solid-js';
 import { useParams } from '@solidjs/router';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import type { SessionId } from '@forge/ipc';
+import type { ProviderId, SessionId } from '@forge/ipc';
 import {
   onSessionEvent,
   sessionHello,
@@ -83,6 +83,10 @@ export const SessionWindow: Component = () => {
   };
 
   const subject = () => `Session ${sessionId()}`;
+  // Phase 1 ships only the Ollama provider; once the active session carries
+  // its provider id over IPC (Phase 2), wire it through here so the pill
+  // accent follows the live provider per ai-patterns.md §7 (F-091).
+  const providerId = (): ProviderId => 'ollama' as ProviderId;
   const providerLabel = () => 'ollama \u00b7 pending';
   const costLabel = () => 'in 0 \u00b7 out 0 \u00b7 $0.00';
 
@@ -91,6 +95,7 @@ export const SessionWindow: Component = () => {
       <section class="session-window__pane" aria-label="Session pane">
         <PaneHeader
           subject={subject()}
+          providerId={providerId()}
           providerLabel={providerLabel()}
           costLabel={costLabel()}
           onClose={handleClose}

--- a/web/packages/app/src/routes/Session/providerAccent.test.ts
+++ b/web/packages/app/src/routes/Session/providerAccent.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderId } from '@forge/ipc';
+import { providerAccent } from './providerAccent';
+
+// F-091: per ai-patterns.md §7 each provider has a fixed accent token:
+//   anthropic → ember-400, openai → amber, local/ollama/lm-studio → steel,
+//   custom (and any unknown) → iron-200.
+// The helper returns a `var(--color-provider-*)` reference so callers can
+// drop it directly into an inline-style CSS custom property without touching
+// CSS files when new provider ids land.
+
+describe('providerAccent (F-091)', () => {
+  it.each<[ProviderId, string]>([
+    ['anthropic' as ProviderId, 'var(--color-provider-anthropic)'],
+    ['openai' as ProviderId, 'var(--color-provider-openai)'],
+    ['ollama' as ProviderId, 'var(--color-provider-local)'],
+    ['local' as ProviderId, 'var(--color-provider-local)'],
+    ['lm-studio' as ProviderId, 'var(--color-provider-local)'],
+    ['custom' as ProviderId, 'var(--color-provider-custom)'],
+  ])('maps %s to %s', (id, expected) => {
+    expect(providerAccent(id)).toBe(expected);
+  });
+
+  it('falls back to the custom accent for an unknown provider id', () => {
+    // ProviderId is a string newtype, so unknown ids are reachable at runtime.
+    expect(providerAccent('made-up-provider' as ProviderId)).toBe(
+      'var(--color-provider-custom)',
+    );
+  });
+});

--- a/web/packages/app/src/routes/Session/providerAccent.ts
+++ b/web/packages/app/src/routes/Session/providerAccent.ts
@@ -1,0 +1,29 @@
+import type { ProviderId } from '@forge/ipc';
+
+/**
+ * Per-provider pane accent (F-091, ai-patterns.md §7).
+ *
+ * Returns a `var(--color-provider-*)` reference suitable for assignment to a
+ * CSS custom property in an inline `style` attribute. The four accent tokens
+ * live in `web/packages/design/src/tokens.css` and are governed by
+ * `scripts/check-tokens.mjs`.
+ *
+ * `ProviderId` is a string newtype on the IPC boundary, so unknown ids are
+ * reachable at runtime — they fall back to the custom-endpoint accent.
+ */
+export function providerAccent(id: ProviderId): string {
+  switch (id) {
+    case 'anthropic':
+      return 'var(--color-provider-anthropic)';
+    case 'openai':
+      return 'var(--color-provider-openai)';
+    case 'ollama':
+    case 'lm-studio':
+    case 'local':
+      return 'var(--color-provider-local)';
+    case 'custom':
+      return 'var(--color-provider-custom)';
+    default:
+      return 'var(--color-provider-custom)';
+  }
+}


### PR DESCRIPTION
Closes forge-ide/forge#164

## Summary
- `PaneHeader` accepts a `providerId: ProviderId` prop and applies the matching accent to the provider pill via the `--pane-header-provider-accent` inline custom property; the rule reads that property with the steel token as a Phase-1 default
- New `providerAccent(ProviderId)` helper maps anthropic→ember-400, openai→amber, ollama/lm-studio/local→steel, custom (and unknown ids) → iron-200, per `docs/design/ai-patterns.md §7` and `docs/ui-specs/pane-header.md §PH.3`
- `SessionWindow` passes the active `providerId` (Phase 1: `ollama`); plumbing scales without CSS edits when more providers land
- Regression coverage: `providerAccent.test.ts` (per-id mapping including unknown), `PaneHeader.test.tsx` (inline-style assertion per provider id), `PaneHeader.css.test.ts` (rule reads custom property with steel fallback, blocks regression to bare hardcoded value)

## Test plan
- `pnpm -r typecheck` passes
- `pnpm -r test` passes (267 frontend tests)
- `node scripts/check-tokens.mjs` passes
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` pass

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)