### PR TITLE
docs(security): document NPROC uid-wide scope and cgroup follow-up plan (F-078)

### DIFF
--- a/docs/dev/security.md
+++ b/docs/dev/security.md
@@ -30,7 +30,43 @@ Tool invocations that the user has approved are spawned through `crates/forge-se
 
 Soft and hard limits are set to the same value, so the child cannot raise them. The `rlimits_bound_child_via_setrlimit` test in the same module probes `/proc/self/limits` from inside the sandbox to confirm `pre_exec` actually applied them — that test is the load-bearing regression for F-055.
 
-**NPROC caveat.** `RLIMIT_NPROC` is enforced per real-uid by the kernel, not per-sandbox. Because `forged` typically shares its uid with the user's desktop session (or CI's test harness), the 4096 cap is tuned to stop a fork bomb (which saturates any cap within milliseconds) while leaving headroom for the uid's baseline process count — it is **not** a per-sandbox process budget. Per-sandbox isolation requires cgroups; that work is tracked in [F-078](https://github.com/forge-ide/forge/issues/151).
+### NPROC scope and cgroup follow-up (F-078)
+
+Of the five `setrlimit(2)` caps above, four are per-process and one is uid-wide. That asymmetry is load-bearing for how operators should tune them:
+
+| Cap | Kernel scope | Per-sandbox? |
+|---|---|---|
+| `RLIMIT_CPU` | per-process | yes |
+| `RLIMIT_AS` | per-process | yes |
+| `RLIMIT_NOFILE` | per-process | yes |
+| `RLIMIT_FSIZE` | per-process | yes |
+| `RLIMIT_NPROC` | **per real-uid** | **no — see below** |
+
+`RLIMIT_NPROC` is checked at `fork(2)` time against the count of processes already owned by the calling task's real uid, not against a per-sandbox counter. Because `forged` runs as the operator's normal uid (it shares the desktop session, or in CI it shares the test harness's uid), every other process the same uid owns counts against the 4096 default. The 4096 ceiling is therefore tuned for one job: stopping a runaway `fork()` loop within milliseconds — which saturates any cap regardless of headroom — not for budgeting a sandbox's legitimate process count.
+
+**Operator scenarios.** Two extremes make the asymmetry concrete:
+
+- **Desktop session.** A user with a browser, IDE, terminal multiplexer, and a few language-server processes typically already owns 800–4000 uid-wide processes. A sandboxed tool inherits whatever headroom is left — perhaps 96 processes on a busy session — before `fork(2)` returns `EAGAIN`. Tools that legitimately fan out (a `make -j16` build, a `cargo test` matrix) can hit the cap without any abuse.
+- **Bare CI host.** A CI runner with one job and a handful of system services owns ~50 uid-wide processes. The same sandboxed tool gets ~4046 forks before tripping the cap. A malicious or buggy tool on this host has effectively the entire 4096 budget to itself.
+
+The same default cap therefore behaves as "tight headroom" on a desktop and "permissive ceiling" on CI. Neither end is wrong — both still stop a fork bomb — but operators tuning for legitimate fan-out should treat `SandboxConfig::max_processes` as a **whole-uid** number and pick from these reference points:
+
+| Host class | Suggested `max_processes` | Rationale |
+|---|---|---|
+| Desktop / shared workstation | 4096 (default) — raise to 8192 only if `fork: Resource temporarily unavailable` shows up under normal use | uid baseline is variable; the cap exists to bound a runaway, not to budget the tool |
+| Dedicated CI runner | 1024 or lower | the uid baseline is small and predictable; tightening the cap reduces the blast radius of a compromised tool without affecting realistic build fan-out |
+| Container with one user per container | leave at default | container PID namespaces already provide per-container isolation; the rlimit is a defense-in-depth backstop |
+
+Because the cap is uid-wide, two sandboxes started on the same daemon **do not** each get an independent budget — they share whatever the cap permits at the moment each `fork(2)` runs. A misbehaving tool can therefore starve a well-behaved sibling by consuming the uid's headroom first. This is the core asymmetry that the four per-process limits do not have, and it is the reason `RLIMIT_NPROC` cannot be used as a per-sandbox process budget no matter how the default is tuned.
+
+**Phase-2 plan: cgroup v2 `pids.max`.** The fix is to move per-sandbox process counting off the rlimit machinery and onto the cgroup v2 PID controller. The shape:
+
+1. At sandbox spawn, create a fresh cgroup v2 leaf under the daemon's delegated cgroup (e.g. `/sys/fs/cgroup/forge.slice/sandbox-<uuid>/`). On systemd hosts this works cleanly via `systemd-run --user --scope --property=TasksMax=N`.
+2. Write the desired ceiling to `pids.max` (the controller's per-cgroup task ceiling).
+3. Move the freshly-spawned sandbox PID into the leaf's `cgroup.procs` before `execve(2)` — practically, this means writing the child PID from the parent right after `fork(2)` returns, gated on the cgroup mount and write succeeding.
+4. On sandbox shutdown, kill any survivors via `cgroup.kill` (cgroup v2 ≥ 5.14) and then remove the leaf.
+
+`pids.max` is checked at `fork(2)`/`clone(2)` against the cgroup's current task count only, so each sandbox gets its own independent budget regardless of what the daemon's uid is doing elsewhere. The existing `RLIMIT_NPROC` setrlimit can stay as a uid-wide backstop; the cgroup controller becomes the per-sandbox enforcement primitive. This is tracked as the Phase-2 deliverable on [F-078](https://github.com/forge-ide/forge/issues/151) and is the pattern Linux container runtimes already use for the same reason.
 
 ## Webview Content Security Policy (F-050)
 


### PR DESCRIPTION
Refs forge-ide/forge#151

## Summary

Expands `docs/dev/security.md` (under the existing **Sandbox resource limits (F-055)** section) with a new `### NPROC scope and cgroup follow-up (F-078)` subsection that surfaces, for the first time outside `crates/forge-session/src/sandbox.rs`, the asymmetry the F-055 audit comment hinted at:

