### PR TITLE
[F-119] Implement minimum-width pane collapse rules

### DIFF
--- a/web/packages/app/src/layout/usePaneWidth.test.ts
+++ b/web/packages/app/src/layout/usePaneWidth.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, createSignal } from 'solid-js';
+import { usePaneWidth, type Compactness } from './usePaneWidth';
+
+// -----------------------------------------------------------------------------
+// ResizeObserver mock — jsdom doesn't ship ResizeObserver. Capture the last
+// instance's callback so tests can drive synthetic entries through it.
+// -----------------------------------------------------------------------------
+
+type ROCallback = (entries: ResizeObserverEntry[]) => void;
+
+interface MockROHandle {
+  callback: ROCallback;
+  observed: Element[];
+  disconnected: boolean;
+}
+
+let lastObserver: MockROHandle | null = null;
+
+class MockResizeObserver implements ResizeObserver {
+  private readonly handle: MockROHandle;
+  constructor(cb: ROCallback) {
+    this.handle = { callback: cb, observed: [], disconnected: false };
+    lastObserver = this.handle;
+  }
+  observe(target: Element): void {
+    this.handle.observed.push(target);
+  }
+  unobserve(target: Element): void {
+    this.handle.observed = this.handle.observed.filter((e) => e !== target);
+  }
+  disconnect(): void {
+    this.handle.disconnected = true;
+    this.handle.observed = [];
+  }
+}
+
+/**
+ * Synthesize the tiny slice of ResizeObserverEntry the hook reads — just
+ * `contentRect.width` on the target element. Other ResizeObserver consumers
+ * should migrate to a shared helper if this mock grows.
+ */
+const emitWidth = (target: Element, width: number): void => {
+  if (lastObserver === null) throw new Error('no observer registered');
+  const entry = {
+    target,
+    contentRect: { width } as DOMRectReadOnly,
+  } as unknown as ResizeObserverEntry;
+  lastObserver.callback([entry]);
+};
+
+beforeEach(() => {
+  lastObserver = null;
+  // Stub the global — vi.stubGlobal auto-unstubs via the afterEach below.
+  vi.stubGlobal('ResizeObserver', MockResizeObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// -----------------------------------------------------------------------------
+// Breakpoint semantics (per docs/ui-specs/layout-panes.md §3.7 and
+// pane-header.md §2.3)
+//   full:       width >= 320
+//   compact:    240 <= width < 320
+//   icon-only:  width < 240
+// hideMinimap === true for compactness !== 'full'.
+// -----------------------------------------------------------------------------
+
+describe('usePaneWidth — compactness thresholds', () => {
+  const makeTarget = (): HTMLDivElement => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    return el;
+  };
+
+  it('starts at "full" when no measurement has arrived yet (>=320px assumed)', () => {
+    createRoot((dispose) => {
+      const target = makeTarget();
+      const { compactness, hideMinimap } = usePaneWidth(() => target);
+      expect(compactness()).toBe<Compactness>('full');
+      expect(hideMinimap()).toBe(false);
+      dispose();
+    });
+  });
+
+  it('reports "full" for width >= 320', () => {
+    createRoot((dispose) => {
+      const target = makeTarget();
+      const { compactness, hideMinimap } = usePaneWidth(() => target);
+      emitWidth(target, 400);
+      expect(compactness()).toBe<Compactness>('full');
+      expect(hideMinimap()).toBe(false);
+
+      emitWidth(target, 320);
+      expect(compactness()).toBe<Compactness>('full');
+      expect(hideMinimap()).toBe(false);
+      dispose();
+    });
+  });
+
+  it('reports "compact" for 240 <= width < 320', () => {
+    createRoot((dispose) => {
+      const target = makeTarget();
+      const { compactness, hideMinimap } = usePaneWidth(() => target);
+      emitWidth(target, 319);
+      expect(compactness()).toBe<Compactness>('compact');
+      expect(hideMinimap()).toBe(true);
+
+      emitWidth(target, 280);
+      expect(compactness()).toBe<Compactness>('compact');
+      expect(hideMinimap()).toBe(true);
+
+      emitWidth(target, 240);
+      expect(compactness()).toBe<Compactness>('compact');
+      expect(hideMinimap()).toBe(true);
+      dispose();
+    });
+  });
+
+  it('reports "icon-only" for width < 240', () => {
+    createRoot((dispose) => {
+      const target = makeTarget();
+      const { compactness, hideMinimap } = usePaneWidth(() => target);
+      emitWidth(target, 239);
+      expect(compactness()).toBe<Compactness>('icon-only');
+      expect(hideMinimap()).toBe(true);
+
+      emitWidth(target, 120);
+      expect(compactness()).toBe<Compactness>('icon-only');
+      expect(hideMinimap()).toBe(true);
+      dispose();
+    });
+  });
+
+  it('transitions full → compact → icon-only → compact → full as width shrinks and grows', () => {
+    createRoot((dispose) => {
+      const target = makeTarget();
+      const { compactness } = usePaneWidth(() => target);
+
+      emitWidth(target, 500);
+      expect(compactness()).toBe<Compactness>('full');
+
+      emitWidth(target, 319);
+      expect(compactness()).toBe<Compactness>('compact');
+
+      emitWidth(target, 239);
+      expect(compactness()).toBe<Compactness>('icon-only');
+
+      emitWidth(target, 260);
+      expect(compactness()).toBe<Compactness>('compact');
+
+      emitWidth(target, 321);
+      expect(compactness()).toBe<Compactness>('full');
+
+      dispose();
+    });
+  });
+});
+
+describe('usePaneWidth — lifecycle', () => {
+  it('observes the target element exactly once on mount', () => {
+    createRoot((dispose) => {
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+      usePaneWidth(() => target);
+      if (lastObserver === null) throw new Error('expected an observer');
+      expect(lastObserver.observed).toEqual([target]);
+      dispose();
+    });
+  });
+
+  it('disconnects the ResizeObserver on disposal', () => {
+    createRoot((dispose) => {
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+      usePaneWidth(() => target);
+      if (lastObserver === null) throw new Error('expected an observer');
+      expect(lastObserver.disconnected).toBe(false);
+      dispose();
+      expect(lastObserver.disconnected).toBe(true);
+    });
+  });
+
+  it('ignores entries whose target is not the observed element', () => {
+    createRoot((dispose) => {
+      const target = document.createElement('div');
+      const other = document.createElement('div');
+      document.body.append(target, other);
+      const { compactness } = usePaneWidth(() => target);
+
+      // A ResizeObserver can receive entries for other elements if the
+      // consumer re-uses the same instance — the hook should filter.
+      emitWidth(other, 100);
+      expect(compactness()).toBe<Compactness>('full');
+
+      emitWidth(target, 100);
+      expect(compactness()).toBe<Compactness>('icon-only');
+      dispose();
+    });
+  });
+
+  it('stays inert with a null target accessor — no observer registered', () => {
+    createRoot((dispose) => {
+      // Callers often hold a Solid ref that's null before mount. The hook
+      // should no-op until the ref resolves. Observe that no
+      // MockResizeObserver is constructed for a persistent-null accessor.
+      const api = usePaneWidth(() => null);
+      expect(api.compactness()).toBe<Compactness>('full');
+      expect(api.hideMinimap()).toBe(false);
+      expect(lastObserver).toBeNull();
+      dispose();
+    });
+  });
+
+  it('attaches the observer once a ref-signal accessor resolves to an element', () => {
+    // This is the ref-callback pattern SessionWindow uses:
+    //   const [el, setEl] = createSignal<HTMLElement | null>(null);
+    //   usePaneWidth(el);  <section ref={setEl} />
+    // JSX ref callbacks fire *after* the component body returns, so the
+    // hook's target accessor returns null at call time. The hook must
+    // reactively re-attach once the ref resolves.
+    createRoot((dispose) => {
+      const [el, setEl] = createSignal<HTMLElement | null>(null);
+      const { compactness } = usePaneWidth(el);
+
+      // No observer yet — the accessor is null.
+      expect(lastObserver).toBeNull();
+      expect(compactness()).toBe<Compactness>('full');
+
+      // Simulate the ref callback firing after the component returns.
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+      setEl(target);
+
+      // Render-effect re-runs queue synchronously in Solid's reactive
+      // graph; once the setEl call returns, the effect has re-executed
+      // and the observer is attached to the new target.
+      if (lastObserver === null) throw new Error('expected an observer');
+      expect(lastObserver.observed).toEqual([target]);
+      emitWidth(target, 200);
+      expect(compactness()).toBe<Compactness>('icon-only');
+      dispose();
+    });
+  });
+});

--- a/web/packages/app/src/layout/usePaneWidth.ts
+++ b/web/packages/app/src/layout/usePaneWidth.ts
@@ -1,0 +1,121 @@
+import {
+  type Accessor,
+  createComputed,
+  createSignal,
+  onCleanup,
+} from 'solid-js';
+
+/**
+ * Compactness levels derived from the pane's content-box width.
+ *
+ * Thresholds come from `docs/ui-specs/layout-panes.md §3.7` and
+ * `docs/ui-specs/pane-header.md §2.3`:
+ *   - `full`        — width ≥ 320px; show all chrome at normal density
+ *   - `compact`     — 240 ≤ width < 320; label → icon, secondary badges
+ *                     auto-hide, editor/terminal hosts drop the minimap
+ *   - `icon-only`   — width < 240; all non-essential badges/chrome collapse
+ *
+ * The 320px floor is the pane-minimum from §3.7; 240px is the "icon-only"
+ * threshold noted in §3.7 and `pane-header.md §2.3` for the narrowest docked
+ * layout (four-pane grid on a 1080px window, roughly).
+ */
+export type Compactness = 'full' | 'compact' | 'icon-only';
+
+/** Threshold below which panes drop to `compact` (label→icon, badges hide). */
+export const COMPACT_THRESHOLD_PX = 320;
+/** Threshold below which panes drop to `icon-only` (all secondary chrome off). */
+export const ICON_ONLY_THRESHOLD_PX = 240;
+
+export interface UsePaneWidthApi {
+  /** Current compactness bucket derived from the observed width. */
+  compactness: Accessor<Compactness>;
+  /**
+   * True when the pane should suppress its minimap — i.e. any compactness
+   * narrower than `full`. Future Editor/Terminal hosts read this signal.
+   */
+  hideMinimap: Accessor<boolean>;
+}
+
+/**
+ * Bucket a measured width into a `Compactness` level. Exported for tests
+ * and for callers that have a width already (e.g. imperative layout code).
+ */
+export function compactnessForWidth(width: number): Compactness {
+  if (width < ICON_ONLY_THRESHOLD_PX) return 'icon-only';
+  if (width < COMPACT_THRESHOLD_PX) return 'compact';
+  return 'full';
+}
+
+/**
+ * Observe a pane host element's content-box width via `ResizeObserver` and
+ * expose its derived `compactness` level + a convenience `hideMinimap`
+ * signal.
+ *
+ * The target accessor is re-read inside a `createComputed` so both call
+ * patterns are supported:
+ *
+ *   - **Imperative** — `usePaneWidth(() => someElement)`. The accessor
+ *     returns the element synchronously; the computation attaches
+ *     immediately. Tests use this form.
+ *   - **Ref signal** — `const [el, setEl] = createSignal<HTMLElement | null>(null);
+ *     usePaneWidth(el); return <div ref={setEl} />`. The accessor returns
+ *     `null` at hook-call time because JSX ref callbacks fire *after* the
+ *     component body returns. The computation re-runs once `el()` flips
+ *     to the element, which attaches the observer at the right moment.
+ *
+ *   `createComputed` (not `createEffect` or `createRenderEffect`) is the
+ *   only Solid primitive that re-runs **synchronously** on signal change
+ *   inside `createRoot`. The hook needs synchronous re-attach so tests can
+ *   drive `setEl(el)` followed by `emitWidth(el, …)` in a straight line,
+ *   and so production mounts of `SessionWindow` see the observer attach
+ *   in the same tick their ref callback fires. `onCleanup` inside the
+ *   computation releases the previous observer when the accessor changes
+ *   and on root disposal.
+ *
+ * Starts at `full` until the first `ResizeObserver` callback fires — the
+ * default pane width in F-117 is wider than 320px, and starting at `full`
+ * avoids a mount-time flash to `icon-only` while the DOM is still laying
+ * out. If `targetAccessor()` returns `null`, the hook stays inert until
+ * the accessor resolves.
+ */
+export function usePaneWidth(
+  targetAccessor: Accessor<Element | null>,
+): UsePaneWidthApi {
+  const [compactness, setCompactness] = createSignal<Compactness>('full');
+
+  // Derived accessor instead of a signal so the two stay in lockstep — no
+  // chance of `hideMinimap` lagging a `compactness` update by a tick.
+  const hideMinimap: Accessor<boolean> = () => compactness() !== 'full';
+
+  createComputed(() => {
+    const target = targetAccessor();
+    if (target === null) return;
+
+    // `ResizeObserver` is present in every modern browser the Tauri shell
+    // embeds. jsdom's absence is handled by callers stubbing the global in
+    // tests that drive the hook directly. If a caller (e.g. SessionWindow)
+    // uses the hook in a test environment without that stub, degrade to
+    // `full` — the hook must not throw.
+    if (typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        // A single observer instance can receive entries for elements that
+        // are not this hook's target if the caller reuses the observer —
+        // filter to the one we care about.
+        if (entry.target !== target) continue;
+        const width = entry.contentRect.width;
+        const next = compactnessForWidth(width);
+        // Avoid redundant setSignal calls so downstream memos don't churn.
+        if (next !== compactness()) setCompactness(next);
+      }
+    });
+    observer.observe(target);
+
+    onCleanup(() => {
+      observer.disconnect();
+    });
+  });
+
+  return { compactness, hideMinimap };
+}

