### PR TITLE
feat(web): add monaco-host iframe with monaco-languageclient (F-121)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,8 @@
   "pnpm": {
     "overrides": {
       "vite": "^6.4.2",
-      "esbuild": "^0.25.0"
+      "esbuild": "^0.25.0",
+      "dompurify": "^3.4.0"
     }
   }
 }

--- a/web/packages/monaco-host/README.md
+++ b/web/packages/monaco-host/README.md
@@ -1,0 +1,73 @@
+# monaco-host
+
+Isolated iframe app that hosts the Monaco editor and `monaco-languageclient`. Loaded by the parent `app` as `<iframe src="/monaco-host.html">` so Monaco's AMD loader, web workers, and global scope don't pollute the Solid tree. Communicates with the parent via `window.postMessage`; never talks to Tauri directly.
+
+## Role in the workspace
+
+- Depended on by: nothing — the parent `app` loads `dist/index.html` at runtime. No TypeScript import path crosses the package boundary.
+- Depends on: `monaco-editor`, `monaco-languageclient`, `vscode-languageclient`, `vscode-ws-jsonrpc`, `vscode-jsonrpc`. Dev: `vitest`, `jsdom`, `typescript`, `vite`.
+
+## postMessage protocol
+
+All messages use a discriminated union on `kind`. The full TypeScript union is in `src/protocol.ts`; the summary below is the contract other packages rely on.
+
+### Parent -> iframe
+
+| `kind` | Payload | Effect |
+| --- | --- | --- |
+| `open` | `{ uri, languageId, value }` | Replace buffer, remember `uri` as active. |
+| `close` | `{ uri }` | If `uri` is active, clear the buffer and forget it. |
+| `save` | `{ uri }` | If `uri` is active, emit `save` back with current contents. |
+| `focus` | `{}` | Focus the editor. No reply. |
+| `client.message` | `{ payload }` | Deliver an LSP response/notification to the in-iframe language client. |
+
+### Iframe -> parent
+
+| `kind` | Payload | Meaning |
+| --- | --- | --- |
+| `ready` | `{}` | Emitted once on boot after the protocol is wired. |
+| `opened` | `{ uri }` | Acknowledges an `open`. |
+| `closed` | `{ uri }` | Acknowledges a `close`. |
+| `save` | `{ uri, value }` | User/parent requested save; `value` is the current buffer. |
+| `change` | `{ uri, value }` | Every buffer edit, full post-change contents. |
+| `client.message` | `{ payload }` | Outbound LSP request/response (parent relays to `forge-lsp`, awaits reply). |
+| `client.notification` | `{ payload }` | Outbound LSP notification (fire-and-forget; no reply bookkeeping). |
+
+Outbound split rule (JSON-RPC 2.0): payloads with a `method` string and no `id` are classified as `client.notification`; anything else is `client.message`. Inbound `client.message` and `client.notification` are accepted symmetrically so the parent can forward server-initiated notifications such as `window/logMessage`.
+
+The iframe signals readiness with `ready`; the parent should queue `open` messages until it arrives.
+
+### LSP lifecycle
+
+`MonacoLanguageClient` is instantiated at boot but **not started**. F-123 is responsible for:
+
+1. Wiring the parent side to `forge-lsp` over Tauri IPC.
+2. Telling the iframe when a language is ready so the client can `.start()`.
+
+Until F-123 lands the language client is idle: it holds the postMessage transport so that the construction path is verified on every boot, but no LSP traffic flows.
+
+## Test harness
+
+The smoke test (`tests/protocol.test.ts`) imports **only** `src/protocol.ts`. That file deliberately has no transitive dependency on `monaco-editor` or `monaco-languageclient` — both pull in workers, AMD globals, and the `@codingame/monaco-vscode-*` peer graph, none of which are jsdom-safe.
+
+To add coverage that exercises Monaco, write a Playwright test in the parent `app` package (outside this PR's scope) and boot the built iframe via its Vite preview server. Do not try to mount Monaco in Vitest.
+
+## Theme drift
+
+`src/theme.ts` duplicates hex values from `web/packages/design/src/tokens.css`. `scripts/check-tokens.mjs` does not cover this file — Monaco's `defineTheme` needs literal color strings, not CSS variables. When tokens change, update both in the same PR.
+
+## Key types / entry points
+
+- `src/index.ts` — Vite entry; mounts Monaco, wires the protocol, constructs the language client.
+- `src/protocol.ts` — jsdom-safe. Message types, `IframeSocket` (a postMessage-backed `IWebSocket`), and `createIframeProtocol`.
+- `src/editor.ts` — Monaco mount + `EditorLike` adapter.
+- `src/client.ts` — `MonacoLanguageClient` construction wired to `IframeSocket` through `vscode-ws-jsonrpc`.
+- `src/theme.ts` — Forge Ember theme for Monaco.
+- Scripts: `pnpm dev` (Vite, port 5174), `pnpm build`, `pnpm test` (Vitest smoke), `pnpm typecheck`.
+
+## Further reading
+
+- [Build approach — Editor: Monaco in iframe](../../../docs/build/approach.md)
+- [Architecture overview §7](../../../docs/architecture/overview.md)
+- [Frontend architecture §9.3](../../../docs/frontend/architecture.md) — note: §9.3 currently describes direct Tauri process spawn from the iframe; F-121 follows the parent-relay model from the issue scope. Reconcile in a follow-up.
+- [Color system](../../../docs/design/color-system.md)

--- a/web/packages/monaco-host/index.html
+++ b/web/packages/monaco-host/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Content-Security-Policy (F-121).
+      This iframe's CSP is independent of the parent `app` document's CSP
+      (web/packages/app/index.html). Differences from the parent:
+        - `frame-ancestors 'self'`: the parent `app` embeds this document
+          as an <iframe>; 'none' would block embedding.
+        - `worker-src 'self' blob:`: Monaco spawns language-service workers
+          from blob URLs.
+        - `script-src 'self' 'wasm-unsafe-eval'`: Monaco uses WebAssembly
+          for some tokenisers; 'wasm-unsafe-eval' allows instantiation
+          without broader 'unsafe-eval'.
+        - `style-src 'self' 'unsafe-inline'`: Monaco injects styles at
+          runtime.
+      Keep in sync with the parent's CSP where they share concerns.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: asset: https://asset.localhost; connect-src 'self' ipc: http://ipc.localhost; frame-ancestors 'self'; base-uri 'self'; object-src 'none'"
+    />
+    <title>Forge Monaco Host</title>
+    <style>
+      html,
+      body,
+      #editor {
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: #07080a;
+        color: #eae6de;
+        font-family: 'Fira Code', monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="editor"></div>
+    <script type="module" src="/src/index.ts"></script>
+  </body>
+</html>

--- a/web/packages/monaco-host/package.json
+++ b/web/packages/monaco-host/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "monaco-host",
+  "version": "0.2.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "monaco-editor": "^0.55.0",
+    "monaco-languageclient": "^10.7.0",
+    "vscode-jsonrpc": "^8.2.1",
+    "vscode-languageclient": "~9.0.1",
+    "vscode-ws-jsonrpc": "~3.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "jsdom": "^25.0.1",
+    "typescript": "^5.6.3",
+    "vite": "^6.0.1",
+    "vitest": "^2.1.5"
+  }
+}

