### PR TITLE
[F-076] Replace anyhow wrapping in Session::emit with typed SessionError

### DIFF
--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -68,3 +68,7 @@ path = "tests/socket_path_fallback.rs"
 [[test]]
 name = "uds_bind_symlink_race"
 path = "tests/uds_bind_symlink_race.rs"
+
+[[test]]
+name = "session_error"
+path = "tests/session_error.rs"

--- a/crates/forge-session/src/error.rs
+++ b/crates/forge-session/src/error.rs
@@ -1,0 +1,45 @@
+//! Typed errors for the session crate.
+//!
+//! F-076: `Session::emit` previously wrapped every `EventLog::append` /
+//! `EventLog::flush` failure in `anyhow::anyhow!(e)`, erasing the typed
+//! `forge_core::ForgeError` underneath and forcing top-level callers to
+//! match on Display strings to distinguish retryable I/O from fatal
+//! state. Surfacing a typed enum lets callers (e.g. orchestrator,
+//! server loop) decide on retry / escalate per failure mode.
+//!
+//! Variants intentionally keep `forge_core::ForgeError` as the inner
+//! type rather than collapsing to `std::io::Error` — `EventLog`'s
+//! return type already carries Io / Serde / Other discrimination, and
+//! downcasting at the boundary would silently drop the Serde and Other
+//! cases.
+
+use forge_core::ForgeError;
+
+/// Error returned by [`crate::session::Session::emit`].
+///
+/// The two `EventLog*` variants share an inner type but represent
+/// distinct failure modes: an `append` failure means the event was
+/// never durably staged, while a `flush` failure means the event was
+/// staged in the buffer but the durable write never completed. Callers
+/// that retry should distinguish these cases — re-emitting after a
+/// flush failure risks duplicate events on the next successful flush.
+///
+/// No `#[from]` impl is provided because both variants wrap the same
+/// inner type; the caller (`Session::emit`) selects the variant
+/// explicitly via `.map_err(SessionError::EventLogAppend)` /
+/// `.map_err(SessionError::EventLogFlush)`.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    /// `EventLog::append` failed before the event was buffered.
+    /// Inner is the typed `forge_core::ForgeError` so callers can
+    /// match on `ForgeError::Io` (e.g. `ErrorKind::PermissionDenied`)
+    /// without parsing the outer Display.
+    #[error("event log append failed: {0}")]
+    EventLogAppend(#[source] ForgeError),
+
+    /// `EventLog::flush` failed after the event was buffered. The event
+    /// may or may not be durable — treat as ambiguous and surface to
+    /// the operator rather than silently retrying.
+    #[error("event log flush failed: {0}")]
+    EventLogFlush(#[source] ForgeError),
+}

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod archive;
+pub mod error;
 pub mod orchestrator;
 pub mod pid_file;
 pub mod provider_spec;
@@ -7,3 +8,5 @@ pub mod server;
 pub mod session;
 pub mod socket_path;
 pub mod tools;
+
+pub use error::SessionError;

--- a/crates/forge-session/src/session.rs
+++ b/crates/forge-session/src/session.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use forge_core::{Event, EventLog};
 use tokio::sync::{broadcast, Mutex};
 
+use crate::error::SessionError;
+
 pub struct Session {
     pub log_path: PathBuf,
     pub event_tx: broadcast::Sender<(u64, Event)>,
@@ -28,14 +30,25 @@ impl Session {
         })
     }
 
