### PR TITLE
feat(app): split-pane primitives SplitPane + GridContainer (F-117)

### DIFF
--- a/web/packages/app/src/layout/GridContainer.test.tsx
+++ b/web/packages/app/src/layout/GridContainer.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@solidjs/testing-library';
+import { GridContainer, type LayoutNode } from './GridContainer';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('GridContainer — leaf rendering', () => {
+  it('renders a single leaf tree by calling its render callback', () => {
+    const tree: LayoutNode = {
+      kind: 'leaf',
+      id: 'chat-1',
+      render: () => <div data-testid="leaf-content">hello</div>,
+    };
+    const { getByTestId } = render(() => (
+      <GridContainer tree={tree} onRatioChange={vi.fn()} />
+    ));
+    expect(getByTestId('leaf-content').textContent).toBe('hello');
+    expect(getByTestId('grid-leaf-chat-1')).toBeTruthy();
+  });
+});
+
+describe('GridContainer — recursive split tree', () => {
+  it('renders nested H/V splits with the correct leaves', () => {
+    // Shape: v-split [ chat | h-split [ editor / terminal ] ]
+    const tree: LayoutNode = {
+      kind: 'split',
+      id: 'root',
+      direction: 'v',
+      ratio: 0.5,
+      a: {
+        kind: 'leaf',
+        id: 'chat',
+        render: () => <div data-testid="chat">chat</div>,
+      },
+      b: {
+        kind: 'split',
+        id: 'right',
+        direction: 'h',
+        ratio: 0.6,
+        a: {
+          kind: 'leaf',
+          id: 'editor',
+          render: () => <div data-testid="editor">editor</div>,
+        },
+        b: {
+          kind: 'leaf',
+          id: 'terminal',
+          render: () => <div data-testid="terminal">terminal</div>,
+        },
+      },
+    };
+
+    const { getAllByTestId, getByTestId } = render(() => (
+      <GridContainer tree={tree} onRatioChange={vi.fn()} />
+    ));
+
+    expect(getByTestId('chat')).toBeTruthy();
+    expect(getByTestId('editor')).toBeTruthy();
+    expect(getByTestId('terminal')).toBeTruthy();
+
+    const splits = getAllByTestId('split-pane');
+    // Two SplitPane nodes: the root v-split and the nested h-split.
+    expect(splits.length).toBe(2);
+    const [rootSplit, innerSplit] = splits as [HTMLElement, HTMLElement];
+    expect(rootSplit.getAttribute('data-direction')).toBe('v');
+    expect(innerSplit.getAttribute('data-direction')).toBe('h');
+  });
+
+  it('propagates onRatioChange with the originating split node id', () => {
+    const onRatioChange = vi.fn();
+    const tree: LayoutNode = {
+      kind: 'split',
+      id: 'root',
+      direction: 'v',
+      ratio: 0.5,
+      a: {
+        kind: 'split',
+        id: 'left',
+        direction: 'h',
+        ratio: 0.5,
+        a: { kind: 'leaf', id: 'a1', render: () => <div>a1</div> },
+        b: { kind: 'leaf', id: 'a2', render: () => <div>a2</div> },
+      },
+      b: { kind: 'leaf', id: 'b1', render: () => <div>b1</div> },
+    };
+
+    const { getAllByTestId } = render(() => (
+      <GridContainer tree={tree} onRatioChange={onRatioChange} />
+    ));
+
+    const splits = getAllByTestId('split-pane') as HTMLElement[];
+    // Double-click the inner (h) split divider → 'left' should be the id.
+    const innerSplit = splits[1] as HTMLElement;
+    const innerDivider = innerSplit.querySelector(
+      '[data-testid="split-pane-divider"]',
+    ) as HTMLElement;
+    innerDivider.dispatchEvent(
+      new MouseEvent('dblclick', { bubbles: true, cancelable: true }),
+    );
+
+    expect(onRatioChange).toHaveBeenCalledWith('left', 0.5);
+  });
+});

