### PR TITLE
[F-103] Add explicit cross-reference links between design docs

### DIFF
--- a/docs/design/ai-patterns.md
+++ b/docs/design/ai-patterns.md
@@ -2,6 +2,8 @@
 
 > Extracted from DESIGN.md §7 — provider identity, streaming state, tool call visibility, sub-agent banners, agent monitor, and MCP indicators
 
+**Related docs:** [Color System](color-system.md) · [Component Principles](component-principles.md) · [Voice & Terminology](voice-terminology.md)
+
 ---
 
 ## 7. AI-Specific UI Patterns
@@ -10,7 +12,7 @@ These patterns are Forge-specific. Follow them consistently — they are part of
 
 ### Provider identity
 
-Each AI provider gets an accent color used consistently across all panes:
+Each AI provider gets an accent color used consistently across all panes (see [Color System](color-system.md) for the named scales and [Token Reference](token-reference.md) for the `--color-provider-*` CSS variables):
 - Anthropic / Claude: `ember-400` (`#ff4a12`)
 - OpenAI / GPT: `amber` (`#ffaa33`)
 - Local / Ollama / LM Studio: `steel` (`#7aaaff`)

--- a/docs/design/color-system.md
+++ b/docs/design/color-system.md
@@ -2,13 +2,15 @@
 
 > Extracted from DESIGN.md §3 — Ember brand scale, Iron surface scale, semantic colors, Steel accent, token usage rules, and agent coding rules
 
+**Related docs:** [Token Reference](token-reference.md) · [Component Principles](component-principles.md) · [Design Philosophy](philosophy.md)
+
 ---
 
 ## 3. Color System
 
 ### Palette overview
 
-Forge uses two base scales (Ember and Iron) and a set of semantic tokens. Always use tokens in code — never raw hex values except when defining the tokens themselves.
+Forge uses two base scales (Ember and Iron) and a set of semantic tokens. Always use tokens in code — never raw hex values except when defining the tokens themselves. The CSS custom properties for every value below are defined in [Token Reference](token-reference.md).
 
 ### Ember scale — brand
 

--- a/docs/design/component-principles.md
+++ b/docs/design/component-principles.md
@@ -2,13 +2,15 @@
 
 > Extracted from DESIGN.md §6 — buttons, inputs, toasts, status bar, and code blocks
 
+**Related docs:** [Color System](color-system.md) · [Token Reference](token-reference.md) · [Typography](typography.md)
+
 ---
 
 ## 6. Component Principles
 
 ### Buttons
 
-Four variants: **primary**, **secondary**, **ghost**, **icon**.
+Four variants: **primary**, **secondary**, **ghost**, **icon**. Color names below (`ember-400`, `iron-600`, etc.) are defined in the [Color System](color-system.md) and exposed as CSS custom properties in [Token Reference](token-reference.md).
 
 - **Primary** (`ember-400` fill): one per view maximum. The most important action.
 - **Secondary** (ember outline): alternative actions, same importance as primary but not the default.

--- a/docs/design/philosophy.md
+++ b/docs/design/philosophy.md
@@ -2,6 +2,8 @@
 
 > Extracted from DESIGN.md §1-2 — principles, visual identity, mark construction, wordmark, and colorways
 
+**Related docs:** [Color System](color-system.md) · [Typography](typography.md) · [Voice & Terminology](voice-terminology.md)
+
 ---
 
 ## 1. Design Philosophy
@@ -58,6 +60,8 @@ The Forge mark is a hub-and-spoke diagram with a minimal flat hammer at the cent
 - Tagline: `"Any AI. One editor."` in Fira Code, 9px, `#6a7e98`
 
 ### Colorways
+
+The hex values below are referenced by name (`ember-400`, `iron-900`, etc.) elsewhere in the design system; see [Color System](color-system.md) for the full Ember and Iron scales and [Token Reference](token-reference.md) for the corresponding CSS custom properties.
 
 | Context | Background | Usage |
 |---|---|---|