- A per-cap scope table making explicit that `RLIMIT_CPU`, `RLIMIT_AS`, `RLIMIT_NOFILE`, and `RLIMIT_FSIZE` are per-process while `RLIMIT_NPROC` is per real-uid.
- Operator-scenario walk-through with concrete numbers: desktop session (~800–4000 baseline → tight headroom) vs bare CI host (~50 baseline → permissive ceiling). The same default cap behaves very differently across the two.
- A `max_processes` tuning matrix (desktop / dedicated CI runner / container) with rationale for each.
- A Phase-2 plan describing the cgroup v2 PID controller (`pids.max`) approach: leaf-cgroup creation, `systemd-run --user --scope --property=TasksMax=N`, child-PID enrollment via `cgroup.procs`, and shutdown via `cgroup.kill`. Calls out that the existing rlimit can stay as a uid-wide backstop while cgroups become the per-sandbox primitive.

## Scope decision

The original DoD pointed at a new `docs/dev/sandbox-limits.md`. Since F-078 was filed, F-100 + F-077 consolidated all sandbox/DoS-ceiling docs into `docs/dev/security.md`, including a brief NPROC caveat paragraph and an existing F-078 cross-reference at the bottom. Creating a separate `sandbox-limits.md` would fragment the operator-facing reference. This PR instead expands the existing brief caveat into a full subsection in the same file, matching the structure of the surrounding F-055 / F-077 sections.

Per the issue's own phasing, this PR closes only the Phase-1 documentation deliverable. The two Phase-2 DoD items (cgroup PID controller integration + regression test) remain open as follow-up work; this PR uses `Refs` rather than `Closes` so #151 stays open as the tracking issue. The bottom-of-file cross-reference at `security.md` continues to point there.

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- Pure-docs PR; no behavioral changes, no new automated tests added

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)