### PR TITLE
refactor(forge-session): extract shared arg-extraction helpers for tools (F-075)

### DIFF
--- a/crates/forge-session/src/tools/args.rs
+++ b/crates/forge-session/src/tools/args.rs
@@ -1,0 +1,243 @@
+//! Shared argument-extraction helpers for `Tool` implementations.
+//!
+//! Each tool's `invoke` and `approval_preview` repeats the same
+//! `args.get(key).and_then(|v| v.as_str())…` pattern. Concentrating those
+//! patterns here keeps validation semantics consistent across tools and gives
+//! future tools (and refactors that change the error shape) a single edit
+//! point.
+//!
+//! Three helpers cover every existing call site:
+//! - [`get_required_str`] — required string, returns the unified
+//!   `MissingRequiredArg` error on miss / wrong-type. Empty string is
+//!   intentionally accepted; see the F-074 rationale on the function.
+//! - [`get_optional_str`] — optional string, returns `None` on miss /
+//!   wrong-type. Used by `approval_preview` (which tolerates missing args
+//!   so the user sees the literal request) and by `shell.exec`'s `cwd`.
+//! - [`get_optional_u64`] — optional unsigned integer, returns `None` on
+//!   miss / wrong-type. Used by `shell.exec`'s `timeout_ms`.
+//!
+//! All helpers are pure value extractors: they never coerce, never default,
+//! and never log. Callers that need a default chain `.unwrap_or(default)`
+//! at the use site so the default is visible in context.
+
+use super::ToolError;
+
+/// Extract a required string argument from a tool-call's JSON args object.
+///
+/// Returns `Err(ToolError::MissingRequiredArg { tool, arg: key })` when the
+/// key is absent or the value is not a JSON string. Empty strings are
+/// **accepted** — `fs.write` with `{"content": ""}` is a legitimate
+/// "truncate file to zero bytes" operation, and rejecting it here would
+/// regress that behaviour with a misleading "missing parameter" error
+/// (the parameter is supplied; it is just empty). Tools that need to
+/// additionally reject empty (e.g. `shell.exec` on `command`) layer that
+/// check on top of this helper.
+///
+/// The `Display` shape of the returned error is contractual:
+/// `tool.{tool}: missing required parameter '{arg}'`. IPC-level regression
+/// tests assert that exact string — see `tools::tests` and the per-tool
+/// tests added in F-074. Do not change the format without updating those
+/// tests in lockstep.
+pub fn get_required_str<'a>(
+    args: &'a serde_json::Value,
+    tool: &str,
+    key: &str,
+) -> Result<&'a str, ToolError> {
+    match args.get(key).and_then(|v| v.as_str()) {
+        Some(s) => Ok(s),
+        None => Err(ToolError::MissingRequiredArg {
+            tool: tool.to_string(),
+            arg: key.to_string(),
+        }),
+    }
+}
+
+/// Extract an optional string argument from a tool-call's JSON args object.
+///
+/// Returns `Some(s)` only when `key` is present and the value is a JSON
+/// string. Returns `None` for both "key absent" and "wrong type" — these
+/// are equivalent for optional args (the caller's `.unwrap_or(default)`
+/// or `match` arm handles both uniformly).
+///
+/// Used by `approval_preview` for required parameters: the preview
+/// reflects the literal request so the user can see exactly what the
+/// model asked for before consenting. Required-argument validation runs
+/// in `invoke`, not in the preview — there is no point rejecting a
+/// malformed call until the user has had a chance to refuse it.
+pub fn get_optional_str<'a>(args: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    args.get(key).and_then(|v| v.as_str())
+}
+
+/// Extract an optional `u64` argument from a tool-call's JSON args object.
+///
+/// Returns `Some(n)` only when `key` is present and the value is a JSON
+/// number that fits in `u64` (per `serde_json::Value::as_u64` — i.e.
+/// non-negative, integral, within range). Returns `None` for missing
+/// keys, wrong types (string, bool, array, object), negative numbers,
+/// non-integral floats, and out-of-range integers.
+///
+/// Used by `shell.exec` for `timeout_ms`. Callers that need a default
+/// chain `.unwrap_or(default)` at the use site so the default value
+/// stays visible next to the call.
+pub fn get_optional_u64(args: &serde_json::Value, key: &str) -> Option<u64> {
+    args.get(key).and_then(|v| v.as_u64())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ---- get_required_str (moved from F-074) ----
+
+    #[test]
+    fn get_required_str_returns_string_when_present() {
+        let v = json!({ "path": "/tmp/x" });
+        assert_eq!(get_required_str(&v, "fs.read", "path").unwrap(), "/tmp/x");
+    }
+
+    #[test]
+    fn get_required_str_accepts_empty_string() {
+        // F-074: empty is intentionally allowed so `fs.write` can truncate
+        // a file via `{"content": ""}`. Tools that need stricter checks
+        // (e.g. `shell.exec` rejecting `""` for `command`) layer the
+        // empty-guard on top of this helper.
+        let v = json!({ "content": "" });
+        assert_eq!(get_required_str(&v, "fs.write", "content").unwrap(), "");
+    }
+
+    #[test]
+    fn get_required_str_rejects_missing_key_with_unified_shape() {
+        let v = json!({});
+        let err = get_required_str(&v, "fs.read", "path").unwrap_err();
+        assert_eq!(
+            err,
+            ToolError::MissingRequiredArg {
+                tool: "fs.read".to_string(),
+                arg: "path".to_string()
+            }
+        );
+        assert_eq!(
+            err.to_string(),
+            "tool.fs.read: missing required parameter 'path'"
+        );
+    }
+
+    #[test]
+    fn get_required_str_rejects_non_string_value() {
+        let v = json!({ "path": 42 });
+        let err = get_required_str(&v, "fs.read", "path").unwrap_err();
+        assert_eq!(
+            err,
+            ToolError::MissingRequiredArg {
+                tool: "fs.read".to_string(),
+                arg: "path".to_string()
+            }
+        );
+    }
+
+    // ---- get_optional_str ----
+
+    #[test]
+    fn get_optional_str_returns_some_when_present() {
+        let v = json!({ "path": "/tmp/x" });
+        assert_eq!(get_optional_str(&v, "path"), Some("/tmp/x"));
+    }
+
+    #[test]
+    fn get_optional_str_returns_some_for_empty_string() {
+        // Symmetric with `get_required_str`: empty is a valid string
+        // value, distinct from "absent". Callers that want to treat
+        // empty as absent must do so explicitly.
+        let v = json!({ "content": "" });
+        assert_eq!(get_optional_str(&v, "content"), Some(""));
+    }
+
+    #[test]
+    fn get_optional_str_returns_none_when_missing() {
+        let v = json!({});
+        assert_eq!(get_optional_str(&v, "path"), None);
+    }
+
+    #[test]
+    fn get_optional_str_returns_none_for_non_string_value() {
+        // Number, bool, array, object, null — all treated as absent so
+        // the caller's `.unwrap_or(default)` fires uniformly.
+        for (label, val) in [
+            ("number", json!({ "k": 42 })),
+            ("bool", json!({ "k": true })),
+            ("array", json!({ "k": ["a"] })),
+            ("object", json!({ "k": { "x": 1 } })),
+            ("null", json!({ "k": null })),
+        ] {
+            assert_eq!(
+                get_optional_str(&val, "k"),
+                None,
+                "expected None for {label}"
+            );
+        }
+    }
+
+    // ---- get_optional_u64 ----
+
+    #[test]
+    fn get_optional_u64_returns_some_when_present() {
+        let v = json!({ "timeout_ms": 5000 });
+        assert_eq!(get_optional_u64(&v, "timeout_ms"), Some(5000));
+    }
+
+    #[test]
+    fn get_optional_u64_returns_some_for_zero() {
+        // Zero is a valid u64. Callers that treat 0 as "unset" must do
+        // so explicitly (none currently do — `shell.exec` clamps via
+        // `.min(MAX_TIMEOUT_MS)` and 0 yields an immediate timeout,
+        // which is a legitimate caller request).
+        let v = json!({ "timeout_ms": 0 });
+        assert_eq!(get_optional_u64(&v, "timeout_ms"), Some(0));
+    }
+
+    #[test]
+    fn get_optional_u64_returns_some_for_u64_max() {
+        let v = json!({ "timeout_ms": u64::MAX });
+        assert_eq!(get_optional_u64(&v, "timeout_ms"), Some(u64::MAX));
+    }
+
+    #[test]
+    fn get_optional_u64_returns_none_when_missing() {
+        let v = json!({});
+        assert_eq!(get_optional_u64(&v, "timeout_ms"), None);
+    }
+
+    #[test]
+    fn get_optional_u64_returns_none_for_non_numeric() {
+        for (label, val) in [
+            ("string", json!({ "k": "5000" })),
+            ("bool", json!({ "k": true })),
+            ("array", json!({ "k": [5000] })),
+            ("object", json!({ "k": { "ms": 5000 } })),
+            ("null", json!({ "k": null })),
+        ] {
+            assert_eq!(
+                get_optional_u64(&val, "k"),
+                None,
+                "expected None for {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn get_optional_u64_returns_none_for_negative() {
+        // Negative numbers fail `as_u64` even though they are JSON
+        // numbers. `shell.exec` would clamp them to `MAX_TIMEOUT_MS`
+        // anyway via `.unwrap_or(DEFAULT)`, but flagging them as
+        // "absent" here is more honest about the type mismatch.
+        let v = json!({ "timeout_ms": -1 });
+        assert_eq!(get_optional_u64(&v, "timeout_ms"), None);
+    }
+
+    #[test]
+    fn get_optional_u64_returns_none_for_non_integral_float() {
+        let v = json!({ "timeout_ms": 1.5 });
+        assert_eq!(get_optional_u64(&v, "timeout_ms"), None);
+    }
+}

--- a/crates/forge-session/src/tools/fs_edit.rs
+++ b/crates/forge-session/src/tools/fs_edit.rs
@@ -2,7 +2,7 @@
 //! returns `{ ok: true }` or `{ error }`. Preview delegates to
 //! [`forge_fs::edit_preview`].
 
-use super::{get_required_str, Tool, ToolCtx};
+use super::{get_optional_str, get_required_str, Tool, ToolCtx};
 use forge_core::ApprovalPreview;
 
 pub struct FsEditTool;
@@ -19,8 +19,8 @@ impl Tool for FsEditTool {
     fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
         // Preview reflects whatever the client sent so the approval UI shows
         // the literal request; `invoke` performs the required-arg check (F-074).
-        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
-        let patch = args.get("patch").and_then(|v| v.as_str()).unwrap_or("");
+        let path = get_optional_str(args, "path").unwrap_or("");
+        let patch = get_optional_str(args, "patch").unwrap_or("");
         let fs_preview = forge_fs::edit_preview(path, patch);
         ApprovalPreview {
             description: fs_preview.description,

--- a/crates/forge-session/src/tools/fs_read.rs
+++ b/crates/forge-session/src/tools/fs_read.rs
@@ -1,7 +1,7 @@
 //! `fs.read` tool: reads a file via [`forge_fs::read_file`] and returns
 //! `{ content, bytes, sha256 }` or `{ error }`.
 
-use super::{get_required_str, Tool, ToolCtx};
+use super::{get_optional_str, get_required_str, Tool, ToolCtx};
 use forge_core::ApprovalPreview;
 
 pub struct FsReadTool;
@@ -20,7 +20,7 @@ impl Tool for FsReadTool {
         // sees exactly what was requested before approval. Required-argument
         // validation runs in `invoke` only — no point rejecting a malformed
         // call until the user has had a chance to refuse it. (F-074)
-        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let path = get_optional_str(args, "path").unwrap_or("");
         ApprovalPreview {
             description: format!("Read file '{path}'"),
         }

--- a/crates/forge-session/src/tools/fs_write.rs
+++ b/crates/forge-session/src/tools/fs_write.rs
@@ -2,7 +2,7 @@
 //! `{ ok: true }` or `{ error }`. Preview delegates to
 //! [`forge_fs::write_preview`].
 
-use super::{get_required_str, Tool, ToolCtx};
+use super::{get_optional_str, get_required_str, Tool, ToolCtx};
 use forge_core::ApprovalPreview;
 
 pub struct FsWriteTool;
@@ -19,8 +19,8 @@ impl Tool for FsWriteTool {
     fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
         // Preview reflects whatever the client sent so the approval UI shows
         // the literal request; `invoke` performs the required-arg check (F-074).
-        let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
-        let content = args.get("content").and_then(|v| v.as_str()).unwrap_or("");
+        let path = get_optional_str(args, "path").unwrap_or("");
+        let content = get_optional_str(args, "content").unwrap_or("");
         let fs_preview = forge_fs::write_preview(path, content);
         ApprovalPreview {
             description: fs_preview.description,

--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -3,11 +3,13 @@
 use crate::sandbox::ChildRegistry;
 use forge_core::ApprovalPreview;
 
+pub mod args;
 pub mod fs_edit;
 pub mod fs_read;
 pub mod fs_write;
 pub mod shell_exec;
 
+pub use args::{get_optional_str, get_optional_u64, get_required_str};
 pub use fs_edit::FsEditTool;
 pub use fs_read::FsReadTool;
 pub use fs_write::FsWriteTool;
@@ -36,42 +38,12 @@ pub enum ToolError {
     #[error("unknown tool '{0}'")]
     UnknownTool(String),
     /// A required string argument was absent or the value was not a JSON
-    /// string. Empty strings are accepted — see [`get_required_str`] for the
-    /// rationale. `Display` shape is
+    /// string. Empty strings are accepted — see [`args::get_required_str`]
+    /// for the rationale. `Display` shape is
     /// `tool.{tool}: missing required parameter '{arg}'` and is asserted by
-    /// IPC-level regression tests; treat it as contractual. F-075 will
-    /// broaden the extractor to cover optional / non-string arguments;
-    /// keep this variant minimal so that extension stays additive.
+    /// IPC-level regression tests; treat it as contractual.
     #[error("tool.{tool}: missing required parameter '{arg}'")]
     MissingRequiredArg { tool: String, arg: String },
-}
-
-/// Extract a required string argument from a tool-call's JSON args object.
-///
-/// Returns `Err(ToolError::MissingRequiredArg { tool, arg: key })` when the
-/// key is absent or the value is not a JSON string. Empty strings are
-/// **accepted** — `fs.write` with `{"content": ""}` is a legitimate
-/// "truncate file to zero bytes" operation, and rejecting it here would
-/// regress that behaviour with a misleading "missing parameter" error
-/// (the parameter is supplied; it is just empty). Tools that need to
-/// additionally reject empty (e.g. `shell.exec` on `command`) layer that
-/// check on top of this helper.
-///
-/// F-075 will refactor this into a broader extractor (optional values,
-/// non-string types). Keep the signature narrow so that extension is purely
-/// additive — do not bake in a generic here.
-pub fn get_required_str<'a>(
-    args: &'a serde_json::Value,
-    tool: &str,
-    key: &str,
-) -> Result<&'a str, ToolError> {
-    match args.get(key).and_then(|v| v.as_str()) {
-        Some(s) => Ok(s),
-        None => Err(ToolError::MissingRequiredArg {
-            tool: tool.to_string(),
-            arg: key.to_string(),
-        }),
-    }
 }
 
 #[derive(Default)]
@@ -178,53 +150,10 @@ mod tests {
         assert_eq!(err, ToolError::UnknownTool("nope".to_string()));
     }
 
-    // ---- F-074: shared `get_required_str` helper ----
-
-    #[test]
-    fn get_required_str_returns_string_when_present() {
-        let v = json!({ "path": "/tmp/x" });
-        assert_eq!(get_required_str(&v, "fs.read", "path").unwrap(), "/tmp/x");
-    }
-
-    #[test]
-    fn get_required_str_accepts_empty_string() {
-        // F-074: empty is intentionally allowed so `fs.write` can truncate
-        // a file via `{"content": ""}`. Tools that need stricter checks
-        // (e.g. `shell.exec` rejecting `""` for `command`) layer the
-        // empty-guard on top of this helper.
-        let v = json!({ "content": "" });
-        assert_eq!(get_required_str(&v, "fs.write", "content").unwrap(), "");
-    }
-
-    #[test]
-    fn get_required_str_rejects_missing_key_with_unified_shape() {
-        let v = json!({});
-        let err = get_required_str(&v, "fs.read", "path").unwrap_err();
-        assert_eq!(
-            err,
-            ToolError::MissingRequiredArg {
-                tool: "fs.read".to_string(),
-                arg: "path".to_string()
-            }
-        );
-        assert_eq!(
-            err.to_string(),
-            "tool.fs.read: missing required parameter 'path'"
-        );
-    }
-
-    #[test]
-    fn get_required_str_rejects_non_string_value() {
-        let v = json!({ "path": 42 });
-        let err = get_required_str(&v, "fs.read", "path").unwrap_err();
-        assert_eq!(
-            err,
-            ToolError::MissingRequiredArg {
-                tool: "fs.read".to_string(),
-                arg: "path".to_string()
-            }
-        );
-    }
+    // ---- shared `args` helpers (`get_required_str`, `get_optional_str`,
+    // `get_optional_u64`) live in `tools::args` with their own unit tests.
+    // The per-tool integration tests below assert the unified IPC error
+    // shape that those helpers produce on the `invoke` boundary. ----
 
     // ---- F-074: each tool surfaces the unified missing-arg error from
     // `invoke` rather than coercing missing required args to "" and producing

--- a/crates/forge-session/src/tools/shell_exec.rs
+++ b/crates/forge-session/src/tools/shell_exec.rs
@@ -15,9 +15,9 @@
 //!
 //! Result shape: `{ stdout, stderr, exit_code, signal? }` or `{ error }`.
 
+use super::{get_optional_str, Tool, ToolCtx};
 #[cfg(target_os = "linux")]
-use super::{get_required_str, ToolError};
-use super::{Tool, ToolCtx};
+use super::{get_optional_u64, get_required_str, ToolError};
 #[cfg(target_os = "linux")]
 use crate::sandbox::SandboxedCommand;
 use forge_core::ApprovalPreview;
@@ -44,7 +44,7 @@ impl Tool for ShellExecTool {
     }
 
     fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
-        let command = args.get("command").and_then(|v| v.as_str()).unwrap_or("");
+        let command = get_optional_str(args, "command").unwrap_or("");
         let argv = args
             .get("args")
             .and_then(|v| v.as_array())
@@ -60,7 +60,7 @@ impl Tool for ShellExecTool {
         // the user to distinguish, so no `cwd` line is shown. When present,
         // the directory context is load-bearing and must appear in consent
         // (F-054 / audit finding M8).
-        let cwd = args.get("cwd").and_then(|v| v.as_str());
+        let cwd = get_optional_str(args, "cwd");
         let head = if argv.is_empty() {
             format!("Run command: {command}")
         } else {
@@ -126,7 +126,7 @@ fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
     // the workspace that points out is rejected by the post-canonical prefix
     // check (F-054 / audit finding M8, symmetric with forge-fs root checks
     // for F-043). If no cwd is supplied, fall back to the workspace root.
-    let cwd = match args.get("cwd").and_then(|v| v.as_str()) {
+    let cwd = match get_optional_str(args, "cwd") {
         Some(requested) => {
             let Some(root) = ctx.workspace_root.as_ref() else {
                 return serde_json::json!({
@@ -168,9 +168,7 @@ fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
         }),
     };
 
-    let timeout_ms = args
-        .get("timeout_ms")
-        .and_then(|v| v.as_u64())
+    let timeout_ms = get_optional_u64(args, "timeout_ms")
         .unwrap_or(DEFAULT_TIMEOUT_MS)
         .min(MAX_TIMEOUT_MS);
 


### PR DESCRIPTION
Closes forge-ide/forge#148

## Summary

- Promote F-074's `get_required_str` into a new `crates/forge-session/src/tools/args.rs` module and add two siblings: `get_optional_str(args, key) -> Option<&str>` and `get_optional_u64(args, key) -> Option<u64>`. Re-export all three from `tools::mod` so existing `use super::get_required_str` call sites keep compiling.
- Refactor every `Tool` impl in `forge-session` (`fs_read`, `fs_write`, `fs_edit`, `shell_exec`) so both `invoke` and `approval_preview` go through the shared helpers. Preview sites previously used `args.get(k).and_then(|v| v.as_str()).unwrap_or("")`; they now use `get_optional_str(args, k).unwrap_or("")`. `shell.exec` additionally routes `cwd` (string) and `timeout_ms` (u64) through the new helpers.
- Add unit tests for each helper covering present / missing / wrong-type, plus empty-string for the string helpers and zero / `u64::MAX` / negative / non-integral float for the numeric helper. Move the F-074 `get_required_str_*` tests from `tools::mod` into `tools::args::tests` so the helper module owns its own coverage.

Behaviour is preserved end-to-end: `get_required_str` keeps its 3-param signature `(args, tool, key)` so the contractual `tool.{tool}: missing required parameter '{arg}'` Display string asserted by F-074's per-tool IPC tests stays byte-identical; empty strings remain valid for required args (so `fs.write { content: \"\" }` still truncates); `shell.exec` keeps its empty-`command` guard layered on top of the helper; `timeout_ms` continues to default to `DEFAULT_TIMEOUT_MS` and clamp to `MAX_TIMEOUT_MS`.

## Test plan

- `cargo test --workspace` passes — `forge-session` runs 66 unit tests including the 15 new helper tests plus the F-074 per-tool integration tests
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)