--- a/docs/design/spacing-layout.md
+++ b/docs/design/spacing-layout.md
@@ -2,13 +2,15 @@
 
 > Extracted from DESIGN.md §5 — base-4 spacing scale, border radii, shell structure, and surface elevation order
 
+**Related docs:** [Token Reference](token-reference.md) · [Color System](color-system.md) · [Component Principles](component-principles.md)
+
 ---
 
 ## 5. Spacing & Layout
 
 ### Spacing scale
 
-Forge uses a base-4 spacing scale. All spacing values should come from this scale.
+Forge uses a base-4 spacing scale. All spacing values should come from this scale. The `--sp-*` CSS custom properties for these tokens are declared in [Token Reference](token-reference.md).
 
 | Token | Value | Usage |
 |---|---|---|
@@ -52,7 +54,7 @@ Window
 
 ### Surface elevation order
 
-Surfaces must always stack from dark (deep) to light (elevated). Never violate this order.
+Surfaces must always stack from dark (deep) to light (elevated). Never violate this order. The `iron-*` colors below come from the [Color System](color-system.md) Iron scale.
 
 ```
 iron-900 (bg)        ← deepest — app background

--- a/docs/design/token-reference.md
+++ b/docs/design/token-reference.md
@@ -2,13 +2,15 @@
 
 > Extracted from DESIGN.md §10 — complete CSS custom properties for colors, spacing, radii, transitions, typography, and provider accents
 
+**Related docs:** [Color System](color-system.md) · [Spacing & Layout](spacing-layout.md) · [Typography](typography.md)
+
 ---
 
 ## 10. Token Reference
 
 ### CSS custom properties
 
-These tokens should be defined at `:root` and used throughout. Never use raw values in component styles.
+These tokens should be defined at `:root` and used throughout. Never use raw values in component styles. The semantics behind each token (Ember scale, Iron scale, Steel accent, semantic colors) are documented in [Color System](color-system.md); the spacing/radius scales are documented in [Spacing & Layout](spacing-layout.md); type families are documented in [Typography](typography.md).
 
 ```css
 :root {

--- a/docs/design/typography.md
+++ b/docs/design/typography.md
@@ -2,11 +2,15 @@
 
 > Extracted from DESIGN.md §4 — font families, type scale, per-family rules, and ligature usage
 
+**Related docs:** [Token Reference](token-reference.md) · [Voice & Terminology](voice-terminology.md) · [Component Principles](component-principles.md)
+
 ---
 
 ## 4. Typography
 
 ### Type families
+
+The font-family CSS variables (`--font-display`, `--font-body`, `--font-mono`) for the table below are defined in [Token Reference](token-reference.md).
 
 | Role | Family | Usage |
 |---|---|---|

--- a/docs/design/voice-terminology.md
+++ b/docs/design/voice-terminology.md
@@ -2,6 +2,8 @@
 
 > Extracted from DESIGN.md §8-9 — copy principles, formatting rules, terminology table, and do/don't reference
 
+**Related docs:** [Design Philosophy](philosophy.md) · [Component Principles](component-principles.md) · [AI Patterns](ai-patterns.md)
+
 ---
 
 ## 8. Writing & Voice
@@ -44,6 +46,8 @@ Always show technical identifiers verbatim: `ECONNREFUSED 127.0.0.1:11434` not `
 ## 9. Do and Don't
 
 ### Visual
+
+The `ember-400` and `iron` color names referenced below are defined in the [Color System](color-system.md) and exposed as CSS custom properties in [Token Reference](token-reference.md).
 
 | ✓ Do | ✕ Don't |
 |---|---|


### PR DESCRIPTION
Closes forge-ide/forge#176

## Summary
- Add a `Related docs` line at the top of each of the eight `docs/design/*.md` files, pointing to its closest siblings.
- Add inline links on first mention of cross-referenced concepts (Ember/Iron/Steel scales, `--color-*`/`--sp-*`/`--font-*` tokens, `--color-provider-*`) to `color-system.md` and `token-reference.md`.
- Discoverability-only change. No content rewrites, no anchor links (file-only links survive section renames).

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- Manual: every link target resolves to a file in the same directory (verified by listing all `]( *.md)` occurrences).

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)