--- a/web/packages/monaco-host/src/client.ts
+++ b/web/packages/monaco-host/src/client.ts
@@ -1,0 +1,38 @@
+// F-121: monaco-languageclient wiring.
+//
+// The client is constructed with a `MessageTransports` pair built around
+// `IframeSocket` (our postMessage-backed `IWebSocket` adapter). The
+// client is NOT started here — F-123 is responsible for wiring the parent
+// to `forge-lsp` and instructing the iframe when to `.start()`. Until
+// then `MonacoLanguageClient` is idle: it exposes the transport to prove
+// the construction path works, nothing more. See README "LSP lifecycle".
+
+import { MonacoLanguageClient } from 'monaco-languageclient';
+import { CloseAction, ErrorAction } from 'vscode-languageclient/browser.js';
+import { WebSocketMessageReader, WebSocketMessageWriter } from 'vscode-ws-jsonrpc';
+import type { IframeSocket } from './protocol.js';
+
+/**
+ * Instantiate a `MonacoLanguageClient` bound to `socket`'s postMessage
+ * transport. The returned client is not started.
+ */
+export function createLanguageClient(
+  socket: IframeSocket,
+  options: { name?: string; id?: string; documentSelector?: string[] } = {},
+): MonacoLanguageClient {
+  const reader = new WebSocketMessageReader(socket);
+  const writer = new WebSocketMessageWriter(socket);
+
+  return new MonacoLanguageClient({
+    name: options.name ?? 'Forge Iframe LSP Client',
+    id: options.id ?? 'forge-iframe-lsp',
+    clientOptions: {
+      documentSelector: options.documentSelector ?? ['plaintext'],
+      errorHandler: {
+        error: () => ({ action: ErrorAction.Continue }),
+        closed: () => ({ action: CloseAction.DoNotRestart }),
+      },
+    },
+    messageTransports: { reader, writer },
+  });
+}

--- a/web/packages/monaco-host/src/editor.ts
+++ b/web/packages/monaco-host/src/editor.ts
@@ -1,0 +1,44 @@
+// F-121: Monaco editor instantiation + adapter onto `EditorLike`.
+//
+// This module imports `monaco-editor` and therefore must not be imported
+// by anything reachable from the test harness — see README "Test harness".
+
+import * as monaco from 'monaco-editor';
+import type { EditorLike } from './protocol.js';
+import { FORGE_THEME, FORGE_THEME_ID } from './theme.js';
+
+/** Attach a Monaco instance to `host` and return it wrapped as `EditorLike`. */
+export function mountEditor(host: HTMLElement): EditorLike {
+  monaco.editor.defineTheme(FORGE_THEME_ID, FORGE_THEME);
+
+  const instance = monaco.editor.create(host, {
+    value: '',
+    language: 'plaintext',
+    theme: FORGE_THEME_ID,
+    automaticLayout: true,
+    minimap: { enabled: false },
+    fontFamily: 'Fira Code, monospace',
+    fontSize: 13,
+    renderWhitespace: 'selection',
+    scrollBeyondLastLine: false,
+  });
+
+  return {
+    setValue(value) {
+      instance.setValue(value);
+    },
+    getValue() {
+      return instance.getValue();
+    },
+    focus() {
+      instance.focus();
+    },
+    onDidChangeContent(cb) {
+      const sub = instance.onDidChangeModelContent(() => cb(instance.getValue()));
+      return { dispose: () => sub.dispose() };
+    },
+    dispose() {
+      instance.dispose();
+    },
+  };
+}

--- a/web/packages/monaco-host/src/index.ts
+++ b/web/packages/monaco-host/src/index.ts
@@ -1,0 +1,35 @@
+// F-121: iframe entry point.
+//
+// Mounts Monaco into `#editor`, wires the postMessage protocol, and
+// constructs (but does not start) the `MonacoLanguageClient`.
+
+import { mountEditor } from './editor.js';
+import { createLanguageClient } from './client.js';
+import {
+  browserPost,
+  browserSubscribe,
+  createIframeProtocol,
+} from './protocol.js';
+
+const host = document.getElementById('editor');
+if (host === null) {
+  throw new Error('monaco-host: #editor element not found');
+}
+
+const editor = mountEditor(host);
+
+const handles = createIframeProtocol({
+  editor,
+  post: browserPost(),
+  subscribe: browserSubscribe(),
+});
+
+// Construct the LSP client eagerly so the transport path is verified at
+// boot. Starting it is F-123's job; see README "LSP lifecycle".
+const client = createLanguageClient(handles.socket);
+
+// Expose for debugging only; keep off `window` in production builds.
+if (import.meta.env.DEV) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).__forgeMonacoHost = { handles, client };
+}

