### PR TITLE
fix(docs): resolve 4 rustdoc warnings + deny-lint regression guards (F-097)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --check
 
+      # F-097: rustdoc warnings break intra-doc links for anyone browsing
+      # the generated docs. `-D warnings` makes any new warning fail CI.
+      - name: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --all-features
+
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
 

--- a/crates/forge-fs/src/lib.rs
+++ b/crates/forge-fs/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
 use glob::Pattern;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};

--- a/crates/forge-fs/src/mutate.rs
+++ b/crates/forge-fs/src/mutate.rs
@@ -99,7 +99,7 @@ pub fn write(
 /// Apply a unified-diff `patch` to the file at `path` after validating the
 /// path. Rejects source files larger than `limits.max_read_bytes` before
 /// reading them into RAM, and delegates post-patch size enforcement to
-/// [`write`]. Writes atomically. Requires the target to exist.
+/// [`write()`]. Writes atomically. Requires the target to exist.
 pub fn edit(
     path: &str,
     patch: &str,
@@ -147,7 +147,7 @@ pub fn edit(
 /// of the proposed new bytes — does **not** read the existing file.
 ///
 /// Reading the target file here would run before `allowed_paths` enforcement
-/// (which happens in [`write`]) and leak attacker-chosen file contents into
+/// (which happens in [`write()`]) and leak attacker-chosen file contents into
 /// the approval event (see F-042 / audit finding H3). The proposed `content`
 /// is already supplied by the caller, so echoing it back does not expand the
 /// trust surface. If a before/after diff is needed for UX, compute it via an

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -10,7 +10,7 @@
 //! Window labels are set by `window_manager` at window creation and cannot
 //! be forged from webview JS, so they serve as the per-window authenticator
 //! binding a session's control channel to its review channel. Mismatches
-//! return [`LABEL_MISMATCH_ERROR`] and never reach the daemon.
+//! return a label-mismatch error and never reach the daemon.
 //!
 //! **Webview isolation (F-062 / M10 / T5):** the event sink targets a single
 //! webview (`session-{session_id}`) instead of broadcasting app-wide. Prior
@@ -156,8 +156,9 @@ impl<R: Runtime> EventSink for AppHandleSink<R> {
     }
 }
 
-/// Test-only constructor for [`AppHandleSink`]. Gated behind the
-/// `webview-test` feature so production builds cannot reach into the sink.
+/// Test-only constructor for the per-session app-handle event sink. Gated
+/// behind the `webview-test` feature so production builds cannot reach into
+/// the sink.
 #[cfg(feature = "webview-test")]
 pub fn make_app_handle_sink<R: Runtime>(
     app: AppHandle<R>,

--- a/crates/forge-shell/src/lib.rs
+++ b/crates/forge-shell/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 //! forge-shell: Tauri 2 host for the Forge Solid app.
 //!
 //! Modules:


### PR DESCRIPTION
Closes forge-ide/forge#170

## Summary
- Disambiguated two `` [`write`] `` intra-doc links in `forge-fs/src/mutate.rs` (lines 102, 150) using `` [`write()`] ``.
- Replaced two private-item links in `forge-shell/src/ipc.rs` (lines 13, 159 — `LABEL_MISMATCH_ERROR`, `AppHandleSink`) with inline prose so the items can stay `pub(crate)` (private-by-default intent preserved).
- Added `#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]` at both `forge-fs` and `forge-shell` crate roots. The DoD names only `broken_intra_doc_links` (and marks it optional), but the ipc.rs warnings come from `private_intra_doc_links` — a separate lint — so denying both is required to actually prevent the regression class we just fixed.
- Added a `cargo doc` CI step with `RUSTDOCFLAGS="-D warnings"` between `cargo fmt` and `cargo clippy` (DoD item 3).

## Test plan
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` exits 0 (was 4 warnings on `main`).
- `cargo fmt --check` passes.
- `cargo check --workspace` passes.
- `cargo test --workspace` passes.
- `cargo clippy --all-targets -- -D warnings` passes.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code.