### PR TITLE
fix(design): tokenize remaining raw hex and non-token pixel values (F-090)

### DIFF
--- a/docs/design/token-reference.md
+++ b/docs/design/token-reference.md
@@ -35,6 +35,7 @@ These tokens should be defined at `:root` and used throughout. Never use raw val
   --color-text-disabled:  #252f3e;
   --color-text-ember:     #ff4a12;
   --color-text-link:      #7aaaff;
+  --color-text-inverted:  #fff;
 
   /* Semantic */
   --color-success:   #3ddc84;

--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css
@@ -59,8 +59,9 @@
 
 .approval-prompt__pattern-label {
   font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: 9px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
   color: var(--color-text-secondary);
 }
 
@@ -173,7 +174,6 @@
   border-bottom-left-radius: 0;
   padding-left: var(--sp-2);
   padding-right: var(--sp-2);
-  font-size: 9px;
 }
 
 /* -------------------------------------------------------------------------

--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tokens.test.ts
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tokens.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ApprovalPrompt token adherence (F-090):
+// voice-terminology.md §9 agent rule #1 — "Use design tokens, never raw hex
+// or pixel values." Two sub-elements previously declared raw values that
+// did not match any token in docs/design/typography.md §4:
+//
+//   .approval-prompt__pattern-label   font-size: 10px; letter-spacing: 0.08em;
+//   .approval-prompt__dropdown-toggle font-size: 9px;   (override of parent 11px)
+//
+// After F-090:
+//   - `.approval-prompt__pattern-label` matches `mono-xs` (9px / 0.3em /
+//     uppercase) per typography.md §4.
+//   - `.approval-prompt__dropdown-toggle` removes the unjustified font-size
+//     override and inherits 11px from its parent button.
+//
+// JSDOM cannot reliably resolve var() / inheritance at the source level, so
+// assert the source-string contract on the CSS rule blocks (matches the
+// F-084/F-085 pattern in ApprovalPrompt.css.test.ts).
+
+const cssPath = resolve(__dirname, 'ApprovalPrompt.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+function ruleBody(selector: string): string {
+  const at = css.indexOf(selector);
+  if (at < 0) throw new Error(`selector not found in ApprovalPrompt.css: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  if (open < 0 || close < 0) {
+    throw new Error(`malformed rule block for selector: ${selector}`);
+  }
+  return css.slice(open + 1, close).trim();
+}
+
+function hasDecl(body: string, name: string, value: string): boolean {
+  const normalised = body.replace(/\s+/g, ' ');
+  return normalised.includes(`${name}: ${value};`);
+}
+
+describe('ApprovalPrompt — pattern-label matches mono-xs (F-090)', () => {
+  const body = ruleBody('.approval-prompt__pattern-label');
+
+  it('font-size: 9px (mono-xs)', () => {
+    expect(hasDecl(body, 'font-size', '9px')).toBe(true);
+    expect(body).not.toMatch(/font-size:\s*10px\b/);
+  });
+
+  it('letter-spacing: 0.3em (mono-xs)', () => {
+    expect(hasDecl(body, 'letter-spacing', '0.3em')).toBe(true);
+    expect(body).not.toMatch(/letter-spacing:\s*0\.08em\b/);
+  });
+
+  it('text-transform: uppercase (mono-xs convention)', () => {
+    expect(hasDecl(body, 'text-transform', 'uppercase')).toBe(true);
+  });
+});
+
+describe('ApprovalPrompt — dropdown-toggle has no font-size override (F-090)', () => {
+  const body = ruleBody('.approval-prompt__dropdown-toggle');
+
+  it('does not override font-size — inherits 11px from .approval-prompt__btn', () => {
+    expect(body).not.toMatch(/font-size:/);
+  });
+});

--- a/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.css
+++ b/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.css
@@ -11,12 +11,12 @@
   display: inline-flex;
   align-items: center;
   gap: var(--sp-1);
-  padding: 2px var(--sp-2);
+  padding: var(--sp-1) var(--sp-2);
   background: var(--color-success-bg);
   border: 1px solid var(--color-success-border);
   border-radius: 999px;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 9px;
   color: var(--color-success);
   cursor: pointer;
   transition: var(--ease);

--- a/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.css.test.ts
+++ b/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.css.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// WhitelistedPill token adherence (F-090):
+// voice-terminology.md §9 agent rule #1 — "Use design tokens, never raw hex
+// or pixel values." `.whitelisted-pill` previously declared
+//   padding: 2px var(--sp-2);   // 2px is not in the spacing scale
+//   font-size: 10px;            // 10px is not in the mono scale
+// After F-090, padding must use `var(--sp-1) var(--sp-2)` (4px vertical) and
+// font-size must match `mono-xs` (9px) per the badge convention in
+// docs/design/typography.md §4. JSDOM cannot reliably resolve var() at the
+// source level, so assert the source-string contract on the CSS rule block
+// (matches the F-084/F-085 pattern).
+
+const cssPath = resolve(__dirname, 'WhitelistedPill.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+function ruleBody(selector: string): string {
+  const at = css.indexOf(selector);
+  if (at < 0) throw new Error(`selector not found in WhitelistedPill.css: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  if (open < 0 || close < 0) {
+    throw new Error(`malformed rule block for selector: ${selector}`);
+  }
+  return css.slice(open + 1, close).trim();
+}
+
+function hasDecl(body: string, name: string, value: string): boolean {
+  const normalised = body.replace(/\s+/g, ' ');
+  return normalised.includes(`${name}: ${value};`);
+}
+
+describe('WhitelistedPill — design-token adherence (F-090)', () => {
+  // Anchor on `.whitelisted-pill {` to disambiguate from the wrapper class
+  // (`.whitelisted-pill-wrapper`) and from descendant/state selectors
+  // (`.whitelisted-pill:hover`, `.whitelisted-pill__dot`, etc.) that all
+  // share the same prefix.
+  const body = ruleBody('.whitelisted-pill {');
+
+  it('padding uses spacing tokens (no raw 2px)', () => {
+    expect(hasDecl(body, 'padding', 'var(--sp-1) var(--sp-2)')).toBe(true);
+    expect(body).not.toMatch(/padding:\s*2px\b/);
+  });
+
+  it('font-size matches mono-xs scale (9px), not raw 10px', () => {
+    expect(hasDecl(body, 'font-size', '9px')).toBe(true);
+    expect(body).not.toMatch(/font-size:\s*10px\b/);
+  });
+});

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.css
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.css
@@ -138,7 +138,7 @@
 .provider-panel__btn--primary {
   background: var(--color-ember-400);
   border-color: var(--color-ember-400);
-  color: #fff;
+  color: var(--color-text-inverted);
 }
 
 .provider-panel__unreachable {

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.css.test.ts
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.css.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ProviderPanel token adherence (F-090):
+// voice-terminology.md §9 agent rule #1 — "Use design tokens, never raw hex
+// or pixel values." `.provider-panel__btn--primary` previously declared
+// `color: #fff` (raw hex). After F-090 it must use `var(--color-text-inverted)`,
+// a new token added to `tokens.css` and `token-reference.md`. JSDOM cannot
+// reliably resolve var() at the source level, so assert the source-string
+// contract on the CSS rule block (matches F-084/F-085 pattern).
+
+const cssPath = resolve(__dirname, 'ProviderPanel.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+function ruleBody(selector: string): string {
+  const at = css.indexOf(selector);
+  if (at < 0) throw new Error(`selector not found in ProviderPanel.css: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  if (open < 0 || close < 0) {
+    throw new Error(`malformed rule block for selector: ${selector}`);
+  }
+  return css.slice(open + 1, close).trim();
+}
+
+function hasDecl(body: string, name: string, value: string): boolean {
+  const normalised = body.replace(/\s+/g, ' ');
+  return normalised.includes(`${name}: ${value};`);
+}
+
+describe('ProviderPanel — design-token adherence (F-090)', () => {
+  it('.provider-panel__btn--primary uses --color-text-inverted, not raw #fff', () => {
+    const body = ruleBody('.provider-panel__btn--primary');
+    expect(hasDecl(body, 'color', 'var(--color-text-inverted)')).toBe(true);
+    expect(body).not.toMatch(/color:\s*#fff\b/i);
+    expect(body).not.toMatch(/color:\s*#ffffff\b/i);
+  });
+});

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.css
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.css
@@ -157,9 +157,9 @@
 }
 
 .session-card__badge--persist {
-  background: rgba(255, 74, 18, 0.08);
+  background: var(--color-error-bg);
   color: var(--color-ember-300);
-  border-color: rgba(255, 74, 18, 0.22);
+  border-color: var(--color-error-border);
 }
 
 .session-card__badge--ephemeral {

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.css.test.ts
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.css.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// SessionsPanel token adherence (F-090):
+// voice-terminology.md §9 agent rule #1 — "Use design tokens, never raw hex
+// or pixel values." `.session-card__badge--persist` previously declared
+// raw `rgba(255, 74, 18, 0.08)` for its background and `rgba(255, 74, 18, 0.22)`
+// for its border. After F-090 these must use `var(--color-error-bg)` and
+// `var(--color-error-border)` (which already encode the same channels at the
+// canonical 0.07/0.22 alpha). JSDOM cannot reliably resolve var() at the
+// source level, so assert the source-string contract on the CSS rule block
+// (matches the F-084/F-085 pattern).
+
+const cssPath = resolve(__dirname, 'SessionsPanel.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+function ruleBody(selector: string): string {
+  const at = css.indexOf(selector);
+  if (at < 0) throw new Error(`selector not found in SessionsPanel.css: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  if (open < 0 || close < 0) {
+    throw new Error(`malformed rule block for selector: ${selector}`);
+  }
+  return css.slice(open + 1, close).trim();
+}
+
+function hasDecl(body: string, name: string, value: string): boolean {
+  const normalised = body.replace(/\s+/g, ' ');
+  return normalised.includes(`${name}: ${value};`);
+}
+
+describe('SessionsPanel — design-token adherence (F-090)', () => {
+  const body = ruleBody('.session-card__badge--persist');
+
+  it('uses var(--color-error-bg) for background, not raw rgba', () => {
+    expect(hasDecl(body, 'background', 'var(--color-error-bg)')).toBe(true);
+  });
+
+  it('uses var(--color-error-border) for border-color, not raw rgba', () => {
+    expect(hasDecl(body, 'border-color', 'var(--color-error-border)')).toBe(true);
+  });
+
+  it('no longer contains the raw rgba(255, 74, 18, 0.08) literal', () => {
+    expect(body).not.toMatch(/rgba\(\s*255\s*,\s*74\s*,\s*18\s*,\s*0\.08\s*\)/);
+  });
+
+  it('no longer contains the raw rgba(255, 74, 18, 0.22) literal', () => {
+    expect(body).not.toMatch(/rgba\(\s*255\s*,\s*74\s*,\s*18\s*,\s*0\.22\s*\)/);
+  });
+});

--- a/web/packages/design/src/tokens.css
+++ b/web/packages/design/src/tokens.css
@@ -25,6 +25,7 @@
   --color-text-disabled:  #252f3e;
   --color-text-ember:     #ff4a12;
   --color-text-link:      #7aaaff;
+  --color-text-inverted:  #fff;
 
   /* Semantic */
   --color-success:   #3ddc84;


