### PR TITLE
fix(ci): add audit.toml to mirror deny.toml advisory ignores

### DIFF
--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,44 @@
+# cargo-audit configuration for forge.
+#
+# Mirrors the `[advisories].ignore` list in `deny.toml`. Both files exist
+# because CI runs both `rustsec/audit-check` (which reads `audit.toml`)
+# and `cargo deny check` (which reads `deny.toml`). Keep the two lists
+# in sync — when updating one, update the other.
+#
+# Every entry here is an informational advisory (`unmaintained` or
+# `unsound`) on a transitive dep we cannot upgrade from this repo —
+# they all reach Forge via Tauri 2's webkit2gtk chain or its proc-macro
+# toolchain. No crate with a real `vulnerability` advisory is present.
+#
+# See `deny.toml` for the rationale on each entry, and
+# `docs/dev/security.md` for the suppression policy.
+
+[advisories]
+ignore = [
+    # gtk-rs GTK3 family — archived upstream, pulled transitively by Tauri 2.
+    "RUSTSEC-2024-0411",
+    "RUSTSEC-2024-0412",
+    "RUSTSEC-2024-0413",
+    "RUSTSEC-2024-0414",
+    "RUSTSEC-2024-0415",
+    "RUSTSEC-2024-0416",
+    "RUSTSEC-2024-0417",
+    "RUSTSEC-2024-0418",
+    "RUSTSEC-2024-0419",
+    "RUSTSEC-2024-0420",
+
+    # open-i18n/rust-unic family — archived upstream, pulled via Tauri macros.
+    "RUSTSEC-2025-0075",
+    "RUSTSEC-2025-0080",
+    "RUSTSEC-2025-0081",
+    "RUSTSEC-2025-0098",
+    "RUSTSEC-2025-0100",
+
+    # Misc unmaintained transitives.
+    "RUSTSEC-2025-0057",
+    "RUSTSEC-2024-0370",
+
+    # Unsound in transitive deps — not reachable from Forge code paths.
+    "RUSTSEC-2024-0429",
+    "RUSTSEC-2026-0097",
+]


### PR DESCRIPTION
## Summary

Main CI has been failing on the `cargo audit` step since the Phase 1 perf-fix cluster (#218-#224) merged. Root cause: `rustsec/audit-check@v2.0.0` fails on informational advisories even with `denyWarnings: false` configured. The project's policy is already documented: `deny.toml` suppresses all 19 advisories with 6-month expiry dates — but `cargo-audit` (used by the audit-check action) doesn't read `deny.toml`.

Fix: add `audit.toml` at repo root with the same ignore list. `cargo-audit` reads this file automatically, and the GitHub Action then exits 0.

## Changes

- `audit.toml` (new, 44 lines) — 19 RUSTSEC IDs, organized by ecosystem (gtk-rs, unic-*, misc unmaintained, unsound), with a top comment explaining the two-file pattern and pointing to `deny.toml` as the canonical source.

## Verification

Local `cargo audit` run with the new file:
```
warning: 19 allowed warnings found
exit=0
```

All 19 are informational (`unmaintained` or `unsound`) on transitive deps — zero `vulnerability`-severity entries per the action's own JSON output (`\"vulnerabilities\":{\"count\":0}`).

## Unblocks

- Phase 1 release (all 7 perf fixes #218-#224 have merged, main CI has been red since).
- Any subsequent PR whose CI currently inherits this failure.

## Long-term

The two-file pattern is a workaround for the action's semantics. A later cleanup could either:

- Remove the `cargo audit` step from `.github/workflows/ci.yml` entirely — `cargo deny check` covers the same advisory surface and reads `deny.toml` authoritatively.
- Replace the action with a direct `cargo audit` invocation that honors `deny.toml` via a small wrapper.

Not doing either here to keep the fix minimal and audit-trail clear.

## Test plan

- [x] `cargo audit` passes locally with the new file
- [x] Zero new advisory types added to the ignore list; every entry already existed in `deny.toml`
- [ ] CI green on this PR (will verify after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)