-    pub async fn emit(&self, event: Event) -> anyhow::Result<()> {
+    /// Append `event` to the durable event log and broadcast it to
+    /// subscribers.
+    ///
+    /// F-076: returns the typed [`SessionError`] so callers can
+    /// distinguish an append failure (event never staged) from a flush
+    /// failure (event staged but durability uncertain). The broadcast
+    /// `send` failure is intentionally swallowed — `broadcast::Sender`
+    /// returns `Err` when zero receivers are subscribed, which is the
+    /// normal warmup state and not an error condition.
+    pub async fn emit(&self, event: Event) -> Result<(), SessionError> {
         let mut seq = self.seq.lock().await;
         *seq += 1;
         let seq_num = *seq;
 
         let mut log = self.log.lock().await;
-        log.append(&event).await.map_err(|e| anyhow::anyhow!(e))?;
-        log.flush().await.map_err(|e| anyhow::anyhow!(e))?;
+        log.append(&event)
+            .await
+            .map_err(SessionError::EventLogAppend)?;
+        log.flush().await.map_err(SessionError::EventLogFlush)?;
         drop(log);
         drop(seq);
 

--- a/crates/forge-session/tests/session_error.rs
+++ b/crates/forge-session/tests/session_error.rs
@@ -1,0 +1,108 @@
+//! F-076: regression tests for the typed `SessionError` returned from
+//! `Session::emit`. These assert the *variant shape* — not real disk
+//! failures, which on tokio::fs::File backed by an open fd cannot be
+//! reliably induced from the outside (chmod doesn't affect open fds,
+//! deleting the file doesn't either, /dev/full only fails at create-time,
+//! and RLIMIT_FSIZE delivers SIGXFSZ which kills the process).
+//!
+//! Mirrors the F-074 `ToolError` test style: construct the variant
+//! directly via the same conversion path the production code uses
+//! (`ForgeError -> SessionError::EventLog{Append,Flush}`) and assert
+//! discriminant, `Display`, and `source()`. This is the boundary the
+//! change actually introduces — wrapping `EventLog::append`/`flush`'s
+//! typed `forge_core::ForgeError` into `SessionError`.
+
+use std::io;
+
+use forge_core::ForgeError;
+use forge_session::SessionError;
+
+#[test]
+fn event_log_append_wraps_forge_error_and_preserves_source() {
+    // Production path: `EventLog::append` returns `forge_core::Result<()>`
+    // (i.e. `Result<(), ForgeError>`). `Session::emit` maps the failure
+    // into `SessionError::EventLogAppend`. Assert that the `?`-chained
+    // source survives so callers wanting to switch on retryable I/O can
+    // still drill down to the underlying `io::Error`.
+    let inner: ForgeError = io::Error::new(io::ErrorKind::PermissionDenied, "denied").into();
+    let err = SessionError::EventLogAppend(inner);
+
+    assert!(matches!(err, SessionError::EventLogAppend(_)));
+    assert!(err.to_string().starts_with("event log append failed:"));
+
+    // The forge_core::ForgeError must be reachable via `source()` so a
+    // future caller can downcast to the typed inner without parsing the
+    // outer Display string.
+    let src = std::error::Error::source(&err).expect("source must be exposed");
+    let inner_str = src.to_string();
+    assert!(
+        inner_str.contains("denied"),
+        "underlying ForgeError text lost: {inner_str}"
+    );
+}
+
+#[test]
+fn event_log_flush_wraps_forge_error_and_preserves_source() {
+    let inner: ForgeError = io::Error::other("disk full").into();
+    let err = SessionError::EventLogFlush(inner);
+
+    assert!(matches!(err, SessionError::EventLogFlush(_)));
+    assert!(err.to_string().starts_with("event log flush failed:"));
+
+    let src = std::error::Error::source(&err).expect("source must be exposed");
+    assert!(src.to_string().contains("disk full"));
+}
+
+#[test]
+fn append_and_flush_are_distinguishable_variants() {
+    // The whole point of F-076: callers must be able to pattern-match
+    // on the specific failure mode. If the two variants collapse into
+    // a single one (e.g. `EventLogIo` covering both), the typed
+    // information needed for retry/escalate decisions is lost again.
+    let inner_a: ForgeError = io::Error::new(io::ErrorKind::PermissionDenied, "a").into();
+    let inner_b: ForgeError = io::Error::new(io::ErrorKind::PermissionDenied, "b").into();
+
+    let append = SessionError::EventLogAppend(inner_a);
+    let flush = SessionError::EventLogFlush(inner_b);
+
+    let is_append = matches!(append, SessionError::EventLogAppend(_));
+    let is_flush_not_append = !matches!(flush, SessionError::EventLogAppend(_));
+    assert!(is_append);
+    assert!(is_flush_not_append);
+}
+
+#[test]
+fn session_error_is_anyhow_compatible_for_existing_callers() {
+    // `orchestrator::run_turn` returns `anyhow::Result<()>` and propagates
+    // `session.emit(...).await?`. anyhow has a blanket `From<E>` for any
+    // `E: std::error::Error + Send + Sync + 'static`, which thiserror
+    // derives for us. This test pins that contract: if someone strips
+    // a derive from `SessionError` the orchestrator's `?` would stop
+    // compiling, and that breakage should be caught here, not in a
+    // distant caller.
+    fn require_sync_error<E: std::error::Error + Send + Sync + 'static>(_: &E) {}
+    let inner: ForgeError = io::Error::from(io::ErrorKind::PermissionDenied).into();
+    let err = SessionError::EventLogAppend(inner);
+    require_sync_error(&err);
+
+    let _: anyhow::Error = anyhow::Error::new(err);
+}
+
+#[tokio::test]
+async fn session_emit_signature_returns_session_error() {
+    // Lock the public surface: `Session::emit` must return
+    // `Result<(), SessionError>`. A test that compiles is the assertion;
+    // if the signature drifts back to `anyhow::Result<()>` this stops
+    // compiling, which is the regression we want to catch.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("events.jsonl");
+    let session = forge_session::session::Session::create(path).await.unwrap();
+    let result: Result<(), SessionError> = session
+        .emit(forge_core::Event::SessionEnded {
+            at: chrono::Utc::now(),
+            reason: forge_core::EndReason::Completed,
+            archived: false,
+        })
+        .await;
+    result.unwrap();
+}


### PR DESCRIPTION
Closes forge-ide/forge#149

## Summary
- Add `SessionError` enum (thiserror) in `crates/forge-session/src/error.rs` with `EventLogAppend(#[source] forge_core::ForgeError)` and `EventLogFlush(#[source] forge_core::ForgeError)` variants — wrapping `ForgeError` rather than `std::io::Error` to preserve the existing `Io`/`Serde`/`Other` discrimination at the boundary.
- Change `Session::emit` to return `Result<(), SessionError>`. Existing `?`-using callers (orchestrator, server.rs) require **zero edits** because anyhow's blanket `From<E: std::error::Error + Send + Sync + 'static>` handles the conversion.
- The broadcast-send path is intentionally left swallowing `SendError` — `broadcast::Sender::send` returns `Err` when zero receivers are subscribed, which is the normal warmup state and is asserted by `subscribe_replay.rs`. Promoting it would be a behaviour change outside this issue's scope.
- `Session::create`'s `anyhow!(e)` wrap (line 21) is the same shape but explicitly out of scope per the issue body, which pins the location to lines 37-38.
- Match the F-074 `ToolError` test style: 5 unit tests for variant shape, `Display`, `source()` chain preservation, distinct discriminants (the whole point — callers must be able to pattern-match append vs flush), anyhow compatibility, and the locked `emit` signature.

## Test plan
- `cargo fmt --all --check` passes
- `cargo test --workspace` passes (including the 5 new `session_error` tests)
- `cargo clippy --all-targets --all-features -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)