### PR TITLE
fix(forge-session): use tokio::fs::rename in archive_or_purge (F-110)

### DIFF
--- a/crates/forge-session/src/archive.rs
+++ b/crates/forge-session/src/archive.rs
@@ -49,14 +49,20 @@ fn archived_destination(session_dir: &Path) -> Result<PathBuf> {
 }
 
 async fn move_dir(src: &Path, dst: &Path) -> Result<()> {
-    move_dir_with_rename(src, dst, |s, d| std::fs::rename(s, d)).await
+    // Async rename keeps the tokio worker unblocked; large session directories
+    // on cross-device renames can otherwise stall for 50-500 ms (F-110).
+    handle_rename_result(tokio::fs::rename(src, dst).await, src, dst).await
 }
 
 async fn move_dir_with_rename<F>(src: &Path, dst: &Path, rename: F) -> Result<()>
 where
     F: FnOnce(&Path, &Path) -> io::Result<()>,
 {
-    match rename(src, dst) {
+    handle_rename_result(rename(src, dst), src, dst).await
+}
+
+async fn handle_rename_result(rename_result: io::Result<()>, src: &Path, dst: &Path) -> Result<()> {
+    match rename_result {
         Ok(()) => Ok(()),
         Err(e) if is_cross_device(&e) => {
             copy_dir_all(src, dst).await?;


### PR DESCRIPTION
## Summary

Fixes #214 (F-110). The session archival path (`archive_or_purge()` -> `move_dir` -> `move_dir_with_rename`) called `std::fs::rename` from inside an `async fn`, blocking the tokio worker for 50-500 ms on cross-device renames of large session directories. That delay stalls streaming for sessions sharing the worker and slows the next session's startup after closing a large one.

- Production rename in `move_dir` now uses `tokio::fs::rename` (no worker-blocking syscall in the archival hot path).
- EXDEV copy-fallback is factored into a shared `handle_rename_result` helper so the sync-closure test hook (`move_dir_with_rename_for_test`) keeps its `FnOnce(&Path, &Path) -> io::Result<()>` signature — the existing cross-device fallback test continues to exercise the same branch.
- No `std::fs::*` calls remain in `archive.rs`.

Surgical: +12 / -2 lines, single file.

## Definition of Done

- [x] `archive.rs:52` uses `tokio::fs::rename` (via `move_dir`)
- [x] No `std::fs::` calls remain under `archive_or_purge()` path
- [x] Existing archive tests pass (`tests/archive.rs` 7/7, `tests/archive_shutdown.rs` 2/2)
- [x] `cargo clippy --all-targets -- -D warnings` clean

## Test plan

- [x] `cargo test -p forge-session --test archive --test archive_shutdown`
- [x] `cargo clippy -p forge-session --all-targets -- -D warnings`
- [x] `cargo build -p forge-session`

## Related

- F-106 (#210) — sibling cluster in the same crate (sync I/O in tool invocations). Different files, no conflict.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>