### PR TITLE
feat(forge-agents): AgentInstance + Orchestrator runtime foundation (F-133)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,9 +1102,15 @@ name = "forge-agents"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "forge-core",
+ "futures",
  "gray_matter",
  "serde",
  "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -4568,6 +4574,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/forge-agents/Cargo.toml
+++ b/crates/forge-agents/Cargo.toml
@@ -6,8 +6,15 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+forge-core = { path = "../forge-core" }
 gray_matter = "0.3"
 serde = { version = "1", features = ["derive"] }
+thiserror = "1"
+tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 
 [dev-dependencies]
+futures = "0.3"
 tempfile = "3"
+tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }

--- a/crates/forge-agents/README.md
+++ b/crates/forge-agents/README.md
@@ -1,21 +1,33 @@
 # forge-agents
 
-Loads agent definitions from the workspace and user home — `<workspace_root>/.agents/*.md` and `~/.agents/*.md` — parsing each Markdown file's YAML frontmatter into a typed `AgentDef` and merging the two scopes so workspace agents win on name collisions. Also reads the optional workspace-level `AGENTS.md` preamble that callers inject into every agent's system prompt. The richer orchestration responsibilities described in the architecture doc (sub-agent spawning, isolation enforcement, background agents) land in later phases; this Phase 1 crate is the loader.
+Agent definitions plus the runtime foundation. Parses `<workspace_root>/.agents/*.md` and `~/.agents/*.md` into typed `AgentDef`s (YAML frontmatter + prose body), merges user and workspace scopes so workspace agents win on name collisions, and reads the optional workspace-level `AGENTS.md` preamble. On top of that, exposes `Orchestrator` — the runtime side that instantiates `AgentInstance`s, registers them by `AgentInstanceId`, and forwards lifecycle events on a broadcast stream. Sub-agent spawning (F-134), AGENTS.md injection (F-135), sub-agent banners (F-136), background agents (F-137), and the session-side `AgentMonitor` (F-140) compose on this foundation.
 
 ## Role in the workspace
 
-- Depended on by: future session/orchestrator wiring (see `docs/architecture/crate-architecture.md` §3.4 for the Phase 2+ shape).
-- Depends on: `gray_matter` (YAML frontmatter), `serde`, `anyhow`.
+- Depends on: `forge-core` (`AgentInstanceId`), `gray_matter`, `serde`, `anyhow`, `thiserror`, `tokio`, `tokio-stream`, `chrono`.
+- Depended on by: upcoming session/orchestrator wiring (see `docs/architecture/crate-architecture.md` §3.4).
 
 ## Key types / entry points
 
-- `AgentDef` — parsed agent: `name`, optional `description`, prompt `body`, and `allowed_paths` glob list.
-- `parse_agent_file` (private) — single-file parser; rejects `isolation: trusted` for user-defined agents with a clear error.
-- `load_workspace_agents(workspace_root)` — load `<root>/.agents/*.md`, returning `Ok(vec![])` if the directory is absent.
-- `load_user_agents(user_home)` — load `<home>/.agents/*.md` similarly.
+Parser:
+
+- `AgentDef` — parsed agent: `name`, optional `description`, prompt `body`, `allowed_paths` glob list, `isolation`.
+- `Isolation` — `Trusted` (reserved for built-in skills), `Process` (default), `Container` (placeholder).
+- `load_workspace_agents(workspace_root)` / `load_user_agents(user_home)` — scan `<root>/.agents/*.md`.
 - `load_agents(workspace_root, user_home)` — merged loader: user first, workspace overlays by name.
 - `load_agents_md(workspace_root)` — read the optional `AGENTS.md` preamble.
 - `AgentLoader::{load, agents, agents_md}` — bundled one-shot loader used per session.
