### PR TITLE
fix(docs): unlink rustdoc intra-doc links to private/cfg-gated items

### DIFF
--- a/crates/forge-fs/src/lib.rs
+++ b/crates/forge-fs/src/lib.rs
@@ -28,15 +28,15 @@ pub struct ReadResult {
 /// `read_file` uses **strict** [`std::fs::canonicalize`], which fails when any
 /// component of `path` is missing or a broken symlink. This is intentional and
 /// asymmetric with [`mutate::write`] / [`mutate::edit`], which use
-/// [`canonicalize_no_symlink`] — a lenient helper that accepts not-yet-existing
+/// `canonicalize_no_symlink` — a lenient helper that accepts not-yet-existing
 /// targets so a caller can `fs.write` a brand-new file.
 ///
 /// Threat-model rationale: a read against a non-existent path can only ever
 /// fail (there is nothing to read), and surfacing the failure as an explicit
 /// `Io` error keeps the trust boundary loud. By contrast, `write` and `edit`
 /// must support file creation — the path-traversal protection there comes from
-/// the explicit symlink-component check in [`canonicalize_no_symlink`] plus
-/// the [`enforce_allowed`] glob match against the resolved parent. Both entry
+/// the explicit symlink-component check in `canonicalize_no_symlink` plus
+/// the `enforce_allowed` glob match against the resolved parent. Both entry
 /// points still reject `..` traversal because the canonical form is what gets
 /// glob-matched; the asymmetry is purely about whether the leaf must exist.
 pub fn read_file(

--- a/crates/forge-fs/src/mutate.rs
+++ b/crates/forge-fs/src/mutate.rs
@@ -54,7 +54,7 @@ pub struct ApprovalPreview {
 /// # Canonicalization policy (write vs read asymmetry)
 ///
 /// Unlike [`crate::read_file`], which uses strict [`std::fs::canonicalize`],
-/// `write` uses [`crate::canonicalize_no_symlink`] — a lenient helper that
+/// `write` uses `canonicalize_no_symlink` — a lenient helper that
 /// canonicalizes the parent directory and joins the file name, so a
 /// not-yet-existing leaf is permitted. This is required for the
 /// file-creation case; without it `fs.write` could only ever overwrite
@@ -116,7 +116,7 @@ pub fn write(
 ///
 /// # Canonicalization policy (edit vs read asymmetry)
 ///
-/// `edit` uses the same lenient [`crate::canonicalize_no_symlink`] as
+/// `edit` uses the same lenient `canonicalize_no_symlink` as
 /// [`write()`] (not the strict [`std::fs::canonicalize`] used by
 /// [`crate::read_file`]) so the helper is shared across both mutation paths.
 /// `edit` then explicitly re-asserts that the canonical target *is* a file

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -94,7 +94,7 @@ pub(crate) fn require_size(field: &str, value: &str, limit_bytes: usize) -> Resu
 /// accepts a webview-supplied socket path; the path is always derived via
 /// [`crate::bridge::default_socket_path`]. Integration tests (which run
 /// against ephemeral tempdir sockets) wire an override through the
-/// `webview-test`-gated [`Self::test_socket_override`] field. The field is
+/// `webview-test`-gated `test_socket_override` field. The field is
 /// absent from production builds entirely.
 pub struct BridgeState {
     pub bridge: SessionBridge,


### PR DESCRIPTION
## Summary

Main CI has been red on `cargo doc` because six intra-doc links on the `main` tip point to private (`pub(crate)`) helpers or `#[cfg]`-gated fields. `F-097` turned on `rustdoc::broken_intra_doc_links` and `rustdoc::private_intra_doc_links` as deny-lints, which escalates those from warnings to errors.

The references are narrative (the doc text is explaining behavior, not pointing at an API item), so the minimal fix is to strip the bracket syntax and leave plain code spans. No API surface change; no semantic change.

## Changes

- `crates/forge-fs/src/lib.rs` — `read_file` doc: unlink `canonicalize_no_symlink` (×2), `enforce_allowed`
- `crates/forge-fs/src/mutate.rs` — `write` doc: unlink `crate::canonicalize_no_symlink`; `edit` doc: unlink `crate::canonicalize_no_symlink`
- `crates/forge-shell/src/ipc.rs` — `BridgeState` doc: unlink `Self::test_socket_override` (the field only exists under `#[cfg(feature = "webview-test")]`, so it's invisible to default-feature rustdoc)

Total: 6 insertions / 6 deletions across 3 files.

## Why this appeared now

The lint became deny-level with F-097 (#205). Any intra-doc link that points to a private or cfg-gated item is now a build failure, not a warning. The six sites fixed here have been in the codebase for some time; they became fatal only after F-097 flipped the lint level.

## Test plan

- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` — passes locally
- [x] `cargo fmt --check` — clean
- [x] No runtime code affected; docs-only change

## Unblocks

PRs #218, #219, #220, #221, #222, #223, #224 (the Phase 1 perf audit fix cluster). All currently fail CI on the inherited `cargo doc` failure from main. After this merges, those PRs will go green on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)