--- a/web/packages/monaco-host/src/protocol.ts
+++ b/web/packages/monaco-host/src/protocol.ts
@@ -1,0 +1,275 @@
+// F-121: parent <-> iframe postMessage protocol.
+//
+// This module is deliberately free of any `monaco-editor` or
+// `monaco-languageclient` import so it can be exercised in jsdom without
+// pulling Monaco's workers/globals. The iframe boot wires a real Monaco
+// instance into `createIframeProtocol`; tests pass a stub editor.
+
+/** Opaque handle for a document the parent has asked us to edit. */
+export type DocumentUri = string;
+
+/** Parent -> iframe: editor lifecycle messages. */
+export type EditorInboundMessage =
+  | {
+      kind: 'open';
+      /** Stable document URI (e.g. `file:///path/to/foo.rs`). */
+      uri: DocumentUri;
+      /** Monaco language id (e.g. `rust`, `typescript`). */
+      languageId: string;
+      /** Initial buffer contents. */
+      value: string;
+    }
+  | { kind: 'close'; uri: DocumentUri }
+  | { kind: 'save'; uri: DocumentUri }
+  | { kind: 'focus' }
+  | {
+      /**
+       * LSP response/notification flowing from the parent-side relay back
+       * into the iframe's language client. F-123 will wire the parent to
+       * `forge-lsp`; until then the parent never emits these and the
+       * language client stays idle. Inbound `client.message` and
+       * `client.notification` are accepted symmetrically — LSP is
+       * bidirectional and the parent may forward `window/logMessage` or
+       * similar server-initiated notifications.
+       */
+      kind: 'client.message' | 'client.notification';
+      /** Opaque vscode-jsonrpc Message payload. */
+      payload: unknown;
+    };
+
+/** Iframe -> parent: editor + LSP outbound messages. */
+export type EditorOutboundMessage =
+  | { kind: 'ready' }
+  | { kind: 'opened'; uri: DocumentUri }
+  | { kind: 'closed'; uri: DocumentUri }
+  | {
+      kind: 'save';
+      uri: DocumentUri;
+      /** Buffer contents at save time. */
+      value: string;
+    }
+  | {
+      kind: 'change';
+      uri: DocumentUri;
+      /** Full post-change buffer contents (simple v1 protocol). */
+      value: string;
+    }
+  | {
+      /** LSP request/notification flowing out to the parent relay. */
+      kind: 'client.message';
+      payload: unknown;
+    }
+  | {
+      /** LSP notification from the client (fire-and-forget). */
+      kind: 'client.notification';
+      payload: unknown;
+    };
+
+/** Minimal editor surface we need. Real Monaco satisfies this via an adapter. */
+export interface EditorLike {
+  setValue(value: string): void;
+  getValue(): string;
+  focus(): void;
+  onDidChangeContent(cb: (value: string) => void): { dispose(): void };
+  dispose(): void;
+}
+
+/** A single subscriber callback. */
+export type MessageListener = (data: unknown) => void;
+
+/**
+ * Decide whether a parsed JSON-RPC payload is a notification (no `id`
+ * with a `method`) or a request/response. String payloads are treated as
+ * opaque messages.
+ */
+function classifyOutbound(payload: unknown): 'client.message' | 'client.notification' {
+  if (
+    typeof payload === 'object' &&
+    payload !== null &&
+    typeof (payload as { method?: unknown }).method === 'string' &&
+    (payload as { id?: unknown }).id === undefined
+  ) {
+    return 'client.notification';
+  }
+  return 'client.message';
+}
+
+/**
+ * `IWebSocket` (from vscode-ws-jsonrpc) compatible surface, adapted over
+ * postMessage. Exposed as a class rather than an interface so both
+ * `vscode-ws-jsonrpc` and the protocol router can hold the same instance.
+ *
+ * The LSP reader/writer pair drives this socket with `client.message`
+ * payloads. Editor lifecycle messages (`open`, `close`, etc.) bypass it.
+ */
+export class IframeSocket {
+  private readonly messageListeners: Array<(data: unknown) => void> = [];
+  private readonly errorListeners: Array<(reason: unknown) => void> = [];
+  private readonly closeListeners: Array<(code: number, reason: string) => void> = [];
+  private disposed = false;
+
+  constructor(private readonly post: (msg: EditorOutboundMessage) => void) {}
+
+  send(content: string): void {
+    if (this.disposed) return;
+    // vscode-ws-jsonrpc stringifies messages before calling send(); we parse
+    // here so the parent relay sees structured JSON, not a string-in-string.
+    let payload: unknown;
+    try {
+      payload = JSON.parse(content);
+    } catch {
+      // Fall back to opaque string; the parent relay can still forward it.
+      payload = content;
+    }
+    // JSON-RPC 2.0: a request without an `id` is a notification. Splitting
+    // the outbound kind lets the parent relay skip reply bookkeeping for
+    // notifications — important because `forge-lsp` relays may drop them
+    // rather than ferry a reply back.
+    this.post({ kind: classifyOutbound(payload), payload });
+  }
+
+  onMessage(cb: (data: unknown) => void): void {
+    this.messageListeners.push(cb);
+  }
+
+  onError(cb: (reason: unknown) => void): void {
+    this.errorListeners.push(cb);
+  }
+
+  onClose(cb: (code: number, reason: string) => void): void {
+    this.closeListeners.push(cb);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const cb of this.closeListeners) cb(1000, 'disposed');
+  }
+
+  /** Feed an inbound LSP `client.message` payload to subscribed readers. */
+  receive(payload: unknown): void {
+    if (this.disposed) return;
+    // vscode-ws-jsonrpc's WebSocketMessageReader accepts the parsed object
+    // shape; string is also fine for it, but we normalise to string for
+    // parity with the ws-server reference implementations.
+    const data = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    for (const cb of this.messageListeners) cb(data);
+  }
+}
+
+/** What the iframe boot gives the protocol factory. */
+export interface IframeProtocolConfig {
+  /** The editor (real Monaco or a stub). */
+  editor: EditorLike;
+  /**
+   * Send a message to the parent window. Defaults to
+   * `window.parent.postMessage(msg, '*')` when running inside the browser;
+   * tests inject a recording stub.
+   */
+  post: (msg: EditorOutboundMessage) => void;
+  /**
+   * Subscribe to messages from the parent. Defaults to
+   * `window.addEventListener('message', ...)` in the browser; tests drive
+   * this directly.
+   */
+  subscribe: (listener: MessageListener) => { dispose(): void };
+}
+
+/** The handles the iframe boot needs to hand to the LSP client. */
+export interface IframeProtocolHandles {
+  /** Socket adapter suitable for `WebSocketMessageReader`/`...Writer`. */
+  socket: IframeSocket;
+  /** URI of the currently-open document, if any. */
+  currentUri(): DocumentUri | null;
+  /** Tear everything down. Idempotent. */
+  dispose(): void;
+}
+
+/**
+ * Wire an editor up to the parent-window postMessage protocol. Returns the
+ * socket the LSP client should use, plus a disposer.
+ */
+export function createIframeProtocol(config: IframeProtocolConfig): IframeProtocolHandles {
+  const { editor, post, subscribe } = config;
+  const socket = new IframeSocket(post);
+
+  let currentUri: DocumentUri | null = null;
+
+  const changeSub = editor.onDidChangeContent((value) => {
+    if (currentUri !== null) {
+      post({ kind: 'change', uri: currentUri, value });
+    }
+  });
+
+  const messageSub = subscribe((data) => {
+    const msg = data as EditorInboundMessage;
+    if (!msg || typeof msg !== 'object' || typeof (msg as { kind?: unknown }).kind !== 'string') {
+      return;
+    }
+    switch (msg.kind) {
+      case 'open':
+        currentUri = msg.uri;
+        editor.setValue(msg.value);
+        post({ kind: 'opened', uri: msg.uri });
+        break;
+      case 'close':
+        if (currentUri === msg.uri) {
+          currentUri = null;
+          editor.setValue('');
+        }
+        post({ kind: 'closed', uri: msg.uri });
+        break;
+      case 'save':
+        if (currentUri === msg.uri) {
+          post({ kind: 'save', uri: msg.uri, value: editor.getValue() });
+        }
+        break;
+      case 'focus':
+        editor.focus();
+        break;
+      case 'client.message':
+      case 'client.notification':
+        socket.receive(msg.payload);
+        break;
+    }
+  });
+
+  // Signal to the parent that we are ready to receive `open` messages.
+  post({ kind: 'ready' });
+
+  let disposed = false;
+  return {
+    socket,
+    currentUri: () => currentUri,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      changeSub.dispose();
+      messageSub.dispose();
+      socket.dispose();
+      editor.dispose();
+    },
+  };
+}
+
+/** Default browser `subscribe` that listens on `window.message`. */
+export function browserSubscribe(
+  target: Window = window,
+): (listener: MessageListener) => { dispose(): void } {
+  return (listener) => {
+    const handler = (e: MessageEvent) => listener(e.data);
+    target.addEventListener('message', handler);
+    return {
+      dispose: () => target.removeEventListener('message', handler),
+    };
+  };
+}
+
+/** Default browser `post` that targets `window.parent`. */
+export function browserPost(parent: Window | null = window.parent): (msg: EditorOutboundMessage) => void {
+  return (msg) => {
+    if (parent !== null) {
+      parent.postMessage(msg, '*');
+    }
+  };
+}