--- a/web/packages/app/src/routes/Session/PaneHeader.css
+++ b/web/packages/app/src/routes/Session/PaneHeader.css
@@ -17,6 +17,19 @@
   color: var(--color-text-tertiary);
 }
 
+/*
+ * F-119: narrow-width chrome rules. The root carries `data-compactness` so
+ * descendant styling can respond without per-component prop plumbing. The
+ * type-label cell drops its tracked/uppercase treatment when rendering as
+ * an icon so the emoji glyph isn't visually blown apart.
+ */
+.pane-header[data-compactness='compact'] .pane-header__type-label,
+.pane-header[data-compactness='icon-only'] .pane-header__type-label {
+  letter-spacing: 0;
+  text-transform: none;
+  font-family: var(--font-body);
+}
+
 .pane-header__subject {
   font-size: 13px;
   color: var(--color-text-primary);

--- a/web/packages/app/src/routes/Session/PaneHeader.test.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.test.tsx
@@ -87,3 +87,93 @@ describe('PaneHeader provider pill accent (F-091)', () => {
     );
   });
 });
+
+// PaneHeader compactness (F-119): per layout-panes.md §3.7 + pane-header.md
+// §2.3, the header must collapse chrome as the pane narrows. The prop is
+// optional — omitting it is `full`. At `compact` the type label collapses
+// to an icon; at `icon-only` the provider pill + cost meter also hide.
+// Callers derive the prop from `usePaneWidth` against the enclosing pane.
+
+describe('PaneHeader compactness (F-119)', () => {
+  it('defaults to `full` when no compactness prop is passed — all chrome visible', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <PaneHeader
+        subject="example"
+        providerId={'ollama' as ProviderId}
+        providerLabel="local"
+        costLabel="$0.00"
+        onClose={vi.fn()}
+      />
+    ));
+    const root = getByTestId('pane-header-subject').parentElement;
+    expect(root?.getAttribute('data-compactness')).toBe('full');
+    expect(queryByTestId('pane-header-provider')).not.toBeNull();
+    expect(queryByTestId('pane-header-cost')).not.toBeNull();
+  });
+
+  it('at `compact`: marks root with data-compactness="compact" and collapses the type label to an icon', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <PaneHeader
+        subject="example"
+        providerId={'ollama' as ProviderId}
+        providerLabel="local"
+        costLabel="$0.00"
+        compactness="compact"
+        onClose={vi.fn()}
+      />
+    ));
+    const root = getByTestId('pane-header-subject').parentElement;
+    expect(root?.getAttribute('data-compactness')).toBe('compact');
+    // Type label swapped to an icon glyph (aria-hidden; the a11y name is
+    // carried by the pane-header-type-label element via aria-label).
+    const typeLabel = getByTestId('pane-header-type-label');
+    expect(typeLabel.getAttribute('data-icon-only')).toBe('true');
+    // Badges (provider pill + cost meter) still render at `compact` — they
+    // only disappear at `icon-only`. This matches DoD: labels collapse at
+    // 320px, badges collapse at 240px.
+    expect(queryByTestId('pane-header-provider')).not.toBeNull();
+    expect(queryByTestId('pane-header-cost')).not.toBeNull();
+  });
+
+  it('at `icon-only`: hides both the provider pill and the cost meter badges', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <PaneHeader
+        subject="example"
+        providerId={'ollama' as ProviderId}
+        providerLabel="local"
+        costLabel="$0.00"
+        compactness="icon-only"
+        onClose={vi.fn()}
+      />
+    ));
+    const root = getByTestId('pane-header-subject').parentElement;
+    expect(root?.getAttribute('data-compactness')).toBe('icon-only');
+    // Label is still in icon mode at `icon-only` (`compact` or narrower).
+    const typeLabel = getByTestId('pane-header-type-label');
+    expect(typeLabel.getAttribute('data-icon-only')).toBe('true');
+    // Badges removed from the tree entirely — the narrow-width spec treats
+    // them as non-essential chrome. Keeping them with `display: none`
+    // would leave them discoverable by screen readers.
+    expect(queryByTestId('pane-header-provider')).toBeNull();
+    expect(queryByTestId('pane-header-cost')).toBeNull();
+  });
+
+  it('keeps the close button visible at every compactness level', () => {
+    for (const c of ['full', 'compact', 'icon-only'] as const) {
+      const { getByRole, unmount } = render(() => (
+        <PaneHeader
+          subject="example"
+          providerId={'ollama' as ProviderId}
+          providerLabel="local"
+          costLabel="$0.00"
+          compactness={c}
+          onClose={vi.fn()}
+        />
+      ));
+      // Close is essential at every width — no pane is useful without a
+      // way to dismiss it. (Per pane-header.md §PH.6 the close button stays.)
+      expect(getByRole('button', { name: 'Close session window' })).not.toBeNull();
+      unmount();
+    }
+  });
+});

