### PR TITLE
[F-077] Document DoS ceiling semantics and add session-level aggregate byte budget

### DIFF
--- a/crates/forge-session/src/byte_budget.rs
+++ b/crates/forge-session/src/byte_budget.rs
@@ -1,0 +1,151 @@
+//! Per-session aggregate byte budget (F-077).
+//!
+//! Per-op caps in `forge-fs` (10 MiB) and `forge-providers`
+//! (1 MiB / 4 MiB per-line) bound the size of a single tool invocation
+//! but do not compose into a session ceiling: a tool-chained adversary
+//! can issue 1000 within-cap calls and exhaust host memory without
+//! tripping any per-op limit. `ByteBudget` is the missing aggregate —
+//! a monotonically-increasing counter shared across every tool
+//! invocation in a session, refusing further ops once the configured
+//! limit is reached.
+//!
+//! # Semantics
+//!
+//! Enforcement is **post-decrement**: the dispatcher executes the tool,
+//! charges the budget by the bytes the result actually consumed
+//! (content / stdout / stderr), then refuses the *next* call if the
+//! budget is exhausted. A single op that overshoots the cap is allowed
+//! to complete — the next call is refused. This matches the brief's
+//! "refuses further ops when exhausted" wording and avoids forcing
+//! tools to pre-declare their output size (`shell.exec` cannot know
+//! its stdout volume until the child exits).
+//!
+//! Refusal happens at the `ToolDispatcher` boundary so every tool routes
+//! through the same gate. The tool itself never runs after exhaustion;
+//! the dispatcher returns `{"error": "session byte budget exceeded:
+//! <consumed>/<limit> bytes"}` directly.
+//!
+//! # Default
+//!
+//! [`ByteBudget::default`] is **500 MiB** per session. The number is
+//! large enough that a normal session of fs.read / fs.write / shell.exec
+//! calls never trips it, and small enough that a runaway loop cannot
+//! exhaust desktop or CI memory before the daemon refuses. Tests
+//! configure smaller budgets (1 MiB-class) to exercise the boundary
+//! without paying the memory cost of the production default.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Default aggregate byte budget per session: 500 MiB. See module docs.
+pub const DEFAULT_BUDGET_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Monotonic per-session counter of bytes consumed by tool results.
+///
+/// `Ordering::Relaxed` is sufficient for both the load and the
+/// fetch-add: the budget enforces a *cumulative* ceiling, not
+/// happens-before ordering between writes. A single op may race past
+/// the limit by the size of one in-flight tool call — that is the
+/// "single op overshoot" already documented in the module preamble,
+/// not a correctness gap.
+#[derive(Debug)]
+pub struct ByteBudget {
+    consumed: AtomicU64,
+    limit: u64,
+}
+
+impl ByteBudget {
+    /// Construct a budget with `limit` bytes of headroom.
+    pub fn new(limit: u64) -> Self {
+        Self {
+            consumed: AtomicU64::new(0),
+            limit,
+        }
+    }
+
+    /// Bytes consumed so far.
+    pub fn consumed(&self) -> u64 {
+        self.consumed.load(Ordering::Relaxed)
+    }
+
+    /// Configured ceiling.
+    pub fn limit(&self) -> u64 {
+        self.limit
+    }
+
+    /// True iff `consumed() >= limit()` — subsequent dispatch calls
+    /// will be refused.
+    pub fn is_exhausted(&self) -> bool {
+        self.consumed() >= self.limit
+    }
+
+    /// Record `bytes` against the budget. Saturating add prevents
+    /// counter wrap on a pathologically long-lived session: once
+    /// the counter reaches `u64::MAX` the budget stays exhausted.
+    pub fn charge(&self, bytes: u64) {
+        let mut current = self.consumed.load(Ordering::Relaxed);
+        loop {
+            let next = current.saturating_add(bytes);
+            match self.consumed.compare_exchange_weak(
+                current,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+impl Default for ByteBudget {
+    /// 500 MiB default budget (`DEFAULT_BUDGET_BYTES`).
+    fn default() -> Self {
+        Self::new(DEFAULT_BUDGET_BYTES)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_starts_at_zero_consumed() {
+        let b = ByteBudget::new(1024);
+        assert_eq!(b.consumed(), 0);
+        assert_eq!(b.limit(), 1024);
+        assert!(!b.is_exhausted());
+    }
+
+    #[test]
+    fn charge_accumulates() {
+        let b = ByteBudget::new(1024);
+        b.charge(100);
+        b.charge(200);
+        assert_eq!(b.consumed(), 300);
+        assert!(!b.is_exhausted());
+    }
+
+    #[test]
+    fn is_exhausted_at_or_above_limit() {
+        let b = ByteBudget::new(1024);
+        b.charge(1024);
+        assert!(b.is_exhausted());
+        b.charge(1);
+        assert!(b.is_exhausted());
+    }
+
+    #[test]
+    fn charge_saturates_on_overflow() {
+        let b = ByteBudget::new(u64::MAX);
+        b.charge(u64::MAX - 10);
+        b.charge(100); // would overflow without saturating_add
+        assert_eq!(b.consumed(), u64::MAX);
+    }
+
+    #[test]
+    fn default_is_500_mib() {
+        assert_eq!(ByteBudget::default().limit(), 500 * 1024 * 1024);
+        assert_eq!(DEFAULT_BUDGET_BYTES, 500 * 1024 * 1024);
+    }
+}

--- a/crates/forge-session/src/error.rs
+++ b/crates/forge-session/src/error.rs
@@ -42,4 +42,16 @@ pub enum SessionError {
     /// the operator rather than silently retrying.
     #[error("event log flush failed: {0}")]
     EventLogFlush(#[source] ForgeError),
+
+    /// F-077: the per-session aggregate byte budget tracked by
+    /// [`crate::byte_budget::ByteBudget`] was exhausted at the
+    /// `ToolDispatcher` boundary. The tool was **not** executed; the
+    /// caller should surface this as a final-turn outcome rather than
+    /// retrying. Inner fields carry the consumed and limit byte counts
+    /// so an operator parsing `Display` can quote the breach precisely
+    /// (the per-op caps in `forge-fs` / `forge-providers` use distinct
+    /// error shapes; collapsing them here would erase the aggregate
+    /// vs. per-op distinction documented in `docs/dev/security.md`).
+    #[error("session byte budget exceeded: {consumed}/{limit} bytes")]
+    ByteBudgetExceeded { consumed: u64, limit: u64 },
 }

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod archive;
+pub mod byte_budget;
 pub mod error;
 pub mod orchestrator;
 pub mod pid_file;

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -12,6 +12,7 @@ use forge_providers::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, 
 use futures::StreamExt;
 use tokio::sync::{oneshot, Mutex};
 
+use crate::byte_budget::ByteBudget;
 use crate::sandbox::ChildRegistry;
 use crate::session::Session;
 use crate::tools::{
@@ -49,6 +50,7 @@ pub async fn run_turn<P: Provider>(
     auto_approve: bool,
     workspace_root: Option<std::path::PathBuf>,
     child_registry: Option<ChildRegistry>,
+    byte_budget: Option<Arc<ByteBudget>>,
 ) -> Result<()> {
     let msg_id = MessageId::new();
 
@@ -87,6 +89,7 @@ pub async fn run_turn<P: Provider>(
         allowed_paths,
         workspace_root,
         child_registry,
+        byte_budget,
     };
 
     run_request_loop(

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -216,6 +216,11 @@ pub async fn serve_with_session<P: Provider + 'static>(
     // session shutdown so tool subprocesses (e.g. `shell.exec`) cannot outlive
     // the daemon.
     let child_registry = ChildRegistry::new();
+    // F-077: per-session aggregate byte budget. One `ByteBudget` is shared
+    // across every `run_turn` invocation in this session so chained tool
+    // calls collectively decrement against the same ceiling. Default is
+    // 500 MiB (`ByteBudget::default`); see `docs/dev/security.md`.
+    let byte_budget = Arc::new(crate::byte_budget::ByteBudget::default());
 
     if ephemeral {
         // Accept exactly one connection, serve it to completion, then exit.
@@ -234,6 +239,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
             workspace_path,
             allowed_paths,
             child_registry,
+            byte_budget,
         )
         .await;
     }
@@ -287,6 +293,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
                 let workspace_path = workspace_path.clone();
                 let allowed_paths = Arc::clone(&allowed_paths);
                 let child_registry = child_registry.clone();
+                let byte_budget = Arc::clone(&byte_budget);
                 tokio::spawn(async move {
                     if let Err(e) = handle_connection(
                         stream,
@@ -300,6 +307,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
                         workspace_path,
                         allowed_paths,
                         child_registry,
+                        byte_budget,
                     )
                     .await
                     {
@@ -348,6 +356,7 @@ async fn handle_connection<P: Provider + 'static>(
     workspace_path: Option<PathBuf>,
     allowed_paths: Arc<Vec<String>>,
     child_registry: ChildRegistry,
+    byte_budget: Arc<crate::byte_budget::ByteBudget>,
 ) -> Result<()> {
     // ── Handshake ──────────────────────────────────────────────────────────────
     let msg = forge_ipc::read_frame(&mut stream).await?;
@@ -443,6 +452,7 @@ async fn handle_connection<P: Provider + 'static>(
                         let workspace_path = workspace_path.clone();
                         let allowed_paths = Arc::clone(&allowed_paths);
                         let child_registry = child_registry.clone();
+                        let byte_budget = Arc::clone(&byte_budget);
                         tokio::spawn(async move {
                             let result = run_turn(
                                 Arc::clone(&session),
@@ -453,6 +463,7 @@ async fn handle_connection<P: Provider + 'static>(
                                 auto_approve,
                                 workspace_path,
                                 Some(child_registry),
+                                Some(byte_budget),
                             ).await;
                             if let Err(e) = &result {
                                 eprintln!("turn error: {e}");

--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -1,7 +1,9 @@
 //! Tool dispatch: name → handler routing for orchestrator tool calls.
 
+use crate::byte_budget::ByteBudget;
 use crate::sandbox::ChildRegistry;
 use forge_core::ApprovalPreview;
+use std::sync::Arc;
 
 pub mod fs_edit;
 pub mod fs_read;
@@ -21,6 +23,12 @@ pub struct ToolCtx {
     /// Registry of live sandboxed children — populated for tools that spawn
     /// processes so session shutdown can kill them.
     pub child_registry: Option<ChildRegistry>,
+    /// F-077: per-session aggregate byte budget. When `Some`, the
+    /// dispatcher refuses further calls once the budget is exhausted
+    /// and charges each successful call by the bytes its result
+    /// occupies. `None` means no aggregate enforcement — preserves the
+    /// pre-F-077 behaviour for tests and any embedding that opts out.
+    pub byte_budget: Option<Arc<ByteBudget>>,
 }
 
 pub trait Tool: Send + Sync {
@@ -106,8 +114,69 @@ impl ToolDispatcher {
         args: &serde_json::Value,
         ctx: &ToolCtx,
     ) -> Result<serde_json::Value, ToolError> {
-        Ok(self.get(name)?.invoke(args, ctx))
+        let tool = self.get(name)?;
+
+        // F-077: pre-check the per-session aggregate byte budget. The
+        // tool itself never runs after exhaustion — short-circuiting at
+        // the dispatcher is what makes the cap meaningful (an attacker
+        // who can drive the tool past the cap, even with no payload
+        // returned, defeats the budget). On a success, post-charge the
+        // budget by the bytes the result occupies so the *next* call
+        // sees the updated counter.
+        if let Some(budget) = ctx.byte_budget.as_ref() {
+            if budget.is_exhausted() {
+                return Ok(serde_json::json!({
+                    "error": format!(
+                        "session byte budget exceeded: {}/{} bytes",
+                        budget.consumed(),
+                        budget.limit(),
+                    )
+                }));
+            }
+        }
+
+        let result = tool.invoke(args, ctx);
+
+        if let Some(budget) = ctx.byte_budget.as_ref() {
+            budget.charge(result_byte_cost(&result));
+        }
+
+        Ok(result)
     }
+}
+
+/// F-077: cost a tool result for budget accounting. The intent is to
+/// approximate the in-memory footprint the result imposes on the
+/// session — we sum the lengths of the *opaque payload* fields each
+/// tool returns and ignore framing / metadata. Specifically:
+///
+/// - `fs.read` charges the `content` byte length (not `bytes`, since
+///   `bytes` reflects on-disk size and `content` is the lossy-UTF-8
+///   string actually held in memory).
+/// - `fs.write` / `fs.edit` carry no payload back — `{"ok": true}` —
+///   so the cost is the JSON envelope length as a small token charge.
+///   This intentionally lets a write-heavy session run past the
+///   budget for far longer than a read-heavy one (writes do not
+///   buffer remote-fetched bytes in the daemon).
+/// - `shell.exec` charges the lengths of `stdout` and `stderr`.
+/// - Errors and unknown shapes fall back to the serialized JSON length;
+///   that bounds even a tool that returns a giant unstructured blob.
+fn result_byte_cost(result: &serde_json::Value) -> u64 {
+    if let Some(obj) = result.as_object() {
+        // fs.read shape
+        if let Some(content) = obj.get("content").and_then(|v| v.as_str()) {
+            return content.len() as u64;
+        }
+        // shell.exec shape
+        if obj.contains_key("stdout") || obj.contains_key("stderr") {
+            let so = obj.get("stdout").and_then(|v| v.as_str()).unwrap_or("");
+            let se = obj.get("stderr").and_then(|v| v.as_str()).unwrap_or("");
+            return so.len() as u64 + se.len() as u64;
+        }
+    }
+    serde_json::to_string(result)
+        .map(|s| s.len() as u64)
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -344,6 +413,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
+            byte_budget: None,
         };
         let result = d.dispatch("shell.exec", &json!({}), &ctx).unwrap();
         assert_eq!(
@@ -367,6 +437,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
+            byte_budget: None,
         };
         let result = d
             .dispatch("shell.exec", &json!({ "command": "" }), &ctx)
@@ -480,6 +551,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
+            byte_budget: None,
         };
         let result = d
             .dispatch(
@@ -511,6 +583,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
+            byte_budget: None,
         };
 
         // Run dispatch on a blocking task so we're inside the runtime but
@@ -548,6 +621,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(registry.clone()),
+            byte_budget: None,
         };
 
         // Background a long sleep, write its pid, detach its stdio from
@@ -661,6 +735,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
+            byte_budget: None,
         };
         let result = d
             .dispatch(
@@ -699,6 +774,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
+            byte_budget: None,
         };
         let result = d
             .dispatch(
@@ -733,6 +809,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
+            byte_budget: None,
         };
         let result = d
             .dispatch(
@@ -774,6 +851,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
+            byte_budget: None,
         };
 
         let started = std::time::Instant::now();
@@ -809,6 +887,7 @@ mod tests {
             allowed_paths: vec![],
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
+            byte_budget: None,
         };
         let result = d
             .dispatch(

--- a/crates/forge-session/tests/byte_budget.rs
+++ b/crates/forge-session/tests/byte_budget.rs
@@ -1,0 +1,176 @@
+//! F-077: per-session aggregate byte budget regression tests.
+//!
+//! The per-op caps in `forge-fs` (10 MiB read/write) and `forge-providers`
+//! (1 MiB / 4 MiB per-line) protect against single-op blow-up but compose
+//! into no aggregate ceiling — a tool-chained adversary can issue many
+//! within-cap calls and exhaust host memory. These tests pin the
+//! per-session aggregate enforcement at the dispatcher boundary.
+
+use forge_session::byte_budget::ByteBudget;
+use forge_session::tools::{FsReadTool, ToolCtx, ToolDispatcher};
+use serde_json::json;
+use std::sync::Arc;
+
+/// A small helper that materialises a file of `size` bytes inside `dir` and
+/// returns its absolute path as a `String`.
+fn make_file(dir: &std::path::Path, name: &str, size: usize) -> String {
+    let path = dir.join(name);
+    let body = vec![b'x'; size];
+    std::fs::write(&path, body).unwrap();
+    let canonical = std::fs::canonicalize(&path).unwrap();
+    canonical.to_str().unwrap().to_string()
+}
+
+/// Chained `fs.read` calls whose summed bytes exceed the configured budget
+/// must be refused once the budget is exhausted. The error shape carries
+/// the budget identifier so a reviewer (or operator parsing logs) can
+/// distinguish budget exhaustion from any other tool error.
+#[test]
+fn chained_fs_reads_exceeding_budget_are_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let canonical_root = std::fs::canonicalize(dir.path()).unwrap();
+    let allowed = format!("{}/**", canonical_root.to_str().unwrap());
+
+    // 10 files of 200 KiB each = ~2 MiB total. Budget at 1 MiB so the
+    // sequence overshoots cleanly partway through.
+    const FILE_BYTES: usize = 200 * 1024;
+    const NUM_FILES: usize = 10;
+    const BUDGET: u64 = 1024 * 1024;
+
+    let mut paths = Vec::with_capacity(NUM_FILES);
+    for i in 0..NUM_FILES {
+        paths.push(make_file(dir.path(), &format!("f{i}.bin"), FILE_BYTES));
+    }
+
+    let mut d = ToolDispatcher::new();
+    d.register(Box::new(FsReadTool)).unwrap();
+
+    let budget = Arc::new(ByteBudget::new(BUDGET));
+    let ctx = ToolCtx {
+        allowed_paths: vec![allowed],
+        byte_budget: Some(budget.clone()),
+        ..ToolCtx::default()
+    };
+
+    let mut succeeded = 0usize;
+    let mut refused = 0usize;
+    let mut last_error: Option<String> = None;
+    for path in &paths {
+        let result = d
+            .dispatch("fs.read", &json!({ "path": path }), &ctx)
+            .unwrap();
+        if result.get("error").is_some() {
+            refused += 1;
+            last_error = result["error"].as_str().map(str::to_owned);
+        } else {
+            succeeded += 1;
+        }
+    }
+
+    assert!(
+        succeeded > 0 && succeeded < NUM_FILES,
+        "expected partial success: succeeded={succeeded}, refused={refused}"
+    );
+    assert!(refused > 0, "expected at least one budget refusal");
+    let err = last_error.expect("refused call must surface an error string");
+    assert!(
+        err.contains("byte budget exceeded") || err.contains("byte budget exhausted"),
+        "error string does not identify budget exhaustion: {err}"
+    );
+    assert!(
+        budget.consumed() >= BUDGET,
+        "budget should be marked exhausted after refusal: consumed={}, limit={}",
+        budget.consumed(),
+        BUDGET
+    );
+}
+
+/// Once the budget is exhausted, subsequent calls must be refused
+/// immediately at the dispatcher — the underlying tool must not run.
+/// Distinguishing "tool ran but result was an error" from "dispatcher
+/// short-circuited" matters for the DoS guarantee: an attacker who can
+/// drive the tool past the cap (even with no payload returned) defeats
+/// the budget. Use a write-side observation: a `fs.read` of an
+/// allow-listed file must NOT return content / sha256 once budget is
+/// exhausted; the result must be the budget error only.
+#[test]
+fn dispatcher_short_circuits_after_budget_exhaustion() {
+    let dir = tempfile::tempdir().unwrap();
+    let canonical_root = std::fs::canonicalize(dir.path()).unwrap();
+    let allowed = format!("{}/**", canonical_root.to_str().unwrap());
+    let path = make_file(dir.path(), "f.bin", 100 * 1024);
+
+    let mut d = ToolDispatcher::new();
+    d.register(Box::new(FsReadTool)).unwrap();
+
+    // Budget too small to cover even one full read — first call exhausts it.
+    let budget = Arc::new(ByteBudget::new(1));
+    let ctx = ToolCtx {
+        allowed_paths: vec![allowed],
+        byte_budget: Some(budget.clone()),
+        ..ToolCtx::default()
+    };
+
+    // First call: tool may execute (post-decrement model) and return content.
+    let _ = d
+        .dispatch("fs.read", &json!({ "path": &path }), &ctx)
+        .unwrap();
+    assert!(budget.is_exhausted(), "budget should be exhausted now");
+
+    // Second call: must be short-circuited — no content, only an error.
+    let result = d
+        .dispatch("fs.read", &json!({ "path": &path }), &ctx)
+        .unwrap();
+    assert!(
+        result.get("content").is_none(),
+        "tool must not run after budget exhaustion: result={result}"
+    );
+    assert!(
+        result.get("error").is_some(),
+        "expected budget error: {result}"
+    );
+    let err = result["error"].as_str().unwrap();
+    assert!(
+        err.contains("byte budget"),
+        "error must identify budget: {err}"
+    );
+}
+
+/// `ToolCtx::default()` (no budget configured) must still dispatch
+/// successfully — the budget check is opt-in so existing tests and
+/// production code paths that haven't been migrated keep working
+/// during rollout.
+#[test]
+fn dispatcher_with_no_budget_runs_unrestricted() {
+    let dir = tempfile::tempdir().unwrap();
+    let canonical_root = std::fs::canonicalize(dir.path()).unwrap();
+    let allowed = format!("{}/**", canonical_root.to_str().unwrap());
+    let path = make_file(dir.path(), "f.bin", 16 * 1024);
+
+    let mut d = ToolDispatcher::new();
+    d.register(Box::new(FsReadTool)).unwrap();
+
+    let ctx = ToolCtx {
+        allowed_paths: vec![allowed],
+        ..ToolCtx::default()
+    };
+    // 100 unrestricted calls succeed; no budget configured.
+    for _ in 0..100 {
+        let result = d
+            .dispatch("fs.read", &json!({ "path": &path }), &ctx)
+            .unwrap();
+        assert!(
+            result.get("error").is_none(),
+            "no-budget dispatch should succeed: {result}"
+        );
+    }
+}
+
+/// `ByteBudget::default()` must match the documented production budget
+/// (500 MiB). Pinning this constant in a test prevents silent drift
+/// between code and `docs/dev/security.md`.
+#[test]
+fn default_byte_budget_is_500_mib() {
+    let budget = ByteBudget::default();
+    assert_eq!(budget.limit(), 500 * 1024 * 1024);
+}

--- a/docs/dev/security.md
+++ b/docs/dev/security.md
@@ -49,11 +49,38 @@ Notable directives:
 
 If a future feature embeds a third-party renderer (e.g. a Markdown sandbox iframe, a remote LSP UI, or a model-hosted preview), expect to add a narrow `frame-src` allow-list and likely a `connect-src` host. Update both `tauri.conf.json` and `index.html` in the same change and re-run the Playwright harness — silently mismatched policies were the entire premise of H9.
 
+## DoS ceilings (F-077)
+
+Forge layers several byte-size and resource caps to bound any single tool call's memory cost. Each cap is correct in isolation; the table below makes the **unit** of each cap explicit so an operator can reason about the worst-case in-memory footprint of a session without cross-referencing seven files.
+
+| Cap | Unit | Default | Source | Protects against |
+|---|---|---|---|---|
+| `forge_fs::Limits::max_read_bytes` | per-`fs.read` call | 10 MiB | `crates/forge-fs/src/limits.rs` | one `fs.read` blowing up the daemon's heap on a giant log/blob |
+| `forge_fs::Limits::max_write_bytes` | per-`fs.write` / per-`fs.edit` call | 10 MiB | `crates/forge-fs/src/limits.rs` | one tool-issued write filling the disk or RAM |
+| `forge_providers::ollama::DEFAULT_MAX_LINE_BYTES` | per-NDJSON-line on the SSE/JSON stream | 1 MiB | `crates/forge-providers/src/ollama.rs` | a malformed/giant JSON event from a malicious or buggy provider |
+| `list_models` body cap | per-HTTP-response from `/api/tags` | 1 MiB | `crates/forge-providers/src/ollama.rs` | a model registry handshake returning a multi-GiB body |
+| `forge_core::event_log::MAX_LINE_BYTES` | per-line in the on-disk session log | 4 MiB | `crates/forge-core/src/event_log.rs`, `transcript.rs` | log replay loading a single oversized event into memory |
+| `RLIMIT_FSIZE` | per-`shell.exec` child process | 100 MiB | `crates/forge-session/src/sandbox.rs` (`SandboxConfig`) | "cat to disk" attacks (kernel raises SIGXFSZ at the limit) |
+| `RLIMIT_NOFILE` | per-`shell.exec` child process | 256 fds | `crates/forge-session/src/sandbox.rs` (`SandboxConfig`) | fd-table exhaustion inside a sandboxed tool |
+| `RLIMIT_AS` / `RLIMIT_CPU` / `RLIMIT_NPROC` | per-`shell.exec` child process | see "Sandbox resource limits" above | `crates/forge-session/src/sandbox.rs` | covered in the dedicated sandbox section |
+| **`ByteBudget`** | **per session, aggregate across every tool call** | **500 MiB** | `crates/forge-session/src/byte_budget.rs` | **chained-tool exhaustion (e.g. 1000× `fs.read` of small files summing past per-op caps)** |
+
+The numeric values differ on purpose. The `forge-fs` 10 MiB cap is sized for "agents reading source / config / lockfiles" without tripping on a `pnpm-lock.yaml` or a generated SQL dump. The provider 1 MiB / 4 MiB caps are sized for "one chat-turn payload" — multi-megabyte single events are a strong signal of attacker-shaped input. The sandbox 100 MiB FSIZE matches the largest legitimate compiler / archiver output a tool might write to disk in one invocation. The aggregate 500 MiB session ceiling is sized for "an agent doing real work over a multi-hour session" without forcing operators to retune for every workflow class.
+
+### Aggregate session budget (`ByteBudget`)
+
+Per-op caps do not compose into an aggregate ceiling: an LLM that has been adversarially prompted (or compromised) can issue many within-cap calls and exhaust host memory without tripping any single cap. F-077 closes that gap with `crates/forge-session/src/byte_budget.rs::ByteBudget` — a session-scoped `AtomicU64` counter shared across every `run_turn` invocation and gated at the `ToolDispatcher` boundary (so all four current tools — `fs.read`, `fs.write`, `fs.edit`, `shell.exec` — and any future tool routes through the same gate).
+
+**Enforcement is post-decrement.** The dispatcher executes the tool, charges the budget by the bytes the result occupies (`content` for `fs.read`; `stdout` + `stderr` for `shell.exec`; the JSON envelope length for write-style results that carry no payload), then refuses the **next** call with `{"error": "session byte budget exceeded: <consumed>/<limit> bytes"}` once `consumed >= limit`. A single op that overshoots the cap is allowed to complete — the next call is refused. This is intentional: `shell.exec` cannot pre-declare its stdout volume until the child exits, and forcing every tool to reserve up front would either (a) over-charge by the per-op maximum or (b) require speculative two-phase APIs that complicate every future tool. The single-op overshoot is bounded by the per-op caps already documented above.
+
+The typed `SessionError::ByteBudgetExceeded { consumed, limit }` variant carries the breach values for top-level callers; the dispatcher itself surfaces the error inside the tool result envelope so the assistant turn fails cleanly without blowing up the orchestrator. Enforcement is synchronous at dispatch; **no discrete `BudgetExhausted` event is emitted** — the tool-result error already carries the signal and adding a parallel event-schema variant would force every consumer (UI, dashboard, log replay) to handle the same condition twice.
+
+The 500 MiB default lives in `ByteBudget::DEFAULT_BUDGET_BYTES`. Every new tool MUST route through `ToolDispatcher::dispatch` (do not call `Tool::invoke` directly from production code paths) so the gate is automatic.
+
 ## Operator runbook cross-reference
 
 - Full Phase 1 threat models, exploit walk-throughs, and audit evidence: [`docs/audits/phase-1/`](../audits/phase-1/) — start with `REPORT.md`, then individual `H#.md` / `M#.md` / `L#.md` findings. These files are immutable snapshots; they are not updated as code evolves.
 - Tracking issues for follow-up hardening:
-  - [F-077](https://github.com/forge-ide/forge/issues/150) — DoS ceiling semantics + per-session aggregate byte budget (current per-message NDJSON cap is documented but the aggregate is not yet enforced).
   - [F-078](https://github.com/forge-ide/forge/issues/151) — `RLIMIT_NPROC` uid-wide caveat above + cgroup-based per-sandbox PID limit.
 
 # Supply-chain security


### PR DESCRIPTION
Closes forge-ide/forge#150

## Summary

Per-op caps in `forge-fs` (10 MiB) and `forge-providers` (1 MiB / 4 MiB per-line) bound the size of a *single* tool call, but they do not compose into a session ceiling — a tool-chained adversary can issue many within-cap calls and exhaust host memory without tripping any single cap. This PR adds the missing aggregate enforcement and documents every existing cap so an operator can predict the worst-case per-session footprint without cross-referencing seven files.

- New `crates/forge-session/src/byte_budget.rs` with `ByteBudget` (`AtomicU64` shared across `run_turn` invocations) and `DEFAULT_BUDGET_BYTES = 500 MiB` matching the issue body.
- `ToolDispatcher::dispatch` now pre-checks the budget (refuses when exhausted, never invokes the tool) and post-charges by the bytes the result occupies — `content` for `fs.read`; `stdout`+`stderr` for `shell.exec`; JSON envelope length for `fs.write`/`fs.edit`.
- `ToolCtx.byte_budget: Option<Arc<ByteBudget>>` carries the budget; `None` preserves all pre-F-077 behaviour for tests and any embedding that opts out.
- `serve_with_session` constructs one `ByteBudget::default()` per session and shares it with every connection's `run_turn`.
- `SessionError::ByteBudgetExceeded { consumed, limit }` extends the F-076 enum rather than introducing a parallel error type, per the issue body's instruction.
- `docs/dev/security.md` gains a "DoS ceilings" section listing every cap (unit, default, source, threat) plus the aggregate-budget semantics (post-decrement, single-op overshoot, no discrete event variant). The pre-existing F-077 forward-reference is closed.

Design notes:
- **Post-decrement** instead of pre-reservation because `shell.exec` cannot pre-declare its stdout volume. A single op may overshoot by the per-op maximum; the next op is refused. The single-op overshoot is bounded by the per-op caps already documented in the same section.
- **Refusal at the dispatcher** (not inside each tool) so an attacker who can drive the tool past the cap with no payload returned cannot defeat the budget. Every current and future tool routes through this gate automatically.
- **No discrete `BudgetExhausted` event variant** — the tool-result error already carries the signal, and adding a parallel event would force every consumer (UI, dashboard, log replay) to handle the same condition twice. The decision is documented in `docs/dev/security.md` so reviewers do not think the optional event was missed.

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes — including 4 new integration tests in `crates/forge-session/tests/byte_budget.rs`:
  - `chained_fs_reads_exceeding_budget_are_refused` — the load-bearing DoD regression. 10 × 200 KiB reads against a 1 MiB budget; partway through, the dispatcher refuses with the documented error string.
  - `dispatcher_short_circuits_after_budget_exhaustion` — proves the tool body does not run once the budget is exhausted (no `content` field surfaces; only the budget error).
  - `dispatcher_with_no_budget_runs_unrestricted` — pins `ToolCtx::byte_budget = None` as the opt-out path.
  - `default_byte_budget_is_500_mib` — pins the documented production default so docs and code cannot drift silently.
- 5 unit tests inside `byte_budget.rs` covering arithmetic, saturation on overflow, the at/above-limit threshold, and the `Default` impl.
- `cargo clippy --all-targets --all-features -- -D warnings` passes.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)