### PR TITLE
[F-102] Clarify docs/product/scope.md Windows/WSL phrasing

### DIFF
--- a/docs/product/scope.md
+++ b/docs/product/scope.md
@@ -7,7 +7,7 @@
 ## 12. Scope boundaries
 
 ### In v1.0
-Everything in §§2–11. Including Windows (via WSL2, native build pending).
+Everything in §§2–11, on Linux. Windows is not supported in v1.0 — see deferred items below.
 
 ### Out of v1.0 — deliberately
 - **Remote development** (SSH sessions, containers-as-dev-env) — v1.1 focus
@@ -17,7 +17,8 @@ Everything in §§2–11. Including Windows (via WSL2, native build pending).
 - **OAuth provider login** — stdin credentials in v1, browser flow in v1.1
 - **Bundled OCI runtime** — users install podman or docker themselves in v1
 - **HTTP tarball skill distribution** — Git URLs and local paths only in v1; checksummed tarballs in v1.1
-- **Native Windows build** — v1.3; WSL covers v1
+- **Windows (WSL2)** — planned for v1.1; v1.0 is Linux-only and WSL2 is untested
+- **Native Windows build** — planned for v1.3
 - **Image attachments in composer** — v1.1
 - **Native Rust editor** — a possibility if Monaco constraints bite, but not planned
 


### PR DESCRIPTION
Closes forge-ide/forge#175

## Summary
- `docs/product/scope.md` "In v1.0" now reads "Everything in §§2–11, on Linux." with an explicit pointer to deferred items, removing the implication that v1.0 ships on Windows via WSL2.
- The deferred "Native Windows build" bullet is split into two entries with explicit version targets: **Windows (WSL2)** planned for v1.1 (and called out as untested in v1.0), and **Native Windows build** planned for v1.3.
- Aligns the doc with reality: `deny.toml` Linux-only targets, CI Linux-only runners, `socket_path.rs` targeting `XDG_RUNTIME_DIR` systemd, and uds tests gated `#![cfg(target_os = "linux")]`.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- Docs-only change; no behavior to test beyond the workspace build.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)