--- a/web/packages/app/src/routes/Session/PaneHeader.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.tsx
@@ -11,6 +11,25 @@ import './PaneHeader.css';
  */
 export type PaneHeaderType = 'CHAT' | 'TERMINAL' | 'EDITOR';
 
+/**
+ * Responsive compactness level per F-119 (`layout-panes.md §3.7`,
+ * `pane-header.md §PH.4`). Derived from the enclosing pane's width via
+ * `usePaneWidth`. See that hook for threshold semantics.
+ */
+export type Compactness = 'full' | 'compact' | 'icon-only';
+
+/**
+ * Map each pane type to its icon-only glyph. Used when the header collapses
+ * its type-label text under F-119's `compact` / `icon-only` thresholds.
+ * Emoji keeps the glyph system-font-safe (no extra icon dependency) and
+ * stable across Phase 1's token refresh cadence.
+ */
+const TYPE_ICON: Record<PaneHeaderType, string> = {
+  CHAT: '\u{1F4AC}',
+  TERMINAL: '\u2328\uFE0F',
+  EDITOR: '\u270E\uFE0F',
+};
+
 export interface PaneHeaderProps {
   subject: string;
   /**
@@ -45,6 +64,14 @@ export interface PaneHeaderProps {
    * `CHAT` for call-site compatibility with the Phase-1 session window.
    */
   typeLabel?: PaneHeaderType;
+  /**
+   * Responsive compactness level, typically derived from `usePaneWidth`
+   * against the enclosing pane element. Controls label collapse (`compact`
+   * at <320px) and badge removal (`icon-only` at <240px). Defaults to
+   * `full`, preserving pre-F-119 layout for untouched callers.
+   * Per `docs/ui-specs/layout-panes.md §3.7` and `pane-header.md §2.3`.
+   */
+  compactness?: Compactness;
   onClose: () => void;
 }
 