--- a/web/packages/app/src/layout/GridContainer.tsx
+++ b/web/packages/app/src/layout/GridContainer.tsx
@@ -1,0 +1,83 @@
+import { type Component, type JSX, Match, Switch } from 'solid-js';
+import { SplitPane } from './SplitPane';
+
+/**
+ * A terminal node in the layout tree. `render` produces the pane body for
+ * the leaf — F-117 stays agnostic about pane type (chat, terminal, editor,
+ * files, agent monitor); the caller supplies the renderer.
+ */
+export interface LeafNode {
+  kind: 'leaf';
+  id: string;
+  render: () => JSX.Element;
+}
+
+/**
+ * An internal node that splits its area between `a` and `b`. `ratio` is the
+ * fraction of the container occupied by `a` (0..1).
+ */
+export interface SplitNode {
+  kind: 'split';
+  id: string;
+  direction: 'h' | 'v';
+  ratio: number;
+  a: LayoutNode;
+  b: LayoutNode;
+}
+
+export type LayoutNode = LeafNode | SplitNode;
+
+export interface GridContainerProps {
+  /** The root of the layout tree. Arbitrarily deep H/V combinations. */
+  tree: LayoutNode;
+  /**
+   * Emitted when a split node's ratio changes (drag or double-click
+   * reset). `id` is the split node's id; the parent owns persistence
+   * and tree mutation. GridContainer keeps no state of its own.
+   */
+  onRatioChange: (id: string, next: number) => void;
+}
+
+/**
+ * Recursive N-ary layout renderer over `SplitPane`. Each split node maps to
+ * one `SplitPane`; each leaf renders via its callback. GridContainer is a
+ * pure function of its props — the tree walks parent-side, which keeps
+ * persistence (F-120) and drag-to-dock (F-118) trivial to layer on later.
+ */
+export const GridContainer: Component<GridContainerProps> = (props) => {
+  return <GridNode node={props.tree} onRatioChange={props.onRatioChange} />;
+};
+
+const GridNode: Component<{
+  node: LayoutNode;
+  onRatioChange: (id: string, next: number) => void;
+}> = (props) => {
+  return (
+    <Switch>
+      <Match when={props.node.kind === 'leaf' && (props.node as LeafNode)}>
+        {(leaf) => (
+          <div
+            class="grid-leaf"
+            data-testid={`grid-leaf-${leaf().id}`}
+            data-leaf-id={leaf().id}
+            style={{ width: '100%', height: '100%' }}
+          >
+            {leaf().render()}
+          </div>
+        )}
+      </Match>
+      <Match when={props.node.kind === 'split' && (props.node as SplitNode)}>
+        {(split) => (
+          <SplitPane
+            direction={split().direction}
+            ratio={split().ratio}
+            onRatioChange={(next) => props.onRatioChange(split().id, next)}
+          >
+            <GridNode node={split().a} onRatioChange={props.onRatioChange} />
+            <GridNode node={split().b} onRatioChange={props.onRatioChange} />
+          </SplitPane>
+        )}
+      </Match>
+    </Switch>
+  );
+};

--- a/web/packages/app/src/layout/SplitPane.css
+++ b/web/packages/app/src/layout/SplitPane.css
@@ -1,0 +1,94 @@
+/*
+ * SplitPane — two-child splitter with draggable divider.
+ *
+ * Gridline is 1px in `--color-border-1` per layout-panes.md §3.1. The
+ * divider itself is a wider (≥8px) hit area that renders the 1px gridline
+ * via an inner pseudo-element so the resize affordance is comfortable to
+ * grab without visually inflating the line.
+ */
+
+.split-pane {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.split-pane--v {
+  flex-direction: row;
+}
+
+.split-pane--h {
+  flex-direction: column;
+}
+
+.split-pane__child {
+  position: relative;
+  overflow: hidden;
+  flex: 0 0 auto;
+  min-width: 0;
+  min-height: 0;
+}
+
+.split-pane--v > .split-pane__child {
+  height: 100%;
+}
+
+.split-pane--h > .split-pane__child {
+  width: 100%;
+}
+
+.split-pane__divider {
+  position: relative;
+  flex: 0 0 auto;
+  background: transparent;
+  touch-action: none;
+  user-select: none;
+}
+
+/* Vertical split → divider is a tall narrow bar with a col-resize cursor. */
+.split-pane--v > .split-pane__divider {
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+}
+
+/* Horizontal split → divider is a wide short bar with a row-resize cursor. */
+.split-pane--h > .split-pane__divider {
+  height: 8px;
+  width: 100%;
+  cursor: row-resize;
+}
+
+/* 1px gridline painted inside the hit area via a pseudo-element. */
+.split-pane__divider::before {
+  content: '';
+  position: absolute;
+  background: var(--color-border-1);
+}
+
+.split-pane--v > .split-pane__divider::before {
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  transform: translateX(-0.5px);
+}
+
+.split-pane--h > .split-pane__divider::before {
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  transform: translateY(-0.5px);
+}
+
+.split-pane__divider:hover::before,
+.split-pane__divider:focus-visible::before {
+  background: var(--color-border-2);
+}
+
+.split-pane__divider:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: -2px;
+}