### PR DESCRIPTION
Closes forge-ide/forge#163

## Summary

Six sites across four component CSS files were using raw hex / rgba / off-scale pixel values, bypassing the design token system enforced by `voice-terminology.md §9`:

- `ProviderPanel.css` — `.provider-panel__btn--primary { color: #fff }` → `var(--color-text-inverted)` (new token added to both `tokens.css` and `docs/design/token-reference.md`).
- `SessionsPanel.css` — `.session-card__badge--persist` raw `rgba(255, 74, 18, 0.08/0.22)` → `var(--color-error-bg)` / `var(--color-error-border)`.
- `ApprovalPrompt.css` — `.approval-prompt__pattern-label` 10px / 0.08em → `mono-xs` (9px / 0.3em / uppercase).
- `ApprovalPrompt.css` — `.approval-prompt__dropdown-toggle` removes unjustified `font-size: 9px` override (now inherits 11px from parent button).
- `WhitelistedPill.css` — `.whitelisted-pill` padding 2px → `var(--sp-1)`; font-size 10px → 9px (mono-xs badge convention).

Adds per-file source-string regression tests matching the F-084/F-085 pattern so any future raw-value re-introduction fails CI.

## Test plan

- `node scripts/check-tokens.mjs` passes (57 tokens match reference doc, +1 new `--color-text-inverted`)
- `pnpm -r typecheck` clean
- `pnpm -r test` — 280/280 passing (4 new test files, 11 new assertions)

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)