--- a/web/packages/monaco-host/src/theme.ts
+++ b/web/packages/monaco-host/src/theme.ts
@@ -1,0 +1,75 @@
+// F-121: Forge design-token theme for Monaco.
+//
+// `monaco.editor.defineTheme()` takes literal color strings; it does not
+// resolve CSS custom properties. The hex values below mirror
+// `web/packages/design/src/tokens.css` (authoritative source
+// `docs/design/token-reference.md`). `scripts/check-tokens.mjs` does NOT
+// cover this file — if tokens change, update both in the same PR. See
+// README "Theme drift" for the rationale.
+
+/**
+ * Token hex values, pinned from tokens.css. Keep this list small — only
+ * the tokens the Monaco theme actually consumes.
+ */
+export const TOKENS = {
+  bg: '#07080a',
+  surface1: '#0d0f13',
+  surface2: '#13161d',
+  surface3: '#181c26',
+  border1: '#1c2230',
+  border2: '#252f3e',
+  textPrimary: '#eae6de',
+  textSecondary: '#8a9aac',
+  textTertiary: '#3a4558',
+  ember400: '#ff4a12',
+  ember300: '#ff7a30',
+  syntaxKw: '#ff7a30',
+  syntaxFn: '#ffd166',
+  syntaxStr: '#3ddc84',
+  syntaxType: '#7a9fff',
+  syntaxNum: '#ff9966',
+  syntaxComment: '#3a4558',
+  info: '#7aaaff',
+  success: '#3ddc84',
+  error: '#ff4a12',
+} as const;
+
+export const FORGE_THEME_ID = 'forge-ember';
+
+/** Monaco `IStandaloneThemeData` shape (typed loosely to avoid an import). */
+export interface ForgeThemeData {
+  base: 'vs-dark';
+  inherit: boolean;
+  rules: Array<{ token: string; foreground?: string; fontStyle?: string }>;
+  colors: Record<string, string>;
+}
+
+/** Theme definition in the shape Monaco's `defineTheme` accepts. */
+export const FORGE_THEME: ForgeThemeData = {
+  base: 'vs-dark',
+  inherit: true,
+  rules: [
+    { token: 'comment', foreground: TOKENS.syntaxComment.slice(1), fontStyle: 'italic' },
+    { token: 'keyword', foreground: TOKENS.syntaxKw.slice(1) },
+    { token: 'string', foreground: TOKENS.syntaxStr.slice(1) },
+    { token: 'number', foreground: TOKENS.syntaxNum.slice(1) },
+    { token: 'type', foreground: TOKENS.syntaxType.slice(1) },
+    { token: 'function', foreground: TOKENS.syntaxFn.slice(1) },
+    { token: 'operator', foreground: TOKENS.ember300.slice(1) },
+  ],
+  colors: {
+    'editor.background': TOKENS.bg,
+    'editor.foreground': TOKENS.textPrimary,
+    'editorCursor.foreground': TOKENS.ember400,
+    'editor.lineHighlightBackground': TOKENS.surface2,
+    'editor.selectionBackground': TOKENS.surface3,
+    'editorLineNumber.foreground': TOKENS.textTertiary,
+    'editorLineNumber.activeForeground': TOKENS.textSecondary,
+    'editor.inactiveSelectionBackground': TOKENS.border1,
+    'editorIndentGuide.background': TOKENS.border1,
+    'editorIndentGuide.activeBackground': TOKENS.border2,
+    'editorError.foreground': TOKENS.error,
+    'editorWarning.foreground': TOKENS.ember300,
+    'editorInfo.foreground': TOKENS.info,
+  },
+};

--- a/web/packages/monaco-host/tests/protocol.test.ts
+++ b/web/packages/monaco-host/tests/protocol.test.ts
@@ -1,0 +1,253 @@
+// F-121 smoke test. Exercises the postMessage protocol with a stub editor.
+// Does NOT import monaco-editor or monaco-languageclient — those bundles
+// are not jsdom-safe. See README "Test harness".
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createIframeProtocol,
+  type EditorInboundMessage,
+  type EditorLike,
+  type EditorOutboundMessage,
+  type MessageListener,
+} from '../src/protocol.js';
+
+/** Recording stub editor. Satisfies the `EditorLike` surface. */
+function makeStubEditor(): EditorLike & {
+  setValueCalls: string[];
+  focusCalls: number;
+  emitChange: (value: string) => void;
+} {
+  let buffer = '';
+  const listeners: Array<(v: string) => void> = [];
+  const stub = {
+    setValueCalls: [] as string[],
+    focusCalls: 0,
+    setValue(value: string) {
+      buffer = value;
+      stub.setValueCalls.push(value);
+    },
+    getValue() {
+      return buffer;
+    },
+    focus() {
+      stub.focusCalls += 1;
+    },
+    onDidChangeContent(cb: (v: string) => void) {
+      listeners.push(cb);
+      return { dispose: () => void 0 };
+    },
+    dispose() {},
+    emitChange(value: string) {
+      buffer = value;
+      for (const cb of listeners) cb(value);
+    },
+  };
+  return stub;
+}
+
+/** Minimal harness that replaces `window.parent.postMessage` with a recorder. */
+function makeHarness() {
+  const outbound: EditorOutboundMessage[] = [];
+  let listener: MessageListener | null = null;
+
+  const post = (msg: EditorOutboundMessage) => {
+    outbound.push(msg);
+  };
+  const subscribe = (cb: MessageListener) => {
+    listener = cb;
+    return {
+      dispose: () => {
+        listener = null;
+      },
+    };
+  };
+  const sendFromParent = (msg: EditorInboundMessage) => {
+    if (listener !== null) listener(msg);
+  };
+  return { outbound, post, subscribe, sendFromParent };
+}
+
+describe('postMessage protocol', () => {
+  it('emits `ready` on startup', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+
+    expect(h.outbound[0]).toEqual({ kind: 'ready' });
+    handles.dispose();
+  });
+
+  it('round-trips `open`: parent sends -> editor.setValue called -> `opened` emitted', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+    h.outbound.length = 0;
+
+    h.sendFromParent({
+      kind: 'open',
+      uri: 'file:///tmp/foo.ts',
+      languageId: 'typescript',
+      value: 'const x = 1;\n',
+    });
+
+    expect(editor.setValueCalls).toEqual(['const x = 1;\n']);
+    expect(editor.getValue()).toBe('const x = 1;\n');
+    expect(h.outbound).toEqual([{ kind: 'opened', uri: 'file:///tmp/foo.ts' }]);
+
+    handles.dispose();
+  });
+
+  it('editor edits emit `change` to the parent', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+
+    h.sendFromParent({ kind: 'open', uri: 'file:///a.txt', languageId: 'plaintext', value: 'a' });
+    h.outbound.length = 0;
+
+    editor.emitChange('ab');
+
+    expect(h.outbound).toEqual([{ kind: 'change', uri: 'file:///a.txt', value: 'ab' }]);
+    handles.dispose();
+  });
+
+  it('`save` echoes current buffer back to the parent', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+
+    h.sendFromParent({ kind: 'open', uri: 'file:///b.md', languageId: 'markdown', value: 'hello' });
+    editor.emitChange('hello world');
+    h.outbound.length = 0;
+
+    h.sendFromParent({ kind: 'save', uri: 'file:///b.md' });
+
+    expect(h.outbound).toEqual([{ kind: 'save', uri: 'file:///b.md', value: 'hello world' }]);
+    handles.dispose();
+  });
+
+  it('`close` clears the active URI and notifies the parent', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+
+    h.sendFromParent({ kind: 'open', uri: 'file:///c.txt', languageId: 'plaintext', value: 'hi' });
+    h.outbound.length = 0;
+
+    h.sendFromParent({ kind: 'close', uri: 'file:///c.txt' });
+
+    expect(handles.currentUri()).toBeNull();
+    expect(editor.getValue()).toBe('');
+    expect(h.outbound).toEqual([{ kind: 'closed', uri: 'file:///c.txt' }]);
+    handles.dispose();
+  });
+
+  it('`focus` calls editor.focus but emits nothing', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+    h.outbound.length = 0;
+
+    h.sendFromParent({ kind: 'focus' });
+
+    expect(editor.focusCalls).toBe(1);
+    expect(h.outbound).toEqual([]);
+    handles.dispose();
+  });
+
+  it('iframe-side LSP request (has id) posts `client.message`', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+    h.outbound.length = 0;
+
+    handles.socket.send(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }));
+
+    expect(h.outbound).toEqual([
+      { kind: 'client.message', payload: { jsonrpc: '2.0', id: 1, method: 'initialize' } },
+    ]);
+    handles.dispose();
+  });
+
+  it('iframe-side LSP notification (no id) posts `client.notification`', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+    h.outbound.length = 0;
+
+    handles.socket.send(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'textDocument/didOpen',
+        params: { textDocument: { uri: 'file:///x.rs', languageId: 'rust', version: 0, text: '' } },
+      }),
+    );
+
+    expect(h.outbound).toEqual([
+      {
+        kind: 'client.notification',
+        payload: {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: { uri: 'file:///x.rs', languageId: 'rust', version: 0, text: '' },
+          },
+        },
+      },
+    ]);
+    handles.dispose();
+  });
+
+  it('parent -> `client.message` delivers to socket subscribers', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+    const sink = vi.fn();
+    handles.socket.onMessage(sink);
+
+    h.sendFromParent({
+      kind: 'client.message',
+      payload: { jsonrpc: '2.0', id: 1, result: null },
+    });
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0]?.[0]).toBe('{"jsonrpc":"2.0","id":1,"result":null}');
+    handles.dispose();
+  });
+
+  it('parent -> `client.notification` delivers to the same subscribers (LSP bidirectional)', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+    const sink = vi.fn();
+    handles.socket.onMessage(sink);
+
+    h.sendFromParent({
+      kind: 'client.notification',
+      payload: {
+        jsonrpc: '2.0',
+        method: 'window/logMessage',
+        params: { type: 3, message: 'hello' },
+      },
+    });
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    handles.dispose();
+  });
+
+  it('ignores malformed messages silently', () => {
+    const editor = makeStubEditor();
+    const h = makeHarness();
+    const handles = createIframeProtocol({ editor, post: h.post, subscribe: h.subscribe });
+    h.outbound.length = 0;
+
+    // `listener` is typed as `unknown`, so we send a nonsense shape through.
+    (h as unknown as { sendFromParent: (v: unknown) => void }).sendFromParent({ nope: true });
+    (h as unknown as { sendFromParent: (v: unknown) => void }).sendFromParent(null);
+    (h as unknown as { sendFromParent: (v: unknown) => void }).sendFromParent('not an object');
+
+    expect(editor.setValueCalls).toEqual([]);
+    expect(h.outbound).toEqual([]);
+    handles.dispose();
+  });
+});