+
+Runtime:
+
+- `Orchestrator::new()` — build a registry + broadcast bus.
+- `Orchestrator::spawn(def, ctx)` — instantiate, register, emit `AgentEvent::Spawned`. Rejects user-scope `Isolation::Trusted` with the typed `Error::IsolationViolation` (enforced at parse time *and* again at runtime, covering programmatically-constructed defs).
+- `Orchestrator::stop(id)` / `Orchestrator::fail(id, reason)` — terminate an instance, emit the terminal `Completed` / `Failed` event.
+- `Orchestrator::record_step_started(id, step)` / `Orchestrator::record_step_finished(id, step)` — emit step transitions; `InstanceState` is not mutated (steps are events, not states).
+- `Orchestrator::state_stream()` — `BroadcastStream<AgentEvent>` subscribers consume to follow per-instance progress.
+- `AgentInstance { id, def, state, started_at }` — one live instantiation.
+- `AgentEvent::{Spawned, StepStarted, StepFinished, Completed, Failed}` — per-instance lifecycle vocabulary.
+- `SpawnContext::user()` / `SpawnContext::built_in()` — origin marker that governs the trusted-isolation escape hatch.
 
 ## Further reading
 

--- a/crates/forge-agents/src/def.rs
+++ b/crates/forge-agents/src/def.rs
@@ -1,0 +1,116 @@
+//! Agent definition types and the `.agents/*.md` loader.
+//!
+//! `AgentDef` is the parsed shape of one agent file; [`crate::AgentLoader`]
+//! bundles the workspace + user merge plus the optional `AGENTS.md` preamble.
+
+use anyhow::Context;
+use gray_matter::{engine::YAML, Matter, ParsedEntity};
+use serde::Deserialize;
+use std::{fs, path::Path};
+
+use crate::error::{Error, Result};
+
+/// Runtime isolation level applied to a live [`AgentInstance`](crate::AgentInstance).
+///
+/// `Trusted` bypasses sandboxing and is reserved for built-in skills shipped
+/// with Forge — user-authored agents are rejected both at parse time and at
+/// [`crate::Orchestrator::spawn`] if they declare it. `Process` is the
+/// default for user agents. `Container(_)` is planned for later phases; for
+/// now we encode the variant as `Container` (unit) so the enum is closed and
+/// future work can attach a `ContainerSpec` without a breaking rename.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum Isolation {
+    Trusted,
+    #[default]
+    Process,
+    Container,
+}
+
+/// Canonical agent definition parsed from a Markdown file with YAML frontmatter.
+///
+/// `name` defaults to the file stem when frontmatter is absent or omits it,
+/// `body` holds the prompt content with the frontmatter stripped, and
+/// `allowed_paths` scopes filesystem access for tools the agent may invoke.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentDef {
+    pub name: String,
+    pub description: Option<String>,
+    pub body: String,
+    pub allowed_paths: Vec<String>,
+    pub isolation: Isolation,
+}
+
+#[derive(Deserialize, Default)]
+struct Frontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    isolation: Option<String>,
+    allowed_paths: Option<Vec<String>>,
+}
+
+pub(crate) fn parse_agent_file(path: &Path) -> Result<AgentDef> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))
+        .map_err(Error::from)?;
+
+    let matter = Matter::<YAML>::new();
+    let parsed: ParsedEntity<Frontmatter> = matter
+        .parse(&raw)
+        .with_context(|| format!("parsing frontmatter in {}", path.display()))
+        .map_err(Error::from)?;
+
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    match parsed.data {
+        Some(fm) => {
+            let name = fm.name.unwrap_or_else(|| stem.clone());
+            let isolation = match fm.isolation.as_deref() {
+                Some("trusted") => {
+                    return Err(Error::IsolationViolation {
+                        name,
+                        path: Some(path.to_path_buf()),
+                    })
+                }
+                Some("container") => Isolation::Container,
+                Some("process") | None => Isolation::Process,
+                Some(other) => {
+                    return Err(Error::Other(anyhow::anyhow!(
+                        "unknown isolation level '{other}' in {}",
+                        path.display()
+                    )))
+                }
+            };
+            Ok(AgentDef {
+                name,
+                description: fm.description,
+                body: parsed.content,
+                allowed_paths: fm.allowed_paths.unwrap_or_default(),
+                isolation,
+            })
+        }
+        None => Ok(AgentDef {
+            name: stem,
+            description: None,
+            body: parsed.content,
+            allowed_paths: vec![],
+            isolation: Isolation::Process,
+        }),
+    }
+}
+
+pub(crate) fn load_from_dir(dir: &Path) -> Result<Vec<AgentDef>> {
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut paths: Vec<_> = fs::read_dir(dir)
+        .map_err(|e| Error::Other(anyhow::Error::from(e)))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
+        .collect();
+    paths.sort();
+    paths.iter().map(|p| parse_agent_file(p)).collect()
+}

