### PR TITLE
[F-108] perf: typed-deserialize Ollama NDJSON parse_line (-8.8x allocs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +407,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -528,6 +567,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +614,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -848,6 +927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1159,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "criterion",
  "dirs 6.0.0",
  "forge-core",
  "futures",
@@ -1589,6 +1675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,10 +2065,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2531,6 +2648,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "option-ext"
@@ -4306,6 +4429,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/forge-providers/Cargo.toml
+++ b/crates/forge-providers/Cargo.toml
@@ -22,7 +22,14 @@ tokio = { version = "1", features = ["fs", "rt", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 
 [dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "time"] }
 futures = "0.3"
 wiremock = "0.6"
+
+# F-108: criterion bench covering the hottest per-token path in the app.
+# `harness = false` disables libtest so criterion's own harness runs.
+[[bench]]
+name = "ollama_stream"
+harness = false

--- a/crates/forge-providers/benches/ollama_stream.rs
+++ b/crates/forge-providers/benches/ollama_stream.rs
@@ -1,0 +1,241 @@
+//! F-108 criterion bench — Ollama NDJSON parse_line allocation budget.
+//!
+//! The NDJSON decode in `ollama::parse_line` is the hottest per-token path in
+//! the application: every streamed assistant token flows through it. The old
+//! two-step decode (`serde_json::from_str::<Value>` + `.as_str().to_string()`)
+//! allocated three Strings per text-delta token, producing allocator pressure
+//! and jitter on long responses.
+//!
+//! This bench feeds 1000 mock NDJSON lines through both the old (baseline)
+//! and new (typed) implementations and reports two numbers per pass:
+//! - wall-time (via criterion's sampler)
+//! - heap allocations (via a counting global allocator)
+//!
+//! The baseline implementation (`legacy_parse_line`) is inlined below so the
+//! bench can compare against it without polluting the production module. The
+//! comparison is the DoD's "baseline shows high allocation count, fix shows
+//! reduction" — asserted at the end of the bench run.
+//!
+//! Run locally with `cargo bench -p forge-providers`.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use forge_providers::ollama::parse_line;
+use forge_providers::ChatChunk;
+
+// ── Counting allocator ────────────────────────────────────────────────────────
+//
+// Wraps the system allocator with a pair of atomic counters so the bench can
+// snapshot allocation deltas around a block of work. The counters are
+// process-global: the wrapper is installed as `#[global_allocator]` below,
+// and `record()` opts in to counting for the duration of a closure. Counting
+// is disabled by default so criterion's own warmup / sampler noise doesn't
+// accumulate into the reported numbers.
+
+struct CountingAllocator;
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+static ENABLED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if ENABLED.load(Ordering::Relaxed) != 0 {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        // SAFETY: delegating to the system allocator with the caller's layout.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: delegating to the system allocator with the caller's ptr/layout.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static A: CountingAllocator = CountingAllocator;
+
+/// Run `f`, returning `(allocations, bytes)` observed during the call. Only
+/// one scope at a time is meaningful; criterion runs benches serially within
+/// a group, so that's fine for our purposes.
+fn record<F: FnOnce()>(f: F) -> (usize, usize) {
+    ALLOCS.store(0, Ordering::Relaxed);
+    BYTES.store(0, Ordering::Relaxed);
+    ENABLED.store(1, Ordering::Relaxed);
+    f();
+    ENABLED.store(0, Ordering::Relaxed);
+    (
+        ALLOCS.load(Ordering::Relaxed),
+        BYTES.load(Ordering::Relaxed),
+    )
+}
+
+// ── Baseline (pre-F-108) implementation ───────────────────────────────────────
+//
+// Verbatim copy of the pre-fix `parse_line`. Lives here — not in the
+// production module — so the production binary doesn't carry both. Kept only
+// for the reduction assertion at the end of the bench. If this ever drifts
+// from the fixed version's behavior, the bench still serves its purpose
+// (measuring the old allocation shape); the correctness contract lives in
+// the src/ollama.rs unit tests.
+fn legacy_parse_line(line: &str) -> Option<ChatChunk> {
+    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+
+    if value.get("done").and_then(|d| d.as_bool()) == Some(true) {
+        let reason = value
+            .get("done_reason")
+            .and_then(|r| r.as_str())
+            .unwrap_or("")
+            .to_string();
+        return Some(ChatChunk::Done(reason));
+    }
+
+    if let Some(first_call) = value
+        .get("message")
+        .and_then(|m| m.get("tool_calls"))
+        .and_then(|tc| tc.as_array())
+        .and_then(|arr| arr.first())
+    {
+        if let Some(func) = first_call.get("function") {
+            let name = func.get("name").and_then(|n| n.as_str())?.to_string();
+            let args = func
+                .get("arguments")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
+            return Some(ChatChunk::ToolCall { name, args });
+        }
+    }
+
+    if let Some(content) = value
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+    {
+        if !content.is_empty() {
+            return Some(ChatChunk::TextDelta(content.to_string()));
+        }
+    }
+
+    None
+}
+
+// ── Mock NDJSON corpus ────────────────────────────────────────────────────────
+//
+// 1000 lines shaped like a realistic Ollama response: mostly text-delta tokens
+// (the hot path), with periodic tool-call chunks and a terminal `done` frame.
+// Token strings are short (1–6 ASCII chars, no JSON escapes) so the typed
+// parser hits its Cow::Borrowed fast path on the delta fields — the common
+// case the DoD budgets for.
+
+fn mock_ndjson_lines() -> Vec<String> {
+    let text_tokens = [
+        "the ", "quick", " brown", " fox ", "jumps", " over ", "a ", "lazy ", "dog", ".", " it ",
+        "was ", "a ", "sunny", " day", " in ", "spring", ".",
+    ];
+
+    let mut out = Vec::with_capacity(1000);
+    for i in 0..999 {
+        if i % 97 == 96 {
+            // Tool-call chunk — exercises the args-move path.
+            out.push(
+                r#"{"message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"fs.read","arguments":{"path":"/tmp/x"}}}]},"done":false}"#
+                    .to_string(),
+            );
+        } else {
+            let tok = text_tokens[i % text_tokens.len()];
+            out.push(format!(
+                r#"{{"message":{{"role":"assistant","content":"{tok}"}},"done":false}}"#
+            ));
+        }
+    }
+    out.push(r#"{"model":"llama3","done":true,"done_reason":"stop"}"#.to_string());
+    out
+}
+
+// ── Benchmarks ────────────────────────────────────────────────────────────────
+
+fn bench_parse_line(c: &mut Criterion) {
+    let lines = mock_ndjson_lines();
+
+    let mut group = c.benchmark_group("ollama_parse_line");
+    group.throughput(criterion::Throughput::Elements(lines.len() as u64));
+
+    group.bench_function("legacy (Value-tree)", |b| {
+        b.iter(|| {
+            for line in &lines {
+                black_box(legacy_parse_line(black_box(line)));
+            }
+        });
+    });
+
+    group.bench_function("typed (F-108)", |b| {
+        b.iter(|| {
+            for line in &lines {
+                black_box(parse_line(black_box(line)));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+// ── Allocation-count assertion ────────────────────────────────────────────────
+//
+// The criterion time bench covers wall-time. The DoD additionally requires a
+// recorded allocation count per 1000 lines. This runs once per bench invocation,
+// prints both numbers, and panics if the typed path is not a strict reduction —
+// serving as the "bench shows reduction" evidence in the DoD.
+fn assert_alloc_reduction(_c: &mut Criterion) {
+    let lines = mock_ndjson_lines();
+
+    // Warm up: allocator counters are noisy on first touch (page-in costs).
+    for line in &lines {
+        black_box(legacy_parse_line(black_box(line)));
+        black_box(parse_line(black_box(line)));
+    }
+
+    let (legacy_allocs, legacy_bytes) = record(|| {
+        for line in &lines {
+            black_box(legacy_parse_line(black_box(line)));
+        }
+    });
+
+    let (typed_allocs, typed_bytes) = record(|| {
+        for line in &lines {
+            black_box(parse_line(black_box(line)));
+        }
+    });
+
+    println!(
+        "F-108 allocation budget (1000 lines):\n  \
+         legacy Value-tree: {legacy_allocs} allocations, {legacy_bytes} bytes\n  \
+         typed (F-108):     {typed_allocs} allocations, {typed_bytes} bytes"
+    );
+
+    assert!(
+        typed_allocs < legacy_allocs,
+        "F-108 DoD: typed path must allocate less than the legacy Value-tree \
+         path — measured legacy={legacy_allocs} typed={typed_allocs}"
+    );
+
+    // The text-delta common case carries no JSON escapes in the corpus, so the
+    // Cow field borrows from the source buffer and only the emission String
+    // allocates. 1000 lines ≈ 1000 text-delta emissions + ~10 tool-call
+    // branches. Anything meaningfully above ~1100 allocations means the Cow
+    // path is silently owning when it shouldn't.
+    assert!(
+        typed_allocs < 2 * lines.len(),
+        "F-108 DoD: typed path exceeded ~1 allocation per text-delta token — \
+         measured {typed_allocs} for {} lines; Cow<'_, str> is likely falling \
+         back to Owned on a path that could borrow",
+        lines.len()
+    );
+}
+
+criterion_group!(benches, bench_parse_line, assert_alloc_reduction);
+criterion_main!(benches);

--- a/crates/forge-providers/src/ollama.rs
+++ b/crates/forge-providers/src/ollama.rs
@@ -21,6 +21,7 @@
 //! conditions that occur *before* the NDJSON decoder starts and therefore
 //! cannot be caught by its stream-level timers.
 
+use std::borrow::Cow;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
@@ -28,6 +29,7 @@ use crate::{ChatChunk, ChatMessage, ChatRequest, Provider, StreamErrorKind};
 use forge_core::Result;
 use futures::stream::{BoxStream, StreamExt};
 use reqwest::Url;
+use serde::Deserialize;
 
 pub const DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434";
 
@@ -473,45 +475,88 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
-fn parse_line(line: &str) -> Option<ChatChunk> {
-    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+// ── NDJSON line decode ────────────────────────────────────────────────────────
+//
+// F-108: this was previously a two-step decode (`serde_json::from_str::<Value>`
+// then `Value::get(..).as_str().to_string()`), which allocated three Strings
+// per streamed text-delta token — the hottest per-token path in the app.
+//
+// The structures below deserialize a single line directly into stack storage.
+// String fields carry `Cow<'a, str>`, so `#[serde(borrow)]` points them at the
+// input slice for the common case (no JSON escapes) and only allocates when
+// unescaping is necessary. `.into_owned()` runs exactly once at the
+// `ChatChunk::*` emission boundary, matching the "0 or 1 allocation per
+// text-delta token" budget in the F-108 DoD.
+//
+// `tool_calls` / `arguments` are held as owned `serde_json::Value` so the
+// previous `.cloned()` on the tool-call path is now a move. That replaces one
+// `Value`-tree clone per tool-call token (issue §Finding, line 498).
+//
+// `#[serde(default)]` on every optional field means the common text-delta
+// shape (`{"message":{"content":".."},"done":false}`) deserializes without
+// erroring on missing tool-call / done-reason fields.
+#[derive(Deserialize)]
+struct RawLine<'a> {
+    #[serde(default)]
+    done: bool,
+    #[serde(default, borrow)]
+    done_reason: Option<Cow<'a, str>>,
+    #[serde(default, borrow)]
+    message: Option<RawMessage<'a>>,
+}
 
-    if value.get("done").and_then(|d| d.as_bool()) == Some(true) {
-        let reason = value
-            .get("done_reason")
-            .and_then(|r| r.as_str())
-            .unwrap_or("")
-            .to_string();
+#[derive(Deserialize)]
+struct RawMessage<'a> {
+    #[serde(default, borrow)]
+    content: Option<Cow<'a, str>>,
+    #[serde(default)]
+    tool_calls: Vec<RawToolCall<'a>>,
+}
+
+#[derive(Deserialize)]
+struct RawToolCall<'a> {
+    #[serde(borrow)]
+    function: Option<RawFunction<'a>>,
+}
+
+#[derive(Deserialize)]
+struct RawFunction<'a> {
+    #[serde(borrow)]
+    name: Cow<'a, str>,
+    #[serde(default)]
+    arguments: serde_json::Value,
+}
+
+/// Parse one Ollama NDJSON line into a [`ChatChunk`]. Public for the criterion
+/// bench at `benches/ollama_stream.rs`; not part of the stable API surface.
+#[doc(hidden)]
+pub fn parse_line(line: &str) -> Option<ChatChunk> {
+    let raw: RawLine<'_> = serde_json::from_str(line).ok()?;
+
+    if raw.done {
+        let reason = raw.done_reason.map(Cow::into_owned).unwrap_or_default();
         return Some(ChatChunk::Done(reason));
     }
 
-    if let Some(first_call) = value
-        .get("message")
-        .and_then(|m| m.get("tool_calls"))
-        .and_then(|tc| tc.as_array())
-        .and_then(|arr| arr.first())
-    {
-        if let Some(func) = first_call.get("function") {
-            let name = func.get("name").and_then(|n| n.as_str())?.to_string();
-            let args = func
-                .get("arguments")
-                .cloned()
-                .unwrap_or(serde_json::Value::Null);
-            return Some(ChatChunk::ToolCall { name, args });
+    let message = raw.message?;
+
+    // Tool-call chunks take priority over the text field — the shape is
+    // `{"content":"","tool_calls":[..]}` and the empty content would otherwise
+    // be discarded by the text-delta branch below.
+    if let Some(first) = message.tool_calls.into_iter().next() {
+        if let Some(func) = first.function {
+            return Some(ChatChunk::ToolCall {
+                name: func.name.into_owned(),
+                args: func.arguments,
+            });
         }
     }
 
-    if let Some(content) = value
-        .get("message")
-        .and_then(|m| m.get("content"))
-        .and_then(|c| c.as_str())
-    {
-        if !content.is_empty() {
-            return Some(ChatChunk::TextDelta(content.to_string()));
-        }
+    let content = message.content?;
+    if content.is_empty() {
+        return None;
     }
-
-    None
+    Some(ChatChunk::TextDelta(content.into_owned()))
 }
 
 /// Cap on `log_unparseable_line` emissions per process. A hostile or buggy
@@ -752,6 +797,45 @@ mod tests {
                 args: serde_json::json!({"path": "/tmp/x"}),
             })
         );
+    }
+
+    // F-108: tool-call chunks used to carry an empty `content: ""` field
+    // alongside `tool_calls`; the old `Value`-tree parser discarded that field
+    // by testing `!content.is_empty()` after the tool-call branch. The typed
+    // parser must preserve that ordering — tool_calls win over empty content.
+    #[test]
+    fn parse_line_tool_call_beats_empty_content() {
+        let line = r#"{"message":{"content":"","tool_calls":[{"function":{"name":"n","arguments":{}}}]},"done":false}"#;
+        assert!(matches!(parse_line(line), Some(ChatChunk::ToolCall { .. })));
+    }
+
+    // F-108: the common-case text delta has no `tool_calls`, no `done_reason`,
+    // and no `done: true`. The typed decode must accept the lean shape without
+    // requiring a `done: false` field.
+    #[test]
+    fn parse_line_text_delta_accepts_lean_shape() {
+        let line = r#"{"message":{"content":"hello"}}"#;
+        assert_eq!(parse_line(line), Some(ChatChunk::TextDelta("hello".into())));
+    }
+
+    // F-108: JSON escapes in the content field exercise the Cow::Owned path
+    // (serde must allocate to unescape). The decoded payload must still be
+    // the unescaped string, not the raw source bytes.
+    #[test]
+    fn parse_line_text_delta_with_escapes_is_unescaped() {
+        let line = r#"{"message":{"content":"a\"b\nc"},"done":false}"#;
+        assert_eq!(
+            parse_line(line),
+            Some(ChatChunk::TextDelta("a\"b\nc".into()))
+        );
+    }
+
+    // F-108: empty content with no tool_calls emits nothing (the stream sends
+    // these as keepalives on some models).
+    #[test]
+    fn parse_line_empty_content_without_tool_calls_returns_none() {
+        let line = r#"{"message":{"content":""},"done":false}"#;
+        assert_eq!(parse_line(line), None);
     }
 
     // ── validate_base_url: scheme/host policy ─────────────────────────────────


### PR DESCRIPTION
Closes forge-ide/forge#212

## Summary

`parse_line` was the hottest per-token path in the app — every streamed Ollama token flowed through it, and the two-step decode (`serde_json::from_str::<Value>` + `Value::get(..).as_str().to_string()`) allocated ~3 Strings per text-delta token plus a full `Value` tree. A 2000-token response allocated ~6000 Strings needlessly; allocator pressure surfaced as jitter on lower-end hardware during long responses.

- Replaced the `Value`-tree decode with a typed `#[derive(Deserialize)]` tower (`RawLine` → `RawMessage` → `RawToolCall` → `RawFunction`) using `#[serde(borrow)]` + `Cow<'_, str>` for the `content`, `done_reason`, and `name` fields. The `Cow` borrows from the NDJSON input slice for the common no-escape text token; `.into_owned()` runs exactly once at the `ChatChunk::*` emission boundary — **1 allocation per text-delta token** instead of 3+.
- Tool-call `arguments` is now an owned `serde_json::Value` deserialized in place, so the prior `.cloned()` at line 498 is now a move. No `Arc<Value>` indirection was needed.
- Added criterion bench at `crates/forge-providers/benches/ollama_stream.rs` with a `#[global_allocator]` counting wrapper over `System`. Feeds 1000 mock NDJSON lines through both the legacy `Value`-tree path (inlined in the bench for baseline evidence) and the new typed path, and asserts a strict allocation reduction.

### Measured delta (1000-line mixed corpus: text deltas + periodic tool calls)

| | allocations | bytes | wall time |
|---|---|---|---|
| legacy `Value`-tree | 9128 | 1,329,503 | 319 µs |
| typed (F-108) | **1040** | **12,695** | **125 µs** |

~8.8× allocation reduction, ~105× bytes reduction, ~2.5× faster. Typed-path alloc count matches the DoD's "0 or 1 allocation per text-delta token" budget.

### Design notes for the reviewer

- `parse_line` is now `#[doc(hidden)] pub fn` because criterion benches link as external crates. This is the minimum public-surface leak needed to satisfy the DoD's bench requirement; `#[doc(hidden)]` keeps it off the rustdoc surface.
- The public `ChatChunk` and `Provider` trait shapes are unchanged. `Arc<str>` hoisting on delta payloads is F-112's concern (per the F-107 / F-108 / F-112 parallel-work coordination note).
- `#[serde(default)]` on every optional field lets the lean common-case shape (`{"message":{"content":".."}}`) decode without requiring a `done: false` field.
- Tool-call priority over empty content is preserved (regression-locked by `parse_line_tool_call_beats_empty_content`).

## Test plan

- `cargo test --workspace` passes (workspace-wide; 28 unit + 7 integration tests in `forge-providers` including the 4 new F-108 regression tests)
- `cargo clippy --all-targets --workspace -- -D warnings` passes
- `cargo bench -p forge-providers` runs cleanly and asserts the allocation reduction

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the `forge-finish-task` handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)