--- a/web/packages/monaco-host/tsconfig.json
+++ b/web/packages/monaco-host/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vite/client", "vitest/globals", "node"],
+    "noEmit": true,
+    "rootDir": "./"
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vite.config.ts"]
+}

--- a/web/packages/monaco-host/vite.config.ts
+++ b/web/packages/monaco-host/vite.config.ts
@@ -1,0 +1,25 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+// F-121: isolated iframe hosting Monaco + monaco-languageclient. Runs in its
+// own Vite build so Monaco's AMD loader, web workers, and global scope do not
+// pollute the parent `app` bundle.
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    target: 'es2022',
+  },
+  server: {
+    port: 5174,
+    strictPort: false,
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    // Integration/e2e that needs real Monaco goes elsewhere; unit tests here
+    // must not import `monaco-editor` or `monaco-languageclient` directly —
+    // they exercise `src/protocol.ts` with a stub editor. See README.
+    exclude: ['node_modules', 'dist'],
+  },
+});

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   vite: ^6.4.2
   esbuild: ^0.25.0
+  dompurify: ^3.4.0
 
 importers:
 
@@ -65,6 +66,40 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+
+  packages/monaco-host:
+    dependencies:
+      monaco-editor:
+        specifier: ^0.55.0
+        version: 0.55.1
+      monaco-languageclient:
+        specifier: ^10.7.0
+        version: 10.7.0
+      vscode-jsonrpc:
+        specifier: ^8.2.1
+        version: 8.2.1
+      vscode-languageclient:
+        specifier: ~9.0.1
+        version: 9.0.1
+      vscode-ws-jsonrpc:
+        specifier: ~3.5.0
+        version: 3.5.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.17
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.2
+        version: 6.4.2(@types/node@22.19.17)
+      vitest:
+        specifier: ^2.1.5
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
 packages:
 
