### PR TITLE
[F-096] Resolve session-state drift between crate-architecture.md §3.5 and SessionState enum

### DIFF
--- a/docs/architecture/crate-architecture.md
+++ b/docs/architecture/crate-architecture.md
@@ -247,21 +247,18 @@ async fn main() -> Result<()> {
 - Perform context compaction at 98% or on explicit user request
 - On end: archive (move to `.forge/sessions/archived/<id>/` if persist) or purge (if ephemeral)
 
-**State machine.**
+**Lifecycle.** `forge-session` does not run an internal `Spawned/Initializing/Ready/Running/Draining/Stopped` state machine. The `SessionState` enum in `crates/forge-core/src/types.rs` (see §3.1) has exactly three variants — `Active`, `Archived`, `Ended` — and the daemon is a long-running listener whose progress is observable through the event log, not through a session-level state field.
+
 ```
-  [Spawned] ─> [Initializing] ─> [Ready]
-                                    │
-                                    ▼
-  ┌─────────────── [Running] ─┐
-  │                            │
-  ▼                            ▼
-[PausedForApproval]         [Idle]
-  │                            │
-  └──────────> (resume) ───────┘
-                               │
-                               ▼
-                        [Draining] ─> [Stopped] ─> {Archived | Purged}
+  [Active] ──(SIGTERM/SIGINT, ephemeral)──> [Ended]   (session dir purged)
+     │
+     └──(SIGTERM/SIGINT, persist)──────────> [Archived] (moved to .forge/sessions/archived/<id>/)
 ```
+
+- The daemon starts in `Active` and emits an `Event::SessionStarted` to `events.jsonl` (`crates/forge-core/src/event.rs`).
+- Approval waiting is **event-driven, not a state transition**: when a tool call needs approval, the session emits `ToolCallApprovalRequested` and waits for an `ApproveToolCall` / `RejectToolCall` command from any connected client. The session remains `Active` throughout — there is no `PausedForApproval` state, and other reads can continue in parallel.
+- On `SIGTERM` / `SIGINT`, `crates/forge-session/src/server.rs` emits `Event::SessionEnded { archived }` and calls `archive_or_purge` from `crates/forge-session/src/archive.rs` (per F-039). Persistent sessions are renamed into `.forge/sessions/archived/<id>/` and `meta.toml.state` is rewritten to `Archived`; ephemeral sessions have their session directory removed and the in-memory state is `Ended` (no `meta.toml` survives).
+- The richer `Spawned → Initializing → Ready → Draining → Stopped` machine in earlier drafts is **not implemented** and is not currently planned for Phase 1. If a future phase grows the enum, update this section and `SessionState` in lockstep.
 
 **Client connections.**
 - Multiple clients (GUI instances, `forge session tail`, `forge session attach`) can connect simultaneously


### PR DESCRIPTION
Closes forge-ide/forge#169

## Summary
- Replaces the aspirational `Spawned → Initializing → Ready → Running/PausedForApproval/Idle → Draining → Stopped → {Archived | Purged}` diagram in §3.5 with one that matches the actual `SessionState { Active, Archived, Ended }` enum already shown in §3.1 (`crates/forge-core/src/types.rs:13`).
- Clarifies that approval waiting is event-driven (`Event::ToolCallApprovalRequested` emitted, `ApproveToolCall` / `RejectToolCall` command awaited) — there is no `PausedForApproval` state and the session stays `Active` while waiting.
- Cross-references the real Phase 1 lifecycle code: `crates/forge-session/src/server.rs` (SIGTERM/SIGINT handling that emits `Event::SessionEnded { archived }` then calls `archive_or_purge`) and `crates/forge-session/src/archive.rs` (rename-into-`archived/` for persist; `remove_dir_all` for ephemeral; `meta.toml.state = Archived`), per F-039.
- Notes that the richer state machine is not implemented and not currently planned for Phase 1; if a future phase grows the enum, doc and `SessionState` should be updated in lockstep.

Picked remediation #1 from the issue body (replace the diagram, keep §3.5 truthful-today) over #2 (label as "Phase 2+ planned"). §3.1 — just aligned in F-095 — already shows the 3-variant enum three paragraphs above; making §3.5 consistent reduces doc surface rather than stacking an aspirational diagram next to a "Phase 1 reality" box. No roadmap entry asks for the larger machine.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (no regressions; docs-only change)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)