### PR TITLE
feat(forge-session): agent.spawn built-in tool with isolation pass-through (F-134)

### DIFF
--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -88,3 +88,7 @@ path = "tests/session_error.rs"
 [[test]]
 name = "rerun_replace"
 path = "tests/rerun_replace.rs"
+
+[[test]]
+name = "agent_spawn"
+path = "tests/agent_spawn.rs"

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -17,7 +17,8 @@ use crate::byte_budget::ByteBudget;
 use crate::sandbox::ChildRegistry;
 use crate::session::Session;
 use crate::tools::{
-    FsEditTool, FsReadTool, FsWriteTool, ShellExecTool, ToolCtx, ToolDispatcher, ToolError,
+    AgentSpawnTool, FsEditTool, FsReadTool, FsWriteTool, ShellExecTool, ToolCtx, ToolDispatcher,
+    ToolError,
 };
 
 /// Client decision for a pending tool call approval. Carries the
@@ -104,11 +105,20 @@ pub async fn run_turn<P: Provider>(
     dispatcher
         .register(Box::new(ShellExecTool))
         .expect("shell.exec must register on a fresh dispatcher");
+    // F-134: `agent.spawn` is registered on every `run_turn` dispatcher
+    // so a provider can discover and invoke it. `agent_ctx` below is
+    // `None` by default — the tool returns a typed "agent runtime not
+    // configured" error until the session-level plumbing (F-140
+    // AgentMonitor, parent instance wiring) lands.
+    dispatcher
+        .register(Box::new(AgentSpawnTool))
+        .expect("agent.spawn must register on a fresh dispatcher");
     let ctx = ToolCtx {
         allowed_paths,
         workspace_root,
         child_registry,
         byte_budget,
+        agent_ctx: None,
     };
 
     run_request_loop(
@@ -499,11 +509,20 @@ impl Orchestrator {
         dispatcher
             .register(Box::new(crate::tools::ShellExecTool))
             .expect("shell.exec must register on a fresh dispatcher");
+        // F-134: register `agent.spawn` on the rerun dispatcher too —
+        // rerun regenerates a provider turn that may emit `agent.spawn`
+        // calls. The `agent_ctx` is deliberately `None`: rerun replaces
+        // an assistant message; the existing sub-agents from the
+        // original turn remain registered with the orchestrator.
+        dispatcher
+            .register(Box::new(crate::tools::AgentSpawnTool))
+            .expect("agent.spawn must register on a fresh dispatcher");
         let ctx = crate::tools::ToolCtx {
             allowed_paths,
             workspace_root,
             child_registry,
             byte_budget,
+            agent_ctx: None,
         };
 
         let new_id = MessageId::new();

--- a/crates/forge-session/src/tools/agent_spawn.rs
+++ b/crates/forge-session/src/tools/agent_spawn.rs
@@ -1,0 +1,540 @@
+//! `agent.spawn` tool (F-134): a parent agent spawns a sub-agent by name.
+//!
+//! The dispatcher resolves `agent_name` against the agent defs loaded for the
+//! session, hands the **child's** `AgentDef` to `forge_agents::Orchestrator::spawn`
+//! (so the child runs under its own `isolation`, not the parent's), then emits
+//! `Event::SubAgentSpawned` against the session's event log.
+//!
+//! Isolation invariant: the orchestrator is given `child_def` verbatim — the
+//! tool never synthesises isolation from the parent. A parent `Process` agent
+//! that spawns a `Container` child must end up with the child registered at
+//! `Isolation::Container`. See the integration test
+//! `agent_spawn_child_runs_under_child_isolation_not_parent` which exercises
+//! this under the user scope.
+//!
+//! The event wire shape matches the existing `forge_core::Event::SubAgentSpawned
+//! { parent, child, from_msg }` variant — the DoD in issue #248 names a
+//! hypothetical `{ parent_id, child_id, agent_name }` shape that does not
+//! exist in the tree. Adjusting the event variant would ripple through the
+//! `event_wire_shape` regression tests and is deliberately out of scope here.
+
+use super::{get_required_str, Tool, ToolCtx};
+use forge_agents::{AgentDef, AgentScope, SpawnContext};
+use forge_core::{ApprovalPreview, Event};
+
+pub struct AgentSpawnTool;
+
+impl AgentSpawnTool {
+    pub const NAME: &'static str = "agent.spawn";
+}
+
+#[async_trait::async_trait]
+impl Tool for AgentSpawnTool {
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+
+    fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
+        let name = super::get_optional_str(args, "agent_name").unwrap_or("");
+        ApprovalPreview {
+            description: format!("Spawn sub-agent '{name}'"),
+        }
+    }
+
+    async fn invoke(&self, args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value {
+        let agent_name = match get_required_str(args, Self::NAME, "agent_name") {
+            Ok(s) => s.to_owned(),
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
+        // `prompt` is part of the public tool contract so a provider that
+        // wires up `agent.spawn` can pass the child its seed input. F-134
+        // only validates presence; carrying it forward to the runtime lands
+        // alongside the step executor (post-F-140).
+        let _prompt = match get_required_str(args, Self::NAME, "prompt") {
+            Ok(s) => s.to_owned(),
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
+        // `context` is the third DoD argument (`AgentContext`). It is
+        // accepted as an opaque JSON envelope for now — the concrete type
+        // lands in the follow-up that introduces `AgentContext` in
+        // `forge-agents`. Tolerating any shape keeps F-134 forward-
+        // compatible without committing to a type the runtime cannot yet
+        // interpret. If present, it must at least be an object or null so
+        // obviously-malformed calls (`"context": 42`) fail loudly rather
+        // than silently.
+        if let Some(v) = args.get("context") {
+            if !(v.is_object() || v.is_null()) {
+                return serde_json::json!({
+                    "error": format!(
+                        "tool.{}: 'context' must be a JSON object or null, got {}",
+                        Self::NAME,
+                        type_of(v),
+                    )
+                });
+            }
+        }
+
+        let Some(agent_ctx) = ctx.agent_ctx.as_ref() else {
+            return serde_json::json!({
+                "error": format!(
+                    "tool.{}: agent runtime not configured for this session",
+                    Self::NAME,
+                )
+            });
+        };
+
+        let child_def = match resolve_def(&agent_ctx.agent_defs, &agent_name) {
+            Some(def) => def.clone(),
+            None => {
+                return serde_json::json!({
+                    "error": format!(
+                        "tool.{}: unknown agent '{}'",
+                        Self::NAME,
+                        agent_name,
+                    )
+                });
+            }
+        };
+
+        // Critical invariant: hand the CHILD's def to the orchestrator.
+        // Never synthesise isolation from the parent — that would be a
+        // privilege-escalation regression. User scope is enforced here so
+        // a sub-agent cannot request `Trusted` via this tool even if
+        // someone later allows it in `AgentDef`.
+        let spawn_ctx = SpawnContext {
+            scope: AgentScope::User,
+        };
+
+        let instance = match agent_ctx.orchestrator.spawn(child_def, spawn_ctx).await {
+            Ok(inst) => inst,
+            Err(e) => {
+                return serde_json::json!({
+                    "error": format!("tool.{}: spawn failed: {}", Self::NAME, e),
+                });
+            }
+        };
+
+        // Emit the session-level event so replay / UI banners pick up the
+        // spawn. We use the existing `SubAgentSpawned { parent, child,
+        // from_msg }` variant — see module docs for why `agent_name` is
+        // not carried on the event itself.
+        if let Err(e) = agent_ctx
+            .session
+            .emit(Event::SubAgentSpawned {
+                parent: agent_ctx.parent_instance_id.clone(),
+                child: instance.id.clone(),
+                from_msg: agent_ctx.current_msg_id.clone(),
+            })
+            .await
+        {
+            // The orchestrator already registered the child and emitted a
+            // lifecycle event on its own broadcast stream; the session
+            // event emit is a best-effort durability signal. Surface the
+            // failure in the tool result so the provider sees it, but do
+            // not unregister the child — that would leave the orchestrator
+            // state inconsistent with its already-emitted `Spawned`.
+            return serde_json::json!({
+                "error": format!(
+                    "tool.{}: spawned {} but SubAgentSpawned emit failed: {}",
+                    Self::NAME,
+                    instance.id,
+                    e,
+                ),
+                "child_instance_id": instance.id.to_string(),
+            });
+        }
+
+        serde_json::json!({
+            "ok": true,
+            "child_instance_id": instance.id.to_string(),
+            "agent_name": agent_name,
+        })
+    }
+}
+
+fn resolve_def<'a>(defs: &'a [AgentDef], name: &str) -> Option<&'a AgentDef> {
+    defs.iter().find(|d| d.name == name)
+}
+
+fn type_of(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::Session;
+    use crate::tools::{AgentSpawnCtx, ToolCtx, ToolDispatcher};
+    use forge_agents::{AgentDef, Isolation, Orchestrator as AgentOrchestrator};
+    use forge_core::ids::AgentInstanceId;
+    use forge_core::MessageId;
+    use serde_json::json;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn def(name: &str, isolation: Isolation) -> AgentDef {
+        AgentDef {
+            name: name.to_string(),
+            description: None,
+            body: String::new(),
+            allowed_paths: vec![],
+            isolation,
+        }
+    }
+
+    async fn session_fixture() -> (TempDir, Arc<Session>) {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("events.jsonl");
+        let session = Arc::new(Session::create(log_path).await.unwrap());
+        (dir, session)
+    }
+
+    fn ctx_with(agent_ctx: AgentSpawnCtx) -> ToolCtx {
+        ToolCtx {
+            allowed_paths: vec![],
+            workspace_root: None,
+            child_registry: None,
+            byte_budget: None,
+            agent_ctx: Some(agent_ctx),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_agent_name_returns_unified_error_shape() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        let result = d
+            .dispatch(
+                "agent.spawn",
+                &json!({ "prompt": "hi" }),
+                &ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.agent.spawn: missing required parameter 'agent_name'"),
+            "result: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_prompt_returns_unified_error_shape() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        let result = d
+            .dispatch(
+                "agent.spawn",
+                &json!({ "agent_name": "child" }),
+                &ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.agent.spawn: missing required parameter 'prompt'"),
+            "result: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_agent_returns_typed_error() {
+        let (_dir, session) = session_fixture().await;
+
+        let agent_ctx = AgentSpawnCtx {
+            agent_defs: Arc::new(vec![def("other", Isolation::Process)]),
+            orchestrator: Arc::new(AgentOrchestrator::new()),
+            session,
+            parent_instance_id: AgentInstanceId::new(),
+            current_msg_id: MessageId::new(),
+        };
+        let ctx = ctx_with(agent_ctx);
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        let result = d
+            .dispatch(
+                "agent.spawn",
+                &json!({ "agent_name": "missing", "prompt": "hi" }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        let err = result["error"].as_str().unwrap_or_default();
+        assert!(
+            err.contains("unknown agent 'missing'"),
+            "expected unknown-agent error, got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn not_configured_ctx_returns_typed_error() {
+        // Embedders that omit the agent runtime plumbing (e.g. `rerun_replace`,
+        // tests that don't need spawning) must still be able to register the
+        // tool without panicking when it's invoked.
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        let result = d
+            .dispatch(
+                "agent.spawn",
+                &json!({ "agent_name": "child", "prompt": "hi" }),
+                &ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("agent runtime not configured"),
+            "result: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn child_runs_under_child_isolation_not_parent() {
+        // Critical invariant: a Process-isolation parent that spawns a
+        // Container-isolation child must end up with the registered instance
+        // using the child's isolation. The orchestrator never promotes or
+        // demotes based on parent scope.
+        let (_dir, session) = session_fixture().await;
+        let orchestrator = Arc::new(AgentOrchestrator::new());
+
+        let parent_def = def("parent", Isolation::Process);
+        let child_def = def("child", Isolation::Container);
+
+        // Register the parent instance up front so we have a realistic
+        // parent_instance_id to pass into the tool.
+        let parent_inst = orchestrator
+            .spawn(parent_def, SpawnContext::user())
+            .await
+            .unwrap();
+        assert_eq!(parent_inst.def.isolation, Isolation::Process);
+
+        let agent_ctx = AgentSpawnCtx {
+            agent_defs: Arc::new(vec![child_def.clone()]),
+            orchestrator: Arc::clone(&orchestrator),
+            session,
+            parent_instance_id: parent_inst.id.clone(),
+            current_msg_id: MessageId::new(),
+        };
+        let ctx = ctx_with(agent_ctx);
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        let result = d
+            .dispatch(
+                "agent.spawn",
+                &json!({ "agent_name": "child", "prompt": "go" }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result["ok"].as_bool(), Some(true), "result: {result}");
+
+        let child_id_s = result["child_instance_id"].as_str().unwrap();
+        let child_id = AgentInstanceId::from_string(child_id_s.to_string());
+        let child_inst = orchestrator.get(&child_id).await.expect("child registered");
+
+        assert_eq!(
+            child_inst.def.isolation,
+            Isolation::Container,
+            "child isolation must match the child's def, not the parent's"
+        );
+        assert_ne!(
+            child_inst.def.isolation, parent_inst.def.isolation,
+            "privilege escalation guard: parent Process must not bleed into child Container"
+        );
+    }
+
+    #[tokio::test]
+    async fn emits_sub_agent_spawned_on_session_event_bus() {
+        let (_dir, session) = session_fixture().await;
+        let orchestrator = Arc::new(AgentOrchestrator::new());
+        let parent_id = AgentInstanceId::new();
+        let from_msg = MessageId::new();
+
+        let mut rx = session.event_tx.subscribe();
+
+        let agent_ctx = AgentSpawnCtx {
+            agent_defs: Arc::new(vec![def("child", Isolation::Process)]),
+            orchestrator: Arc::clone(&orchestrator),
+            session: Arc::clone(&session),
+            parent_instance_id: parent_id.clone(),
+            current_msg_id: from_msg.clone(),
+        };
+        let ctx = ctx_with(agent_ctx);
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        let result = d
+            .dispatch(
+                "agent.spawn",
+                &json!({ "agent_name": "child", "prompt": "go" }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result["ok"].as_bool(), Some(true), "result: {result}");
+
+        // Drain events looking for SubAgentSpawned. Anything else emitted
+        // is test noise.
+        let mut found = None;
+        while let Ok((_seq, event)) = rx.try_recv() {
+            if let Event::SubAgentSpawned {
+                parent,
+                child,
+                from_msg: emitted_from,
+            } = event
+            {
+                found = Some((parent, child, emitted_from));
+                break;
+            }
+        }
+        let (p, c, m) = found.expect("SubAgentSpawned must be emitted");
+        assert_eq!(p, parent_id, "parent must match ctx.parent_instance_id");
+        assert_eq!(m, from_msg, "from_msg must match ctx.current_msg_id");
+        // child is the fresh orchestrator-assigned id; just assert it
+        // resolves to a registered instance with the child's isolation.
+        let inst = orchestrator.get(&c).await.expect("child registered");
+        assert_eq!(inst.def.name, "child");
+        assert_eq!(inst.def.isolation, Isolation::Process);
+    }
+
+    #[tokio::test]
+    async fn rejects_trusted_child_under_user_scope() {
+        // The tool pins `SpawnContext::user()` regardless of what scope the
+        // parent holds. A user-authored agent def with `Isolation::Trusted`
+        // (which the parser already rejects at load time, but a test / fuzz
+        // input can construct programmatically) must still be rejected at
+        // runtime rather than silently promoted.
+        let (_dir, session) = session_fixture().await;
+
+        let agent_ctx = AgentSpawnCtx {
+            agent_defs: Arc::new(vec![def("evil", Isolation::Trusted)]),
+            orchestrator: Arc::new(AgentOrchestrator::new()),
+            session,
+            parent_instance_id: AgentInstanceId::new(),
+            current_msg_id: MessageId::new(),
+        };
+        let ctx = ctx_with(agent_ctx);
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        let result = d
+            .dispatch(
+                "agent.spawn",
+                &json!({ "agent_name": "evil", "prompt": "escalate" }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        let err = result["error"].as_str().unwrap_or_default();
+        assert!(
+            err.contains("spawn failed") && err.to_lowercase().contains("trusted"),
+            "expected isolation-violation rejection, got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn approval_preview_shows_agent_name() {
+        let tool = AgentSpawnTool;
+        let preview = tool.approval_preview(&json!({ "agent_name": "reviewer" }));
+        assert!(
+            preview.description.contains("reviewer"),
+            "preview missing agent name: {}",
+            preview.description,
+        );
+        assert!(
+            preview.description.contains("Spawn sub-agent"),
+            "preview missing action prefix: {}",
+            preview.description,
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_context_arg_is_rejected() {
+        // DoD names `context: AgentContext` as the third argument. The
+        // concrete type lands in a follow-up; here we accept any JSON
+        // object or null and reject everything else so a forged / buggy
+        // provider call fails loud rather than silently dropping the arg.
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        let result = d
+            .dispatch(
+                "agent.spawn",
+                &json!({ "agent_name": "child", "prompt": "go", "context": 42 }),
+                &ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("'context' must be a JSON object or null"),
+            "result: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn well_formed_context_arg_is_accepted() {
+        // A missing or null or object context is fine; the tool still
+        // reaches the "not configured" branch because no agent_ctx was
+        // wired in. Asserting that branch fires (rather than the context
+        // branch) proves the validator didn't misfire on a valid call.
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        for ctx_val in [
+            json!({ "agent_name": "c", "prompt": "p" }),
+            json!({ "agent_name": "c", "prompt": "p", "context": null }),
+            json!({ "agent_name": "c", "prompt": "p", "context": {"k":"v"} }),
+        ] {
+            let result = d
+                .dispatch("agent.spawn", &ctx_val, &ToolCtx::default())
+                .await
+                .unwrap();
+            assert!(
+                result["error"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("agent runtime not configured"),
+                "valid context should not trip the validator; result: {result}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_registration_fails() {
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+        let err = d.register(Box::new(AgentSpawnTool)).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::tools::ToolError::DuplicateName(ref n) if n == "agent.spawn"
+        ));
+    }
+}

--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -2,15 +2,20 @@
 
 use crate::byte_budget::ByteBudget;
 use crate::sandbox::ChildRegistry;
-use forge_core::ApprovalPreview;
+use crate::session::Session;
+use forge_agents::{AgentDef, Orchestrator as AgentOrchestrator};
+use forge_core::ids::AgentInstanceId;
+use forge_core::{ApprovalPreview, MessageId};
 use std::sync::Arc;
 
+pub mod agent_spawn;
 pub mod args;
 pub mod fs_edit;
 pub mod fs_read;
 pub mod fs_write;
 pub mod shell_exec;
 
+pub use agent_spawn::AgentSpawnTool;
 pub use args::{get_optional_str, get_optional_u64, get_required_str};
 pub use fs_edit::FsEditTool;
 pub use fs_read::FsReadTool;
@@ -31,6 +36,36 @@ pub struct ToolCtx {
     /// occupies. `None` means no aggregate enforcement — preserves the
     /// pre-F-077 behaviour for tests and any embedding that opts out.
     pub byte_budget: Option<Arc<ByteBudget>>,
+    /// F-134: per-turn agent runtime plumbing for the `agent.spawn` tool.
+    pub agent_ctx: Option<AgentSpawnCtx>,
+}
+
+/// F-134: context threaded to the `agent.spawn` tool so it can resolve a
+/// child `AgentDef` by name, call `Orchestrator::spawn(child_def, ctx)` with
+/// the child's own isolation, and emit `Event::SubAgentSpawned` against the
+/// session event log.
+///
+/// Every field is required for the tool to succeed; the outer
+/// `ToolCtx.agent_ctx: Option<_>` lets embedders (tests, `rerun_replace`)
+/// omit the plumbing entirely — the tool then returns a typed "not
+/// configured" error rather than panicking.
+#[derive(Clone)]
+pub struct AgentSpawnCtx {
+    /// The agent definitions the tool can resolve `agent_name` against.
+    /// Loaded once per turn via `forge_agents::load_agents`.
+    pub agent_defs: Arc<Vec<AgentDef>>,
+    /// Runtime orchestrator that actually registers the child instance
+    /// and emits lifecycle events. Shared across the turn so F-140's
+    /// monitor can subscribe once and see every spawn.
+    pub orchestrator: Arc<AgentOrchestrator>,
+    /// Session whose event log the tool writes `SubAgentSpawned` into.
+    pub session: Arc<Session>,
+    /// Parent agent instance id — the "parent" field in the emitted event.
+    pub parent_instance_id: AgentInstanceId,
+    /// The `msg_id` of the assistant turn that issued the tool call —
+    /// the `from_msg` field in the emitted event (matches the existing
+    /// `forge_core::Event::SubAgentSpawned` wire shape).
+    pub current_msg_id: MessageId,
 }
 
 /// Tool handler. `invoke` is `async` so filesystem / blocking work can be
@@ -360,6 +395,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
             byte_budget: None,
+            agent_ctx: None,
         };
         let result = d.dispatch("shell.exec", &json!({}), &ctx).await.unwrap();
         assert_eq!(
@@ -384,6 +420,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
             byte_budget: None,
+            agent_ctx: None,
         };
         let result = d
             .dispatch("shell.exec", &json!({ "command": "" }), &ctx)
@@ -504,6 +541,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
             byte_budget: None,
+            agent_ctx: None,
         };
         let result = d
             .dispatch(
@@ -538,6 +576,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
             byte_budget: None,
+            agent_ctx: None,
         };
 
         let result = d
@@ -575,6 +614,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(registry.clone()),
             byte_budget: None,
+            agent_ctx: None,
         };
 
         // Background a long sleep, write its pid, detach its stdio from
@@ -688,6 +728,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
             byte_budget: None,
+            agent_ctx: None,
         };
         let result = d
             .dispatch(
@@ -728,6 +769,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
             byte_budget: None,
+            agent_ctx: None,
         };
         let result = d
             .dispatch(
@@ -764,6 +806,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
             byte_budget: None,
+            agent_ctx: None,
         };
         let result = d
             .dispatch(
@@ -807,6 +850,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
             byte_budget: None,
+            agent_ctx: None,
         };
 
         let started = std::time::Instant::now();
@@ -844,6 +888,7 @@ mod tests {
             workspace_root: Some(dir.path().to_path_buf()),
             child_registry: Some(crate::sandbox::ChildRegistry::new()),
             byte_budget: None,
+            agent_ctx: None,
         };
         let result = d
             .dispatch(

--- a/crates/forge-session/tests/agent_spawn.rs
+++ b/crates/forge-session/tests/agent_spawn.rs
@@ -1,0 +1,291 @@
+//! F-134 integration tests for the `agent.spawn` built-in tool.
+//!
+//! These exercise the tool through the public `forge_session::tools`
+//! surface — the same code path `run_request_loop` uses when a provider
+//! emits a tool call. They complement the per-tool unit tests by proving
+//! the dispatcher round-trip works against a real `Session` event log.
+
+use forge_agents::{
+    AgentDef, AgentScope, Isolation, Orchestrator as AgentOrchestrator, SpawnContext,
+};
+use forge_core::ids::AgentInstanceId;
+use forge_core::{Event, MessageId};
+use forge_session::session::Session;
+use forge_session::tools::{AgentSpawnCtx, AgentSpawnTool, ToolCtx, ToolDispatcher};
+use serde_json::json;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn agent_def(name: &str, isolation: Isolation) -> AgentDef {
+    AgentDef {
+        name: name.to_string(),
+        description: None,
+        body: String::new(),
+        allowed_paths: vec![],
+        isolation,
+    }
+}
+
+async fn fresh_session() -> (TempDir, Arc<Session>) {
+    let dir = TempDir::new().unwrap();
+    let session = Arc::new(
+        Session::create(dir.path().join("events.jsonl"))
+            .await
+            .unwrap(),
+    );
+    (dir, session)
+}
+
+/// DoD: parent agent invokes `agent.spawn("child")`; verify child ran in
+/// correct isolation and event was emitted. The parent is `Process`, the
+/// child is `Container`; the registered instance must reflect the
+/// **child's** isolation — never the parent's.
+#[tokio::test]
+async fn parent_process_spawning_container_child_does_not_escalate_or_demote_privilege() {
+    let (_dir, session) = fresh_session().await;
+    let orchestrator = Arc::new(AgentOrchestrator::new());
+
+    // Register a realistic parent instance up front so the
+    // `parent_instance_id` we thread into the tool is a real registered id.
+    let parent_inst = orchestrator
+        .spawn(
+            agent_def("parent", Isolation::Process),
+            SpawnContext::user(),
+        )
+        .await
+        .unwrap();
+
+    // Subscribe to session events *before* dispatching so we don't miss the
+    // emit. `broadcast::Sender` drops events with no active receivers.
+    let mut rx = session.event_tx.subscribe();
+
+    let agent_ctx = AgentSpawnCtx {
+        agent_defs: Arc::new(vec![
+            agent_def("parent", Isolation::Process),
+            agent_def("child", Isolation::Container),
+        ]),
+        orchestrator: Arc::clone(&orchestrator),
+        session: Arc::clone(&session),
+        parent_instance_id: parent_inst.id.clone(),
+        current_msg_id: MessageId::new(),
+    };
+
+    let ctx = ToolCtx {
+        allowed_paths: vec![],
+        workspace_root: None,
+        child_registry: None,
+        byte_budget: None,
+        agent_ctx: Some(agent_ctx),
+    };
+
+    let mut dispatcher = ToolDispatcher::new();
+    dispatcher.register(Box::new(AgentSpawnTool)).unwrap();
+
+    let result = dispatcher
+        .dispatch(
+            "agent.spawn",
+            &json!({ "agent_name": "child", "prompt": "go" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result["ok"].as_bool(),
+        Some(true),
+        "dispatch result: {result}"
+    );
+    let child_id =
+        AgentInstanceId::from_string(result["child_instance_id"].as_str().unwrap().to_string());
+
+    // 1. Isolation invariant: the registered child carries the CHILD's
+    //    isolation, distinct from the parent's.
+    let child_inst = orchestrator.get(&child_id).await.expect("child registered");
+    assert_eq!(child_inst.def.isolation, Isolation::Container);
+    assert_ne!(child_inst.def.isolation, parent_inst.def.isolation);
+    assert_eq!(child_inst.def.name, "child");
+
+    // 2. Event emitted on the session event bus with the right ids.
+    let mut saw_event = false;
+    while let Ok((_seq, event)) = rx.try_recv() {
+        if let Event::SubAgentSpawned {
+            parent,
+            child,
+            from_msg: _,
+        } = event
+        {
+            assert_eq!(
+                parent, parent_inst.id,
+                "parent must match parent_instance_id"
+            );
+            assert_eq!(child, child_id, "child must match the spawn's returned id");
+            saw_event = true;
+            break;
+        }
+    }
+    assert!(saw_event, "SubAgentSpawned must be emitted");
+}
+
+/// DoD: "Dispatcher resolves agent_name via forge_agents::load_agents, fails
+/// with typed error if not found." The dispatcher's direct failure carries a
+/// machine-readable error prefix so callers can distinguish name-lookup
+/// failure from runtime failure.
+#[tokio::test]
+async fn unknown_agent_name_fails_with_typed_error_not_panic() {
+    let (_dir, session) = fresh_session().await;
+
+    let agent_ctx = AgentSpawnCtx {
+        agent_defs: Arc::new(vec![agent_def("other", Isolation::Process)]),
+        orchestrator: Arc::new(AgentOrchestrator::new()),
+        session,
+        parent_instance_id: AgentInstanceId::new(),
+        current_msg_id: MessageId::new(),
+    };
+
+    let ctx = ToolCtx {
+        allowed_paths: vec![],
+        workspace_root: None,
+        child_registry: None,
+        byte_budget: None,
+        agent_ctx: Some(agent_ctx),
+    };
+
+    let mut dispatcher = ToolDispatcher::new();
+    dispatcher.register(Box::new(AgentSpawnTool)).unwrap();
+
+    let result = dispatcher
+        .dispatch(
+            "agent.spawn",
+            &json!({ "agent_name": "does-not-exist", "prompt": "go" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+    let err = result["error"].as_str().unwrap_or_default();
+    assert!(
+        err.starts_with("tool.agent.spawn: unknown agent"),
+        "expected typed error, got: {result}"
+    );
+}
+
+/// DoD guardrail: an attacker who programmatically constructs a user-scope
+/// `Trusted` child def (bypassing the parser's reject at load time) must
+/// still be refused at spawn. The tool pins `AgentScope::User`, so the
+/// orchestrator's runtime check fires and the sub-agent is not registered.
+#[tokio::test]
+async fn user_scope_cannot_spawn_trusted_child_even_if_def_is_forged() {
+    let (_dir, session) = fresh_session().await;
+    let orchestrator = Arc::new(AgentOrchestrator::new());
+
+    let agent_ctx = AgentSpawnCtx {
+        agent_defs: Arc::new(vec![agent_def("evil", Isolation::Trusted)]),
+        orchestrator: Arc::clone(&orchestrator),
+        session,
+        parent_instance_id: AgentInstanceId::new(),
+        current_msg_id: MessageId::new(),
+    };
+    let ctx = ToolCtx {
+        allowed_paths: vec![],
+        workspace_root: None,
+        child_registry: None,
+        byte_budget: None,
+        agent_ctx: Some(agent_ctx),
+    };
+
+    let mut dispatcher = ToolDispatcher::new();
+    dispatcher.register(Box::new(AgentSpawnTool)).unwrap();
+
+    // Subscribe to orchestrator lifecycle events BEFORE the rejected spawn
+    // so we can prove no `Spawned` arrives. Dropping the ctx (and the Arc<_>
+    // it holds for the orchestrator) closes the channel and lets the stream
+    // terminate cleanly; polling with a timeout guards against a hang if
+    // the invariant ever regresses.
+    let mut stream = orchestrator.state_stream();
+
+    let result = dispatcher
+        .dispatch(
+            "agent.spawn",
+            &json!({ "agent_name": "evil", "prompt": "escalate" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+    let err = result["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("spawn failed"),
+        "expected spawn-failure error, got: {result}"
+    );
+    assert!(
+        err.to_lowercase().contains("trusted"),
+        "error should name the offending isolation level, got: {result}"
+    );
+
+    // Close every Arc<Orchestrator> so the broadcast stream ends.
+    drop(dispatcher);
+    drop(ctx);
+    drop(orchestrator);
+
+    use futures::StreamExt;
+    let mut collected = vec![];
+    // `state_stream` ends when the last Sender drops; a bounded timeout
+    // prevents a dangling receiver from stalling the test.
+    let drain = async {
+        while let Some(Ok(ev)) = stream.next().await {
+            collected.push(ev);
+        }
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(2), drain)
+        .await
+        .expect("broadcast stream should terminate after last sender drops");
+
+    assert!(
+        !collected
+            .iter()
+            .any(|e| matches!(e, forge_agents::AgentEvent::Spawned { .. })),
+        "no Spawned event should have been emitted for a rejected trusted child, got: {collected:?}"
+    );
+}
+
+/// Regression guard: embedders that don't need spawning (e.g. `rerun_replace`)
+/// register the tool but leave `ToolCtx.agent_ctx` as `None`. Invocation must
+/// return a typed error, not panic, not deadlock, not silently no-op.
+#[tokio::test]
+async fn tool_is_registered_but_inert_when_agent_ctx_is_absent() {
+    let mut dispatcher = ToolDispatcher::new();
+    dispatcher.register(Box::new(AgentSpawnTool)).unwrap();
+
+    let result = dispatcher
+        .dispatch(
+            "agent.spawn",
+            &json!({ "agent_name": "child", "prompt": "go" }),
+            &ToolCtx::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("agent runtime not configured"),
+        "result: {result}"
+    );
+}
+
+/// Sanity check that the `AgentScope::User` pinning in the tool is not
+/// circumvented by the caller's choice of parent_instance_id. We construct
+/// the `SpawnContext::user()` locally so this test is explicit about the
+/// contract rather than implicit via the isolation tests above.
+#[tokio::test]
+async fn spawn_context_scope_is_always_user_for_this_tool() {
+    use std::mem::discriminant;
+    let user = SpawnContext::user();
+    assert_eq!(
+        discriminant(&user.scope),
+        discriminant(&AgentScope::User),
+        "agent.spawn is meant to pin user scope; breaking that changes \
+         the privilege model and needs dedicated review"
+    );
+}


### PR DESCRIPTION
## Summary

Wire the `agent.spawn` built-in tool so a parent agent can spawn sub-agents through `forge_agents::Orchestrator::spawn` (F-133). The dispatcher resolves the named child `AgentDef`, hands it **verbatim** to the orchestrator, and emits `Event::SubAgentSpawned` on the session event log.

Critical invariant: the sub-agent runs under its **own** `AgentDef.isolation` — never the parent's. A privilege-escalation regression would be caught by:
- `parent_process_spawning_container_child_does_not_escalate_or_demote_privilege`
- `user_scope_cannot_spawn_trusted_child_even_if_def_is_forged`
- unit tests `child_runs_under_child_isolation_not_parent` + `rejects_trusted_child_under_user_scope`

Closes #248.

## DoD coverage

- [x] `agent.spawn(agent_name, prompt, context)` registered as a built-in tool in `forge-session` (`ToolDispatcher` wire-up in both `run_turn` and `rerun_replace`).
- [x] Dispatcher resolves `agent_name` via the caller's loaded defs (`forge_agents::load_agents` is the production loader — see notes below on live-session wiring); unknown names return a typed error `tool.agent.spawn: unknown agent '<name>'`.
- [x] Spawned instance runs under its own `AgentDef.isolation` — `Orchestrator::spawn(child_def, ctx)` receives the child's def directly. Covered by two parent=Process/child=Container tests.
- [x] Emits `Event::SubAgentSpawned` on success — see `emits_sub_agent_spawned_on_session_event_bus` (unit) and `parent_process_spawning_container_child_does_not_escalate_or_demote_privilege` (integration).
- [x] Integration test: parent invokes `agent.spawn(\"child\")`; asserts child-isolation passthrough + event emission (see `tests/agent_spawn.rs`).
- [x] Tests pass: `just check-rust` + `just test-rust` green locally on rebased branch.

## Deferrals (flagged per Wave-1 DoD-skip policy)

1. **Event shape.** DoD #248 names `Event::SubAgentSpawned { parent_id, child_id, agent_name }`. The existing `forge_core::Event::SubAgentSpawned` variant is `{ parent: AgentInstanceId, child: AgentInstanceId, from_msg: MessageId }`. This PR wires to the existing shape — changing the variant would touch `event_wire_shape` / replay-path regression tests and belongs in a dedicated PR.

2. **`prompt` arg is validated-only.** The tool rejects a missing `prompt` with the unified error shape but does not yet forward it to a child step executor. Threading the prompt into runtime execution lands with the step executor (post-F-140).

3. **`context` arg is validated-as-envelope.** The DoD signature names `context: AgentContext`, which does not exist as a concrete type yet. The tool accepts any JSON object or `null` and rejects scalars/arrays so a malformed call fails loud; the concrete `AgentContext` type will be validated strictly once it lands.

4. **Live-session wiring.** `run_turn` / `rerun_replace` currently set `ToolCtx.agent_ctx: None`, so in a real session `agent.spawn` returns `tool.agent.spawn: agent runtime not configured for this session`. Populating the ctx (session-scoped `Arc<Orchestrator>`, a synthesised parent-instance id, `forge_agents::load_agents(...)`-loaded defs, current `MessageId`) depends on the parent-agent-instance concept that lands with F-140 (AgentMonitor). The dispatcher plumbing is complete and ready to receive that wiring with no tool-side changes.

## Breaking API surface

- `forge_session::tools::ToolCtx` gains a public `agent_ctx: Option<AgentSpawnCtx>` field. All in-tree constructors are updated; downstream consumers that use a full struct literal (not `..ToolCtx::default()`) will need to add the field. `#[derive(Default)]` is preserved.
- New public type `forge_session::tools::AgentSpawnCtx { agent_defs, orchestrator, session, parent_instance_id, current_msg_id }`.
- New public tool `forge_session::tools::AgentSpawnTool` with `NAME = \"agent.spawn\"`.

## Test plan

- [x] `just check-rust` — fmt, clippy -D warnings, rustdoc -D warnings all clean
- [x] `just test-rust` — workspace green
- [x] 11 agent_spawn unit tests (missing-arg / unknown-agent / isolation pass-through / trusted-reject / session-event / context-validation)
- [x] 5 agent_spawn integration tests (dispatcher round-trip through `forge_session::tools` public API against a real `Session` event log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)