@@ -158,6 +193,132 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@codingame/monaco-vscode-api@25.1.2':
+    resolution: {integrity: sha512-K04QcQA+Zb0KXucBAK/BGCT5dldiwIqdUbBQq7yuLvBLbof3cP1WSUuxasMHGYwM0MWyzIAsDtyAYMS7is8ZuA==}
+
+  '@codingame/monaco-vscode-base-service-override@25.1.2':
+    resolution: {integrity: sha512-OwYs6h1ATUAeMmX+Q1c8esTG7GLMqniBs+fLEr1/9b/ciY485ArKo5UvrUxVPDtRNy/7F06vRW9IUCq9iKP14w==}
+
+  '@codingame/monaco-vscode-bulk-edit-service-override@25.1.2':
+    resolution: {integrity: sha512-+EfSzjiFakCf0IIJKPZrHVGioq5N8GBsp51bXuKBR5J/B58cUaJY0Dc12PNTSpgAusAGOppUIOSBqUk4F/7IaQ==}
+
+  '@codingame/monaco-vscode-configuration-service-override@25.1.2':
+    resolution: {integrity: sha512-oeoZ3WtM42zHA1IWHrx9UGEfE+TixE+G8Bl9M9bjgFj1EROnkB5yOfELwRYPo4WOEtcK1C5nvIvWIj/hL9MaLg==}
+
+  '@codingame/monaco-vscode-editor-api@25.1.2':
+    resolution: {integrity: sha512-dVXoBLRN8vyFHsLY6iYISaNetZ3ispXLut0qL+jvN0e0CEFkUv1F/3EAE7myptrJSS/N1AptrRIxATT3lwFP+Q==}
+
+  '@codingame/monaco-vscode-editor-service-override@25.1.2':
+    resolution: {integrity: sha512-EadvDCyWdgxOPmaIvbcVVDNjTUYuKdjYWwKbPbbcTs9t4z1/DjdE7mV3ZdT6aGh5m6zkEEUOi143l27Y5eRt+Q==}
+
+  '@codingame/monaco-vscode-environment-service-override@25.1.2':
+    resolution: {integrity: sha512-8GoD3lk0CN0dIMZOrZNS/i8RCaF1YSQ6nmrf+rqneOSHG9S382EnsZZD69d4+i7JnoeyttO7Kr9KH8WOhRV6OA==}
+
+  '@codingame/monaco-vscode-extension-api@25.1.2':
+    resolution: {integrity: sha512-SJW/YOhjo+9MXEyzMwQMUWdJVR3Llc6pTq5JQqs6Y30v73gTrpLqtzbd9FNdCuQR8S6bUk5ScH8GL4QrVuL5FA==}
+
+  '@codingame/monaco-vscode-extensions-service-override@25.1.2':
+    resolution: {integrity: sha512-rTTZW2biPxcg+JumhVf2L+38C5ptvNNxiJlwz39VfXFEh6qOHtAsIMy7vIXa0uGg5/y8DNp0SnOQJP/RKhLYZA==}
+
+  '@codingame/monaco-vscode-files-service-override@25.1.2':
+    resolution: {integrity: sha512-TenLLAFIwY7keZFF8e3beUn7OVfnNINR5Noi4PVrjeeTcy6FuNH6Jghdul2JwpRAkvyJLdFMvomE2jlT6F03jQ==}
+
+  '@codingame/monaco-vscode-host-service-override@25.1.2':
+    resolution: {integrity: sha512-lgaalpA9CUQW7i0bBwgBOK0DQNDvOo3QO3p6Rz6yVsHpgA4iMqq2d11dBDUKvuQSwIHPRu8CMHCqhQk/BQN/YA==}
+
+  '@codingame/monaco-vscode-keybindings-service-override@25.1.2':
+    resolution: {integrity: sha512-cp/gGyTvCTAzCYnQm0HJykXJRB0Huz8Lvq60lj5LutgWcb8S3w6dOB2Houm8dHoeUm/jOko8SQNIP8hzWN92Zw==}
+
+  '@codingame/monaco-vscode-language-pack-cs@25.1.2':
+    resolution: {integrity: sha512-v0cB2uAOCwj135aGIf0arGV+DNW32lbWh04bv8ctTxcWRt1Pr2kTQ1pjfE8ynKgxabPfAk8E25/CerKSYOmZ+A==}
+
+  '@codingame/monaco-vscode-language-pack-de@25.1.2':
+    resolution: {integrity: sha512-xA3WOt1w5jlAOnyx4PBwx+qV3vx8C8/zie29qjYbgJMxGKDkb0HfpuKUwywDA2uUMI2wJZS+PnNG00zPDoLIrw==}
+
+  '@codingame/monaco-vscode-language-pack-es@25.1.2':
+    resolution: {integrity: sha512-1/upuO9lRJilZ3sRr0QLTpz55KYRaBWDe8wtPvghOFYOHyWgW8A4VhUQxa6L9SJgY1JkypUAm0U8WcMX2G4LnQ==}
+
+  '@codingame/monaco-vscode-language-pack-fr@25.1.2':
+    resolution: {integrity: sha512-iq+xx+tv1QIMmFD0eBhFRMF4xMAsVf/HyA1WogqBofteCWeAvRE9HUjZ5JzHz7jXBPe3dLP1LOM0r0GrJZs4fQ==}
+
+  '@codingame/monaco-vscode-language-pack-it@25.1.2':
+    resolution: {integrity: sha512-FajWCML9OR8ppLnJ0mcg+sFHEhYJl8zhb3/DHnd+pNysw8dLfetXoSWjaPnwPPpwiQgkNN1UsToZHOU9czVifQ==}
+
+  '@codingame/monaco-vscode-language-pack-ja@25.1.2':
+    resolution: {integrity: sha512-NwKh0BnPgUrJkxsm0X6vY4ftnd9DjxkcnQqK+bohta6UOzm09J1EjZ6QD42fjWngxrp/xiegtrYQ9NA2q6VpoA==}
+
+  '@codingame/monaco-vscode-language-pack-ko@25.1.2':
+    resolution: {integrity: sha512-fvaisgfcg8YaAwnyPcGmQDLwkwqzamLQUyx9HmnwDpXw0YANzd058Kwn6bz+Vfn9MjwuMNT0nllD0qQMnpdyew==}
+
+  '@codingame/monaco-vscode-language-pack-pl@25.1.2':
+    resolution: {integrity: sha512-9hDRyzFJkDia5rO9QE262JgxwP/cnalFisLFo7FQcw57ZhqzqXIdQIuwcKaHuAgzeQ6W2+A3KOLfTr3m7VZrXw==}
+
+  '@codingame/monaco-vscode-language-pack-pt-br@25.1.2':
+    resolution: {integrity: sha512-7fFnqOTAJGb5RuJ4uwh9sh0JmXALuHPGOl7iL9rZkcgIuVP5y6wVDUDXq5qjiRTNSFDs7Bzh463Ir5m5D6mJbA==}
+
+  '@codingame/monaco-vscode-language-pack-qps-ploc@25.1.2':
+    resolution: {integrity: sha512-IFjoqrSuPtIFWb+KlPT6PFWKszzNX+TCD9drgCV6AigvBO/xfGL3QwHB68l/DLbmDbohOz4Xdkutv20wuENAeA==}
+
+  '@codingame/monaco-vscode-language-pack-ru@25.1.2':
+    resolution: {integrity: sha512-0uDAeXO+GllKUPhJzP893rlDhlFV1IwCu/515rBdcyegt48iGm/xAgj26V90hNz8hmB6EuM/7d8MFeklbiIpYA==}
+
+  '@codingame/monaco-vscode-language-pack-tr@25.1.2':
+    resolution: {integrity: sha512-MJhHxDyJEiuVLQ9+jb8MnnN9lsbJOjJjMswVCeJ7v/Q/msAhq25QYUfn0DbOIzESJE1f7crffRb5e38XP8sYWA==}
+
+  '@codingame/monaco-vscode-language-pack-zh-hans@25.1.2':
+    resolution: {integrity: sha512-c7MMrhnSLb59NxpAa8nVy9aIbxy4gVYrCpDMq8W380LOaXTYb7nueTrw8QJ5QbJBNi2P2KZoGkn2BlONuBtJJg==}
+
+  '@codingame/monaco-vscode-language-pack-zh-hant@25.1.2':
+    resolution: {integrity: sha512-ARedFTM6JCluoPLJqkBcTJaQFdJNcN86OX6B8/NMApIPrnSIAfanMndpyilt8XjzUG6IH22cypR+DAlEjf48cA==}
+
+  '@codingame/monaco-vscode-languages-service-override@25.1.2':
+    resolution: {integrity: sha512-ipuS1V3NgXDkNrj0vBcgMBFnqo+19HVsZjjFGfPFH3x0uptP9aiWWK42wtDK3Qbu4teSjHL7WnSLrmw94rplWw==}
+
+  '@codingame/monaco-vscode-layout-service-override@25.1.2':
+    resolution: {integrity: sha512-SxBGcMK3RgkGtUn7ZDl7dCoyNW0CWFQ/bfSRYUY06A0IA4JNS5jq1lhof57d0WXewm+5l8w1Spr/vMsfx1c9ig==}
+
+  '@codingame/monaco-vscode-localization-service-override@25.1.2':
+    resolution: {integrity: sha512-QLj62A8XDOIQW3KjsZlNxs+sfsNNHYxWMjQMwZu/y2Vw3IIHGly2Lpn4t4SFbeaBHJQJy4i5s7NpzlbF9MbEzQ==}
+
+  '@codingame/monaco-vscode-log-service-override@25.1.2':
+    resolution: {integrity: sha512-OoileAUtPAJ0j3RW31DFSxtOipy0EcFq+iIXEdGvoRlsQPZJ3o9ayjf1JvCXpxUjJ3QkmvQVhXsWNUFREjEFLg==}
+
+  '@codingame/monaco-vscode-model-service-override@25.1.2':
+    resolution: {integrity: sha512-MGz/eV1CxibLvnl6WzK6idUHJCXJOVepJvKM6Trkv5050vRe+f/o1TjCiG8PaznAypYqZvnwkTG0B7/OTizCpQ==}
+
+  '@codingame/monaco-vscode-monarch-service-override@25.1.2':
+    resolution: {integrity: sha512-akyNHOJQRS7YHyk6kf0Encnkt+shlR+bIB84UJRUHFgSeF8s5gkDkQuFJph0YeUDWJWat+yBLUSZx2nHomdbHQ==}
+
+  '@codingame/monaco-vscode-quickaccess-service-override@25.1.2':
+    resolution: {integrity: sha512-7IIrXnwHiF3w9d9p9kspEUz/LCibMLUztmRpGdZQfFtWBJw043q7rk8V1O42KdXr1hVg9IR5vfffwjy9nbiiUg==}
+
+  '@codingame/monaco-vscode-textmate-service-override@25.1.2':
+    resolution: {integrity: sha512-AL0FtSQBW+1vtoXYQvUqB2hfWojpK73Kq/n6KuNXxjLF/XBJ5FpeeZDfrBfwhWPPoHuBTsaFUCQy4L8xQgbVlA==}
+
+  '@codingame/monaco-vscode-theme-defaults-default-extension@25.1.2':
+    resolution: {integrity: sha512-0vTMFiC89YSDSmjFckuQBUKwRuFNtsILNO3k0PBiSLN/MW+VDItjJpiVLXC42+rUWlGgY2lYxOneGVa5slCV1w==}
+
+  '@codingame/monaco-vscode-theme-service-override@25.1.2':
+    resolution: {integrity: sha512-hsTwl6YYTiheFuQMmCmiEGLIdIdgYaf8Z85XWyxe6YgPtDaYGnp0fGSOXKA9/bf0JtuynzoLKtUUfDupK/A7Tw==}
+
+  '@codingame/monaco-vscode-view-banner-service-override@25.1.2':
+    resolution: {integrity: sha512-zhujHd1PQ6rRXsC2OQGrx/282G2v3lpPFl9heDFGKzpdj5119SgcW+B9p/MwJ1qF3LJpuRRgefNiQtqC/KT1eA==}
+
+  '@codingame/monaco-vscode-view-common-service-override@25.1.2':
+    resolution: {integrity: sha512-4Po/YaHUvVf4VmhVCZmM2lc/flOptiWSM140bIRNpMcfH0VwihYg15CcDeu1Oc+6DaauzsG3u59GtEvlMmJ9Zw==}
+
+  '@codingame/monaco-vscode-view-status-bar-service-override@25.1.2':
+    resolution: {integrity: sha512-Jp9ytLaWZ6evabTPtG3Mu3dFx+7WTIPz69BsGpl9PnU0kiSWUqQhPSob0Jz7E2qmMj0ZcNv2Wqvm6bMBu5OyrA==}
+
+  '@codingame/monaco-vscode-view-title-bar-service-override@25.1.2':
+    resolution: {integrity: sha512-NVYtTAFR35NV/Fx7tSlbASicvpAjK5A14fmxF7/LJJN8ZmzhA/P3Y+UzhqOQl6/VcPV4pAMU0Z7Sicgwbn37dw==}
+
+  '@codingame/monaco-vscode-views-service-override@25.1.2':
+    resolution: {integrity: sha512-LfzlztsvobdP5L5EvJ/rqSEgy5fEVmrkMqRteuhEtNGd4hnmdBoX8W7BNMBPff6d4NfCK74pGHJF57RyT4Iixg==}
+
+  '@codingame/monaco-vscode-workbench-service-override@25.1.2':
+    resolution: {integrity: sha512-2LMHr+na03FhOAaXpIGmamq9hf7e4wt2kULn8NqNZRd3i+0v1tx/TSSjGhsA5EkrNrFD7CMSoXayBq8tgpCq/A==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -536,6 +697,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -564,6 +728,9 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vscode/iconv-lite-umd@0.7.1':
+    resolution: {integrity: sha512-tK6k0DXFHW7q5+GGuGZO+phpAqpxO4WXl+BLc/8/uOk3RsM2ssAL3CQUQDb1TGfwltjsauhN6S4ghYZzs4sPFw==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -605,10 +772,16 @@ packages:
       solid-js:
         optional: true
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   baseline-browser-mapping@2.10.19:
     resolution: {integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -684,6 +857,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -818,6 +994,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  jschardet@3.1.4:
+    resolution: {integrity: sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==}
+    engines: {node: '>=0.1.90'}
+
   jsdom@25.0.1:
     resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
     engines: {node: '>=18'}
@@ -853,6 +1033,11 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -872,6 +1057,17 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+
+  monaco-languageclient@10.7.0:
+    resolution: {integrity: sha512-oA5cOFixkF4bspVL2zMSn48LvlNR/Cu3vJ8MCVam3PdjobSULGgHtOASuZIi3FgWK42X1z8/6hrG0LCjvNu1Hw==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -953,6 +1149,11 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   seroval-plugins@1.5.2:
@@ -1132,6 +1333,28 @@ packages:
       jsdom:
         optional: true
 
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-jsonrpc@8.2.1:
+    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageclient@9.0.1:
+    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
+    engines: {vscode: ^1.82.0}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-ws-jsonrpc@3.5.0:
+    resolution: {integrity: sha512-13ZDy7Od4AfEPK2HIfY3DtyRi4FVsvFql1yobVJrpIoHOKGGJpIjVvIJpMxkrHzCZzWlYlg+WEu2hrYkCTvM0Q==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -1304,6 +1527,203 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@codingame/monaco-vscode-api@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-base-service-override': 25.1.2
+      '@codingame/monaco-vscode-environment-service-override': 25.1.2
+      '@codingame/monaco-vscode-extensions-service-override': 25.1.2
+      '@codingame/monaco-vscode-files-service-override': 25.1.2
+      '@codingame/monaco-vscode-host-service-override': 25.1.2
+      '@codingame/monaco-vscode-layout-service-override': 25.1.2
+      '@codingame/monaco-vscode-quickaccess-service-override': 25.1.2
+      '@vscode/iconv-lite-umd': 0.7.1
+      dompurify: 3.4.0
+      jschardet: 3.1.4
+      marked: 14.0.0
+
+  '@codingame/monaco-vscode-base-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-bulk-edit-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-configuration-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-files-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-editor-api@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-editor-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-environment-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-extension-api@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-extensions-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-extensions-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-files-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-files-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-host-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-keybindings-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-files-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-cs@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-de@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-es@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-fr@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-it@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-ja@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-ko@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-pl@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-pt-br@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-qps-ploc@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-ru@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-tr@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-zh-hans@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-language-pack-zh-hant@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-languages-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-files-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-layout-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-localization-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-log-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-environment-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-model-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-monarch-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-quickaccess-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-textmate-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-files-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-theme-defaults-default-extension@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-theme-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-files-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-view-banner-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-view-common-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-bulk-edit-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-view-status-bar-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-view-title-bar-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+
+  '@codingame/monaco-vscode-views-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-keybindings-service-override': 25.1.2
+      '@codingame/monaco-vscode-layout-service-override': 25.1.2
+      '@codingame/monaco-vscode-quickaccess-service-override': 25.1.2
+      '@codingame/monaco-vscode-view-common-service-override': 25.1.2
+
+  '@codingame/monaco-vscode-workbench-service-override@25.1.2':
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-keybindings-service-override': 25.1.2
+      '@codingame/monaco-vscode-quickaccess-service-override': 25.1.2
+      '@codingame/monaco-vscode-view-banner-service-override': 25.1.2
+      '@codingame/monaco-vscode-view-common-service-override': 25.1.2
+      '@codingame/monaco-vscode-view-status-bar-service-override': 25.1.2
+      '@codingame/monaco-vscode-view-title-bar-service-override': 25.1.2
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -1563,6 +1983,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -1603,6 +2026,8 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@vscode/iconv-lite-umd@0.7.1': {}
+
   agent-base@7.1.4: {}
 
   ansi-regex@5.0.1: {}
@@ -1635,7 +2060,13 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.12
 
+  balanced-match@1.0.2: {}
+
   baseline-browser-mapping@2.10.19: {}
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
 
   browserslist@4.28.2:
     dependencies:
@@ -1699,6 +2130,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.0:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -1848,6 +2283,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  jschardet@3.1.4: {}
+
   jsdom@25.0.1:
     dependencies:
       cssstyle: 4.6.0
@@ -1894,6 +2331,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  marked@14.0.0: {}
+
   math-intrinsics@1.1.0: {}
 
   merge-anything@5.1.7:
@@ -1907,6 +2346,52 @@ snapshots:
       mime-db: 1.52.0
 
   min-indent@1.0.1: {}
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.4.0
+      marked: 14.0.0
+
+  monaco-languageclient@10.7.0:
+    dependencies:
+      '@codingame/monaco-vscode-api': 25.1.2
+      '@codingame/monaco-vscode-configuration-service-override': 25.1.2
+      '@codingame/monaco-vscode-editor-api': 25.1.2
+      '@codingame/monaco-vscode-editor-service-override': 25.1.2
+      '@codingame/monaco-vscode-extension-api': 25.1.2
+      '@codingame/monaco-vscode-extensions-service-override': 25.1.2
+      '@codingame/monaco-vscode-language-pack-cs': 25.1.2
+      '@codingame/monaco-vscode-language-pack-de': 25.1.2
+      '@codingame/monaco-vscode-language-pack-es': 25.1.2
+      '@codingame/monaco-vscode-language-pack-fr': 25.1.2
+      '@codingame/monaco-vscode-language-pack-it': 25.1.2
+      '@codingame/monaco-vscode-language-pack-ja': 25.1.2
+      '@codingame/monaco-vscode-language-pack-ko': 25.1.2
+      '@codingame/monaco-vscode-language-pack-pl': 25.1.2
+      '@codingame/monaco-vscode-language-pack-pt-br': 25.1.2
+      '@codingame/monaco-vscode-language-pack-qps-ploc': 25.1.2
+      '@codingame/monaco-vscode-language-pack-ru': 25.1.2
+      '@codingame/monaco-vscode-language-pack-tr': 25.1.2
+      '@codingame/monaco-vscode-language-pack-zh-hans': 25.1.2
+      '@codingame/monaco-vscode-language-pack-zh-hant': 25.1.2
+      '@codingame/monaco-vscode-languages-service-override': 25.1.2
+      '@codingame/monaco-vscode-localization-service-override': 25.1.2
+      '@codingame/monaco-vscode-log-service-override': 25.1.2
+      '@codingame/monaco-vscode-model-service-override': 25.1.2
+      '@codingame/monaco-vscode-monarch-service-override': 25.1.2
+      '@codingame/monaco-vscode-textmate-service-override': 25.1.2
+      '@codingame/monaco-vscode-theme-defaults-default-extension': 25.1.2
+      '@codingame/monaco-vscode-theme-service-override': 25.1.2
+      '@codingame/monaco-vscode-views-service-override': 25.1.2
+      '@codingame/monaco-vscode-workbench-service-override': 25.1.2
+      vscode: '@codingame/monaco-vscode-extension-api@25.1.2'
+      vscode-languageclient: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
+      vscode-ws-jsonrpc: 3.5.0
 
   ms@2.1.3: {}
 
@@ -1999,6 +2484,8 @@ snapshots:
       xmlchars: 2.2.0
 
   semver@6.3.1: {}
+
+  semver@7.7.4: {}
 
   seroval-plugins@1.5.2(seroval@1.5.2):
     dependencies:
@@ -2164,6 +2651,27 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-jsonrpc@8.2.1: {}
+
+  vscode-languageclient@9.0.1:
+    dependencies:
+      minimatch: 5.1.9
+      semver: 7.7.4
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-ws-jsonrpc@3.5.0:
+    dependencies:
+      vscode-jsonrpc: 8.2.1
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

F-121 — stands up `web/packages/monaco-host` as an isolated Vite + TypeScript iframe app hosting Monaco and `monaco-languageclient`. Communicates with the parent `app` via `postMessage` only (no direct Tauri access). LSP relay-to-`forge-lsp` is F-123 and is intentionally not started here.

Closes #235

## What shipped

New package `web/packages/monaco-host`:
- `package.json`, `vite.config.ts`, `tsconfig.json`, `index.html` (with iframe-specific CSP)
- `src/protocol.ts` — jsdom-safe protocol layer; no Monaco imports
- `src/editor.ts` — Monaco mount + `EditorLike` adapter
- `src/client.ts` — `MonacoLanguageClient` construction (not started; deferred to F-123 per issue scope)
- `src/theme.ts` — Forge Ember theme (hex literals mirror `tokens.css` with drift note)
- `src/index.ts` — iframe entry composing the three modules
- `tests/protocol.test.ts` — 11 smoke tests covering `editor.setValue` round-trip via the protocol
- `README.md` — full `postMessage` protocol documentation: `open`, `close`, `save`, `focus`, `client.message`, `client.notification`

Also modified:
- `web/package.json` — added `dompurify: ^3.4.0` pnpm override (clears 10 transitive DOMPurify advisories that would fail CI `pnpm audit`)
- `web/pnpm-lock.yaml` — regenerated

## Architecture decisions

1. **Protocol separable from editor** — `src/protocol.ts` imports neither `monaco-editor` nor `monaco-languageclient`, allowing jsdom-based smoke tests without Monaco's AMD/worker peer quirks.
2. **`MonacoLanguageClient` not started** — constructed with the transport to verify wiring on each boot; `.start()` deferred to F-123.
3. **Outbound `client.message` vs `client.notification` split** — JSON-RPC 2.0 rule (method+no-id → notification), letting the parent relay skip reply bookkeeping for notifications.
4. **Theme hex literals duplicated from `tokens.css`** with drift note — Monaco's `defineTheme` doesn't read CSS vars.

## Deferred (flagged, not silently skipped)

1. **Full-iframe Playwright test** — Monaco isn't jsdom-safe. Belongs under F-122/F-123 once the parent embed exists. Out of scope per issue text.
2. **`docs/frontend/architecture.md` §9.3 reconciliation** — current doc says the iframe spawns LSP processes directly via Tauri; this PR follows the parent-relay model that the issue scope text describes. Doc was left untouched — needs human adjudication on which model is canonical. (Note for reviewer: a small follow-up doc-fix is appropriate either way.)

## Verification

- `pnpm --filter monaco-host test`: 11/11 pass
- `pnpm --filter monaco-host typecheck` / `build`: clean
- `just check-web`: pass (4 typecheck targets + token drift)
- `just test-web`: 286 existing + 11 new all pass
- `pnpm audit --audit-level moderate`: no advisories
- `cargo check --all-targets`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)