### PR TITLE
[F-141] ContextPicker component + @-trigger in composer

### DIFF
--- a/web/packages/app/src/components/ContextChip.css
+++ b/web/packages/app/src/components/ContextChip.css
@@ -1,0 +1,47 @@
+/* ---------------------------------------------------------------------------
+   ContextChip — inline pill for the composer's ctx-chips row (F-141)
+   --------------------------------------------------------------------------- */
+
+.ctx-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 2px var(--sp-2);
+  background: var(--color-surface-3);
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-primary);
+  max-width: 240px;
+}
+
+.ctx-chip__icon {
+  color: var(--color-text-tertiary);
+  flex: 0 0 auto;
+}
+
+.ctx-chip__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ctx-chip__dismiss {
+  background: transparent;
+  border: none;
+  color: var(--color-text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  flex: 0 0 auto;
+  transition: var(--ease);
+}
+
+.ctx-chip__dismiss:hover {
+  color: var(--color-error);
+}

--- a/web/packages/app/src/components/ContextChip.test.tsx
+++ b/web/packages/app/src/components/ContextChip.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import { ContextChip } from './ContextChip';
+
+// F-141: ContextChip is the pill that lands in the `ctx-chips` row when
+// the user picks a ContextPicker result. It owns minimal behavior — icon +
+// label + dismiss — with the per-category resolution pushed to F-142.
+
+describe('ContextChip', () => {
+  it('renders the label', () => {
+    const { getByTestId } = render(() => (
+      <ContextChip category="file" label="src/app.ts" onDismiss={() => {}} />
+    ));
+    expect(getByTestId('ctx-chip')).toHaveTextContent('src/app.ts');
+  });
+
+  it('exposes the category via data attribute for downstream styling', () => {
+    const { getByTestId } = render(() => (
+      <ContextChip category="terminal" label="last 20 lines" onDismiss={() => {}} />
+    ));
+    expect(getByTestId('ctx-chip').getAttribute('data-category')).toBe('terminal');
+  });
+
+  it('invokes onDismiss when the × button is clicked', () => {
+    const onDismiss = vi.fn();
+    const { getByTestId } = render(() => (
+      <ContextChip category="file" label="src/app.ts" onDismiss={onDismiss} />
+    ));
+    fireEvent.click(getByTestId('ctx-chip-dismiss'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an accessible aria-label on the dismiss button', () => {
+    const { getByTestId } = render(() => (
+      <ContextChip category="file" label="src/app.ts" onDismiss={() => {}} />
+    ));
+    expect(getByTestId('ctx-chip-dismiss').getAttribute('aria-label')).toBe(
+      'Remove src/app.ts',
+    );
+  });
+});

--- a/web/packages/app/src/components/ContextChip.tsx
+++ b/web/packages/app/src/components/ContextChip.tsx
@@ -1,0 +1,59 @@
+import { type Component } from 'solid-js';
+import type { ContextCategory } from './ContextPicker';
+import './ContextChip.css';
+
+// ---------------------------------------------------------------------------
+// ContextChip — pill shown in the composer's `ctx-chips` row once a picker
+// result is inserted (F-141). The chip is intentionally minimal: icon +
+// label + dismiss-×. Full resolution (opening the file preview on hover,
+// expanding a directory tree, etc.) is out of scope for F-141.
+// ---------------------------------------------------------------------------
+
+export interface ContextChipProps {
+  category: ContextCategory;
+  label: string;
+  onDismiss: () => void;
+}
+
+function iconFor(category: ContextCategory): string {
+  switch (category) {
+    case 'file':
+      return '[F]';
+    case 'directory':
+      return '[D]';
+    case 'selection':
+      return '[S]';
+    case 'terminal':
+      return '[T]';
+    case 'agent':
+      return '[A]';
+    case 'skill':
+      return '[K]';
+    case 'url':
+      return '[U]';
+  }
+}
+
+export const ContextChip: Component<ContextChipProps> = (props) => {
+  return (
+    <span
+      class="ctx-chip"
+      data-testid="ctx-chip"
+      data-category={props.category}
+    >
+      <span class="ctx-chip__icon" aria-hidden="true">
+        {iconFor(props.category)}
+      </span>
+      <span class="ctx-chip__label">{props.label}</span>
+      <button
+        type="button"
+        class="ctx-chip__dismiss"
+        data-testid="ctx-chip-dismiss"
+        aria-label={`Remove ${props.label}`}
+        onClick={() => props.onDismiss()}
+      >
+        ×
+      </button>
+    </span>
+  );
+};

--- a/web/packages/app/src/components/ContextPicker.css
+++ b/web/packages/app/src/components/ContextPicker.css
@@ -1,0 +1,162 @@
+/* ---------------------------------------------------------------------------
+   ContextPicker — @-trigger popup (F-141)
+
+   Spec: docs/ui-specs/context-picker.md §7.1
+   Tokens: docs/design/typography.md, docs/design/spacing-layout.md
+
+   Sizing: 360–480px wide, up to 360px tall. Placement flips above/below
+   the anchor depending on viewport space (see `computePopupPlacement` in
+   ContextPicker.tsx).
+   --------------------------------------------------------------------------- */
+
+.context-picker {
+  position: absolute;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  min-width: 360px;
+  max-width: 480px;
+  max-height: 360px;
+  overflow: hidden;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-1);
+  border-radius: var(--r-md);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.32);
+  color: var(--color-text-primary);
+}
+
+/* Placement variants are anchored by the composer in ChatPane.css — the
+   `above`/`below` classes flip which edge attaches to the caret. */
+.context-picker--above {
+  bottom: 100%;
+  margin-bottom: var(--sp-2);
+}
+
+.context-picker--below {
+  top: 100%;
+  margin-top: var(--sp-2);
+}
+
+/* -------------------------------------------------------------------------
+   Search row
+   ---------------------------------------------------------------------- */
+
+.context-picker__search {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--color-border-1);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.context-picker__search-icon {
+  color: var(--color-text-ember);
+  font-weight: 600;
+}
+
+.context-picker__search-query {
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* -------------------------------------------------------------------------
+   Category tabs (segmented)
+   ---------------------------------------------------------------------- */
+
+.context-picker__tabs {
+  flex: 0 0 auto;
+  display: flex;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--color-border-1);
+  overflow-x: auto;
+}
+
+.context-picker__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: var(--sp-1) var(--sp-2);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  transition: var(--ease);
+  white-space: nowrap;
+}
+
+.context-picker__tab:hover {
+  color: var(--color-text-secondary);
+  border-color: var(--color-border-2);
+}
+
+.context-picker__tab--active {
+  color: var(--color-text-primary);
+  background: var(--color-surface-3);
+  border-color: var(--color-ember-400);
+}
+
+.context-picker__tab-icon {
+  color: var(--color-text-tertiary);
+}
+
+.context-picker__tab--active .context-picker__tab-icon {
+  color: var(--color-ember-400);
+}
+
+/* -------------------------------------------------------------------------
+   Results list
+   ---------------------------------------------------------------------- */
+
+.context-picker__results {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: var(--sp-1) 0;
+}
+
+.context-picker__empty {
+  padding: var(--sp-3) var(--sp-3);
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}
+
+.context-picker__result {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.context-picker__result:hover {
+  background: var(--color-surface-3);
+}
+
+.context-picker__result--active {
+  background: var(--color-surface-3);
+  color: var(--color-text-primary);
+  border-left: 2px solid var(--color-ember-400);
+  padding-left: calc(var(--sp-3) - 2px);
+}
+
+.context-picker__result-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/web/packages/app/src/components/ContextPicker.test.tsx
+++ b/web/packages/app/src/components/ContextPicker.test.tsx
@@ -1,0 +1,370 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import {
+  ContextPicker,
+  CATEGORIES,
+  computePopupPlacement,
+  detectAtTrigger,
+  type PickerResult,
+} from './ContextPicker';
+
+// ---------------------------------------------------------------------------
+// Pure-function tests (F-141)
+// ---------------------------------------------------------------------------
+//
+// `computePopupPlacement` and `detectAtTrigger` are extracted as pure
+// functions because jsdom does not compute layout — the placement flip
+// cannot be tested by rendering and asserting against `getBoundingClientRect`.
+// Asserting against the pure function directly is the TDD contract for
+// the DoD's "popup anchors intelligently (flip to above when near bottom
+// viewport edge)" checkbox.
+
+describe('computePopupPlacement (F-141)', () => {
+  it('places the popup below when there is room below the anchor', () => {
+    const placement = computePopupPlacement({
+      anchorTop: 100,
+      anchorBottom: 160,
+      viewportHeight: 1080,
+      popupHeight: 360,
+    });
+    expect(placement).toBe('below');
+  });
+
+  it('flips the popup above when the anchor is near the bottom of the viewport', () => {
+    // Anchor at the bottom of a standard viewport — the composer is
+    // pinned to the bottom of the chat pane in practice. A 360px popup
+    // below would be clipped, so the function must flip to 'above'.
+    const placement = computePopupPlacement({
+      anchorTop: 700,
+      anchorBottom: 780,
+      viewportHeight: 800,
+      popupHeight: 360,
+    });
+    expect(placement).toBe('above');
+  });
+
+  it('respects the gap when deciding flip', () => {
+    // Space below (minus gap) is exactly the popup height — should stay below.
+    const placement = computePopupPlacement({
+      anchorTop: 400,
+      anchorBottom: 436,
+      viewportHeight: 800,
+      popupHeight: 360,
+      gap: 4,
+    });
+    expect(placement).toBe('below');
+  });
+
+  it('flips to above when the viewport is shorter than the popup + anchor bottom', () => {
+    const placement = computePopupPlacement({
+      anchorTop: 500,
+      anchorBottom: 540,
+      viewportHeight: 800,
+      popupHeight: 360,
+    });
+    // 800 - 540 = 260 < 360 → above
+    expect(placement).toBe('above');
+  });
+});
+
+describe('detectAtTrigger (F-141)', () => {
+  it('matches a fresh `@` at the start of the textarea', () => {
+    const match = detectAtTrigger('@', 1);
+    expect(match).toEqual({ start: 0, query: '' });
+  });
+
+  it('matches a `@` preceded by a space, with a query', () => {
+    const text = 'hello @fo';
+    const match = detectAtTrigger(text, text.length);
+    expect(match).toEqual({ start: 6, query: 'fo' });
+  });
+
+  it('does not match when `@` is preceded by a non-whitespace character', () => {
+    // e.g. an email address shouldn't open the picker.
+    const text = 'reach me at me@example.com';
+    const match = detectAtTrigger(text, text.length);
+    expect(match).toBeNull();
+  });
+
+  it('does not match once the user types whitespace after the `@`', () => {
+    const text = 'hello @foo ';
+    const match = detectAtTrigger(text, text.length);
+    expect(match).toBeNull();
+  });
+
+  it('matches at the caret inside the middle of text', () => {
+    // Caret sits inside an active `@token`.
+    const text = 'leading @src/foo more';
+    const caret = 'leading @src/foo'.length;
+    const match = detectAtTrigger(text, caret);
+    expect(match).toEqual({ start: 8, query: 'src/foo' });
+  });
+
+  it('returns null when the caret is before any `@`', () => {
+    const text = 'hello @foo';
+    const match = detectAtTrigger(text, 3);
+    expect(match).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component tests (F-141)
+// ---------------------------------------------------------------------------
+
+describe('ContextPicker rendering', () => {
+  const anchor = { top: 100, bottom: 160, left: 0, right: 360 };
+
+  it('renders the popup root', () => {
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    expect(getByTestId('context-picker')).toBeInTheDocument();
+  });
+
+  it('renders all seven category tabs (F-141 DoD item 5)', () => {
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    for (const cat of CATEGORIES) {
+      expect(getByTestId(`context-picker-tab-${cat.id}`)).toBeInTheDocument();
+    }
+    expect(CATEGORIES).toHaveLength(7);
+  });
+
+  it('marks the first category (file) as active on initial render', () => {
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const fileTab = getByTestId('context-picker-tab-file');
+    expect(fileTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('echoes the current `@` query in the search row', () => {
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query="src/foo"
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    expect(getByTestId('context-picker-query')).toHaveTextContent('src/foo');
+  });
+
+  it('renders an empty state for the active category when items are not provided (F-141)', () => {
+    // F-141 ships the component shell with empty category tabs; F-142
+    // populates the results. The empty placeholder must render so the
+    // popup is not collapsed / unusable until F-142 lands.
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    expect(getByTestId('context-picker-empty')).toBeInTheDocument();
+  });
+});
+
+describe('ContextPicker keyboard navigation', () => {
+  const anchor = { top: 100, bottom: 160, left: 0, right: 360 };
+
+  it('Tab moves forward through categories', () => {
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    // file is active initially
+    expect(getByTestId('context-picker-tab-file').getAttribute('aria-selected'))
+      .toBe('true');
+    fireEvent.keyDown(window, { key: 'Tab' });
+    expect(
+      getByTestId('context-picker-tab-directory').getAttribute('aria-selected'),
+    ).toBe('true');
+    fireEvent.keyDown(window, { key: 'Tab' });
+    expect(
+      getByTestId('context-picker-tab-selection').getAttribute('aria-selected'),
+    ).toBe('true');
+  });
+
+  it('Shift+Tab moves backward through categories', () => {
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    // From `file`, Shift+Tab wraps to the last category (`url`).
+    fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
+    expect(
+      getByTestId('context-picker-tab-url').getAttribute('aria-selected'),
+    ).toBe('true');
+  });
+
+  it('Escape fires onDismiss', () => {
+    const onDismiss = vi.fn();
+    render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={onDismiss}
+      />
+    ));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('Enter with an active item fires onPick', () => {
+    const onPick = vi.fn();
+    const items: PickerResult[] = [
+      { category: 'file', label: 'a.ts', value: 'a.ts' },
+      { category: 'file', label: 'b.ts', value: 'b.ts' },
+    ];
+    render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: items }}
+        onPick={onPick}
+        onDismiss={() => {}}
+      />
+    ));
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onPick).toHaveBeenCalledWith({
+      category: 'file',
+      label: 'a.ts',
+      value: 'a.ts',
+    });
+  });
+
+  it('ArrowDown / ArrowUp move the result cursor', () => {
+    const onPick = vi.fn();
+    const items: PickerResult[] = [
+      { category: 'file', label: 'a.ts', value: 'a.ts' },
+      { category: 'file', label: 'b.ts', value: 'b.ts' },
+      { category: 'file', label: 'c.ts', value: 'c.ts' },
+    ];
+    render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: items }}
+        onPick={onPick}
+        onDismiss={() => {}}
+      />
+    ));
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onPick).toHaveBeenCalledWith(items[2]);
+  });
+});
+
+describe('ContextPicker chip insertion flow (F-141)', () => {
+  // Exercises the "selected result inserts a chip" path end-to-end through
+  // the public `onPick` callback. The composer-side mutation (removing the
+  // `@text` span and appending to ctx-chips) is covered by ChatPane.test.tsx;
+  // here we pin that picking a result with Enter fires onPick with the
+  // selected PickerResult shape the composer will turn into a chip.
+  const anchor = { top: 100, bottom: 160, left: 0, right: 360 };
+
+  it('clicking a result invokes onPick with that item', () => {
+    const onPick = vi.fn();
+    const items: PickerResult[] = [
+      { category: 'file', label: 'alpha.ts', value: 'src/alpha.ts' },
+      { category: 'file', label: 'beta.ts', value: 'src/beta.ts' },
+    ];
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: items }}
+        onPick={onPick}
+        onDismiss={() => {}}
+      />
+    ));
+    fireEvent.mouseDown(getByTestId('context-picker-result-1'));
+    expect(onPick).toHaveBeenCalledWith(items[1]);
+  });
+
+  it('resets the result cursor to 0 when Tab switches category', () => {
+    const onPick = vi.fn();
+    const fileItems: PickerResult[] = [
+      { category: 'file', label: 'a.ts', value: 'a.ts' },
+      { category: 'file', label: 'b.ts', value: 'b.ts' },
+    ];
+    const dirItems: PickerResult[] = [
+      { category: 'directory', label: 'src/', value: 'src/' },
+      { category: 'directory', label: 'tests/', value: 'tests/' },
+    ];
+    render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: fileItems, directory: dirItems }}
+        onPick={onPick}
+        onDismiss={() => {}}
+      />
+    ));
+    // Move to file[1], then Tab to directory — cursor should reset to 0.
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    fireEvent.keyDown(window, { key: 'Tab' });
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onPick).toHaveBeenCalledWith(dirItems[0]);
+  });
+});
+
+describe('ContextPicker placement data attribute', () => {
+  it('flags placement=above when the anchor sits near the viewport bottom', () => {
+    // jsdom's default innerHeight is 768. Put the anchor bottom at 700 →
+    // 68px of space → under the 360px popup → should flip to above.
+    const anchor = { top: 640, bottom: 700, left: 0, right: 360 };
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const root = getByTestId('context-picker');
+    expect(root.getAttribute('data-placement')).toBe('above');
+  });
+
+  it('flags placement=below when the anchor sits near the viewport top', () => {
+    const anchor = { top: 50, bottom: 110, left: 0, right: 360 };
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const root = getByTestId('context-picker');
+    expect(root.getAttribute('data-placement')).toBe('below');
+  });
+});

