### PR TITLE
fix(forge-shell): release SessionConnections lock before write_frame in subscribe (F-109)

### DIFF
--- a/crates/forge-shell/src/bridge.rs
+++ b/crates/forge-shell/src/bridge.rs
@@ -5,6 +5,19 @@
 //! tests spawn a real `forge-session` daemon, drive the bridge via
 //! [`SessionBridge`], and capture forwarded events through a generic
 //! [`EventSink`].
+//!
+//! **Locking discipline (F-109):** no function in this file may hold the
+//! `SessionConnections` map lock (`inner`) across an `.await` point. The
+//! map lock serializes every Tauri command's lookup; holding it across a
+//! UDS write stalls concurrent commands on unrelated sessions. The pattern
+//! is always: acquire → capture the per-connection handle (writer `Arc`,
+//! reader `Option`) → drop → await → re-acquire briefly to install state.
+//! The `clippy::await_holding_lock` deny below is structural documentation:
+//! it catches `std::sync::Mutex` regressions even though it does not cover
+//! `tokio::sync::Mutex` (tokio's guards are deliberately excluded from that
+//! lint). Reviewers and the accompanying concurrency regression test are
+//! the enforcement for the tokio case.
+#![deny(clippy::await_holding_lock)]
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -171,32 +184,70 @@ impl SessionBridge {
 
     /// Send `Subscribe { since }` to the daemon and spawn a background task
     /// that reads event frames and delivers them to `sink`. Idempotent per
-    /// connection: a second call is a no-op (task already running).
+    /// connection: a second call is a no-op (task already running or in
+    /// flight).
+    ///
+    /// **F-109:** this function must not hold the `SessionConnections` map
+    /// lock across any `.await`. The sequence is:
+    ///
+    /// 1. Lock the map, validate, clone the writer `Arc`, take the reader
+    ///    half (which also acts as a "subscription-in-flight" reservation),
+    ///    drop the lock.
+    /// 2. Await `write_frame` on the per-connection writer mutex.
+    /// 3. Re-acquire the map lock briefly to install the reader task, or —
+    ///    if the write failed — restore the reader so a retry is possible.
+    ///
+    /// A concurrent second call that lands between step 1 and step 3 sees
+    /// `reader: None` and treats the subscription as already in flight; it
+    /// returns `Ok(())` rather than failing with "reader already consumed".
     pub async fn subscribe(
         &self,
         session_id: &str,
         since: u64,
         sink: Arc<dyn EventSink>,
     ) -> Result<()> {
-        let mut map = self.connections.inner.lock().await;
-        let conn = map
-            .get_mut(session_id)
-            .ok_or_else(|| anyhow!("session_subscribe: no active connection for {session_id}"))?;
+        // Step 1: capture per-connection handles under the map lock, then
+        // drop the lock before any `.await`.
+        let (writer, reader) = {
+            let mut map = self.connections.inner.lock().await;
+            let conn = map.get_mut(session_id).ok_or_else(|| {
+                anyhow!("session_subscribe: no active connection for {session_id}")
+            })?;
 
-        if conn.reader_task.is_some() {
-            return Ok(());
-        }
+            // Idempotent in two states: reader_task already spawned, or an
+            // in-flight subscribe has reserved the reader by taking it.
+            if conn.reader_task.is_some() || conn.reader.is_none() {
+                return Ok(());
+            }
 
+            let writer = Arc::clone(&conn.writer);
+            // Reserve the reader under the map lock so a racing call sees
+            // `reader: None` and bails early rather than duplicating the
+            // subscribe frame or fighting for the reader half.
+            let reader = conn.reader.take().expect("reader present per check above");
+            (writer, reader)
+        };
+
+        // Step 2: await the Subscribe frame with the map lock released.
         let sub = IpcMessage::Subscribe(Subscribe { since });
-        {
-            let mut writer = conn.writer.lock().await;
-            write_frame(&mut *writer, &sub).await?;
+        let write_result = {
+            let mut writer_guard = writer.lock().await;
+            write_frame(&mut *writer_guard, &sub).await
+        };
+
+        // Step 3: re-acquire the map lock briefly to either install the
+        // reader task or restore the reader on failure.
+        let mut map = self.connections.inner.lock().await;
+        let conn = map.get_mut(session_id).ok_or_else(|| {
+            anyhow!("session_subscribe: connection for {session_id} disappeared mid-subscribe")
+        })?;
+
+        if let Err(err) = write_result {
+            // Put the reader back so a subsequent subscribe can try again.
+            conn.reader = Some(reader);
+            return Err(err);
         }
 
-        let reader = conn
-            .reader
-            .take()
-            .ok_or_else(|| anyhow!("session_subscribe: reader already consumed"))?;
         let session_id_owned = session_id.to_string();
         let task = tokio::spawn(async move {
             pump_events(reader, session_id_owned, sink).await;
@@ -249,6 +300,21 @@ impl SessionBridge {
             .get(session_id)
             .ok_or_else(|| anyhow!("no active connection for session {session_id}"))?;
         Ok(Arc::clone(&conn.writer))
+    }
+
+    /// Test-only accessor for a session's writer mutex. Used by concurrency
+    /// tests (F-109) to externally hold the writer so a `subscribe()` frame
+    /// write stalls deterministically, then verify that unrelated sessions'
+    /// commands are not blocked behind the `SessionConnections` map lock.
+    ///
+    /// Not used in production paths.
+    #[doc(hidden)]
+    pub async fn writer_arc_for_testing(
+        &self,
+        session_id: &str,
+    ) -> Option<Arc<Mutex<OwnedWriteHalf>>> {
+        let map = self.connections.inner.lock().await;
+        map.get(session_id).map(|c| Arc::clone(&c.writer))
     }
 }
 

--- a/crates/forge-shell/tests/bridge_e2e.rs
+++ b/crates/forge-shell/tests/bridge_e2e.rs
@@ -149,6 +149,87 @@ async fn approve_tool_proxies_to_daemon() {
         .expect("reject_tool writes frame");
 }
 
+/// F-109: `subscribe()` must not hold the `SessionConnections` map lock
+/// across its `write_frame().await`. If it does, a concurrent command on a
+/// *different* session blocks behind that lock even though its own writer
+/// is unrelated. This test stalls session A's `write_frame` inside
+/// `subscribe()` by externally holding A's writer mutex, then asserts that
+/// `send_message("B", …)` still completes within a tight timeout.
+///
+/// - Without the fix: `subscribe(A)` holds the map lock while awaiting
+///   `writer_A.lock()`. `send_message(B)` calls `writer_for(B)`, which
+///   tries to acquire the same map lock — deadlocks until A's writer is
+///   released. The test times out.
+/// - With the fix: `subscribe(A)` releases the map lock before awaiting
+///   `writer_A.lock()`. `send_message(B)` grabs the map lock, captures B's
+///   writer, writes the frame, and returns. The assertion holds.
+///
+/// The timeout (500 ms) is two orders of magnitude above the expected
+/// send_message latency on a loopback UDS; any flake here almost certainly
+/// indicates a genuine regression of the locking discipline.
+#[tokio::test]
+async fn subscribe_does_not_block_concurrent_send_on_other_session() {
+    let sock_dir = TempDir::new().unwrap();
+    let sock_a = sock_dir.path().join("a.sock");
+    let sock_b = sock_dir.path().join("b.sock");
+    let _daemon_a = spawn_daemon(&sock_a, "session-a").await;
+    let _daemon_b = spawn_daemon(&sock_b, "session-b").await;
+
+    let bridge = SessionBridge::new(SessionConnections::new());
+    bridge
+        .hello("session-a", Some(&sock_a))
+        .await
+        .expect("hello a");
+    bridge
+        .hello("session-b", Some(&sock_b))
+        .await
+        .expect("hello b");
+
+    // Externally hold session A's writer mutex. Any subsequent call that
+    // tries to lock it will stall until we drop this guard.
+    let writer_a = bridge
+        .writer_arc_for_testing("session-a")
+        .await
+        .expect("writer for a");
+    let writer_a_guard = writer_a.lock().await;
+
+    // Fire subscribe(A) in a background task. Its `write_frame` will hang
+    // waiting for the writer mutex we hold. In the buggy version it would
+    // also be holding the `SessionConnections` map lock.
+    let bridge_clone = bridge.clone();
+    let (tx_a, _rx_a) = mpsc::unbounded_channel();
+    let subscribe_task = tokio::spawn(async move {
+        bridge_clone
+            .subscribe("session-a", 0, Arc::new(ChannelSink { tx: tx_a }))
+            .await
+    });
+
+    // Yield so the subscribe task actually reaches its stall point before
+    // we race send_message against it. A brief sleep is sufficient; the
+    // task only needs to pass through its initial lock-acquire/drop.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // This call must NOT block on session A's stall. Under the fix it
+    // completes in < 1 ms on loopback; the 500 ms timeout is pure safety
+    // margin. Under the bug it blocks until writer_a_guard is dropped.
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        bridge.send_message("session-b", "ping".to_string()),
+    )
+    .await;
+
+    // Drop our hold on writer A so the subscribe task can finish cleanly.
+    drop(writer_a_guard);
+    let _ = subscribe_task.await;
+
+    let send_result = result.expect(
+        "send_message(B) timed out while subscribe(A) was stalled: the \
+         SessionConnections map lock is being held across an .await in \
+         subscribe() (F-109 regression)",
+    );
+    send_result.expect("send_message(B) frame write");
+}
+
 #[tokio::test]
 async fn hello_twice_for_same_session_is_rejected() {
     let sock_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixes [#213](https://github.com/forge-ide/forge/issues/213) — F-109: `subscribe()` in `crates/forge-shell/src/bridge.rs` held the `SessionConnections` HashMap lock across `write_frame().await`, stalling every concurrent Tauri command that called `writer_for(..)` on the same lock.

- Refactor `subscribe()` to the lock-capture-drop-await-reacquire pattern: acquire, clone the writer `Arc` and take the reader half, drop the lock, await the `Subscribe` frame, then re-acquire briefly to install the reader task (or restore the reader on write failure).
- Add `#![deny(clippy::await_holding_lock)]` at the module top as documented structural regression insurance (the lint does not cover `tokio::sync::Mutex` guards; the accompanying test is the enforcement for the tokio case).
- Add `subscribe_does_not_block_concurrent_send_on_other_session` — a deterministic integration test that stalls session A's `write_frame` and asserts `send_message(B)` still completes within a 500 ms timeout. Confirmed to fail on the unpatched `subscribe()` (with the exact error message surfaced) and pass on the fix.

### Behavioral note

The idempotency check now also short-circuits when a concurrent `subscribe()` on the same session has taken the reader but not yet finished writing (`reader.is_none() && reader_task.is_none()`). Previously, the racing call would return `Err("reader already consumed")`. Callers that treated `subscribe()` as idempotent already could not depend on that error path; eventual-subscribe semantics are preserved.

## Definition of Done

- [ ] `subscribe()` refactored so the connections lock is never held across `.await`
- [ ] Clippy lint `await_holding_lock` (or `tokio::await_holding_lock` pattern) scan passes across the file
- [ ] Integration test for concurrent subscribe + send_message latency; passes with fix, fails without
- [ ] Tests pass in CI

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p forge-shell --all-targets -- -D warnings` clean (default features, i.e. with `webview`)
- [x] `cargo clippy -p forge-shell --no-default-features --all-targets -- -D warnings` clean
- [x] `cargo test -p forge-shell --no-default-features` — all pass
- [x] `cargo test -p forge-shell --features webview-test` — all pass (including the new regression test)
- [x] Regression test verified RED against a temporary revert of `subscribe()` to the buggy version, then GREEN on the fix
- [x] `cargo check --workspace` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)