### PR TITLE
fix(forge-session): downgrade rustdoc private intra-doc links to backticks

### DIFF
--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -396,10 +396,10 @@ impl Orchestrator {
     ///      don't compound.
     ///   2. Reconstruct the provider request from events up to — but not
     ///      including — `msg_id`'s assistant turn.
-    ///   3. Drive [`run_request_loop`] with a fresh `new_id` to regenerate
+    ///   3. Drive `run_request_loop` with a fresh `new_id` to regenerate
     ///      the response.
     ///   4. After the regenerated assistant message is finalised, emit
-    ///      [`Event::MessageSuperseded { old_id: msg_id, new_id }`] so
+    ///      `Event::MessageSuperseded { old_id: msg_id, new_id }` so
     ///      replay consumers hide the original.
     ///
     /// Ordering matters: the `MessageSuperseded` marker is emitted *after*


### PR DESCRIPTION
## Summary

Main CI's `Check` job is red since F-143 (PR #273) merged. `cargo doc` with `-D rustdoc::private_intra_doc_links` rejected two doc-comment links in `crates/forge-session/src/orchestrator.rs` that target private items (`run_request_loop`, `Event::MessageSuperseded`).

The orchestrator's local verification ran clippy + tests but didn't run rustdoc with the strict lint, so this slipped through. Downgrading to plain backticks preserves the human-readable reference while making rustdoc happy.

## Changes

- `crates/forge-session/src/orchestrator.rs` — two doc-comment lines, ` [` … `] ` → `` `…` ``

## Verification

- \`cargo doc -p forge-session --no-deps\` passes locally with the same `-D warnings` profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)