### PR TITLE
[F-104] Add per-crate and per-web-package READMEs

### DIFF
--- a/crates/forge-agents/README.md
+++ b/crates/forge-agents/README.md
@@ -1,0 +1,22 @@
+# forge-agents
+
+Loads agent definitions from the workspace and user home — `<workspace_root>/.agents/*.md` and `~/.agents/*.md` — parsing each Markdown file's YAML frontmatter into a typed `AgentDef` and merging the two scopes so workspace agents win on name collisions. Also reads the optional workspace-level `AGENTS.md` preamble that callers inject into every agent's system prompt. The richer orchestration responsibilities described in the architecture doc (sub-agent spawning, isolation enforcement, background agents) land in later phases; this Phase 1 crate is the loader.
+
+## Role in the workspace
+
+- Depended on by: future session/orchestrator wiring (see `docs/architecture/crate-architecture.md` §3.4 for the Phase 2+ shape).
+- Depends on: `gray_matter` (YAML frontmatter), `serde`, `anyhow`.
+
+## Key types / entry points
+
+- `AgentDef` — parsed agent: `name`, optional `description`, prompt `body`, and `allowed_paths` glob list.
+- `parse_agent_file` (private) — single-file parser; rejects `isolation: trusted` for user-defined agents with a clear error.
+- `load_workspace_agents(workspace_root)` — load `<root>/.agents/*.md`, returning `Ok(vec![])` if the directory is absent.
+- `load_user_agents(user_home)` — load `<home>/.agents/*.md` similarly.
+- `load_agents(workspace_root, user_home)` — merged loader: user first, workspace overlays by name.
+- `load_agents_md(workspace_root)` — read the optional `AGENTS.md` preamble.
+- `AgentLoader::{load, agents, agents_md}` — bundled one-shot loader used per session.
+
+## Further reading
+
+- [Crate architecture — `forge-agents`](../../docs/architecture/crate-architecture.md#34-forge-agents)

--- a/crates/forge-cli/README.md
+++ b/crates/forge-cli/README.md
@@ -1,0 +1,24 @@
+# forge-cli
+
+The `forge` command-line binary. A thin `clap`-derived front end that spawns and talks to `forged` session daemons over their Unix domain sockets — listing sessions, tailing the live event stream, sending SIGTERM, and starting new agent or provider sessions. All session-id arguments are validated at parse time against the canonical `^[0-9a-f]{16}$` shape so attacker-controlled values can never reach the socket-path resolver.
+
+## Role in the workspace
+
+- Depended on by: nothing internal (leaf binary). `forge-session` pulls it in as a dev-dependency for integration tests.
+- Depends on: `forge-core`, `forge-ipc`, `clap`, `tokio`, `libc`.
+
+## Key types / entry points
+
+- `bin/forge` (`src/main.rs`) — CLI entrypoint.
+- `Cli` / `Commands` — top-level `clap` parser (`session`, `run`).
+- `SessionCommands` — `new`, `list`, `tail <id>`, `kill <id>`, with id-format validation via `parse_session_id`.
+- `SessionNewKind::{Agent, Provider}` — the two ways to start a new session.
+- `RunCommands::Agent` — one-shot ephemeral agent run reading input from `-` (stdin) or a file.
+- `socket` — UDS path / PID file resolution and the `session_id_is_valid` gate.
+- `ipc` — frame-level helpers used by `tail` and the daemon-talking subcommands.
+- `display` — terminal output formatting for events and session listings.
+
+## Further reading
+
+- [Crate architecture — `forge-cli`](../../docs/architecture/crate-architecture.md#37-forge-fs-forge-lsp-forge-term-forge-ipc-forge-cli-forge-shell)
+- [IPC contracts](../../docs/architecture/ipc-contracts.md)

--- a/crates/forge-core/README.md
+++ b/crates/forge-core/README.md
@@ -1,0 +1,23 @@
+# forge-core
+
+Canonical types, identifiers, and shared utilities for the Forge workspace. Every other Forge crate depends on this; it depends on nothing Forge-specific. It defines the strongly-typed identifiers used across IPC and persistence (`SessionId`, `WorkspaceId`, `AgentId`, `MessageId`, `ToolCallId`, `ProviderId`), the append-only `Event` model and `EventLog` writer that backs the session log, the workspace/`.forge/` path layout helpers, and the `ForgeError` / `Result` alias every other crate returns.
+
+## Role in the workspace
+
+- Depended on by: `forge-providers`, `forge-session`, `forge-shell`, `forge-cli`, `forge-fs` (transitively), `forge-ipc` consumers, and ultimately every other Forge crate.
+- Depends on: only third-party crates (`serde`, `tokio`, `chrono`, `thiserror`, `anyhow`, `ts-rs`, `toml`, `rand`).
+
+## Key types / entry points
+
+- `ids::{SessionId, WorkspaceId, AgentId, AgentInstanceId, MessageId, ToolCallId, ProviderId}` — wire-format identifiers, all `ts-rs`-exported for the TypeScript IPC layer.
+- `event::Event` — the append-only event variant emitted to `events.jsonl`; re-exported alongside `ApprovalPreview`, `ApprovalSource`, `ContextRef`, and `EndReason`.
+- `event_log::{EventLog, read_since, MAX_LINE_BYTES}` — the bounded NDJSON writer/reader pair used by `forge-session`.
+- `transcript::Transcript` — in-memory replay of an event stream.
+- `types::{ApprovalScope, CompactTrigger, RosterScope, SessionPersistence, SessionState}` — the small enum vocabulary that flows through approvals, compaction, and session lifecycle.
+- `workspace` / `workspaces` — workspace root detection and `.forge/` directory management.
+- `error::{ForgeError, Result}` — the workspace-wide error type and result alias.
+
+## Further reading
+
+- [Crate architecture — `forge-core`](../../docs/architecture/crate-architecture.md#31-forge-core)
+- [IPC contracts](../../docs/architecture/ipc-contracts.md)

--- a/crates/forge-fs/README.md
+++ b/crates/forge-fs/README.md
@@ -1,0 +1,23 @@
+# forge-fs
+
+Scoped filesystem operations with path validation. Every Forge write or edit goes through this crate; the session dispatcher refuses direct writes so the rules here — glob-based `allowed_paths` enforcement, symlink rejection, byte-size limits, and unified diff/preview generation — apply uniformly. Reads are also validated and capped so an attacker-controlled path or runaway file size cannot allocate an unbounded buffer.
+
+## Role in the workspace
+
+- Depended on by: `forge-session` (tool dispatcher), and any future tool layers that need bounded FS access.
+- Depends on: `glob`, `sha2`, `hex`, `similar` (diff), `tempfile`, `thiserror`. No Forge-internal deps.
+
+## Key types / entry points
+
+- `read_file(path, allowed_paths, limits) -> ReadResult` — canonicalises, glob-checks, size-checks, then reads. Returns content, byte count, and SHA-256.
+- `ReadResult { content, bytes, sha256 }` — read response shape.
+- `write(...)` and `write_preview(...)` (re-exported from `mutate`) — guarded write + dry-run preview.
+- `edit(...)` and `edit_preview(...)` (re-exported from `mutate`) — guarded edit + dry-run preview using `similar` for diffs.
+- `ApprovalPreview` (re-exported) — the unified-diff preview surfaced to approval prompts.
+- `Limits` — configurable byte ceilings (e.g. `max_read_bytes`).
+- `FsError` — typed error covering `Io`, `TooLarge`, `PathDenied`, `SymlinkDenied`, `ParentMissing`.
+- `canonicalize_no_symlink` (crate-private) — symlink-safe canonicalisation shared by write and edit paths.
+
+## Further reading
+
+- [Crate architecture — `forge-fs`](../../docs/architecture/crate-architecture.md#37-forge-fs-forge-lsp-forge-term-forge-ipc-forge-cli-forge-shell)

--- a/crates/forge-ipc/README.md
+++ b/crates/forge-ipc/README.md
@@ -1,0 +1,25 @@
+# forge-ipc
+
+The shared IPC types and framing used on both Forge boundaries: shell ↔ session over a Unix domain socket, and (via `ts-rs`-exported types in `forge-core`) Tauri ↔ webview. Defines the tagged `IpcMessage` envelope, the `Hello` / `HelloAck` handshake with `PROTO_VERSION` / `SCHEMA_VERSION` advertisement, the client-to-session command set (`SendUserMessage`, `ToolCallApproved`, `ToolCallRejected`, `Subscribe`), and the length-delimited framing helpers (`read_frame`, `write_frame`, `FramedStream`) with a shared 4 MiB max frame size.
+
+## Role in the workspace
+
+- Depended on by: `forge-session`, `forge-shell`, `forge-cli` — every component that speaks the session protocol.
+- Depends on: `tokio` (net + io-util), `tokio-util` (`LengthDelimitedCodec`), `serde`, `serde_json`, `bytes`, `futures`, `anyhow`.
+
+## Key types / entry points
+
+- `PROTO_VERSION`, `SCHEMA_VERSION` — wire-format version constants advertised in the handshake.
+- `IpcMessage` — tagged `enum` envelope: `Hello`, `HelloAck`, `Subscribe`, `Event`, `SendUserMessage`, `ToolCallApproved`, `ToolCallRejected`.
+- `Hello` / `HelloAck` / `ClientInfo` — the connection handshake payloads (kind, pid, user; session id, workspace, started-at, current event seq, schema version).
+- `Subscribe { since: u64 }` — request a replay-then-tail stream from a given event sequence.
+- `IpcEvent { seq, event }` — server-to-client event frame.
+- `SendUserMessage`, `ToolCallApproved`, `ToolCallRejected` — client-to-server commands.
+- `read_frame` / `write_frame` — bare async helpers over any `AsyncRead` / `AsyncWrite`, capped at 4 MiB.
+- `FramedStream` — `LengthDelimitedCodec`-backed wrapper over `tokio::net::UnixStream` with `send` / `recv` for any `Serialize` / `DeserializeOwned` payload.
+
+## Further reading
+
+- [Crate architecture — `forge-ipc`](../../docs/architecture/crate-architecture.md#37-forge-fs-forge-lsp-forge-term-forge-ipc-forge-cli-forge-shell)
+- [Session UDS protocol (ADR-001)](../../docs/architecture/ADR-001-session-uds-protocol.md)
+- [IPC contracts](../../docs/architecture/ipc-contracts.md)

--- a/crates/forge-lsp/README.md
+++ b/crates/forge-lsp/README.md
@@ -1,0 +1,16 @@
+# forge-lsp
+
+Language-server *management* — the layer that downloads, updates, and tracks the default LSP servers Forge bundles for first-use language support. Reserved scaffold in Phase 1 — the crate compiles into the workspace as a placeholder. As the architecture doc notes, the actual LSP client runs in the webview via `monaco-languageclient`, so this crate is deliberately a lifecycle / install layer, not an LSP proxy.
+
+## Role in the workspace
+
+- Depended on by: nothing yet; future webview wiring will trigger downloads through it.
+- Depends on: nothing (intentionally empty until implementation begins).
+
+## Key types / entry points
+
+- _None yet._ The planned shape (per-language download/update jobs, version tracking, install path resolution) is described in the architecture doc.
+
+## Further reading
+
+- [Crate architecture — `forge-lsp`](../../docs/architecture/crate-architecture.md#37-forge-fs-forge-lsp-forge-term-forge-ipc-forge-cli-forge-shell)

--- a/crates/forge-mcp/README.md
+++ b/crates/forge-mcp/README.md
@@ -1,0 +1,16 @@
+# forge-mcp
+
+MCP (Model Context Protocol) client and server lifecycle manager. Reserved scaffold in Phase 1 — the crate compiles into the workspace so dependent crates can be wired against it as MCP support lands, but the implementation work (loading `.mcp.json` / `~/.mcp.json`, spawning stdio and HTTP servers, restart policy, importing from other tool ecosystems, exposing tools through the provider-agnostic `Tool` shape) is deferred to a later milestone per the architecture doc.
+
+## Role in the workspace
+
+- Depended on by: nothing yet; will be consumed by `forge-session`'s tool dispatcher when MCP support ships.
+- Depends on: nothing (intentionally empty until implementation begins).
+
+## Key types / entry points
+
+- _None yet._ The planned API (`McpManager`, `Scope`, `ImportSource`, `McpStateEvent`, the `mcpServers` JSON parsers, and the stdio / HTTP transports) is documented in the architecture doc and will land with the implementation.
+
+## Further reading
+
+- [Crate architecture — `forge-mcp`](../../docs/architecture/crate-architecture.md#33-forge-mcp)

--- a/crates/forge-oci/README.md
+++ b/crates/forge-oci/README.md
@@ -1,0 +1,17 @@
+# forge-oci
+
+Container lifecycle for agent isolation. Reserved scaffold in Phase 1 — the crate compiles into the workspace as a placeholder so the eventual `ContainerRuntime` trait and its `podman` / `docker` shells can land without a workspace-wide reshuffle. The Phase 1 binary does not run any containerised workloads; the architecture doc describes the planned API and runtime detection.
+
+## Role in the workspace
+
+- Depended on by: nothing yet; future agent isolation paths in `forge-agents` / `forge-session` will consume it.
+- Depends on: nothing (intentionally empty until implementation begins).
+
+## Key types / entry points
+
+- _None yet._ The planned `ContainerRuntime` trait, `PodmanRuntime` / `DockerRuntime` implementations, OCI-spec generation via `oci-spec-rs`, and the first-run install banner are described in the architecture doc.
+
+## Further reading
+
+- [Crate architecture — `forge-oci`](../../docs/architecture/crate-architecture.md#36-forge-oci)
+- [Isolation model](../../docs/architecture/isolation-model.md)

--- a/crates/forge-providers/README.md
+++ b/crates/forge-providers/README.md
@@ -1,0 +1,22 @@
+# forge-providers
+
+The streaming chat-provider abstraction and built-in provider implementations. Defines the provider-agnostic `ChatRequest` / `ChatMessage` / `ChatBlock` shape that the rest of Forge speaks, the `Provider` trait that each backend implements, and the normalised `ChatChunk` stream variants (text deltas, tool calls, terminal `Done`, structured stream errors). Today ships an Ollama implementation plus a `MockProvider` used heavily in tests; additional providers (Anthropic, OpenAI-compatible) are planned per the architecture doc.
+
+## Role in the workspace
+
+- Depended on by: `forge-session` (drives chat turns), `forge-shell` (provider status / probe), and tests in dependent crates.
+- Depends on: `forge-core`, `reqwest` (rustls TLS, streaming bodies), `tokio`, `tokio-util` (codec/io), `futures`.
+
+## Key types / entry points
+
+- `Provider` — the streaming chat trait every backend implements. Returns `BoxStream<'static, ChatChunk>`.
+- `ChatRequest`, `ChatMessage`, `ChatRole`, `ChatBlock` — provider-agnostic conversation shape, including tool-call and tool-result blocks.
+- `ChatChunk` — normalised stream chunk: `TextDelta`, `ToolCall`, `Done`, terminal `Error { kind, message }`.
+- `StreamErrorKind` — terminal stream-failure classifier (`LineTooLong`, `IdleTimeout`, `WallClockTimeout`, `Transport`).
+- `MockProvider` — file-backed and scripted-sequence test double; `from_responses(...)` plus `recorded_requests()` for assertions.
+- `ollama` — the live Ollama backend (NDJSON streaming over HTTP).
+
+## Further reading
+
+- [Crate architecture — `forge-providers`](../../docs/architecture/crate-architecture.md#32-forge-providers)
+- [Provider abstraction](../../docs/architecture/provider-abstraction.md)

--- a/crates/forge-session/README.md
+++ b/crates/forge-session/README.md
@@ -1,0 +1,30 @@
+# forge-session
+
+The session daemon — `forged` — and its supporting library. A long-running per-session process that owns the append-only event log, hosts the agent orchestrator and tool dispatcher, accepts client connections over a Unix domain socket under `$XDG_RUNTIME_DIR/forge/sessions/<id>.sock`, and on shutdown either archives or purges the session directory based on the `SessionPersistence` mode. The library half (`forge_session`) exposes the building blocks used by integration tests and the `forge` CLI; the binary half (`forged`) wires them together.
+
+## Role in the workspace
+
+- Depended on by: `forge-cli` (spawns `forged`, talks to its UDS), `forge-shell` (dev-deps for integration tests).
+- Depends on: `forge-core`, `forge-fs`, `forge-ipc`, `forge-providers`, `tokio` (full async runtime), `libc` (resource limits and signal plumbing).
+
+## Key types / entry points
+
+- `bin/forged` (`src/main.rs`) — the daemon entrypoint that parses args, builds a `Session`, binds the UDS, and runs to completion.
+- `session::Session` — owns the event log, orchestrator, and per-client I/O loops.
+- `server` — UDS listener, frame routing, signal-driven shutdown that emits `SessionEnded`.
+- `orchestrator` — drives provider chat turns and dispatches tool calls.
+- `tools/` — built-in tool implementations (fs, shell, etc.) wired through `forge-fs` for write paths.
+- `archive::archive_or_purge` — end-of-life handling: rename into `.forge/sessions/archived/<id>/` or remove the session directory.
+- `socket_path` — resolves the session UDS path with the `XDG_RUNTIME_DIR` / `FORGE_SOCKET_PATH` policy.
+- `pid_file` — daemon liveness file with stale-pid detection.
+- `sandbox` — `pre_exec` hooks that cap NPROC/NOFILE/FSIZE for spawned children.
+- `byte_budget` — per-session aggregate byte budget used to bound output growth.
+- `provider_spec` — parses the `provider:model` selector strings the CLI accepts.
+- `error::SessionError` — the session-local error type.
+
+## Further reading
+
+- [Crate architecture — `forge-session`](../../docs/architecture/crate-architecture.md#35-forge-session)
+- [Session UDS protocol (ADR-001)](../../docs/architecture/ADR-001-session-uds-protocol.md)
+- [Session layout on disk](../../docs/architecture/session-layout.md)
+- [IPC contracts](../../docs/architecture/ipc-contracts.md)

--- a/crates/forge-shell/README.md
+++ b/crates/forge-shell/README.md
@@ -1,0 +1,29 @@
+# forge-shell
+
+The Tauri 2 host binary that boots the Forge desktop GUI. Loads the Solid web bundle from `web/packages/app`, registers the Tauri command surface that the webview calls into, and brokers the IPC dance between the webview and any running `forged` session daemons. The crate is split so its pure pieces (window specs, dashboard helpers, IPC types) compile and unit-test on hosts without WebKitGTK; the live Tauri runtime sits behind the default `webview` feature.
+
+## Role in the workspace
+
+- Depended on by: nothing internal — this is a leaf binary.
+- Depends on: `forge-core`, `forge-ipc`, `forge-providers`, `tauri` (gated), `tokio`.
+
+## Key types / entry points
+
+- `bin/forge-shell` (`src/main.rs`) — Tauri app entrypoint, gated on the `webview` feature.
+- `window_spec` — pure declarative window configuration. Unit-tested with `--no-default-features`.
+- `window_manager` — runtime adapter that applies a `WindowSpec` to a live `tauri::AppHandle` (gated on `webview`).
+- `ipc` — the Tauri command set exposed to the webview, including the per-window-label authorisation helpers (gated on `webview`).
+- `dashboard` / `dashboard_sessions` — provider-status probe with TTL cache and the dashboard sessions list / open commands (`collect_sessions`, `Pinger`).
+- `bridge` — glue between the webview and the session UDS framing.
+
+### Cargo features
+
+- `webview` (default) — pulls the Tauri 2 runtime (`wry` + `webkit2gtk` on Linux).
+- `webview-test` — also enables Tauri's `test` helpers (`mock_builder`, `WebviewWindowBuilder`) for integration tests.
+
+## Further reading
+
+- [Crate architecture — `forge-shell`](../../docs/architecture/crate-architecture.md#37-forge-fs-forge-lsp-forge-term-forge-ipc-forge-cli-forge-shell)
+- [Window hierarchy](../../docs/architecture/window-hierarchy.md)
+- [IPC contracts](../../docs/architecture/ipc-contracts.md)
+- [Frontend architecture](../../docs/frontend/architecture.md)

--- a/crates/forge-term/README.md
+++ b/crates/forge-term/README.md
@@ -1,0 +1,16 @@
+# forge-term
+
+Terminal emulator integration — wraps the `ghostty-vt` state machine and exposes a byte stream over IPC for the webview's xterm.js-compatible renderer. Reserved scaffold in Phase 1 — the crate compiles into the workspace as a placeholder so the eventual VT plumbing has a stable home. The Phase 1 GUI does not yet host a terminal pane.
+
+## Role in the workspace
+
+- Depended on by: nothing yet; future terminal-pane wiring in `forge-shell` will consume it.
+- Depends on: nothing (intentionally empty until implementation begins).
+
+## Key types / entry points
+
+- _None yet._ The planned VT-state wrapper and IPC byte-stream surface are described in the architecture doc.
+
+## Further reading
+
+- [Crate architecture — `forge-term`](../../docs/architecture/crate-architecture.md#37-forge-fs-forge-lsp-forge-term-forge-ipc-forge-cli-forge-shell)

--- a/web/packages/app/README.md
+++ b/web/packages/app/README.md
@@ -1,0 +1,27 @@
+# app
+
+The Forge desktop UI: a Solid + Vite + TypeScript single-page app loaded by the `forge-shell` Tauri host. Defines the route tree (`/` → Dashboard, `/session/:id` → SessionWindow), wires the in-process Solid signal stores, and talks to the Rust side through the typed bindings re-exported from `@forge/ipc`. Component styling pulls CSS variables from `@forge/design`'s tokens; component behaviour is exercised by Vitest unit tests and Playwright end-to-end tests.
+
+## Role in the workspace
+
+- Depended on by: nothing — this is the leaf web app the Tauri host loads.
+- Depends on: `@forge/design` (CSS tokens), `@forge/ipc` (typed wire types), `@solidjs/router`, `@tauri-apps/api`, `solid-js`. Dev: `vitest`, `@solidjs/testing-library`, `@playwright/test`, `vite-plugin-solid`.
+
+## Key types / entry points
+
+- `src/index.tsx` — Vite entry; mounts `<App />` into `#root`.
+- `src/App.tsx` — root component; declares the `<Router>` with `Dashboard` and `SessionWindow` routes.
+- `src/routes/` — per-route Solid components (`Dashboard`, `Session/SessionWindow`).
+- `src/components/` — reusable Solid components.
+- `src/stores/` — module-level Solid signals (active session, sessions store, catalog state).
+- `src/ipc/` — thin wrappers over `@tauri-apps/api/core` `invoke` calls, typed against `@forge/ipc`.
+- `src/lib/` — pure helpers shared across routes and components.
+- `src/styles/` — app-level CSS that consumes `@forge/design`'s tokens.
+- Scripts: `pnpm dev` (Vite dev server), `pnpm build`, `pnpm test` (Vitest), `pnpm test:e2e` (Playwright), `pnpm typecheck`.
+
+## Further reading
+
+- [Frontend architecture](../../../docs/frontend/architecture.md)
+- [Crate architecture — `forge-shell` (Tauri host)](../../../docs/architecture/crate-architecture.md#37-forge-fs-forge-lsp-forge-term-forge-ipc-forge-cli-forge-shell)
+- [Window hierarchy](../../../docs/architecture/window-hierarchy.md)
+- [IPC contracts](../../../docs/architecture/ipc-contracts.md)

--- a/web/packages/design/README.md
+++ b/web/packages/design/README.md
@@ -1,0 +1,20 @@
+# @forge/design
+
+The Forge design-token package. Ships a single static CSS file (`src/tokens.css`) that defines every CSS custom property the UI consumes — the Ember brand scale, Iron surface scale, text colours, semantic states and backgrounds, plus the rest of the typography and spacing scale referenced from `docs/design/token-reference.md`. The package has no runtime: consumers import `@forge/design/tokens.css` once at the app shell and read the variables from their own component CSS.
+
+## Role in the workspace
+
+- Depended on by: `app` (imports `@forge/design/tokens.css`).
+- Depends on: nothing.
+
+## Key types / entry points
+
+- `src/tokens.css` — the single source of truth; mirrored from `docs/design/token-reference.md` and enforced by `scripts/check-tokens.mjs`. Edits to either side without the other will fail the token check.
+- `package.json` `exports` — `./tokens.css` is the only public entry; `files` ships exactly that file.
+- Scripts: `build`, `test`, and `typecheck` are intentional no-ops (static CSS, no compile step).
+
+## Further reading
+
+- [Token pipeline](../../../docs/frontend/token-pipeline.md)
+- [Frontend architecture](../../../docs/frontend/architecture.md)
+- [Crate architecture overview](../../../docs/architecture/crate-architecture.md)

--- a/web/packages/ipc/README.md
+++ b/web/packages/ipc/README.md
@@ -1,0 +1,21 @@
+# @forge/ipc
+
+The TypeScript IPC type surface. Re-exports the `ts-rs`-generated identifier and enum types from `forge-core` so the Solid app and any other web-side consumer speak the same wire format the Rust crates do — without hand-maintaining a parallel set of definitions. The generated files live in `src/generated/` and are produced by the Rust `ts-rs` derives during the workspace test run; this package only re-exports them and provides the public type entrypoint.
+
+## Role in the workspace
+
+- Depended on by: `app`. Future web packages that touch the IPC boundary should depend on this rather than re-deriving types.
+- Depends on: nothing at runtime (types only). Dev: `typescript`.
+
+## Key types / entry points
+
+- `src/index.ts` — public re-exports: `AgentId`, `AgentInstanceId`, `ApprovalScope`, `CompactTrigger`, `MessageId`, `ProviderId`, `RosterScope`, `SessionId`, `SessionPersistence`, `SessionState`, `ToolCallId`, `WorkspaceId`.
+- `src/generated/*.ts` — `ts-rs`-generated, auto-regenerated; do not edit by hand. Add new identifier or enum types by adding `#[derive(TS)]` in `forge-core` and regenerating.
+- `package.json` `exports` — `.` (the curated re-exports) and `./generated/*` (raw access if a consumer needs an unexported type).
+- Scripts: `typecheck` / `build` both run `tsc --noEmit`; the package has no compiled output.
+
+## Further reading
+
+- [IPC contracts](../../../docs/architecture/ipc-contracts.md)
+- [Crate architecture — `forge-core` (id types)](../../../docs/architecture/crate-architecture.md#31-forge-core)
+- [Crate architecture — `forge-ipc` (wire framing)](../../../docs/architecture/crate-architecture.md#37-forge-fs-forge-lsp-forge-term-forge-ipc-forge-cli-forge-shell)


### PR DESCRIPTION
Closes forge-ide/forge#177

## Summary
- Adds a one-screen README to each of the 12 Phase 1 Rust crates (`forge-core`, `forge-providers`, `forge-session`, `forge-shell`, `forge-agents`, `forge-fs`, `forge-mcp`, `forge-oci`, `forge-cli`, `forge-lsp`, `forge-term`, `forge-ipc`) and the 3 web packages (`web/packages/app`, `web/packages/design`, `web/packages/ipc`).
- Each README follows the template from the issue: name + one-paragraph purpose, role in the workspace (depends on / depended on by), key types or entry points, and links back to `docs/architecture/crate-architecture.md` (and adjacent docs where relevant) for the full picture.
- Crates with active implementation describe their real public surface as it stands today; crates that are reserved scaffolds in Phase 1 (`forge-mcp`, `forge-oci`, `forge-lsp`, `forge-term`) say so explicitly and point at the architecture doc for the planned shape rather than inventing API that does not yet exist.
- Web package READMEs source purpose from `package.json` + entry points (the architecture doc only covers crates) and additionally link to `docs/frontend/architecture.md`.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code