--- a/web/packages/app/src/components/ContextPicker.tsx
+++ b/web/packages/app/src/components/ContextPicker.tsx
@@ -1,0 +1,361 @@
+import {
+  type Component,
+  createSignal,
+  createEffect,
+  For,
+  Show,
+  onMount,
+  onCleanup,
+} from 'solid-js';
+import './ContextPicker.css';
+
+// ---------------------------------------------------------------------------
+// Categories (F-141)
+// ---------------------------------------------------------------------------
+//
+// F-141 lands the ContextPicker component shell and chip-insertion plumbing;
+// populating each category with resolved results is F-142. The seven tabs
+// render as empty here — keep the icon/label shape so F-142 only needs to
+// add the resolver + items array per category.
+
+export type ContextCategory =
+  | 'file'
+  | 'directory'
+  | 'selection'
+  | 'terminal'
+  | 'agent'
+  | 'skill'
+  | 'url';
+
+export interface CategoryDef {
+  id: ContextCategory;
+  label: string;
+  icon: string;
+}
+
+export const CATEGORIES: readonly CategoryDef[] = [
+  { id: 'file', label: 'file', icon: '[F]' },
+  { id: 'directory', label: 'directory', icon: '[D]' },
+  { id: 'selection', label: 'selection', icon: '[S]' },
+  { id: 'terminal', label: 'terminal', icon: '[T]' },
+  { id: 'agent', label: 'agent', icon: '[A]' },
+  { id: 'skill', label: 'skill', icon: '[K]' },
+  { id: 'url', label: 'url', icon: '[U]' },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Popup placement (pure — unit-testable without jsdom layout)
+// ---------------------------------------------------------------------------
+//
+// The DoD requires the popup to "flip to above when near bottom viewport
+// edge". jsdom does not compute real layout (`getBoundingClientRect()`
+// returns zeros), so the placement decision is extracted to a pure function
+// and tested directly. The component calls it with the caret/composer's real
+// measurements at mount + on window resize.
+
+export type PopupPlacement = 'above' | 'below';
+
+export interface PlacementInput {
+  /** Viewport-relative top of the anchor (caret or composer). */
+  anchorTop: number;
+  /** Viewport-relative bottom of the anchor. */
+  anchorBottom: number;
+  /** `window.innerHeight`. */
+  viewportHeight: number;
+  /** Height of the popup itself (up to 360px per spec). */
+  popupHeight: number;
+  /** Gap between anchor and popup in px. */
+  gap?: number;
+}
+
+/**
+ * Decide whether the popup renders above or below the anchor.
+ *
+ * Rule: prefer below when there is room for the popup below the anchor;
+ * otherwise flip to above. "Room" means `popupHeight + gap` fits between
+ * the anchor bottom and the viewport bottom.
+ */
+export function computePopupPlacement(input: PlacementInput): PopupPlacement {
+  const gap = input.gap ?? 4;
+  const spaceBelow = input.viewportHeight - input.anchorBottom - gap;
+  if (spaceBelow >= input.popupHeight) return 'below';
+  return 'above';
+}
+
+// ---------------------------------------------------------------------------
+// `@`-trigger detection (pure)
+// ---------------------------------------------------------------------------
+//
+// Detect an active `@` token at the caret. Returns the start index (of the
+// `@`) and the query (text after `@` up to the caret) when the caret sits
+// inside an `@token` that was introduced by the most recent space/newline
+// boundary. Returns null when the caret is not in such a token.
+//
+// The token ends on whitespace — once the user types a space, the trigger
+// is dismissed. Supports only the unicode word-ish chars `\S` (anything
+// non-whitespace), which is intentionally permissive: path-like tokens
+// (`src/foo.ts`) should keep the picker open.
+
+export interface AtTriggerMatch {
+  /** Index of the `@` in the full text. */
+  start: number;
+  /** Substring after `@` up to the caret — the search query. */
+  query: string;
+}
+
+export function detectAtTrigger(text: string, caret: number): AtTriggerMatch | null {
+  if (caret < 1 || caret > text.length) return null;
+  // Walk backwards from the caret looking for an `@` that is either at the
+  // start of the text or preceded by whitespace. Stop on whitespace — the
+  // trigger is dismissed once the user types a space.
+  for (let i = caret - 1; i >= 0; i--) {
+    const ch = text[i];
+    if (ch === undefined) return null;
+    if (/\s/.test(ch)) return null;
+    if (ch === '@') {
+      const before = i > 0 ? text[i - 1] : undefined;
+      if (before === undefined || /\s/.test(before)) {
+        return { start: i, query: text.slice(i + 1, caret) };
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Picker result (what the parent turns into a chip)
+// ---------------------------------------------------------------------------
+
+export interface PickerResult {
+  category: ContextCategory;
+  /** The text to display in the chip. */
+  label: string;
+  /** Opaque identifier the caller can use for downstream resolution. */
+  value: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface ContextPickerProps {
+  /** Current `@`-query (text after the `@`). */
+  query: string;
+  /** Viewport-relative rect of the anchor (composer) for placement. */
+  anchorRect: { top: number; bottom: number; left: number; right: number };
+  /** Called when a result is chosen (Enter or click). */
+  onPick: (result: PickerResult) => void;
+  /** Called when the user dismisses (Esc, blur, or clicks outside). */
+  onDismiss: () => void;
+  /**
+   * Optional category-indexed items — F-141 leaves this empty. F-142 will
+   * wire a resolver that populates per category as the user types.
+   */
+  items?: Partial<Record<ContextCategory, PickerResult[]>>;
+}
+
+const POPUP_MAX_HEIGHT = 360;
+const POPUP_MIN_WIDTH = 360;
+
+export const ContextPicker: Component<ContextPickerProps> = (props) => {
+  const [activeCategoryIndex, setActiveCategoryIndex] = createSignal(0);
+  const [activeItemIndex, setActiveItemIndex] = createSignal(0);
+  const [placement, setPlacement] = createSignal<PopupPlacement>('above');
+
+  let rootRef: HTMLDivElement | undefined;
+
+  const activeCategory = (): ContextCategory => {
+    const def = CATEGORIES[activeCategoryIndex()];
+    return def ? def.id : 'file';
+  };
+
+  const activeItems = (): PickerResult[] => {
+    return props.items?.[activeCategory()] ?? [];
+  };
+
+  // Recompute placement whenever anchorRect updates. In real DOM this runs
+  // on mount, window resize, and scroll; in tests it runs synchronously when
+  // `anchorRect` changes.
+  createEffect(() => {
+    const rect = props.anchorRect;
+    const viewportHeight =
+      typeof window !== 'undefined' ? window.innerHeight : 800;
+    setPlacement(
+      computePopupPlacement({
+        anchorTop: rect.top,
+        anchorBottom: rect.bottom,
+        viewportHeight,
+        popupHeight: POPUP_MAX_HEIGHT,
+      }),
+    );
+  });
+
+  // Reset the item cursor when the active category changes or items change.
+  createEffect(() => {
+    const _cat = activeCategoryIndex();
+    const _items = activeItems();
+    setActiveItemIndex(0);
+  });
+
+  const commitActive = () => {
+    const items = activeItems();
+    const item = items[activeItemIndex()];
+    if (item) {
+      props.onPick(item);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      props.onDismiss();
+      return;
+    }
+    if (e.key === 'Tab') {
+      // Tab switches category (shift+Tab goes backwards). Preventing default
+      // is required — the textarea still has focus while the popup is open,
+      // so the browser's native Tab traversal would otherwise escape into
+      // surrounding UI.
+      e.preventDefault();
+      const dir = e.shiftKey ? -1 : 1;
+      const n = CATEGORIES.length;
+      setActiveCategoryIndex((i) => (i + dir + n) % n);
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const items = activeItems();
+      if (items.length === 0) return;
+      setActiveItemIndex((i) => (i + 1) % items.length);
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const items = activeItems();
+      if (items.length === 0) return;
+      setActiveItemIndex((i) => (i - 1 + items.length) % items.length);
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commitActive();
+      return;
+    }
+  };
+
+  onMount(() => {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', handleKeyDown, true);
+    }
+  });
+
+  onCleanup(() => {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('keydown', handleKeyDown, true);
+    }
+  });
+
+  return (
+    <div
+      class="context-picker"
+      classList={{
+        'context-picker--above': placement() === 'above',
+        'context-picker--below': placement() === 'below',
+      }}
+      data-testid="context-picker"
+      data-placement={placement()}
+      role="combobox"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      ref={rootRef}
+      style={{
+        'min-width': `${POPUP_MIN_WIDTH}px`,
+      }}
+    >
+      {/* Search field — echoes the live `@`-query from the composer. */}
+      <div class="context-picker__search">
+        <span class="context-picker__search-icon" aria-hidden="true">@</span>
+        <span
+          class="context-picker__search-query"
+          data-testid="context-picker-query"
+        >
+          {props.query}
+        </span>
+      </div>
+
+      {/* Seven category tabs (segmented list). */}
+      <div
+        class="context-picker__tabs"
+        role="tablist"
+        data-testid="context-picker-tabs"
+      >
+        <For each={CATEGORIES}>
+          {(cat, i) => (
+            <button
+              type="button"
+              class="context-picker__tab"
+              classList={{
+                'context-picker__tab--active': i() === activeCategoryIndex(),
+              }}
+              role="tab"
+              aria-selected={i() === activeCategoryIndex()}
+              data-testid={`context-picker-tab-${cat.id}`}
+              onMouseDown={(e) => {
+                // onMouseDown so focus stays in the textarea.
+                e.preventDefault();
+                setActiveCategoryIndex(i());
+              }}
+            >
+              <span class="context-picker__tab-icon" aria-hidden="true">
+                {cat.icon}
+              </span>
+              <span class="context-picker__tab-label">{cat.label}</span>
+            </button>
+          )}
+        </For>
+      </div>
+
+      {/* Results list for the active category. F-141 renders empty — F-142
+          will populate via the `items` prop. */}
+      <div
+        class="context-picker__results"
+        role="listbox"
+        data-testid="context-picker-results"
+      >
+        <Show
+          when={activeItems().length > 0}
+          fallback={
+            <div
+              class="context-picker__empty"
+              data-testid="context-picker-empty"
+            >
+              No {activeCategory()} results
+            </div>
+          }
+        >
+          <For each={activeItems()}>
+            {(item, i) => (
+              <div
+                class="context-picker__result"
+                classList={{
+                  'context-picker__result--active':
+                    i() === activeItemIndex(),
+                }}
+                role="option"
+                aria-selected={i() === activeItemIndex()}
+                data-testid={`context-picker-result-${i()}`}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  props.onPick(item);
+                }}
+              >
+                <span class="context-picker__result-label">{item.label}</span>
+              </div>
+            )}
+          </For>
+        </Show>
+      </div>
+    </div>
+  );
+};

--- a/web/packages/app/src/routes/Session/ChatPane.css
+++ b/web/packages/app/src/routes/Session/ChatPane.css
@@ -199,10 +199,26 @@
 
 .composer {
   flex: 0 0 auto;
+  position: relative;
   border-top: 1px solid var(--color-border-1);
   background: var(--color-surface-2);
   display: flex;
   flex-direction: column;
+}
+
+/* F-141: ctx-chips row — sits above the textarea and hosts inserted
+   `ContextChip` pills. Hidden visually (zero padding) when empty so the
+   composer layout doesn't reserve space before the user triggers the
+   picker. */
+.composer__ctx-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-4) 0;
+}
+
+.composer__ctx-chips--empty {
+  padding: 0;
 }
 
 .composer__textarea {

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -13,7 +13,7 @@ import {
 import { setActiveSessionId } from '../../stores/session';
 import { resetApprovalsStore } from '../../stores/approvals';
 import { setInvokeForTesting } from '../../lib/tauri';
-import { ChatPane, MAX_COMPOSER_BYTES } from './ChatPane';
+import { ChatPane, Composer, MAX_COMPOSER_BYTES, removeAtSpan } from './ChatPane';
 
 const SID = 'session-chat-test' as SessionId;
 const invokeMock = vi.fn();
@@ -678,6 +678,139 @@ describe('Composer message-byte cap (F-080)', () => {
 // produces valid JSON, so removing the defensive try/catches in ChatPane
 // must not regress the path-extraction or rendering behavior.
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// F-141: @-trigger + ContextPicker integration in the composer
+// ---------------------------------------------------------------------------
+//
+// The DoD requires: typing `@` opens the picker; selecting a result appends
+// a ContextChip to the `ctx-chips` row above the textarea AND removes the
+// `@text` span; Escape dismisses without inserting. Full keyboard coverage
+// for the picker itself lives in ContextPicker.test.tsx — these tests pin
+// the *composer-side* plumbing (trigger detection, chip row population,
+// textarea mutation on insert).
+describe('Composer @-trigger and ContextPicker integration (F-141)', () => {
+  it('does not render the picker while the textarea holds no `@` token', () => {
+    const { queryByTestId } = render(() => <ChatPane />);
+    expect(queryByTestId('context-picker')).not.toBeInTheDocument();
+  });
+
+  it('opens the picker when the user types `@`', () => {
+    const { getByTestId, queryByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    // Typing `@` at the start of a fresh composer — the simplest trigger.
+    textarea.value = '@';
+    textarea.selectionStart = 1;
+    textarea.selectionEnd = 1;
+    fireEvent.input(textarea);
+    expect(queryByTestId('context-picker')).toBeInTheDocument();
+  });
+
+  it('closes the picker once the user types a space after `@`', () => {
+    const { getByTestId, queryByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    textarea.value = '@foo';
+    textarea.selectionStart = 4;
+    textarea.selectionEnd = 4;
+    fireEvent.input(textarea);
+    expect(queryByTestId('context-picker')).toBeInTheDocument();
+    textarea.value = '@foo ';
+    textarea.selectionStart = 5;
+    textarea.selectionEnd = 5;
+    fireEvent.input(textarea);
+    expect(queryByTestId('context-picker')).not.toBeInTheDocument();
+  });
+
+  it('does not send the message when Enter is pressed while the picker is open', () => {
+    invokeMock.mockReset();
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    textarea.value = '@foo';
+    textarea.selectionStart = 4;
+    textarea.selectionEnd = 4;
+    fireEvent.input(textarea);
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    const sendCalls = invokeMock.mock.calls.filter(
+      (c) => c[0] === 'session_send_message',
+    );
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  it('renders the ctx-chips row above the textarea', () => {
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('ctx-chips')).toBeInTheDocument();
+  });
+
+  // DoD item 4: "selected result appends a `ContextChip` to `ctx-chips` row;
+  // the `@text` span is replaced". `removeAtSpan` is the pure-function half
+  // of that (the span removal + caret positioning). Unit-testing it directly
+  // decouples the invariant from the picker's async onPick wiring.
+  it('removeAtSpan removes an @token at the start of text and keeps the caret at 0', () => {
+    const result = removeAtSpan('@foo', 0, 4);
+    expect(result.text).toBe('');
+    expect(result.caret).toBe(0);
+  });
+
+  it('removeAtSpan removes an @token embedded in text and positions the caret at the join', () => {
+    const text = 'hello @foo world';
+    // caret sits just after "foo" — span is "@foo".
+    const result = removeAtSpan(text, 6, 10);
+    expect(result.text).toBe('hello  world');
+    expect(result.caret).toBe(6);
+  });
+
+  it('removeAtSpan preserves trailing text that was after the caret', () => {
+    const text = '@partial rest';
+    const result = removeAtSpan(text, 0, 8);
+    expect(result.text).toBe(' rest');
+    expect(result.caret).toBe(0);
+  });
+
+  // DoD item 4 end-to-end: render the Composer with a seeded category, open
+  // the picker via `@`, pick a result, and assert the chip lands in the
+  // ctx-chips row AND the `@text` span is removed from the textarea.
+  it('end-to-end: @-trigger → pick result → chip appears in ctx-chips, @text span removed', () => {
+    const items = {
+      file: [
+        { category: 'file' as const, label: 'alpha.ts', value: 'src/alpha.ts' },
+      ],
+    };
+    const { getByTestId, queryByTestId } = render(() => (
+      <Composer disabled={false} onSend={() => {}} items={items} />
+    ));
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    textarea.value = 'pref @foo';
+    textarea.selectionStart = 9;
+    textarea.selectionEnd = 9;
+    fireEvent.input(textarea);
+    // Picker is open with the seeded file result.
+    expect(queryByTestId('context-picker')).toBeInTheDocument();
+    expect(queryByTestId('context-picker-result-0')).toBeInTheDocument();
+    // Click the first result.
+    fireEvent.mouseDown(getByTestId('context-picker-result-0'));
+    // Chip landed in the ctx-chips row with the picked label.
+    const chip = getByTestId('ctx-chip');
+    expect(chip).toHaveTextContent('alpha.ts');
+    // Picker closed.
+    expect(queryByTestId('context-picker')).not.toBeInTheDocument();
+    // `@text` span removed from the textarea.
+    expect(textarea.value).toBe('pref ');
+  });
+
+  it('Escape while picker is open dismisses without inserting a chip', () => {
+    const { getByTestId, queryByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    textarea.value = '@foo';
+    textarea.selectionStart = 4;
+    textarea.selectionEnd = 4;
+    fireEvent.input(textarea);
+    expect(queryByTestId('context-picker')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    // Picker must close, no chip inserted (chips row stays empty).
+    expect(queryByTestId('context-picker')).not.toBeInTheDocument();
+    expect(queryByTestId('ctx-chip')).not.toBeInTheDocument();
+  });
+});
+
 describe('args_json boundary contract (F-080)', () => {
   it('renders the path and uses it for whitelist matching when args is a path-bearing object', () => {
     pushEvent(SID, {

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -23,6 +23,13 @@ import {
 } from '../../stores/approvals';
 import { ApprovalPrompt } from '../../components/ApprovalPrompt/ApprovalPrompt';
 import { WhitelistedPill } from '../../components/ApprovalPrompt/WhitelistedPill';
+import {
+  ContextPicker,
+  detectAtTrigger,
+  type PickerResult,
+  type ContextCategory,
+} from '../../components/ContextPicker';
+import { ContextChip } from '../../components/ContextChip';
 import type { ApprovalScope } from '@forge/ipc';
 import './ChatPane.css';
 
@@ -277,42 +284,247 @@ function utf8ByteLength(text: string): number {
   return new TextEncoder().encode(text).length;
 }
 
-const Composer: Component<{ disabled: boolean; onSend: (text: string) => void }> = (props) => {
+interface InsertedChip {
+  /** Stable id so SolidJS can reconcile chip list updates. */
+  id: string;
+  category: ContextCategory;
+  label: string;
+  value: string;
+}
+
+/**
+ * Remove the active `@text` span from the textarea content when a picker
+ * result is selected (F-141). Exported for direct unit testing — the
+ * integration in Composer calls this while also appending the chip to the
+ * `ctx-chips` row and repositioning the caret.
+ *
+ * The span runs from `triggerStart` (index of the `@`) to `caret`. The
+ * result is the concatenation of the text before `triggerStart` and
+ * after `caret`, plus the new caret position at the join.
+ */
+export function removeAtSpan(
+  text: string,
+  triggerStart: number,
+  caret: number,
+): { text: string; caret: number } {
+  const before = text.slice(0, triggerStart);
+  const after = text.slice(caret);
+  return { text: before + after, caret: before.length };
+}
+
+export interface ComposerProps {
+  disabled: boolean;
+  onSend: (text: string) => void;
+  /**
+   * Optional category-indexed items forwarded to the ContextPicker. F-141
+   * ships with this undefined (the picker shows empty tabs). F-142 will
+   * wire a resolver on top of this prop. Exposed now so component tests
+   * can drive the end-to-end "type @ → pick → chip appears" flow.
+   */
+  items?: Partial<Record<ContextCategory, PickerResult[]>>;
+}
+
+export const Composer: Component<ComposerProps> = (props) => {
   const [text, setText] = createSignal('');
+  const [caret, setCaret] = createSignal(0);
+  const [chips, setChips] = createSignal<InsertedChip[]>([]);
+  // F-141: Esc dismisses the picker but must *retain* the typed `@text`
+  // (spec §7 "close, retain typed text"). We track the dismissed `@`-span
+  // start so the trigger re-opens only after the user edits the text — not
+  // just from a caret move back into the same span.
+  const [dismissedAt, setDismissedAt] = createSignal<number | null>(null);
+  // F-141: the ContextPicker pops open while an active `@token` sits at the
+  // caret. `detectAtTrigger` drives this — whenever the caret or text moves,
+  // we recompute whether we're still in a trigger.
+  const trigger = createMemo(() => {
+    const match = detectAtTrigger(text(), caret());
+    if (!match) return null;
+    if (dismissedAt() === match.start) return null;
+    return match;
+  });
+  const pickerOpen = createMemo(() => trigger() !== null);
+  // Anchor rect used by the ContextPicker for placement. Re-measured on open
+  // and on viewport resize.
+  const [anchorRect, setAnchorRect] = createSignal({
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  });
+
+  let textareaRef: HTMLTextAreaElement | undefined;
+  let composerRef: HTMLDivElement | undefined;
 
   // Byte length of the *trimmed* value because that is what we actually send.
   const trimmedByteLength = createMemo(() => utf8ByteLength(text().trim()));
   const overCap = createMemo(() => trimmedByteLength() > MAX_COMPOSER_BYTES);
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key !== 'Enter') return;
+  const measureAnchor = () => {
+    if (!composerRef) return;
+    const r = composerRef.getBoundingClientRect();
+    setAnchorRect({ top: r.top, bottom: r.bottom, left: r.left, right: r.right });
+  };
 
-    // Option B: modifier keys = newline, bare Enter = send
-    if (e.shiftKey || e.ctrlKey || e.metaKey) return;
+  createEffect(() => {
+    if (pickerOpen()) {
+      measureAnchor();
+    }
+  });
 
-    e.preventDefault();
+  const handleInput = (e: InputEvent & { currentTarget: HTMLTextAreaElement }) => {
+    const t = e.currentTarget.value;
+    setText(t);
+    setCaret(e.currentTarget.selectionStart ?? t.length);
+    // Any text edit re-arms the trigger — the user's dismiss decision only
+    // applied to the span they dismissed.
+    setDismissedAt(null);
+  };
+
+  const handleSelect = (e: Event & { currentTarget: HTMLTextAreaElement }) => {
+    setCaret(e.currentTarget.selectionStart ?? text().length);
+  };
+
+  const handleSend = () => {
     const value = text().trim();
     if (!value) return;
-    // Block the send if the trimmed payload is over the byte cap. The
-    // inline warning in the bar tells the user *why* nothing happened.
     if (utf8ByteLength(value) > MAX_COMPOSER_BYTES) return;
     props.onSend(value);
     setText('');
+    setCaret(0);
+    // Chips persist across sends intentionally — clearing them on send is
+    // F-142 territory once backend context blocks wire up.
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    // When the picker is open it owns Arrow/Enter/Tab/Escape — stop those
+    // from reaching the textarea's send handler. The picker itself installs
+    // a capturing window listener, so we just need to make sure the
+    // textarea-level Enter-to-send doesn't fire while the picker is up.
+    if (pickerOpen()) {
+      if (
+        e.key === 'Enter' ||
+        e.key === 'Escape' ||
+        e.key === 'Tab' ||
+        e.key === 'ArrowUp' ||
+        e.key === 'ArrowDown'
+      ) {
+        return;
+      }
+    }
+    if (e.key !== 'Enter') return;
+    // Option B: modifier keys = newline, bare Enter = send
+    if (e.shiftKey || e.ctrlKey || e.metaKey) return;
+    e.preventDefault();
+    handleSend();
+  };
+
+  const replaceAtSpan = (result: PickerResult) => {
+    // Remove the `@text` span from the textarea and append a chip to the
+    // `ctx-chips` row. The span runs from `trigger.start` to the caret.
+    const t = text();
+    const c = caret();
+    const match = trigger();
+    if (!match) {
+      // Picker was open with no active trigger — append the chip and move
+      // on; the textarea stays as-is.
+      setChips((prev) => [
+        ...prev,
+        {
+          id: `chip-${Date.now()}-${prev.length}`,
+          category: result.category,
+          label: result.label,
+          value: result.value,
+        },
+      ]);
+      return;
+    }
+    const { text: next, caret: nextCaret } = removeAtSpan(t, match.start, c);
+    setText(next);
+    setCaret(nextCaret);
+    setDismissedAt(null);
+    setChips((prev) => [
+      ...prev,
+      {
+        id: `chip-${Date.now()}-${prev.length}`,
+        category: result.category,
+        label: result.label,
+        value: result.value,
+      },
+    ]);
+    // Move the real textarea caret to the join point so subsequent typing
+    // continues where the `@span` was.
+    queueMicrotask(() => {
+      if (textareaRef) {
+        textareaRef.selectionStart = nextCaret;
+        textareaRef.selectionEnd = nextCaret;
+        textareaRef.focus();
+      }
+    });
+  };
+
+  const dismissPicker = () => {
+    // "Esc: close, retain typed text" — the `@text` stays in the textarea.
+    // We suppress re-opening the picker for this particular `@`-span; any
+    // subsequent text edit (via handleInput) clears the suppression.
+    const match = trigger();
+    if (match) {
+      setDismissedAt(match.start);
+      queueMicrotask(() => {
+        if (textareaRef) {
+          textareaRef.focus();
+        }
+      });
+    }
+  };
+
+  const dismissChip = (id: string) => {
+    setChips((prev) => prev.filter((c) => c.id !== id));
   };
 
   return (
-    <div class="composer">
+    <div class="composer" ref={composerRef}>
+      {/* ctx-chips row — chips inserted from the picker live here. The spec
+          places it above the textarea so chips are visually attached to
+          the message being composed. */}
+      <div
+        class="composer__ctx-chips"
+        data-testid="ctx-chips"
+        classList={{ 'composer__ctx-chips--empty': chips().length === 0 }}
+      >
+        <For each={chips()}>
+          {(chip) => (
+            <ContextChip
+              category={chip.category}
+              label={chip.label}
+              onDismiss={() => dismissChip(chip.id)}
+            />
+          )}
+        </For>
+      </div>
       <textarea
         class="composer__textarea"
         data-testid="composer-textarea"
         placeholder="Ask, refine, or @-reference context"
         disabled={props.disabled}
         value={text()}
-        onInput={(e) => setText(e.currentTarget.value)}
+        onInput={handleInput}
+        onSelect={handleSelect}
+        onClick={handleSelect}
+        onKeyUp={handleSelect}
         onKeyDown={handleKeyDown}
         rows={3}
         aria-invalid={overCap() ? true : undefined}
+        ref={textareaRef}
       />
+      <Show when={pickerOpen()}>
+        <ContextPicker
+          query={trigger()!.query}
+          anchorRect={anchorRect()}
+          {...(props.items ? { items: props.items } : {})}
+          onPick={replaceAtSpan}
+          onDismiss={dismissPicker}
+        />
+      </Show>
       <div class="composer__bar">
         <span class="composer__hints">
           <Show


### PR DESCRIPTION
Closes forge-ide/forge#255

## Summary

Builds the `ContextPicker` popup that appears when the user types `@` in
the chat composer. Seven category tabs render as empty shells — per the
issue scope, category data sourcing (resolvers) is **F-142** and
intentionally out of scope here.

## Files

- `web/packages/app/src/components/ContextPicker.tsx` / `.css` — 360–480px
  popup, seven tabs (file/directory/selection/terminal/agent/skill/url),
  keyboard nav (arrows, Enter, Tab, Esc), placement flip logic
- `web/packages/app/src/components/ContextChip.tsx` / `.css` — minimal
  icon + label + × pill rendered in the `ctx-chips` row
- `web/packages/app/src/routes/Session/ChatPane.tsx` / `.css` — composer
  now tracks caret, detects the active `@`-span, renders the picker,
  swaps the span for a chip on pick, and adds the `ctx-chips` row

## Design notes

- **Placement flip extracted as a pure function.** `computePopupPlacement`
  takes `{anchorTop, anchorBottom, viewportHeight, popupHeight, gap}` and
  returns `'above' | 'below'`. jsdom doesn't compute layout, so the flip
  decision is unit-tested against the pure function rather than relying
  on `getBoundingClientRect()` in component render.
- **`@`-span removal extracted.** `removeAtSpan(text, start, caret)`
  computes the post-insertion textarea value + caret position as pure
  data so the invariant is tested without driving the whole composer.
- **Esc preserves typed text.** The picker is suppressed for the current
  `@`-span via a `dismissedAt` cursor; any subsequent edit to the text
  re-arms the trigger.
- **Tab owns category switching.** The popup's capture-phase keydown
  preventDefaults Tab so native focus traversal doesn't escape.
- **Spec vs DoD note.** Spec §7 reads "popped above the composer (never
  below)" while this issue's DoD asks for a viewport-aware flip. The DoD
  is binding; the flip is implemented. A follow-up to reconcile the spec
  text with the built behavior can happen in docs.

## Test plan

- `pnpm --filter app test` — 340 tests pass (adds ContextPicker,
  ContextChip, removeAtSpan, and @-trigger integration coverage)
- `pnpm -r typecheck` passes
- `pnpm -r build` passes
- `node ../scripts/check-tokens.mjs` passes

Scoped deliberately to component + composer wiring; resolvers/data
sourcing land in F-142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)