### PR TITLE
fix(forge-mcp): move user config from XDG path to ~/.mcp.json

### DIFF
--- a/crates/forge-mcp/README.md
+++ b/crates/forge-mcp/README.md
@@ -12,8 +12,8 @@ MCP (Model Context Protocol) client and server lifecycle manager. Phase 2 (F-127
 - `McpServerSpec { kind: ServerKind }` — parsed declaration of a single server.
 - `ServerKind::Stdio { command, args, env }` / `ServerKind::Http { url, headers }` — transport-specific shapes.
 - `config::load_workspace(root)` — read `<root>/.mcp.json`.
-- `config::load_user()` — read `~/.config/forge/mcp.json` (XDG-resolved).
-- `config::load_user_from(config_dir)` — test-friendly variant that takes an explicit base directory.
+- `config::load_user()` — read `~/.mcp.json` from the user's home directory.
+- `config::load_user_from(home_dir)` — test-friendly variant that takes an explicit home directory.
 - `config::load_merged(workspace_root, user_config_dir)` — merge both scopes; workspace wins on name collision.
 
 The `mcpServers` schema is the universal proposal (MCP repo discussion #2218). Transport is discriminated by an explicit `"type"` field (`"stdio"` / `"http"`) when present, otherwise inferred from the presence of `command` (stdio) or `url` (http). Unknown fields are rejected.

--- a/crates/forge-mcp/src/lib.rs
+++ b/crates/forge-mcp/src/lib.rs
@@ -141,19 +141,19 @@ pub mod config {
         read_config_file(&workspace_root.join(".mcp.json"))
     }
 
-    /// Load the user-scope `~/.config/forge/mcp.json`, resolving the base
-    /// directory via the same policy [`dirs::config_dir`] uses (XDG on Linux,
-    /// `Application Support` on macOS, `%APPDATA%` on Windows).
+    /// Load the user-scope `~/.mcp.json` per the architecture doc's universal
+    /// home-directory convention (matches Claude Desktop and the MCP universal
+    /// proposal). Missing file yields an empty map.
     pub fn load_user() -> Result<BTreeMap<String, McpServerSpec>> {
-        let base =
-            dirs::config_dir().ok_or_else(|| anyhow!("could not resolve user config directory"))?;
-        read_config_file(&base.join("forge").join("mcp.json"))
+        let home =
+            dirs::home_dir().ok_or_else(|| anyhow!("could not resolve user home directory"))?;
+        read_config_file(&home.join(".mcp.json"))
     }
 
-    /// Test seam: same as [`load_user`] but with an explicit config-base
-    /// directory (so tests can point at a tempdir).
-    pub fn load_user_from(config_dir: &Path) -> Result<BTreeMap<String, McpServerSpec>> {
-        read_config_file(&config_dir.join("forge").join("mcp.json"))
+    /// Test seam: same as [`load_user`] but with an explicit home directory
+    /// (so tests can point at a tempdir).
+    pub fn load_user_from(home_dir: &Path) -> Result<BTreeMap<String, McpServerSpec>> {
+        read_config_file(&home_dir.join(".mcp.json"))
     }
 
     /// Merge user- and workspace-scope servers, with workspace entries
@@ -329,7 +329,7 @@ mod tests {
         let user_cfg = TempDir::new().unwrap();
 
         write(
-            &user_cfg.path().join("forge").join("mcp.json"),
+            &user_cfg.path().join(".mcp.json"),
             r#"{
                 "mcpServers": {
                     "shared": { "command": "user-binary" },


### PR DESCRIPTION
## Summary

Follow-up to F-127 (#241, PR #263). F-127 merged with the DoD text's `~/.config/forge/mcp.json` path for the user-scope config, but the authoritative source — `docs/architecture/crate-architecture.md` §3.3 — specifies `~/.mcp.json`, matching Claude Desktop's layout and the MCP universal-config proposal (#2218).

This PR aligns the implementation with the arch doc.

## Changes

- `crates/forge-mcp/src/lib.rs`
  - `load_user()` resolves via `dirs::home_dir()` and reads `~/.mcp.json` (no XDG, no `forge/` subdir).
  - `load_user_from(home_dir)` parameter renamed; joins `.mcp.json` at the provided directory.
  - Doc comments updated accordingly.
  - `workspace_overrides_user_on_name_collision` test writes to `<user_cfg>/.mcp.json`.
- `crates/forge-mcp/README.md` — reflects the new path layout.

## Verification

- `cargo test -p forge-mcp` — 9/9 pass locally.

## Test plan

- [x] Local forge-mcp tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)