--- a/crates/forge-agents/src/error.rs
+++ b/crates/forge-agents/src/error.rs
@@ -1,0 +1,33 @@
+//! Typed errors for `forge-agents`.
+//!
+//! A typed error enum rather than bare `anyhow` so the isolation-violation
+//! branch can be pattern-matched by runtime callers (sub-agent spawners, IPC
+//! layers) without string-matching.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    /// A user-authored agent (parsed from `.agents/*.md` or `~/.agents/*.md`,
+    /// or constructed programmatically with `AgentScope::User`) declared
+    /// `isolation: trusted`. That level is reserved for built-in skills
+    /// shipped with Forge itself.
+    #[error("isolation: trusted is not allowed for user-defined agents ({name}{location})",
+            location = source_hint(path))]
+    IsolationViolation { name: String, path: Option<PathBuf> },
+
+    /// Parsing / IO / other non-isolation failures.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+fn source_hint(p: &Option<PathBuf>) -> String {
+    match p {
+        Some(path) => format!(" from {}", path.display()),
+        None => String::new(),
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/forge-agents/src/lib.rs
+++ b/crates/forge-agents/src/lib.rs
@@ -1,87 +1,35 @@
-use anyhow::{bail, Context, Result};
-use gray_matter::{engine::YAML, Matter, ParsedEntity};
-use serde::Deserialize;
+//! `forge-agents` — agent definitions, the `.agents/*.md` loader, and the
+//! runtime orchestrator.
+//!
+//! The loader merges workspace and user-home agent definitions; the runtime
+//! orchestrator instantiates them into live [`AgentInstance`]s and forwards
+//! their lifecycle on a broadcast stream. See:
+//!
+//! - `docs/architecture/crate-architecture.md` §3.4 for the design
+//! - `docs/design/ai-patterns.md` for the UX vocabulary
+
+mod def;
+mod error;
+mod orchestrator;
+
 use std::{fs, path::Path};
 
-/// Canonical agent definition parsed from a Markdown file with YAML frontmatter.
-///
-/// `name` defaults to the file stem when frontmatter is absent or omits it,
-/// `body` holds the prompt content with the frontmatter stripped, and
-/// `allowed_paths` scopes filesystem access for tools the agent may invoke.
-#[derive(Debug, Clone, PartialEq)]
-pub struct AgentDef {
-    pub name: String,
-    pub description: Option<String>,
-    pub body: String,
-    pub allowed_paths: Vec<String>,
-}
+pub use def::{AgentDef, Isolation};
+pub use error::{Error, Result};
+pub use orchestrator::{
+    AgentEvent, AgentInstance, AgentScope, InstanceState, Orchestrator, SpawnContext,
+};
 
-#[derive(Deserialize, Default)]
-struct Frontmatter {
-    name: Option<String>,
-    description: Option<String>,
-    isolation: Option<String>,
-    allowed_paths: Option<Vec<String>>,
-}
-
-fn parse_agent_file(path: &Path) -> Result<AgentDef> {
-    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-
-    let matter = Matter::<YAML>::new();
-    let parsed: ParsedEntity<Frontmatter> = matter
-        .parse(&raw)
-        .with_context(|| format!("parsing frontmatter in {}", path.display()))?;
-
-    let stem = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("unknown")
-        .to_string();
-
-    match parsed.data {
-        Some(fm) => {
-            if fm.isolation.as_deref() == Some("trusted") {
-                bail!(
-                    "isolation: trusted is not allowed for user-defined agents ({})",
-                    path.display()
-                );
-            }
-            Ok(AgentDef {
-                name: fm.name.unwrap_or(stem),
-                description: fm.description,
-                body: parsed.content,
-                allowed_paths: fm.allowed_paths.unwrap_or_default(),
-            })
-        }
-        None => Ok(AgentDef {
-            name: stem,
-            description: None,
-            body: parsed.content,
-            allowed_paths: vec![],
-        }),
-    }
-}
-
-fn load_from_dir(dir: &Path) -> Result<Vec<AgentDef>> {
-    if !dir.exists() {
-        return Ok(vec![]);
-    }
-    let mut paths: Vec<_> = fs::read_dir(dir)?
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
-        .collect();
-    paths.sort();
-    paths.iter().map(|p| parse_agent_file(p)).collect()
-}
+use def::load_from_dir;
 
 /// Load agents from `<workspace_root>/.agents/*.md`, returning an empty vec if the directory is absent.
-pub fn load_workspace_agents(workspace_root: &Path) -> Result<Vec<AgentDef>> {
-    load_from_dir(&workspace_root.join(".agents"))
+pub fn load_workspace_agents(workspace_root: &Path) -> anyhow::Result<Vec<AgentDef>> {
+    load_from_dir(&workspace_root.join(".agents")).map_err(anyhow::Error::from)
 }
 
 /// Load agents from `<user_home>/.agents/*.md`, returning an empty vec if the directory is absent.
-pub fn load_user_agents(user_home: &Path) -> Result<Vec<AgentDef>> {
-    load_from_dir(&user_home.join(".agents"))
+pub fn load_user_agents(user_home: &Path) -> anyhow::Result<Vec<AgentDef>> {
+    load_from_dir(&user_home.join(".agents")).map_err(anyhow::Error::from)
 }
 
 /// Load and merge user-home and workspace-local agent definitions.
@@ -90,7 +38,7 @@ pub fn load_user_agents(user_home: &Path) -> Result<Vec<AgentDef>> {
 /// that on a name collision the workspace definition replaces the user one,
 /// and workspace-only agents are appended. This lets a project pin or override
 /// agents without editing the user's home directory.
-pub fn load_agents(workspace_root: &Path, user_home: &Path) -> Result<Vec<AgentDef>> {
+pub fn load_agents(workspace_root: &Path, user_home: &Path) -> anyhow::Result<Vec<AgentDef>> {
     let workspace = load_workspace_agents(workspace_root)?;
     let mut merged = load_user_agents(user_home)?;
 
@@ -104,7 +52,7 @@ pub fn load_agents(workspace_root: &Path, user_home: &Path) -> Result<Vec<AgentD
 }
 
 /// Read `<workspace_root>/AGENTS.md` if present, returning `Ok(None)` when the file is absent.
-pub fn load_agents_md(workspace_root: &Path) -> Result<Option<String>> {
+pub fn load_agents_md(workspace_root: &Path) -> anyhow::Result<Option<String>> {
     let path = workspace_root.join("AGENTS.md");
     if path.exists() {
         Ok(Some(fs::read_to_string(path)?))
@@ -124,7 +72,7 @@ pub struct AgentLoader {
 
 impl AgentLoader {
     /// Load workspace + user agents and the workspace `AGENTS.md` in one pass.
-    pub fn load(workspace_root: &Path, user_home: &Path) -> Result<Self> {
+    pub fn load(workspace_root: &Path, user_home: &Path) -> anyhow::Result<Self> {
         Ok(Self {
             agents: load_agents(workspace_root, user_home)?,
             agents_md: load_agents_md(workspace_root)?,

--- a/crates/forge-agents/src/orchestrator.rs
+++ b/crates/forge-agents/src/orchestrator.rs
@@ -1,0 +1,240 @@
+//! Runtime orchestration for `forge-agents` (F-133).
+//!
+//! Provides:
+//! - [`AgentInstance`] — one live instantiation of an [`AgentDef`] with a
+//!   registry-assigned [`AgentInstanceId`].
+//! - [`Orchestrator`] — registers instances, emits per-instance lifecycle
+//!   events on a broadcast channel, enforces runtime isolation invariants.
+//! - [`AgentEvent`] — the event vocabulary consumers subscribe to via
+//!   [`Orchestrator::state_stream`].
+//!
+//! This layer is the foundation; sub-agent spawning (F-134), AGENTS.md
+//! injection (F-135), UI banners (F-136), background agents (F-137), and the
+//! session-side `AgentMonitor` (F-140) all compose on top.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use forge_core::AgentInstanceId;
+use tokio::sync::{broadcast, Mutex};
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::def::{AgentDef, Isolation};
+use crate::error::{Error, Result};
+
+/// Runtime lifecycle state of an [`AgentInstance`].
+///
+/// Distinct from [`AgentEvent`]: states are the *current* condition;
+/// `StepStarted`/`StepFinished` are per-step *transitions* reported on the
+/// event stream, not separate states.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstanceState {
+    Running,
+    Completed,
+    Failed { reason: String },
+}
+
+/// One live instantiation of an [`AgentDef`].
+#[derive(Debug, Clone)]
+pub struct AgentInstance {
+    pub id: AgentInstanceId,
+    pub def: AgentDef,
+    pub state: InstanceState,
+    pub started_at: DateTime<Utc>,
+}
+
+/// Origin marker for a spawn. User-scope agents have the [`Isolation::Trusted`]
+/// escape hatch removed at runtime; built-in skills keep it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentScope {
+    User,
+    BuiltIn,
+}
+
+/// Context passed to [`Orchestrator::spawn`]. Currently carries only the
+/// origin scope; future fields (parent id, session binding) land in F-134.
+#[derive(Debug, Clone)]
+pub struct SpawnContext {
+    pub scope: AgentScope,
+}
+
+impl SpawnContext {
+    pub fn user() -> Self {
+        Self {
+            scope: AgentScope::User,
+        }
+    }
+    pub fn built_in() -> Self {
+        Self {
+            scope: AgentScope::BuiltIn,
+        }
+    }
+}
+
+/// Lifecycle events emitted on the per-orchestrator broadcast stream.
+///
+/// Terminal events: `Completed`, `Failed`. Before the terminal event a given
+/// instance may emit any number of `StepStarted` / `StepFinished` pairs.
+#[derive(Debug, Clone)]
+pub enum AgentEvent {
+    Spawned {
+        id: AgentInstanceId,
+        at: DateTime<Utc>,
+    },
+    StepStarted {
+        id: AgentInstanceId,
+        step: String,
+        at: DateTime<Utc>,
+    },
+    StepFinished {
+        id: AgentInstanceId,
+        step: String,
+        at: DateTime<Utc>,
+    },
+    Completed {
+        id: AgentInstanceId,
+        at: DateTime<Utc>,
+    },
+    Failed {
+        id: AgentInstanceId,
+        reason: String,
+        at: DateTime<Utc>,
+    },
+}
+
+/// Channel capacity for the broadcast stream. Matches `forge-session`'s event
+/// bus (32) — enough headroom for a burst of step events without a single
+/// slow consumer dropping lifecycle signals.
+const EVENT_BUS_CAPACITY: usize = 64;
+
+/// Registers [`AgentInstance`]s, drives their lifecycle, and forwards
+/// per-instance events to subscribers.
+pub struct Orchestrator {
+    registry: Arc<Mutex<HashMap<AgentInstanceId, AgentInstance>>>,
+    tx: broadcast::Sender<AgentEvent>,
+}
+
+impl Orchestrator {
+    pub fn new() -> Self {
+        let (tx, _rx) = broadcast::channel(EVENT_BUS_CAPACITY);
+        Self {
+            registry: Arc::new(Mutex::new(HashMap::new())),
+            tx,
+        }
+    }
+
+    /// Instantiate an agent from its definition.
+    ///
+    /// Rejects `isolation: trusted` under [`AgentScope::User`] with a typed
+    /// [`Error::IsolationViolation`]. This re-enforces the parse-time check
+    /// for programmatically-constructed defs that bypass the parser.
+    pub async fn spawn(&self, def: AgentDef, ctx: SpawnContext) -> Result<AgentInstance> {
+        if ctx.scope == AgentScope::User && def.isolation == Isolation::Trusted {
+            return Err(Error::IsolationViolation {
+                name: def.name,
+                path: None,
+            });
+        }
+
+        let now = Utc::now();
+        let instance = AgentInstance {
+            id: AgentInstanceId::new(),
+            def,
+            state: InstanceState::Running,
+            started_at: now,
+        };
+
+        self.registry
+            .lock()
+            .await
+            .insert(instance.id.clone(), instance.clone());
+
+        // `send` fails only when no subscribers are attached; that is a
+        // no-op for us — the event is still valid, just nobody was listening.
+        let _ = self.tx.send(AgentEvent::Spawned {
+            id: instance.id.clone(),
+            at: now,
+        });
+
+        Ok(instance)
+    }
+
+    /// Drive an instance to [`InstanceState::Completed`] and emit the
+    /// terminal event. No-op (returns `Ok`) if the instance is already
+    /// terminal; unknown ids are a silent no-op as well — the orchestrator
+    /// refuses to panic on a stale id from an earlier session.
+    pub async fn stop(&self, id: &AgentInstanceId) -> Result<()> {
+        let mut reg = self.registry.lock().await;
+        if let Some(inst) = reg.get_mut(id) {
+            if matches!(inst.state, InstanceState::Running) {
+                inst.state = InstanceState::Completed;
+                let now = Utc::now();
+                let _ = self.tx.send(AgentEvent::Completed {
+                    id: id.clone(),
+                    at: now,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Drive an instance to [`InstanceState::Failed`] and emit the terminal
+    /// event. Symmetric to [`Orchestrator::stop`]. Exposed so tests and
+    /// F-134's spawner can signal failures without a real step executor.
+    pub async fn fail(&self, id: &AgentInstanceId, reason: String) -> Result<()> {
+        let mut reg = self.registry.lock().await;
+        if let Some(inst) = reg.get_mut(id) {
+            if matches!(inst.state, InstanceState::Running) {
+                inst.state = InstanceState::Failed {
+                    reason: reason.clone(),
+                };
+                let now = Utc::now();
+                let _ = self.tx.send(AgentEvent::Failed {
+                    id: id.clone(),
+                    reason,
+                    at: now,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Emit a `StepStarted` event against an instance. Does not mutate
+    /// `InstanceState` — steps are transitions, not states.
+    pub async fn record_step_started(&self, id: &AgentInstanceId, step: String) -> Result<()> {
+        let _ = self.tx.send(AgentEvent::StepStarted {
+            id: id.clone(),
+            step,
+            at: Utc::now(),
+        });
+        Ok(())
+    }
+
+    /// Emit a `StepFinished` event against an instance.
+    pub async fn record_step_finished(&self, id: &AgentInstanceId, step: String) -> Result<()> {
+        let _ = self.tx.send(AgentEvent::StepFinished {
+            id: id.clone(),
+            step,
+            at: Utc::now(),
+        });
+        Ok(())
+    }
+
+    /// Snapshot of a single instance.
+    pub async fn get(&self, id: &AgentInstanceId) -> Option<AgentInstance> {
+        self.registry.lock().await.get(id).cloned()
+    }
+
+    /// Subscribe to the lifecycle event stream. Each subscriber gets its own
+    /// receiver; late subscribers miss earlier events (bounded broadcast).
+    pub fn state_stream(&self) -> BroadcastStream<AgentEvent> {
+        BroadcastStream::new(self.tx.subscribe())
+    }
+}
+
+impl Default for Orchestrator {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/forge-agents/tests/orchestrator.rs
+++ b/crates/forge-agents/tests/orchestrator.rs
@@ -1,0 +1,249 @@
+//! Runtime tests for `Orchestrator` / `AgentInstance` (F-133).
+//!
+//! These cover the DoD items:
+//! - spawn returns an `AgentInstance` and registers it
+//! - stop terminates an instance cleanly and moves it out of `Running`
+//! - `state_stream()` yields `Spawned` before `Completed` in order
+//! - user-scope `isolation: Trusted` is rejected at spawn with a typed error
+//!   (`Error::IsolationViolation`), independent of parse-time rejection
+
+use forge_agents::{
+    AgentDef, AgentScope, Error, InstanceState, Isolation, Orchestrator, SpawnContext,
+};
+use futures::StreamExt;
+
+fn process_def(name: &str) -> AgentDef {
+    AgentDef {
+        name: name.to_string(),
+        description: None,
+        body: String::new(),
+        allowed_paths: vec![],
+        isolation: Isolation::Process,
+    }
+}
+
+fn trusted_def(name: &str) -> AgentDef {
+    AgentDef {
+        name: name.to_string(),
+        description: None,
+        body: String::new(),
+        allowed_paths: vec![],
+        isolation: Isolation::Trusted,
+    }
+}
+
+#[tokio::test]
+async fn spawn_returns_instance_and_registers_it() {
+    let orch = Orchestrator::new();
+    let def = process_def("helper");
+
+    let inst = orch
+        .spawn(def.clone(), SpawnContext::user())
+        .await
+        .expect("spawn should succeed for Process isolation");
+
+    assert_eq!(inst.def.name, "helper");
+    assert_eq!(inst.state, InstanceState::Running);
+    // Registered: we can look it up by id.
+    assert!(
+        orch.get(&inst.id).await.is_some(),
+        "orchestrator should register the spawned instance"
+    );
+}
+
+#[tokio::test]
+async fn stop_terminates_instance_cleanly() {
+    let orch = Orchestrator::new();
+    let inst = orch
+        .spawn(process_def("helper"), SpawnContext::user())
+        .await
+        .unwrap();
+
+    orch.stop(&inst.id).await.expect("stop should succeed");
+
+    let after = orch
+        .get(&inst.id)
+        .await
+        .expect("instance still in registry");
+    assert_eq!(
+        after.state,
+        InstanceState::Completed,
+        "stop should drive the instance to Completed"
+    );
+}
+
+#[tokio::test]
+async fn state_stream_emits_spawned_then_completed_in_order() {
+    let orch = Orchestrator::new();
+    let mut stream = orch.state_stream();
+
+    let inst = orch
+        .spawn(process_def("flow"), SpawnContext::user())
+        .await
+        .unwrap();
+    orch.stop(&inst.id).await.unwrap();
+
+    // Drop the orchestrator so the broadcast channel closes and the stream
+    // ends after draining.
+    drop(orch);
+
+    let mut events = Vec::new();
+    while let Some(ev) = stream.next().await {
+        if let Ok(ev) = ev {
+            events.push(ev);
+        }
+    }
+
+    assert!(
+        matches!(events.first(), Some(forge_agents::AgentEvent::Spawned { id, .. }) if *id == inst.id),
+        "first event must be Spawned for this instance, got: {events:?}"
+    );
+    assert!(
+        matches!(events.last(), Some(forge_agents::AgentEvent::Completed { id, .. }) if *id == inst.id),
+        "last event must be Completed for this instance, got: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .position(|e| matches!(e, forge_agents::AgentEvent::Spawned { .. }))
+            < events
+                .iter()
+                .position(|e| matches!(e, forge_agents::AgentEvent::Completed { .. })),
+        "Spawned must precede Completed"
+    );
+}
+
+#[tokio::test]
+async fn spawn_rejects_trusted_isolation_for_user_scope() {
+    let orch = Orchestrator::new();
+    let def = trusted_def("evil");
+
+    let err = orch
+        .spawn(def, SpawnContext::user())
+        .await
+        .expect_err("spawn must reject isolation: trusted for user scope");
+
+    assert!(
+        matches!(err, Error::IsolationViolation { .. }),
+        "expected IsolationViolation, got: {err:?}"
+    );
+    assert!(
+        err.to_string().to_lowercase().contains("trusted"),
+        "error message should mention 'trusted': {err}"
+    );
+}
+
+#[tokio::test]
+async fn spawn_allows_trusted_isolation_for_builtin_scope() {
+    // Built-in skills are allowed to spawn trusted instances — this is the
+    // escape hatch the typed runtime check protects.
+    let orch = Orchestrator::new();
+
+    let inst = orch
+        .spawn(trusted_def("builtin"), SpawnContext::built_in())
+        .await
+        .expect("built-in scope may run trusted isolation");
+
+    assert_eq!(inst.def.isolation, Isolation::Trusted);
+    assert_eq!(inst.state, InstanceState::Running);
+}
+
+#[tokio::test]
+async fn failed_instance_emits_failed_event_and_state() {
+    // A test-only helper: fail a running instance. This proves the Failed
+    // terminal state and corresponding event are reachable without
+    // implementing a real step executor (that lands in F-134).
+    let orch = Orchestrator::new();
+    let mut stream = orch.state_stream();
+
+    let inst = orch
+        .spawn(process_def("doomed"), SpawnContext::user())
+        .await
+        .unwrap();
+
+    orch.fail(&inst.id, "synthetic failure".to_string())
+        .await
+        .unwrap();
+
+    let after = orch.get(&inst.id).await.unwrap();
+    assert!(matches!(after.state, InstanceState::Failed { .. }));
+
+    drop(orch);
+    let mut events = Vec::new();
+    while let Some(Ok(ev)) = stream.next().await {
+        events.push(ev);
+    }
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, forge_agents::AgentEvent::Failed { id, .. } if *id == inst.id)),
+        "Failed event should be emitted, got: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn step_events_are_emitted_between_spawn_and_completion() {
+    // Confirms the event vocabulary carries StepStarted/StepFinished (per DoD
+    // `AgentEvent::{Spawned,StepStarted,StepFinished,Completed,Failed}`). For
+    // the runtime foundation we expose `record_step_started / record_step_finished`
+    // so downstream call sites (sub-agent spawning, provider turns) can emit
+    // them — F-134 composes on top.
+    let orch = Orchestrator::new();
+    let mut stream = orch.state_stream();
+
+    let inst = orch
+        .spawn(process_def("stepper"), SpawnContext::user())
+        .await
+        .unwrap();
+    orch.record_step_started(&inst.id, "think".to_string())
+        .await
+        .unwrap();
+    orch.record_step_finished(&inst.id, "think".to_string())
+        .await
+        .unwrap();
+    orch.stop(&inst.id).await.unwrap();
+    drop(orch);
+
+    let mut events = Vec::new();
+    while let Some(Ok(ev)) = stream.next().await {
+        events.push(ev);
+    }
+
+    let positions = |want: fn(&forge_agents::AgentEvent) -> bool| events.iter().position(want);
+    let spawned = positions(|e| matches!(e, forge_agents::AgentEvent::Spawned { .. })).unwrap();
+    let started = positions(|e| matches!(e, forge_agents::AgentEvent::StepStarted { .. })).unwrap();
+    let finished =
+        positions(|e| matches!(e, forge_agents::AgentEvent::StepFinished { .. })).unwrap();
+    let completed = positions(|e| matches!(e, forge_agents::AgentEvent::Completed { .. })).unwrap();
+
+    assert!(
+        spawned < started && started < finished && finished < completed,
+        "event order Spawned < StepStarted < StepFinished < Completed, got: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn scope_marker_is_independent_of_parse_time_check() {
+    // The runtime check must be enforced on programmatically-constructed
+    // defs, not just parser output. We construct an AgentDef manually with
+    // Trusted isolation (bypassing the parser) and confirm spawn still
+    // rejects it under user scope. This is the DoD's "enforced again at
+    // runtime to be safe" clause.
+    let orch = Orchestrator::new();
+    let def = AgentDef {
+        name: "bypass".to_string(),
+        description: None,
+        body: String::new(),
+        allowed_paths: vec![],
+        isolation: Isolation::Trusted,
+    };
+    let result = orch
+        .spawn(
+            def,
+            SpawnContext {
+                scope: AgentScope::User,
+            },
+        )
+        .await;
+    assert!(matches!(result, Err(Error::IsolationViolation { .. })));
+}


### PR DESCRIPTION
## Summary

Lands the runtime side of `forge-agents` on top of the existing parser (design: `docs/architecture/crate-architecture.md` §3.4).

- `AgentInstance { id, def, state, started_at }` — one live instantiation, registered by `AgentInstanceId`.
- `Orchestrator::{new, spawn, stop, fail, state_stream, get, record_step_started, record_step_finished}` — manages instances and forwards lifecycle on a `tokio::sync::broadcast` channel via `BroadcastStream`.
- `AgentEvent::{Spawned, StepStarted, StepFinished, Completed, Failed}` — per-instance event vocabulary.
- `InstanceState::{Running, Completed, Failed}` — current condition; step transitions are events, not states.
- `Isolation::{Trusted, Process, Container}` added to `AgentDef`; parse-time rejection of user-scope `trusted` now emits the typed `Error::IsolationViolation`, and `Orchestrator::spawn` **re-enforces** the same rule for programmatically-constructed defs (closes the parser-bypass gap the DoD flags).
- `SpawnContext { scope: AgentScope }` gates the trusted-isolation escape hatch so built-in skills can still run trusted.

## Scope fence

Explicitly out of scope (separate issues):
- F-134 sub-agent spawning
- F-135 AGENTS.md injection
- F-136 sub-agent banners
- F-137 background agents
- F-140 `AgentMonitor`

This PR is the foundation those compose on.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all suites green, including 8 new orchestrator tests and the 11 existing parser tests.
- [x] Orchestrator tests cover: spawn + registration, stop → `Completed` state, `state_stream` ordering (`Spawned` precedes `Completed`), `StepStarted` < `StepFinished` transitions, user-scope `Trusted` rejection with typed error, built-in scope allowed, programmatically-constructed `Trusted` def still rejected (parse-time bypass protection), `fail` terminal path.

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)