### PR TITLE
[F-111] Patch apply: single-buffer apply_unified_diff, O(1) allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +407,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -528,6 +567,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +614,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -848,6 +927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1120,7 @@ dependencies = [
 name = "forge-fs"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "glob",
  "hex",
  "sha2",
@@ -1589,6 +1675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,10 +2065,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2531,6 +2648,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "option-ext"
@@ -4306,6 +4429,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/forge-fs/Cargo.toml
+++ b/crates/forge-fs/Cargo.toml
@@ -13,4 +13,9 @@ tempfile = "3"
 thiserror = "1"
 
 [dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 tempfile = "3"
+
+[[bench]]
+name = "mutate"
+harness = false

--- a/crates/forge-fs/benches/mutate.rs
+++ b/crates/forge-fs/benches/mutate.rs
@@ -1,0 +1,326 @@
+//! Perf + allocation-budget guard for `apply_unified_diff`.
+//!
+//! This bench does two things:
+//!
+//! 1. Asserts that the optimized impl performs a bounded number of heap
+//!    allocations while applying a 1000-line unified-diff patch to a ~10 MB
+//!    synthetic file — specifically, at least 5× fewer allocations than a
+//!    copy of the pre-F-111 naive implementation included below. The
+//!    assertion runs during the bench binary's startup; the bench therefore
+//!    **fails loudly on baseline** (if someone reverts the optimization) and
+//!    passes on the current impl.
+//!
+//! 2. Reports wall-clock throughput via criterion for both implementations
+//!    so regressions are visible as numbers, not just pass/fail.
+//!
+//! The naive implementation below is a verbatim copy of the pre-F-111
+//! `apply_unified_diff` in `crates/forge-fs/src/mutate.rs` (per-line
+//! `String` allocations + final `Vec<String>::concat()`). It exists only in
+//! the bench binary — production code has a single optimized path.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use forge_fs::__bench_internals::apply_unified_diff;
+
+// ---------------------------------------------------------------------------
+// Allocation-counting global allocator.
+// ---------------------------------------------------------------------------
+
+struct CountingAllocator;
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+static ALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        System.alloc(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        System.alloc_zeroed(layout)
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // realloc can either resize in place or allocate fresh; count it once.
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        if new_size > layout.size() {
+            ALLOC_BYTES.fetch_add(new_size - layout.size(), Ordering::Relaxed);
+        }
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn snapshot() -> (usize, usize) {
+    (
+        ALLOC_COUNT.load(Ordering::Relaxed),
+        ALLOC_BYTES.load(Ordering::Relaxed),
+    )
+}
+
+fn delta(before: (usize, usize)) -> (usize, usize) {
+    let (c, b) = snapshot();
+    (c - before.0, b - before.1)
+}
+
+// ---------------------------------------------------------------------------
+// Naive implementation (pre-F-111). Kept here to prove the allocation delta.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+#[allow(dead_code)] // String is read via #[derive(Debug)] when unwrap panics.
+struct NaiveErr(String);
+
+fn split_preserving_newline(s: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let bytes = s.as_bytes();
+    let mut start = 0usize;
+    for (i, b) in bytes.iter().enumerate() {
+        if *b == b'\n' {
+            out.push(&s[start..=i]);
+            start = i + 1;
+        }
+    }
+    if start < bytes.len() {
+        out.push(&s[start..]);
+    }
+    out
+}
+
+fn parse_hunk_old_start(rest: &str) -> Result<usize, NaiveErr> {
+    let minus = rest
+        .split_whitespace()
+        .find(|t| t.starts_with('-'))
+        .ok_or_else(|| NaiveErr(format!("hunk header missing '-' range: {rest:?}")))?;
+    let spec = minus.trim_start_matches('-');
+    let (start_str, _count_str) = spec.split_once(',').unwrap_or((spec, "1"));
+    start_str
+        .parse::<usize>()
+        .map_err(|_| NaiveErr(format!("hunk start not a number: {start_str:?}")))
+}
+
+fn apply_unified_diff_naive(original: &str, patch: &str) -> Result<String, NaiveErr> {
+    let src_lines: Vec<&str> = split_preserving_newline(original);
+    let mut out: Vec<String> = Vec::with_capacity(src_lines.len());
+    let mut cursor = 0usize;
+    let mut saw_hunk = false;
+    let mut lines = patch.lines().peekable();
+
+    while let Some(raw) = lines.next() {
+        if raw.starts_with("--- ") || raw.starts_with("+++ ") {
+            continue;
+        }
+        if let Some(rest) = raw.strip_prefix("@@ ") {
+            saw_hunk = true;
+            let old_start = parse_hunk_old_start(rest)?;
+            let target = old_start.saturating_sub(1);
+            if target < cursor || target > src_lines.len() {
+                return Err(NaiveErr(format!(
+                    "hunk range out of bounds at line {old_start}"
+                )));
+            }
+            for l in &src_lines[cursor..target] {
+                out.push((*l).to_string());
+            }
+            cursor = target;
+
+            while let Some(peek) = lines.peek() {
+                if peek.starts_with("@@ ") {
+                    break;
+                }
+                let body = lines.next().unwrap();
+                if let Some(ctx) = body.strip_prefix(' ') {
+                    let src = src_lines
+                        .get(cursor)
+                        .ok_or_else(|| NaiveErr("context line past end of source".into()))?;
+                    if src.trim_end_matches('\n') != ctx.trim_end_matches('\n') {
+                        return Err(NaiveErr(format!("context mismatch at line {}", cursor + 1)));
+                    }
+                    out.push((*src).to_string());
+                    cursor += 1;
+                } else if let Some(removed) = body.strip_prefix('-') {
+                    let src = src_lines
+                        .get(cursor)
+                        .ok_or_else(|| NaiveErr("delete past end of source".into()))?;
+                    if src.trim_end_matches('\n') != removed.trim_end_matches('\n') {
+                        return Err(NaiveErr(format!("delete mismatch at line {}", cursor + 1)));
+                    }
+                    cursor += 1;
+                } else if let Some(added) = body.strip_prefix('+') {
+                    out.push(format!("{added}\n"));
+                } else if body.starts_with("\\ ") {
+                    if let Some(last) = out.last_mut() {
+                        if last.ends_with('\n') {
+                            last.pop();
+                        }
+                    }
+                } else if body.is_empty() {
+                    let src = src_lines
+                        .get(cursor)
+                        .ok_or_else(|| NaiveErr("empty context past end of source".into()))?;
+                    if !src.trim_end_matches('\n').is_empty() {
+                        return Err(NaiveErr(format!(
+                            "empty context mismatch at line {}",
+                            cursor + 1
+                        )));
+                    }
+                    out.push((*src).to_string());
+                    cursor += 1;
+                } else {
+                    return Err(NaiveErr(format!("unrecognized line prefix: {body:?}")));
+                }
+            }
+        } else if saw_hunk {
+            return Err(NaiveErr(format!("unexpected line outside hunk: {raw:?}")));
+        }
+    }
+
+    if !saw_hunk {
+        return Err(NaiveErr("no hunks found".into()));
+    }
+    for l in &src_lines[cursor..] {
+        out.push((*l).to_string());
+    }
+    Ok(out.concat())
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic fixture: ~10 MB file + 1000-line unified-diff patch.
+// ---------------------------------------------------------------------------
+
+const LINES: usize = 10_000; // file lines
+const LINE_BYTES: usize = 1000; // line payload length (~1 KB each → ~10 MB file)
+const PATCH_LINES: usize = 1000; // edits scattered across the file
+
+fn build_file() -> String {
+    let mut s = String::with_capacity(LINES * (LINE_BYTES + 16));
+    for i in 0..LINES {
+        // Distinctive per-line content so context verification is meaningful.
+        let payload = format!("line-{i:07}-");
+        s.push_str(&payload);
+        let filler = LINE_BYTES.saturating_sub(payload.len());
+        for _ in 0..filler {
+            s.push('x');
+        }
+        s.push('\n');
+    }
+    s
+}
+
+/// Build a hand-rolled unified-diff that replaces every 10th line in the first
+/// 10_000 lines (so `PATCH_LINES` replacements total). Hand-rolled to avoid
+/// pulling an off-workspace dep and to stay deterministic.
+fn build_patch(original: &str) -> String {
+    let lines: Vec<&str> = original.lines().collect();
+    assert!(lines.len() >= LINES);
+    let stride = LINES / PATCH_LINES;
+    assert!(stride >= 1);
+
+    let mut patch = String::with_capacity(PATCH_LINES * (LINE_BYTES + 32));
+    for edit_idx in 0..PATCH_LINES {
+        let line_no_0 = edit_idx * stride; // 0-indexed
+        let line_no_1 = line_no_0 + 1; // 1-indexed for hunk header
+                                       // Single-line hunk: delete one line, add one line, no context.
+        patch.push_str(&format!("@@ -{line_no_1},1 +{line_no_1},1 @@\n"));
+        patch.push('-');
+        patch.push_str(lines[line_no_0]);
+        patch.push('\n');
+        patch.push('+');
+        patch.push_str(lines[line_no_0]);
+        patch.push_str("-EDITED\n");
+    }
+    patch
+}
+
+// ---------------------------------------------------------------------------
+// Allocation-budget guard. Runs once at bench startup; panics on regression.
+// ---------------------------------------------------------------------------
+
+/// Ratio the DoD requires: optimized impl must do at most `naive / RATIO`
+/// allocations on the 1000-line patch.
+const REQUIRED_RATIO: usize = 5;
+
+fn assert_allocation_budget(original: &str, patch: &str) {
+    // Warm caches, drop any lazily-initialized statics, etc. — we only care
+    // about the steady-state allocations of the two impls. Also cross-check
+    // that both impls produce byte-identical output so the allocation-ratio
+    // guarantee is meaningful (a "faster" impl that drops lines would
+    // otherwise pass silently).
+    let warm_opt =
+        apply_unified_diff(original, patch).expect("optimized impl should apply cleanly");
+    let warm_naive =
+        apply_unified_diff_naive(original, patch).expect("naive impl should apply cleanly");
+    assert_eq!(
+        warm_opt, warm_naive,
+        "optimized and naive apply_unified_diff disagreed on 1000-line patch output"
+    );
+    drop(warm_opt);
+    drop(warm_naive);
+
+    let before = snapshot();
+    let optimized = apply_unified_diff(original, patch).unwrap();
+    let (opt_allocs, opt_bytes) = delta(before);
+    drop(optimized);
+
+    let before = snapshot();
+    let naive = apply_unified_diff_naive(original, patch).unwrap();
+    let (naive_allocs, naive_bytes) = delta(before);
+    drop(naive);
+
+    eprintln!(
+        "F-111 allocation budget: optimized={opt_allocs} allocs ({opt_bytes} bytes), \
+         naive={naive_allocs} allocs ({naive_bytes} bytes), \
+         ratio={:.2}x",
+        naive_allocs as f64 / opt_allocs.max(1) as f64
+    );
+
+    assert!(
+        opt_allocs * REQUIRED_RATIO <= naive_allocs,
+        "F-111 allocation budget regression: optimized impl did {opt_allocs} allocations, \
+         naive did {naive_allocs}; required ≥{REQUIRED_RATIO}× reduction \
+         (i.e. optimized ≤ {} allocations)",
+        naive_allocs / REQUIRED_RATIO
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Criterion benchmarks — report wall-clock deltas.
+// ---------------------------------------------------------------------------
+
+fn bench_apply_unified_diff(c: &mut Criterion) {
+    let original = build_file();
+    let patch = build_patch(&original);
+
+    // Gate: if we regress on allocations, fail the bench binary loudly before
+    // criterion prints numbers.
+    assert_allocation_budget(&original, &patch);
+
+    let mut group = c.benchmark_group("apply_unified_diff");
+    group.sample_size(10);
+    group.bench_function("optimized", |b| {
+        b.iter(|| {
+            let out = apply_unified_diff(black_box(&original), black_box(&patch)).unwrap();
+            black_box(out);
+        })
+    });
+    group.bench_function("naive_pre_f111", |b| {
+        b.iter(|| {
+            let out = apply_unified_diff_naive(black_box(&original), black_box(&patch)).unwrap();
+            black_box(out);
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_apply_unified_diff);
+criterion_main!(benches);

--- a/crates/forge-fs/src/lib.rs
+++ b/crates/forge-fs/src/lib.rs
@@ -9,6 +9,13 @@ mod mutate;
 pub use limits::Limits;
 pub use mutate::{edit, edit_preview, write, write_preview, ApprovalPreview, FsError};
 
+/// Internal entry points exposed solely for the `benches/mutate.rs` allocation
+/// guard. Not part of the public API — do not depend on anything in here.
+#[doc(hidden)]
+pub mod __bench_internals {
+    pub use crate::mutate::apply_unified_diff;
+}
+
 /// Result of a successful `fs.read` operation.
 #[derive(Debug)]
 pub struct ReadResult {

--- a/crates/forge-fs/src/mutate.rs
+++ b/crates/forge-fs/src/mutate.rs
@@ -193,9 +193,22 @@ pub fn edit_preview(path: &str, patch: &str) -> ApprovalPreview {
 /// Minimal unified-diff applier. Supports standard `@@ -a,b +c,d @@` hunks
 /// with `' '`, `'-'`, `'+'` line prefixes. Rejects anything else as
 /// [`FsError::MalformedPatch`].
-fn apply_unified_diff(original: &str, patch: &str) -> Result<String, FsError> {
+///
+/// Perf: writes every emitted line directly into a single `String` buffer
+/// pre-sized to the original file length. Context/removed-verified lines are
+/// appended as borrowed slices (no per-line `String` allocation), and `+`
+/// additions only pay for the one terminating `'\n'` byte on top of the slice
+/// copy. Net effect: allocation count is O(1) in the number of lines, dominated
+/// by the single `with_capacity` up-front plus any overflow growth when
+/// additions exceed the original size. See `benches/mutate.rs` for the
+/// ≥5× allocation-reduction guard.
+#[doc(hidden)]
+pub fn apply_unified_diff(original: &str, patch: &str) -> Result<String, FsError> {
     let src_lines: Vec<&str> = split_preserving_newline(original);
-    let mut out: Vec<String> = Vec::with_capacity(src_lines.len());
+    // Pre-size to the original file: most edits are localized, so this is a
+    // tight upper bound for context + removed lines. Additions grow the buffer
+    // via normal `String` doubling; still amortized O(1) per push.
+    let mut out = String::with_capacity(original.len());
     let mut cursor = 0usize; // index into src_lines
     let mut saw_hunk = false;
     let mut lines = patch.lines().peekable();
@@ -215,7 +228,7 @@ fn apply_unified_diff(original: &str, patch: &str) -> Result<String, FsError> {
                 });
             }
             for l in &src_lines[cursor..target] {
-                out.push((*l).to_string());
+                out.push_str(l);
             }
             cursor = target;
 
@@ -236,7 +249,7 @@ fn apply_unified_diff(original: &str, patch: &str) -> Result<String, FsError> {
                             reason: format!("context mismatch at line {}", cursor + 1),
                         });
                     }
-                    out.push((*src).to_string());
+                    out.push_str(src);
                     cursor += 1;
                 } else if let Some(removed) = body.strip_prefix('-') {
                     let src = src_lines
@@ -254,14 +267,13 @@ fn apply_unified_diff(original: &str, patch: &str) -> Result<String, FsError> {
                     // Preserve newline behavior: input lines are stored without
                     // their trailing '\n' by split_preserving_newline; re-add
                     // unless this was a "\ No newline at end of file" marker.
-                    out.push(format!("{added}\n"));
+                    out.push_str(added);
+                    out.push('\n');
                 } else if body.starts_with("\\ ") {
                     // "\ No newline at end of file" — strip trailing newline
-                    // from last emitted line if present.
-                    if let Some(last) = out.last_mut() {
-                        if last.ends_with('\n') {
-                            last.pop();
-                        }
+                    // from the buffer if present.
+                    if out.ends_with('\n') {
+                        out.pop();
                     }
                 } else if body.is_empty() {
                     // Some diff tools emit a bare empty line as a zero-width context line.
@@ -275,7 +287,7 @@ fn apply_unified_diff(original: &str, patch: &str) -> Result<String, FsError> {
                             reason: format!("empty context mismatch at line {}", cursor + 1),
                         });
                     }
-                    out.push((*src).to_string());
+                    out.push_str(src);
                     cursor += 1;
                 } else {
                     return Err(FsError::MalformedPatch {
@@ -302,10 +314,10 @@ fn apply_unified_diff(original: &str, patch: &str) -> Result<String, FsError> {
 
     // Append any source lines remaining after the last hunk.
     for l in &src_lines[cursor..] {
-        out.push((*l).to_string());
+        out.push_str(l);
     }
 
-    Ok(out.concat())
+    Ok(out)
 }
 
 /// Split `s` into lines while preserving the trailing newline on each line so


### PR DESCRIPTION
Closes forge-ide/forge#215

## Summary

- `apply_unified_diff` now writes directly into a single `String` buffer pre-sized with `String::with_capacity(original.len())`; all 5 per-line `String` allocation sites and the final `Vec<String>::concat()` are gone. Context / removed / added lines are appended via `push_str` on borrowed slices; the `\ No newline at end of file` marker pops from the buffer in place.
- Added `crates/forge-fs/benches/mutate.rs` (new `[[bench]]` + `criterion` dev-dep). The bench builds a ~10 MB synthetic file and a 1000-line unified-diff patch, runs both the new impl and a verbatim copy of the naive pre-F-111 impl under a counting `#[global_allocator]`, and asserts the optimized path does at least 5× fewer allocations than the naive path. Cross-checks that both impls produce byte-identical output so a "faster but wrong" regression can't slip through.
- Output preserved: existing `edit_applies_unified_diff_patch`, `apply_unified_diff_edits_middle_line`, `apply_unified_diff_rejects_non_patch_input`, and all `fs_edit.rs` / `fs_size_limits.rs` integration tests pass unchanged.

## Measured delta (author's box)

```
F-111 allocation budget: optimized=15 allocs (20,282,144 bytes), naive=11,015 allocs (21,542,144 bytes), ratio=734.33x
apply_unified_diff/optimized      time:   [4.15 ms 4.18 ms 4.22 ms]
apply_unified_diff/naive_pre_f111 time:   [5.82 ms 5.93 ms 6.03 ms]
```

734× allocation reduction — well above the 5× DoD floor — and ~30-40% faster in release on this workload, attributable to the eliminated allocator pressure.

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (all 32 forge-fs tests including the 3 `apply_unified_diff` unit tests; no other workspace test affected)
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo bench -p forge-fs --bench mutate` — allocation-budget assertion fires and passes; criterion reports throughput

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

## Notes for reviewers

- `apply_unified_diff` is exposed as `pub` behind `#[doc(hidden)]` inside a `#[doc(hidden)] pub mod __bench_internals` in `lib.rs`. That's the only way to let the bench call the function without round-tripping through the filesystem (`edit()` would add disk noise to the allocation measurement). The symbol is clearly marked for internal-only use.
- The naive implementation lives *only* inside `benches/mutate.rs` — production code has a single optimized path. The bench's naive copy exists solely to prove the ratio; it is not compiled into any non-bench target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)