--- a/web/packages/app/src/layout/SplitPane.test.tsx
+++ b/web/packages/app/src/layout/SplitPane.test.tsx
@@ -1,0 +1,300 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, fireEvent } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
+import { SplitPane, MIN_RATIO, RESET_RATIO, SNAP_PX } from './SplitPane';
+
+// jsdom returns {0,0,0,0} for getBoundingClientRect by default. The divider
+// drag math multiplies pointer delta by container extent, so we stub a
+// deterministic rect on every SplitPane root at render time. This runs at
+// the Element prototype level to avoid having to wire a ref through.
+function stubBoundingRect({ width, height }: { width: number; height: number }): () => void {
+  const original = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function stubbed(this: Element): DOMRect {
+    if (this instanceof HTMLElement && this.classList.contains('split-pane')) {
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        width,
+        height,
+        toJSON() {
+          return this;
+        },
+      } as DOMRect;
+    }
+    return original.call(this);
+  };
+  return () => {
+    Element.prototype.getBoundingClientRect = original;
+  };
+}
+
+// Minimal pointer-event dispatch for jsdom, which does not implement the
+// constructor out of the box. Using a PointerEvent-shaped MouseEvent is fine
+// for Solid's synthetic handlers — they read the familiar fields.
+function firePointer(
+  el: Element,
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  init: { clientX: number; clientY: number; altKey?: boolean; pointerId?: number; button?: number },
+) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX,
+    clientY: init.clientY,
+    altKey: init.altKey ?? false,
+    button: init.button ?? 0,
+  });
+  // Augment with pointerId + capture methods so setPointerCapture / has / release
+  // resolve without throwing under jsdom.
+  Object.defineProperty(event, 'pointerId', { value: init.pointerId ?? 1 });
+  if (!(el as HTMLElement).setPointerCapture) {
+    (el as HTMLElement).setPointerCapture = vi.fn();
+    (el as HTMLElement).releasePointerCapture = vi.fn();
+    (el as HTMLElement).hasPointerCapture = vi.fn(() => true);
+  }
+  fireEvent(el, event);
+}
+
+function Harness(initial: {
+  direction: 'h' | 'v';
+  ratio: number;
+  onChange?: (r: number) => void;
+}) {
+  const [r, setR] = createSignal(initial.ratio);
+  return {
+    component: () => (
+      <SplitPane
+        direction={initial.direction}
+        ratio={r()}
+        onRatioChange={(next) => {
+          initial.onChange?.(next);
+          setR(next);
+        }}
+      >
+        <div data-testid="first">first</div>
+        <div data-testid="second">second</div>
+      </SplitPane>
+    ),
+    ratio: r,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SplitPane — direction', () => {
+  it('vertical split lays children side by side', () => {
+    const h = Harness({ direction: 'v', ratio: 0.5 });
+    const { getByTestId } = render(h.component);
+    const root = getByTestId('split-pane');
+    expect(root.getAttribute('data-direction')).toBe('v');
+    const first = root.querySelector('.split-pane__child--first') as HTMLElement;
+    const second = root.querySelector('.split-pane__child--second') as HTMLElement;
+    expect(first.style.width).toBe('50%');
+    expect(second.style.width).toBe('50%');
+    // Height should NOT be set on children in vertical split — flex row.
+    expect(first.style.height).toBe('');
+  });
+
+  it('horizontal split stacks children top to bottom', () => {
+    const h = Harness({ direction: 'h', ratio: 0.3 });
+    const { getByTestId } = render(h.component);
+    const root = getByTestId('split-pane');
+    expect(root.getAttribute('data-direction')).toBe('h');
+    const first = root.querySelector('.split-pane__child--first') as HTMLElement;
+    const second = root.querySelector('.split-pane__child--second') as HTMLElement;
+    expect(first.style.height).toBe('30%');
+    expect(second.style.height).toBe('70%');
+    expect(first.style.width).toBe('');
+  });
+});
+
+describe('SplitPane — divider hit area & cursor', () => {
+  it('vertical divider has a ≥8px hit area and a vertical separator role', () => {
+    const h = Harness({ direction: 'v', ratio: 0.5 });
+    const { getByTestId } = render(h.component);
+    const divider = getByTestId('split-pane-divider');
+    expect(divider.getAttribute('role')).toBe('separator');
+    expect(divider.getAttribute('aria-orientation')).toBe('vertical');
+    // Width is driven by CSS (`.split-pane--v > .split-pane__divider { width: 8px }`).
+    // jsdom doesn't apply the stylesheet, so we assert the class wiring
+    // that makes the 8px rule match. Visual width is covered by CSS itself.
+    expect(divider.parentElement?.classList.contains('split-pane--v')).toBe(true);
+  });
+
+  it('horizontal divider exposes horizontal orientation for AT', () => {
+    const h = Harness({ direction: 'h', ratio: 0.5 });
+    const { getByTestId } = render(h.component);
+    const divider = getByTestId('split-pane-divider');
+    expect(divider.getAttribute('aria-orientation')).toBe('horizontal');
+    expect(divider.parentElement?.classList.contains('split-pane--h')).toBe(true);
+  });
+});
+
+describe('SplitPane — resize drag (vertical)', () => {
+  it('drags the divider and emits the new ratio', () => {
+    const restore = stubBoundingRect({ width: 1000, height: 600 });
+    try {
+      const onChange = vi.fn();
+      const h = Harness({ direction: 'v', ratio: 0.5, onChange });
+      const { getByTestId } = render(h.component);
+      const divider = getByTestId('split-pane-divider');
+
+      // Drag from the 500px mark to the 700px mark → ratio ≈ 0.7 (snapped to 4px).
+      firePointer(divider, 'pointerdown', { clientX: 500, clientY: 300 });
+      firePointer(divider, 'pointermove', { clientX: 700, clientY: 300 });
+      firePointer(divider, 'pointerup', { clientX: 700, clientY: 300 });
+
+      expect(onChange).toHaveBeenCalled();
+      const last = onChange.mock.calls.at(-1)?.[0] as number;
+      // 700 / 1000 = 0.7, and 700 is already a 4px multiple → exactly 0.7.
+      expect(last).toBeCloseTo(0.7, 5);
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not emit ratio changes on pointermove without pointerdown', () => {
+    const restore = stubBoundingRect({ width: 1000, height: 600 });
+    try {
+      const onChange = vi.fn();
+      const h = Harness({ direction: 'v', ratio: 0.5, onChange });
+      const { getByTestId } = render(h.component);
+      const divider = getByTestId('split-pane-divider');
+      firePointer(divider, 'pointermove', { clientX: 800, clientY: 300 });
+      expect(onChange).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('SplitPane — resize drag (horizontal)', () => {
+  it('uses the Y axis for ratio when direction is "h"', () => {
+    const restore = stubBoundingRect({ width: 1000, height: 600 });
+    try {
+      const onChange = vi.fn();
+      const h = Harness({ direction: 'h', ratio: 0.5, onChange });
+      const { getByTestId } = render(h.component);
+      const divider = getByTestId('split-pane-divider');
+      firePointer(divider, 'pointerdown', { clientX: 500, clientY: 300 });
+      firePointer(divider, 'pointermove', { clientX: 500, clientY: 180 });
+      firePointer(divider, 'pointerup', { clientX: 500, clientY: 180 });
+      const last = onChange.mock.calls.at(-1)?.[0] as number;
+      // 180 / 600 = 0.3, 180 is a 4px multiple.
+      expect(last).toBeCloseTo(0.3, 5);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('SplitPane — clamp to MIN_RATIO', () => {
+  it('clamps to MIN_RATIO when dragging below the floor', () => {
+    const restore = stubBoundingRect({ width: 1000, height: 600 });
+    try {
+      const onChange = vi.fn();
+      const h = Harness({ direction: 'v', ratio: 0.5, onChange });
+      const { getByTestId } = render(h.component);
+      const divider = getByTestId('split-pane-divider');
+      firePointer(divider, 'pointerdown', { clientX: 500, clientY: 300 });
+      // Well below the MIN_RATIO = 0.1 floor (50 / 1000 = 0.05).
+      firePointer(divider, 'pointermove', { clientX: 50, clientY: 300 });
+      firePointer(divider, 'pointerup', { clientX: 50, clientY: 300 });
+      const last = onChange.mock.calls.at(-1)?.[0] as number;
+      expect(last).toBeCloseTo(MIN_RATIO, 5);
+      expect(last).toBeGreaterThan(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('clamps to 1 - MIN_RATIO when dragging past the ceiling', () => {
+    const restore = stubBoundingRect({ width: 1000, height: 600 });
+    try {
+      const onChange = vi.fn();
+      const h = Harness({ direction: 'v', ratio: 0.5, onChange });
+      const { getByTestId } = render(h.component);
+      const divider = getByTestId('split-pane-divider');
+      firePointer(divider, 'pointerdown', { clientX: 500, clientY: 300 });
+      firePointer(divider, 'pointermove', { clientX: 980, clientY: 300 });
+      firePointer(divider, 'pointerup', { clientX: 980, clientY: 300 });
+      const last = onChange.mock.calls.at(-1)?.[0] as number;
+      expect(last).toBeCloseTo(1 - MIN_RATIO, 5);
+      expect(last).toBeLessThan(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('clamps the rendered size for out-of-range controlled ratios', () => {
+    // Negative ratio should never produce a negative width.
+    const h1 = Harness({ direction: 'v', ratio: -0.3 });
+    const { getByTestId: get1, unmount: unmount1 } = render(h1.component);
+    const root1 = get1('split-pane');
+    const first1 = root1.querySelector('.split-pane__child--first') as HTMLElement;
+    expect(first1.style.width).toBe(`${MIN_RATIO * 100}%`);
+    unmount1();
+
+    // Over-1.0 should not produce a >100% width.
+    const h2 = Harness({ direction: 'v', ratio: 1.5 });
+    const { getByTestId: get2 } = render(h2.component);
+    const root2 = get2('split-pane');
+    const first2 = root2.querySelector('.split-pane__child--first') as HTMLElement;
+    expect(first2.style.width).toBe(`${(1 - MIN_RATIO) * 100}%`);
+  });
+});
+
+describe('SplitPane — 4px snap & Alt-unsnapped (§3.1)', () => {
+  it('snaps drag to 4px increments by default', () => {
+    const restore = stubBoundingRect({ width: 1000, height: 600 });
+    try {
+      const onChange = vi.fn();
+      const h = Harness({ direction: 'v', ratio: 0.5, onChange });
+      const { getByTestId } = render(h.component);
+      const divider = getByTestId('split-pane-divider');
+      firePointer(divider, 'pointerdown', { clientX: 500, clientY: 300 });
+      // 503px is between snaps — should land on 504 → 0.504.
+      firePointer(divider, 'pointermove', { clientX: 503, clientY: 300 });
+      firePointer(divider, 'pointerup', { clientX: 503, clientY: 300 });
+      const last = onChange.mock.calls.at(-1)?.[0] as number;
+      const asPixels = last * 1000;
+      expect(asPixels % SNAP_PX).toBeCloseTo(0, 5);
+    } finally {
+      restore();
+    }
+  });
+
+  it('skips the snap when Alt is held', () => {
+    const restore = stubBoundingRect({ width: 1000, height: 600 });
+    try {
+      const onChange = vi.fn();
+      const h = Harness({ direction: 'v', ratio: 0.5, onChange });
+      const { getByTestId } = render(h.component);
+      const divider = getByTestId('split-pane-divider');
+      firePointer(divider, 'pointerdown', { clientX: 500, clientY: 300 });
+      firePointer(divider, 'pointermove', { clientX: 503, clientY: 300, altKey: true });
+      firePointer(divider, 'pointerup', { clientX: 503, clientY: 300, altKey: true });
+      const last = onChange.mock.calls.at(-1)?.[0] as number;
+      expect(last).toBeCloseTo(0.503, 5);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('SplitPane — double-click reset (§3.1)', () => {
+  it('resets to a balanced ratio when the divider is double-clicked', () => {
+    const onChange = vi.fn();
+    const h = Harness({ direction: 'v', ratio: 0.22, onChange });
+    const { getByTestId } = render(h.component);
+    const divider = getByTestId('split-pane-divider');
+    fireEvent.dblClick(divider);
+    expect(onChange).toHaveBeenCalledWith(RESET_RATIO);
+  });
+});

--- a/web/packages/app/src/layout/SplitPane.tsx
+++ b/web/packages/app/src/layout/SplitPane.tsx
@@ -1,0 +1,160 @@
+import { type Component, type JSX, createSignal } from 'solid-js';
+import './SplitPane.css';
+
+/**
+ * Minimum ratio floor for either child. F-117 is ratio-only — the 320px
+ * pixel minimum from `layout-panes.md` §3.7 is F-119 and intentionally
+ * out of scope here. This floor just stops the divider from producing
+ * a zero-width/height child or a negative value.
+ */
+export const MIN_RATIO = 0.1;
+
+/**
+ * Pixel snap increment for divider drag, per `layout-panes.md` §3.1:
+ * "Dragging resizes in 4px snaps; Alt+drag is unsnapped."
+ */
+export const SNAP_PX = 4;
+
+/** Balanced split used by the §3.1 double-click reset. */
+export const RESET_RATIO = 0.5;
+
+export interface SplitPaneProps {
+  /** `"h"` → children stacked top/bottom; `"v"` → side by side. */
+  direction: 'h' | 'v';
+  /** First child's size as a fraction of the container (0..1). */
+  ratio: number;
+  /** Emitted on drag and on double-click reset. Caller owns the ratio. */
+  onRatioChange: (next: number) => void;
+  /** First child (top for `"h"`, left for `"v"`). */
+  children: [JSX.Element, JSX.Element] | JSX.Element[];
+}
+
+/**
+ * Two-child splitter with a draggable divider. Ratio is controlled — the
+ * parent owns the value and receives updates through `onRatioChange`.
+ *
+ * Behavior comes from `docs/ui-specs/layout-panes.md`:
+ *   - §3.1 "Gridlines are 1px in `--color-border-1`. Dragging resizes in
+ *     4px snaps; Alt+drag is unsnapped. Double-clicking a gridline resets
+ *     to balanced split."
+ *   - §3.5 divider handle is the resize affordance — the ≥8px hit area and
+ *     `col-resize` / `row-resize` cursors live here; the buttons in the tab
+ *     bar are a separate concern.
+ *
+ * Out of scope (separate issues):
+ *   F-118 drag-to-dock · F-119 320px min-width collapse · F-120 persistence
+ */
+export const SplitPane: Component<SplitPaneProps> = (props) => {
+  let containerRef: HTMLDivElement | undefined;
+  const [dragging, setDragging] = createSignal(false);
+
+  const clamp = (r: number): number => {
+    if (r < MIN_RATIO) return MIN_RATIO;
+    if (r > 1 - MIN_RATIO) return 1 - MIN_RATIO;
+    return r;
+  };
+
+  // Translate an absolute pointer position into a clamped ratio along the
+  // split axis. `getBoundingClientRect()` is the right primitive for this —
+  // tests stub it on the container to supply a non-zero size in jsdom.
+  const ratioFromPointer = (clientX: number, clientY: number): number | null => {
+    if (!containerRef) return null;
+    const rect = containerRef.getBoundingClientRect();
+    const extent = props.direction === 'v' ? rect.width : rect.height;
+    if (extent <= 0) return null;
+    const offset =
+      props.direction === 'v' ? clientX - rect.left : clientY - rect.top;
+    return clamp(offset / extent);
+  };
+
+  // 4px snap per §3.1. Alt+drag bypasses the snap.
+  const applySnap = (raw: number, altPressed: boolean): number => {
+    if (altPressed || !containerRef) return raw;
+    const rect = containerRef.getBoundingClientRect();
+    const extent = props.direction === 'v' ? rect.width : rect.height;
+    if (extent <= 0) return raw;
+    const px = raw * extent;
+    const snapped = Math.round(px / SNAP_PX) * SNAP_PX;
+    return clamp(snapped / extent);
+  };
+
+  const handlePointerDown = (e: PointerEvent) => {
+    // Only primary button — Tauri's non-native window chrome makes the
+    // right/middle-button semantics of system panes less relevant here.
+    if (e.button !== 0) return;
+    const target = e.currentTarget as HTMLElement;
+    target.setPointerCapture(e.pointerId);
+    setDragging(true);
+    e.preventDefault();
+  };
+
+  const handlePointerMove = (e: PointerEvent) => {
+    if (!dragging()) return;
+    const raw = ratioFromPointer(e.clientX, e.clientY);
+    if (raw === null) return;
+    props.onRatioChange(applySnap(raw, e.altKey));
+  };
+
+  const handlePointerUp = (e: PointerEvent) => {
+    if (!dragging()) return;
+    const target = e.currentTarget as HTMLElement;
+    if (target.hasPointerCapture(e.pointerId)) {
+      target.releasePointerCapture(e.pointerId);
+    }
+    setDragging(false);
+  };
+
+  // §3.1: "Double-clicking a gridline resets to balanced split."
+  const handleDoubleClick = () => {
+    props.onRatioChange(RESET_RATIO);
+  };
+
+  const firstStyle = (): JSX.CSSProperties => {
+    const r = clamp(props.ratio);
+    return props.direction === 'v'
+      ? { width: `${r * 100}%` }
+      : { height: `${r * 100}%` };
+  };
+
+  const secondStyle = (): JSX.CSSProperties => {
+    const r = clamp(props.ratio);
+    const rest = 1 - r;
+    return props.direction === 'v'
+      ? { width: `${rest * 100}%` }
+      : { height: `${rest * 100}%` };
+  };
+
+  const [first, second] = props.children as [JSX.Element, JSX.Element];
+
+  return (
+    <div
+      class="split-pane"
+      classList={{
+        'split-pane--h': props.direction === 'h',
+        'split-pane--v': props.direction === 'v',
+      }}
+      data-direction={props.direction}
+      data-testid="split-pane"
+      ref={containerRef}
+    >
+      <div class="split-pane__child split-pane__child--first" style={firstStyle()}>
+        {first}
+      </div>
+      <div
+        class="split-pane__divider"
+        data-testid="split-pane-divider"
+        role="separator"
+        aria-orientation={props.direction === 'v' ? 'vertical' : 'horizontal'}
+        tabIndex={0}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onDblClick={handleDoubleClick}
+      />
+      <div class="split-pane__child split-pane__child--second" style={secondStyle()}>
+        {second}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Adds the foundational split/grid layout primitives to `web/packages/app` that every Phase 2 pane type (Editor, Terminal, Files, Chat, Agent Monitor) will dock into.

- `SplitPane` — ratio-based two-child splitter (`direction: "h" | "v"`, controlled `ratio` + `onRatioChange`) with an ≥8px-hit-area divider, 1px gridline in `--color-border-1`, `col-resize`/`row-resize` cursor feedback, 4px snap drag (Alt+drag unsnapped), double-click reset to balanced split, and a `MIN_RATIO = 0.1` clamp so no child ever goes negative.
- `GridContainer` — pure recursive renderer over a `{ kind: "split" | "leaf" }` tree. State-free: propagates `onRatioChange(id, next)` to the parent, so F-120 persistence and F-118 drag-to-dock layer in cleanly.
- Unit tests cover h/v split layout, drag math for both axes, `MIN_RATIO` floor/ceiling clamp, out-of-range controlled ratios, 4px snap + Alt bypass, double-click reset, and recursive tree rendering with propagated ratio changes.

Follows the layout model in `docs/ui-specs/layout-panes.md` §3.1–§3.5 and the design tokens in `docs/design/spacing-layout.md`.

**Out of scope (separate issues):** drag-to-dock (F-118), 320px min-width collapse (F-119), persistence (F-120).

Closes #231

## Test plan

- [x] `pnpm --filter app test` — 302 passed (16 new)
- [x] `pnpm --filter app typecheck` — clean
- [x] `pnpm --filter app build` — clean
- [x] `pnpm run check-tokens` — 57 tokens match

🤖 Generated with [Claude Code](https://claude.com/claude-code)