@@ -57,6 +84,12 @@ export interface PaneHeaderProps {
  * / `providerLabel`. `costLabel` is also optional so the terminal variant can
  * render the cwd in the same margin-left-auto slot, and `closeLabel` lets the
  * terminal variant render `CLOSE PANE` instead of `CLOSE SESSION`.
+ *
+ * F-119: at narrow widths the header collapses chrome. The type label swaps
+ * to a compact-safe icon glyph at `compact` (<320px) and the provider pill +
+ * cost meter are removed from the tree entirely at `icon-only` (<240px) —
+ * removed rather than hidden so screen readers don't announce vestigial
+ * content. The close button stays at every compactness level per §PH.6.
  */
 export const PaneHeader: Component<PaneHeaderProps> = (props) => {
   // Inline custom property keeps `.pane-header__provider` rule generic; the
@@ -67,13 +100,30 @@ export const PaneHeader: Component<PaneHeaderProps> = (props) => {
       '--pane-header-provider-accent': providerAccent(props.providerId),
     };
   };
+  const compactness = (): Compactness => props.compactness ?? 'full';
+  const typeLabel = (): PaneHeaderType => props.typeLabel ?? 'CHAT';
+  const isIconLabel = (): boolean => compactness() !== 'full';
+  const showBadges = (): boolean => compactness() !== 'icon-only';
   return (
-    <header class="pane-header" role="banner">
-      <span class="pane-header__type-label">{props.typeLabel ?? 'CHAT'}</span>
+    <header class="pane-header" role="banner" data-compactness={compactness()}>
+      <span
+        class="pane-header__type-label"
+        data-testid="pane-header-type-label"
+        data-icon-only={isIconLabel() ? 'true' : 'false'}
+        aria-label={`${typeLabel().toLowerCase()} pane`}
+      >
+        {isIconLabel() ? TYPE_ICON[typeLabel()] : typeLabel()}
+      </span>
       <span class="pane-header__subject" data-testid="pane-header-subject">
         {props.subject}
       </span>
-      <Show when={props.providerId !== undefined && props.providerLabel !== undefined}>
+      <Show
+        when={
+          showBadges() &&
+          props.providerId !== undefined &&
+          props.providerLabel !== undefined
+        }
+      >
         <span
           class="pane-header__provider"
           data-testid="pane-header-provider"
@@ -82,7 +132,7 @@ export const PaneHeader: Component<PaneHeaderProps> = (props) => {
           {props.providerLabel}
         </span>
       </Show>
-      <Show when={props.costLabel !== undefined}>
+      <Show when={showBadges() && props.costLabel !== undefined}>
         <span class="pane-header__cost" data-testid="pane-header-cost">
           {props.costLabel}
         </span>

--- a/web/packages/app/src/routes/Session/SessionWindow.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.tsx
@@ -1,4 +1,4 @@
-import { type Component, onCleanup, onMount } from 'solid-js';
+import { type Component, createSignal, onCleanup, onMount } from 'solid-js';
 import { useParams } from '@solidjs/router';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import type { ProviderId, SessionId } from '@forge/ipc';
@@ -19,6 +19,7 @@ import { fromRustEvent } from '../../ipc/events';
 import { seedPersistentApprovals } from '../../stores/approvals';
 import { PaneHeader } from './PaneHeader';
 import { ChatPane } from './ChatPane';
+import { usePaneWidth } from '../../layout/usePaneWidth';
 import './SessionWindow.css';
 
 /**
@@ -108,14 +109,28 @@ export const SessionWindow: Component = () => {
   const providerLabel = () => 'ollama \u00b7 pending';
   const costLabel = () => 'in 0 \u00b7 out 0 \u00b7 $0.00';
 
+  // F-119: observe the pane section's width so the header collapses its
+  // chrome below the 320/240 thresholds. The ref is populated synchronously
+  // by Solid when the element mounts, which is the resolution order the
+  // hook expects. In the jsdom test environment ResizeObserver is absent
+  // and the hook degrades to `full` — the existing SessionWindow tests
+  // still pass without a fixture.
+  const [paneEl, setPaneEl] = createSignal<HTMLElement | null>(null);
+  const { compactness } = usePaneWidth(paneEl);
+
   return (
     <main class="session-window">
-      <section class="session-window__pane" aria-label="Session pane">
+      <section
+        class="session-window__pane"
+        aria-label="Session pane"
+        ref={setPaneEl}
+      >
         <PaneHeader
           subject={subject()}
           providerId={providerId()}
           providerLabel={providerLabel()}
           costLabel={costLabel()}
+          compactness={compactness()}
           onClose={handleClose}
         />
         <div class="session-window__pane-body">


### PR DESCRIPTION
Closes forge-ide/forge#233

## Summary
- New `usePaneWidth` hook in `web/packages/app/src/layout/usePaneWidth.ts` observes a pane host via `ResizeObserver` and exposes `compactness` (`full` / `compact` / `icon-only`) plus `hideMinimap` — the minimap signal the DoD calls out for future Editor/Terminal hosts.
- `PaneHeader` honors an optional `compactness` prop: label → icon glyph at `compact` (<320px), provider pill + cost meter removed from the tree at `icon-only` (<240px). Removal (not `display: none`) keeps screen readers from announcing vestigial chrome.
- `SessionWindow` wires the hook through a ref signal so the live header compactness tracks the enclosing pane's width.
- Close button stays visible at every level per `pane-header.md §PH.6`.

## DoD checklist
- [x] `usePaneWidth.ts` hook returns the current compactness level (`{ compactness, hideMinimap }` — see hook doc)
- [x] `PaneHeader` honors `compactness` prop: label → icon at 320px, badges hide at 240px
- [x] Minimap host signal exposed: `hideMinimap` derives to `true` for `compact` or narrower (Editor/Terminal hosts don't exist yet — hook is the contract)
- [x] Unit tests in `usePaneWidth.test.ts` cover each breakpoint transition (10 tests)
- [x] Tests pass in CI

## Path correction (flagged per Wave-2 protocol)
The DoD in #233 refers to `web/packages/app/src/components/PaneHeader.tsx`, but the component actually lives at `web/packages/app/src/routes/Session/PaneHeader.tsx` — F-091 / F-117 / F-125 all landed it there. This PR edits the real file. No `components/PaneHeader.tsx` was created; a duplicate would have diverged from every existing caller.

## Scope / DoD consistency note
The scope paragraph says "secondary badges auto-hide" at <320px; the DoD checkbox says "hiding badges at 240px". I followed the DoD (the acceptance contract) — badges (provider pill + cost meter) remain visible at `compact` and only drop out at `icon-only`. Flagging for the verifier so the behavioral intent is confirmed.

## Out of scope
- `pane-header.md §PH.4` mentions subject-text ellipsis at <320px; not in this DoD, deferred.
- F-120 (layout persistence) is developing in parallel in `web/packages/app/src/layout/` — no file conflict with this PR, but the second-merged PR will need a trivial rebase.

## Test plan
- `just check-web` passes (typecheck + design-token drift gate)
- `just test-web` passes — 424 app tests, including 10 new `usePaneWidth` tests and 4 new `PaneHeader` compactness tests
- `just check-rust` passes (no Rust changes, included for regression safety)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the `forge-finish-task` handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)