### PR TITLE
perf(forge-core): back ID wrapper types with Arc<str> for cheap clones (F-107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +407,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -528,6 +567,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +614,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -848,6 +927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1178,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "criterion",
  "forge-cli",
  "forge-core",
  "forge-fs",
@@ -1589,6 +1675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,10 +2065,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2531,6 +2648,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "option-ext"
@@ -4306,6 +4429,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/forge-core/src/ids.rs
+++ b/crates/forge-core/src/ids.rs
@@ -1,7 +1,16 @@
+use std::sync::Arc;
+
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+// F-107: IDs store their hex payload in `Arc<str>` so `.clone()` on a hot
+// path (orchestrator event emission, per-token AssistantDelta) is a
+// ref-count bump rather than a heap allocation. Public API — constructors,
+// `Display`, `Serialize`/`Deserialize`, `PartialEq`, `Hash` — is unchanged;
+// the wire shape remains a bare JSON string and ts-rs still emits
+// `export type <Id> = string`. See the `*_clone_is_shared_allocation`
+// tests at the bottom of the file for the contract.
 macro_rules! id_type {
     ($(#[$attr:meta])* $name:ident) => {
         id_type!($(#[$attr])* $name, 8);
@@ -10,19 +19,25 @@ macro_rules! id_type {
         $(#[$attr])*
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
         #[ts(export, export_to = "../../../web/packages/ipc/src/generated/", type = "string")]
-        pub struct $name(String);
+        // serde's built-in `Deserialize` for `Arc<str>` is gated behind the
+        // `rc` feature (not enabled here), so we go through `String` for the
+        // wire round-trip. The wrap cost only pays at construction time;
+        // cloning stays O(refcount_bump).
+        #[serde(from = "String", into = "String")]
+        pub struct $name(Arc<str>);
 
         impl $name {
             pub fn new() -> Self {
                 let bytes: [u8; $bytes] = rand::thread_rng().gen();
-                Self(bytes.iter().map(|b| format!("{b:02x}")).collect())
+                let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+                Self(Arc::from(hex))
             }
 
             /// Wrap an existing string as this id type. Use when the id was
             /// generated elsewhere (e.g. read from env, a meta file, or a
             /// client message) and the wire shape is just a string.
             pub fn from_string(s: String) -> Self {
-                Self(s)
+                Self(Arc::from(s))
             }
         }
 
@@ -35,6 +50,19 @@ macro_rules! id_type {
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{}", self.0)
+            }
+        }
+
+        // Bridges for `#[serde(from = "String", into = "String")]`.
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(Arc::from(s))
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(id: $name) -> Self {
+                id.0.as_ref().to_owned()
             }
         }
     };
@@ -73,7 +101,7 @@ mod tests {
 
     #[test]
     fn session_id_display_is_hex() {
-        let id = SessionId(String::from("deadbeefcafebabe"));
+        let id = SessionId(Arc::from("deadbeefcafebabe"));
         assert_eq!(id.to_string(), "deadbeefcafebabe");
     }
 
@@ -112,6 +140,46 @@ mod tests {
             id.to_string().len(),
             16,
             "SessionId must remain 16 hex chars to match F-057/F-063 validators"
+        );
+    }
+
+    // F-107: cloning an id must be a ref-count bump, not a heap allocation.
+    // Hot-path emission sites in `forge-session::orchestrator` clone IDs
+    // (msg_id, provider_id, call_id) multiple times per streamed token; any
+    // per-clone allocation is observable as allocator pressure on long
+    // responses. We enforce the contract at the type level: identical
+    // byte-pointer after clone == shared backing buffer.
+    #[test]
+    fn message_id_clone_is_shared_allocation() {
+        let id = MessageId::new();
+        let cloned = id.clone();
+        assert_eq!(
+            id.0.as_ptr(),
+            cloned.0.as_ptr(),
+            "MessageId::clone() must share its backing buffer (Arc<str> or equivalent) \
+             to keep per-token cost O(refcount_bump)"
+        );
+    }
+
+    #[test]
+    fn provider_id_clone_is_shared_allocation() {
+        let id = ProviderId::new();
+        let cloned = id.clone();
+        assert_eq!(
+            id.0.as_ptr(),
+            cloned.0.as_ptr(),
+            "ProviderId::clone() must share its backing buffer"
+        );
+    }
+
+    #[test]
+    fn tool_call_id_clone_is_shared_allocation() {
+        let id = ToolCallId::new();
+        let cloned = id.clone();
+        assert_eq!(
+            id.0.as_ptr(),
+            cloned.0.as_ptr(),
+            "ToolCallId::clone() must share its backing buffer"
         );
     }
 }

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -26,12 +26,17 @@ thiserror = "1"
 tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync", "process", "time", "signal"] }
 
 [dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 forge-cli = { path = "../forge-cli" }
 libc = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 similar = "2"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros", "time", "net", "process"] }
+
+[[bench]]
+name = "orchestrator"
+harness = false
 
 [[test]]
 name = "headless_session_basic"

--- a/crates/forge-session/benches/orchestrator.rs
+++ b/crates/forge-session/benches/orchestrator.rs
@@ -1,0 +1,391 @@
+//! Per-token allocation-budget guard + throughput bench for the orchestrator
+//! event-emission hot path (F-107).
+//!
+//! The real hot path lives in `forge-session::orchestrator::run_request_loop`:
+//! for every streamed `ChatChunk::TextDelta`, the orchestrator clones
+//! `msg_id: MessageId` into a fresh `Event::AssistantDelta`. On a 2000-token
+//! response that's ~10k ID clones, and before F-107 each clone was a heap
+//! allocation (`String::clone`). F-107 changes the ID wrapper types to
+//! `Arc<str>` at rest; clones become ref-count bumps.
+//!
+//! This bench does two things:
+//!
+//! 1. Asserts that `MessageId`/`ProviderId`/`ToolCallId` clones allocate at
+//!    least 10× fewer times than a byte-identical `String`-backed shadow
+//!    ID ("naive pre-F-107") over a 1000-token synthetic stream. The
+//!    assertion runs during bench startup; **fails loudly on baseline**
+//!    (if someone reverts F-107, `MessageId` goes back to `String` and the
+//!    ratio collapses) and passes on the current impl.
+//!
+//! 2. Reports wall-clock throughput via criterion for both paths so future
+//!    regressions are visible as numbers, not just pass/fail.
+//!
+//! The naive shadow type is defined inline in this bench binary — production
+//! code has a single optimized path. This pattern mirrors F-111's
+//! `crates/forge-fs/benches/mutate.rs`.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use chrono::{DateTime, Utc};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use forge_core::ids::{MessageId, ProviderId, ToolCallId};
+
+// ---------------------------------------------------------------------------
+// Allocation-counting global allocator (mirrors F-111/forge-fs/benches).
+// ---------------------------------------------------------------------------
+
+struct CountingAllocator;
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+static ALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        System.alloc(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        System.alloc_zeroed(layout)
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        if new_size > layout.size() {
+            ALLOC_BYTES.fetch_add(new_size - layout.size(), Ordering::Relaxed);
+        }
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn snapshot() -> (usize, usize) {
+    (
+        ALLOC_COUNT.load(Ordering::Relaxed),
+        ALLOC_BYTES.load(Ordering::Relaxed),
+    )
+}
+
+fn delta(before: (usize, usize)) -> (usize, usize) {
+    let (c, b) = snapshot();
+    (c - before.0, b - before.1)
+}
+
+// ---------------------------------------------------------------------------
+// Naive pre-F-107 shadow ID types. `Clone` on these is a full heap allocation
+// — the exact behaviour the real types had before F-107 flipped them to
+// `Arc<str>`. Kept in the bench binary only; production has one path.
+// ---------------------------------------------------------------------------
+
+// The `.0` payload is never read directly — it's the byte buffer that
+// `Clone::clone` duplicates on every call, which is exactly the behaviour
+// under measurement. Suppress rust's dead-code analysis, which doesn't see
+// `Clone` reads as uses.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct NaiveMessageId(String);
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct NaiveProviderId(String);
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct NaiveToolCallId(String);
+
+/// Shadow of `Event::AssistantDelta` used by the naive path. Carries the
+/// same three pieces the real event does so the two paths are doing
+/// byte-equivalent work aside from the ID clone semantics.
+#[allow(dead_code)] // fields read via Debug / black_box, not direct access
+#[derive(Debug)]
+struct NaiveAssistantDelta {
+    id: NaiveMessageId,
+    at: DateTime<Utc>,
+    delta: String,
+}
+
+/// Shadow of `Event::AssistantMessage`. The orchestrator emits this on open
+/// and on every finalisation, cloning `provider`+`msg_id` each time.
+#[allow(dead_code)]
+#[derive(Debug)]
+struct NaiveAssistantMessage {
+    id: NaiveMessageId,
+    provider: NaiveProviderId,
+    model: String,
+    at: DateTime<Utc>,
+    text: String,
+}
+
+/// Shadow of `Event::ToolCallStarted` — fewer hot-path hits per response than
+/// `AssistantDelta` but still cloned twice per tool call.
+#[allow(dead_code)]
+#[derive(Debug)]
+struct NaiveToolCallStarted {
+    id: NaiveToolCallId,
+    msg: NaiveMessageId,
+    at: DateTime<Utc>,
+}
+
+/// Optimized counterpart — the real `Arc<str>`-backed IDs from `forge-core`.
+#[allow(dead_code)]
+#[derive(Debug)]
+struct OptAssistantDelta {
+    id: MessageId,
+    at: DateTime<Utc>,
+    delta: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct OptAssistantMessage {
+    id: MessageId,
+    provider: ProviderId,
+    model: String,
+    at: DateTime<Utc>,
+    text: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct OptToolCallStarted {
+    id: ToolCallId,
+    msg: MessageId,
+    at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// Hot-loop drivers. Each driver clones the IDs for every "token" in the
+// synthetic stream, exactly the way `run_request_loop` does per chunk.
+// The `delta`/`text`/`model` strings are prebuilt outside the loop so their
+// allocations don't pollute the measurement — we're counting ID clones.
+// ---------------------------------------------------------------------------
+
+const TOKENS: usize = 1_000;
+
+// The `delta: String` field on `Event::AssistantDelta` is the token payload;
+// in the real path it arrives per-chunk from the provider stream and is
+// already owned. For the bench we isolate the *ID-clone* cost by constructing
+// the per-token delta via `String::new()` (zero-alloc) — both paths pay the
+// same zero-alloc for `delta`, so the ratio reflects *only* the change that
+// F-107 introduced: `String::clone` on IDs vs `Arc<str>::clone`.
+
+fn run_naive(
+    msg_id: &NaiveMessageId,
+    provider_id: &NaiveProviderId,
+    sink: &mut Vec<NaiveAssistantDelta>,
+) {
+    sink.clear();
+    let at = Utc::now();
+    // Open event (cloned provider + msg_id).
+    let _open = NaiveAssistantMessage {
+        id: msg_id.clone(),
+        provider: provider_id.clone(),
+        model: String::new(),
+        at,
+        text: String::new(),
+    };
+    black_box(&_open);
+    // Per-token AssistantDelta — the hot path.
+    for _ in 0..TOKENS {
+        sink.push(NaiveAssistantDelta {
+            id: msg_id.clone(),
+            at,
+            delta: String::new(),
+        });
+    }
+    // Final AssistantMessage (cloned provider + msg_id).
+    let _final = NaiveAssistantMessage {
+        id: msg_id.clone(),
+        provider: provider_id.clone(),
+        model: String::new(),
+        at,
+        text: String::new(),
+    };
+    black_box(&_final);
+}
+
+fn run_opt(msg_id: &MessageId, provider_id: &ProviderId, sink: &mut Vec<OptAssistantDelta>) {
+    sink.clear();
+    let at = Utc::now();
+    let _open = OptAssistantMessage {
+        id: msg_id.clone(),
+        provider: provider_id.clone(),
+        model: String::new(),
+        at,
+        text: String::new(),
+    };
+    black_box(&_open);
+    for _ in 0..TOKENS {
+        sink.push(OptAssistantDelta {
+            id: msg_id.clone(),
+            at,
+            delta: String::new(),
+        });
+    }
+    let _final = OptAssistantMessage {
+        id: msg_id.clone(),
+        provider: provider_id.clone(),
+        model: String::new(),
+        at,
+        text: String::new(),
+    };
+    black_box(&_final);
+}
+
+// ---------------------------------------------------------------------------
+// Allocation-budget guard. Runs once at startup; panics on regression.
+// ---------------------------------------------------------------------------
+
+/// Optimized path must allocate at most `naive / REQUIRED_RATIO` times.
+/// The `Arc<str>` clones themselves are zero-alloc; the remaining allocs
+/// come from the `delta: String` clones and the sink `Vec` growth, which
+/// are identical in both paths. So the ratio is dominated by the N
+/// `String::clone` calls on the naive IDs vs. zero on `Arc<str>`.
+const REQUIRED_RATIO: usize = 10;
+
+fn assert_allocation_budget() {
+    let naive_msg = NaiveMessageId("aabbccddeeff0011".to_string());
+    let naive_provider = NaiveProviderId("mock-provider-id".to_string());
+    let opt_msg = MessageId::from_string("aabbccddeeff0011".to_string());
+    let opt_provider = ProviderId::from_string("mock-provider-id".to_string());
+
+    // Pre-allocate the sinks so their initial `Vec::with_capacity` alloc is
+    // out of the measurement window — both paths then only pay for any
+    // overflow growth, which is identical between them.
+    let mut naive_sink: Vec<NaiveAssistantDelta> = Vec::with_capacity(TOKENS);
+    let mut opt_sink: Vec<OptAssistantDelta> = Vec::with_capacity(TOKENS);
+
+    // Warm run to drop any lazily-initialised statics out of the counters.
+    run_naive(&naive_msg, &naive_provider, &mut naive_sink);
+    run_opt(&opt_msg, &opt_provider, &mut opt_sink);
+
+    let before = snapshot();
+    run_naive(&naive_msg, &naive_provider, &mut naive_sink);
+    let (naive_allocs, naive_bytes) = delta(before);
+
+    let before = snapshot();
+    run_opt(&opt_msg, &opt_provider, &mut opt_sink);
+    let (opt_allocs, opt_bytes) = delta(before);
+
+    eprintln!(
+        "F-107 allocation budget: optimized={opt_allocs} allocs ({opt_bytes} bytes), \
+         naive={naive_allocs} allocs ({naive_bytes} bytes), \
+         ratio={:.2}x",
+        naive_allocs as f64 / opt_allocs.max(1) as f64
+    );
+
+    assert!(
+        opt_allocs * REQUIRED_RATIO <= naive_allocs,
+        "F-107 allocation budget regression: optimized path did {opt_allocs} allocations \
+         over {TOKENS} tokens, naive did {naive_allocs}; required >={REQUIRED_RATIO}x reduction \
+         (i.e. optimized <= {} allocations)",
+        naive_allocs / REQUIRED_RATIO
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tool-call hot path — emits the second-order ID type (ToolCallId) and
+// exercises the msg+tool-id dual-clone shape.
+// ---------------------------------------------------------------------------
+
+const TOOL_CALLS: usize = 100;
+
+fn run_naive_toolcalls(
+    msg_id: &NaiveMessageId,
+    call_id: &NaiveToolCallId,
+    sink: &mut Vec<NaiveToolCallStarted>,
+) {
+    sink.clear();
+    let at = Utc::now();
+    for _ in 0..TOOL_CALLS {
+        // ToolCallStarted → ToolCallApproved → ToolCallCompleted is the
+        // per-call triple; orchestrator clones call_id 3-4× per call.
+        for _ in 0..4 {
+            sink.push(NaiveToolCallStarted {
+                id: call_id.clone(),
+                msg: msg_id.clone(),
+                at,
+            });
+        }
+    }
+}
+
+fn run_opt_toolcalls(msg_id: &MessageId, call_id: &ToolCallId, sink: &mut Vec<OptToolCallStarted>) {
+    sink.clear();
+    let at = Utc::now();
+    for _ in 0..TOOL_CALLS {
+        for _ in 0..4 {
+            sink.push(OptToolCallStarted {
+                id: call_id.clone(),
+                msg: msg_id.clone(),
+                at,
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Criterion — wall-clock throughput. The allocation-budget guard above is
+// the real gate; these numbers exist so perf regressions show up as drift
+// over time, per the F-107 DoD ("events/sec materially improved").
+// ---------------------------------------------------------------------------
+
+fn bench_event_emission(c: &mut Criterion) {
+    // Gate: if allocations regress, fail loudly before criterion prints.
+    assert_allocation_budget();
+
+    let naive_msg = NaiveMessageId("aabbccddeeff0011".to_string());
+    let naive_provider = NaiveProviderId("mock-provider-id".to_string());
+    let naive_call = NaiveToolCallId("aabbccddeeff00112233445566778899".to_string());
+    let opt_msg = MessageId::from_string("aabbccddeeff0011".to_string());
+    let opt_provider = ProviderId::from_string("mock-provider-id".to_string());
+    let opt_call = ToolCallId::from_string("aabbccddeeff00112233445566778899".to_string());
+
+    let mut naive_sink: Vec<NaiveAssistantDelta> = Vec::with_capacity(TOKENS);
+    let mut opt_sink: Vec<OptAssistantDelta> = Vec::with_capacity(TOKENS);
+
+    let mut group = c.benchmark_group("orchestrator_event_emission");
+    group.sample_size(20);
+    group.bench_function("arc_str_1000_tokens", |b| {
+        b.iter(|| {
+            run_opt(black_box(&opt_msg), black_box(&opt_provider), &mut opt_sink);
+        })
+    });
+    group.bench_function("naive_string_1000_tokens", |b| {
+        b.iter(|| {
+            run_naive(
+                black_box(&naive_msg),
+                black_box(&naive_provider),
+                &mut naive_sink,
+            );
+        })
+    });
+    group.finish();
+
+    let mut naive_tc: Vec<NaiveToolCallStarted> = Vec::with_capacity(TOOL_CALLS * 4);
+    let mut opt_tc: Vec<OptToolCallStarted> = Vec::with_capacity(TOOL_CALLS * 4);
+
+    let mut group = c.benchmark_group("orchestrator_tool_call_emission");
+    group.sample_size(20);
+    group.bench_function("arc_str_100_tool_calls", |b| {
+        b.iter(|| {
+            run_opt_toolcalls(black_box(&opt_msg), black_box(&opt_call), &mut opt_tc);
+        })
+    });
+    group.bench_function("naive_string_100_tool_calls", |b| {
+        b.iter(|| {
+            run_naive_toolcalls(black_box(&naive_msg), black_box(&naive_call), &mut naive_tc);
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_event_emission);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Flip `id_type!`-generated wrapper types (`SessionId`, `WorkspaceId`, `AgentId`, `ProviderId`, `MessageId`, `ToolCallId`, `AgentInstanceId`) from `String` to `Arc<str>` at rest so `.clone()` on hot paths is a ref-count bump, not a heap allocation. The fix is at the type level — every existing `.clone()` call site, including the 15+ per-iteration clones in `run_request_loop`, becomes cheap automatically with no orchestrator.rs logic change.
- Public API preserved: constructors, `Display`, `PartialEq`, `Hash`, serde wire shape (bare JSON string), and ts-rs bindings (`export type <Id> = string`) are byte-identical. Serde bridges via `#[serde(from = "String", into = "String")]` because serde's built-in `Deserialize for Arc<str>` is gated behind the `rc` feature.
- Add `crates/forge-session/benches/orchestrator.rs` mirroring F-111's `forge-fs/benches/mutate.rs` pattern: `CountingAllocator` global + `String`-backed shadow IDs defined inline. Startup gate asserts a **10x** allocation reduction between the naive (pre-F-107) and optimized paths over a 1000-token synthetic stream; criterion reports wall-clock throughput for both.

## Measured delta

On this hardware, over 1000 synthetic tokens:
- Allocation count: **0** (optimized) vs **1004** (naive) — **1004x reduction** (vs 10x gate)
- Event-emission throughput: **~14.5 µs** (optimized) vs **~25.8 µs** (naive) — **~1.78x faster**
- Tool-call emission (100 calls × 4 clones/call): **~9.2 µs** vs **~17.6 µs** — **~1.9x faster**

## Scope notes

- The macro edit covers all 7 `id_type!` invocations, not just the 3 named in the issue (`provider_id`, `model`, `msg_id`). This is intentional: the issue's three hot clones were the worst offenders, but every ID-clone call site in the codebase benefits, and bifurcating storage by wrapper name would add complexity without benefit.
- `model` in the orchestrator is a `String`, not an ID wrapper, so it is not covered by this change. Follow-up could intern it similarly if needed; the issue's measured hot-path hits are dominated by `msg_id`/`provider_id`/`call_id`.
- Only files touched: `crates/forge-core/src/ids.rs`, `crates/forge-session/Cargo.toml`, `crates/forge-session/benches/orchestrator.rs`, `Cargo.lock`. No TS bindings regenerated (wire type unchanged).

## Test plan

- [x] 3 new RED tests in `ids.rs` (`{message,provider,tool_call}_id_clone_is_shared_allocation`) verify `Arc<str>` backing-buffer sharing via pointer equality — fail on `String`, pass on `Arc<str>`.
- [x] Bench startup gate: asserts `opt_allocs * 10 <= naive_allocs`; fails loudly on baseline regression.
- [x] `cargo test --workspace` — all pre-existing tests pass, including `session_id_serde_roundtrip` and `all_id_types_serde_roundtrip` (wire contract preserved).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `git status web/` — clean (no TS binding drift).

Closes #211

---

Related: F-108 (parse_line per-token allocations — upstream layer), F-112 (IPC hot-type Arc<str> + double-serialization — downstream layer), F-111 (bench harness template — same allocation-counting pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)