### PR TITLE
feat(forge-mcp): six-source import converters + forge mcp import CLI (F-131)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,11 +1143,14 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "dirs 6.0.0",
  "forge-core",
  "forge-ipc",
+ "forge-mcp",
  "libc",
  "serde",
  "serde_json",
+ "similar",
  "tempfile",
  "tokio",
 ]
@@ -1229,6 +1232,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "wiremock",
 ]

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -16,11 +16,18 @@ path = "src/main.rs"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+# Home-dir resolution for `forge mcp import` auto-detect (F-131). Matches
+# the version already used in forge-mcp so Cargo.lock doesn't grow a second.
+dirs = "6.0.0"
 forge-core = { path = "../forge-core" }
 forge-ipc = { path = "../forge-ipc" }
+forge-mcp = { path = "../forge-mcp" }
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Unified-diff rendering for the dry-run output of `forge mcp import`
+# (F-131). `similar` is the workspace's usual choice for text diffs.
+similar = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "process", "io-std", "fs", "io-util"] }
 
 [dev-dependencies]

--- a/crates/forge-cli/src/lib.rs
+++ b/crates/forge-cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod display;
+pub mod mcp;
 pub mod socket;
 
 use clap::{Parser, Subcommand};
@@ -44,6 +45,11 @@ pub enum Commands {
     Run {
         #[command(subcommand)]
         cmd: RunCommands,
+    },
+    /// Manage MCP (Model Context Protocol) servers.
+    Mcp {
+        #[command(subcommand)]
+        cmd: McpCommands,
     },
 }
 
@@ -104,4 +110,51 @@ pub enum RunCommands {
         #[arg(long, default_value = "-")]
         input: String,
     },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum McpCommands {
+    /// Import MCP server definitions from another tool's config.
+    ///
+    /// Dry-run by default: prints a unified diff against the workspace's
+    /// existing `.mcp.json`. Pass `--apply` to write.
+    ///
+    /// Auto source mode (`--source=auto`, the default) walks every known
+    /// location; later sources in the list override earlier ones on name
+    /// collision (ordered: vscode → cursor → claude → continue → kiro →
+    /// codex).
+    Import {
+        /// Which source format to read. Omit or set to `auto` to walk all
+        /// known locations.
+        #[arg(long, default_value = "auto", value_parser = parse_import_source)]
+        source: ImportSourceFlag,
+        /// Write the converted config to `.mcp.json` instead of showing a
+        /// diff.
+        #[arg(long)]
+        apply: bool,
+        /// Workspace root. Defaults to the current working directory.
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+    },
+}
+
+/// CLI-visible form of [`forge_mcp::import::ImportSource`], plus an
+/// explicit `Auto` variant so `--source=auto` is a first-class value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportSourceFlag {
+    Auto,
+    Source(forge_mcp::import::ImportSource),
+}
+
+fn parse_import_source(raw: &str) -> Result<ImportSourceFlag, String> {
+    if raw == "auto" {
+        return Ok(ImportSourceFlag::Auto);
+    }
+    forge_mcp::import::ImportSource::from_slug(raw)
+        .map(ImportSourceFlag::Source)
+        .ok_or_else(|| {
+            format!(
+                "unknown import source {raw:?}; expected one of: auto, vscode, cursor, claude, continue, kiro, codex"
+            )
+        })
 }

--- a/crates/forge-cli/src/main.rs
+++ b/crates/forge-cli/src/main.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
-use forge_cli::{Cli, Commands, RunCommands, SessionCommands, SessionNewKind};
+use forge_cli::{
+    Cli, Commands, ImportSourceFlag, McpCommands, RunCommands, SessionCommands, SessionNewKind,
+};
 use std::path::PathBuf;
 
 #[tokio::main]
@@ -16,7 +18,40 @@ async fn main() -> Result<()> {
         Commands::Run { cmd } => match cmd {
             RunCommands::Agent { name, input } => run_agent(&name, &input).await,
         },
+        Commands::Mcp { cmd } => match cmd {
+            McpCommands::Import {
+                source,
+                apply,
+                workspace,
+            } => mcp_import(source, apply, workspace).await,
+        },
     }
+}
+
+async fn mcp_import(
+    source: ImportSourceFlag,
+    apply: bool,
+    workspace: Option<PathBuf>,
+) -> Result<()> {
+    let workspace_root = workspace.unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    let home =
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve user home directory"))?;
+    let source = match source {
+        ImportSourceFlag::Auto => None,
+        ImportSourceFlag::Source(s) => Some(s),
+    };
+    let args = forge_cli::mcp::ImportArgs {
+        workspace_root,
+        home,
+        source,
+        apply,
+    };
+    let mut stdout = std::io::stdout();
+    let code = forge_cli::mcp::run(&args, &mut stdout)?;
+    if code != 0 {
+        std::process::exit(code);
+    }
+    Ok(())
 }
 
 async fn session_new(kind: SessionNewKind) -> Result<()> {

--- a/crates/forge-cli/src/mcp.rs
+++ b/crates/forge-cli/src/mcp.rs
@@ -1,0 +1,347 @@
+//! `forge mcp import` subcommand (F-131).
+//!
+//! Reads an MCP configuration from one of six source formats and converts
+//! it to Forge's universal `.mcp.json`. Dry-run by default (prints a
+//! unified diff against the current `.mcp.json`); writes only when
+//! `--apply` is passed.
+//!
+//! The source converters live in [`forge_mcp::import`]; this module is the
+//! thin CLI-side wrapper around them.
+
+use anyhow::{anyhow, Context, Result};
+use forge_mcp::{
+    import::{detect_all, Detection, ImportSource},
+    render_universal, McpServerSpec,
+};
+use similar::TextDiff;
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+/// Arguments for `forge mcp import`.
+#[derive(Debug, Clone)]
+pub struct ImportArgs {
+    /// Workspace root. Defaults to the current working directory.
+    pub workspace_root: PathBuf,
+    /// User home directory. Defaults to `dirs::home_dir()`.
+    pub home: PathBuf,
+    /// `None` means auto-detect mode.
+    pub source: Option<ImportSource>,
+    /// Dry-run (print diff) when false; write when true.
+    pub apply: bool,
+}
+
+/// Entry point for `forge mcp import`. Writes human-readable output to
+/// `out` (usually stdout). Returns the exit code the CLI should exit with.
+pub fn run(args: &ImportArgs, out: &mut impl Write) -> Result<i32> {
+    match args.source {
+        Some(source) => run_single(source, args, out),
+        None => run_auto(args, out),
+    }
+}
+
+fn run_single(source: ImportSource, args: &ImportArgs, out: &mut impl Write) -> Result<i32> {
+    let path = source
+        .default_path(&args.workspace_root, &args.home)
+        .ok_or_else(|| anyhow!("cannot resolve default path for source {}", source.slug()))?;
+    if !path.exists() {
+        writeln!(
+            out,
+            "no {} config found at {}",
+            source.slug(),
+            path.display()
+        )?;
+        return Ok(0);
+    }
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("reading {} source at {}", source.slug(), path.display()))?;
+    let servers = source
+        .convert(&raw)
+        .with_context(|| format!("converting {} source at {}", source.slug(), path.display()))?;
+    writeln!(
+        out,
+        "found {} MCP server(s) in {} ({})",
+        servers.len(),
+        path.display(),
+        source.slug()
+    )?;
+    finalize(&servers, args, out)
+}
+
+fn run_auto(args: &ImportArgs, out: &mut impl Write) -> Result<i32> {
+    let report = detect_all(&args.workspace_root, &args.home)?;
+    if report.found.is_empty() {
+        writeln!(out, "no MCP configs detected in any known source location")?;
+        return Ok(0);
+    }
+
+    writeln!(out, "detected {} source(s):", report.found.len())?;
+    for Detection {
+        source,
+        path,
+        servers,
+    } in &report.found
+    {
+        writeln!(
+            out,
+            "  - {:<8} {} ({} server(s))",
+            source.slug(),
+            path.display(),
+            servers.len()
+        )?;
+    }
+
+    // Auto-merge policy: walk sources in `ImportSource::all()` order;
+    // later sources override earlier ones on name collision. Documented
+    // both here and in the CLI `--help` text. We surface collisions to
+    // the user so the override isn't silent.
+    let mut merged: BTreeMap<String, McpServerSpec> = BTreeMap::new();
+    for Detection {
+        source, servers, ..
+    } in &report.found
+    {
+        for (name, spec) in servers {
+            if merged.insert(name.clone(), spec.clone()).is_some() {
+                writeln!(
+                    out,
+                    "note: {} overrides an earlier definition of {:?}",
+                    source.slug(),
+                    name
+                )?;
+            }
+        }
+    }
+    writeln!(out, "merged into {} unique MCP server(s)", merged.len())?;
+
+    finalize(&merged, args, out)
+}
+
+fn finalize(
+    servers: &BTreeMap<String, McpServerSpec>,
+    args: &ImportArgs,
+    out: &mut impl Write,
+) -> Result<i32> {
+    let target = args.workspace_root.join(".mcp.json");
+    let existing = if target.exists() {
+        fs::read_to_string(&target)
+            .with_context(|| format!("reading existing {}", target.display()))?
+    } else {
+        String::new()
+    };
+    let proposed = render_universal(servers)?;
+
+    if args.apply {
+        fs::write(&target, &proposed).with_context(|| format!("writing {}", target.display()))?;
+        writeln!(
+            out,
+            "wrote {} server(s) to {}",
+            servers.len(),
+            target.display()
+        )?;
+    } else {
+        let diff = render_diff(&existing, &proposed, &target);
+        if diff.is_empty() {
+            writeln!(out, "no changes to {}", target.display())?;
+        } else {
+            writeln!(out, "{}", diff)?;
+            writeln!(
+                out,
+                "dry-run: re-run with --apply to write {}",
+                target.display()
+            )?;
+        }
+    }
+    Ok(0)
+}
+
+/// Produce a unified diff between `old` and `new`. Empty string when the
+/// two sides are identical — callers treat that as "no changes".
+pub(crate) fn render_diff(old: &str, new: &str, target: &Path) -> String {
+    if old == new {
+        return String::new();
+    }
+    let diff = TextDiff::from_lines(old, new);
+    let header_old = if old.is_empty() {
+        "(missing)".to_string()
+    } else {
+        target.display().to_string()
+    };
+    let header_new = format!("{} (proposed)", target.display());
+    diff.unified_diff()
+        .header(&header_old, &header_new)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &Path, rel: &str, body: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn dry_run_single_source_prints_diff_and_does_not_write() {
+        let ws = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        write_file(
+            home.path(),
+            ".cursor/mcp.json",
+            r#"{ "mcpServers": { "gh": { "command": "npx", "args": ["-y", "server-github"] } } }"#,
+        );
+
+        let args = ImportArgs {
+            workspace_root: ws.path().to_path_buf(),
+            home: home.path().to_path_buf(),
+            source: Some(ImportSource::Cursor),
+            apply: false,
+        };
+        let mut buf = Vec::new();
+        let code = run(&args, &mut buf).unwrap();
+        assert_eq!(code, 0);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("found 1 MCP server"), "output: {output}");
+        assert!(output.contains("dry-run"), "output: {output}");
+        assert!(
+            output.contains("+  \"mcpServers\""),
+            "diff expected: {output}"
+        );
+        assert!(!ws.path().join(".mcp.json").exists());
+    }
+
+    #[test]
+    fn apply_writes_universal_config_and_reports_count() {
+        let ws = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        write_file(
+            home.path(),
+            ".cursor/mcp.json",
+            r#"{ "mcpServers": { "gh": { "command": "npx" } } }"#,
+        );
+        let args = ImportArgs {
+            workspace_root: ws.path().to_path_buf(),
+            home: home.path().to_path_buf(),
+            source: Some(ImportSource::Cursor),
+            apply: true,
+        };
+        let mut buf = Vec::new();
+        let code = run(&args, &mut buf).unwrap();
+        assert_eq!(code, 0);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("wrote 1 server"), "output: {output}");
+        let written = fs::read_to_string(ws.path().join(".mcp.json")).unwrap();
+        assert!(written.contains("\"gh\""), "written: {written}");
+        assert!(
+            written.contains("\"command\": \"npx\""),
+            "written: {written}"
+        );
+    }
+
+    #[test]
+    fn auto_detect_lists_all_sources_and_merges() {
+        let ws = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        write_file(
+            ws.path(),
+            ".vscode/mcp.json",
+            r#"{ "servers": { "shared": { "command": "vs" }, "vs-only": { "command": "vsx" } } }"#,
+        );
+        write_file(
+            home.path(),
+            ".cursor/mcp.json",
+            r#"{ "mcpServers": { "shared": { "command": "cur" }, "cursor-only": { "command": "curx" } } }"#,
+        );
+        let args = ImportArgs {
+            workspace_root: ws.path().to_path_buf(),
+            home: home.path().to_path_buf(),
+            source: None,
+            apply: false,
+        };
+        let mut buf = Vec::new();
+        run(&args, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("detected 2 source"), "output: {output}");
+        assert!(output.contains("vscode"), "output: {output}");
+        assert!(output.contains("cursor"), "output: {output}");
+        // Later source (cursor, walked after vscode) wins on collision.
+        assert!(output.contains("overrides"), "output: {output}");
+        assert!(output.contains("merged into 3"), "output: {output}");
+    }
+
+    #[test]
+    fn auto_detect_reports_when_nothing_found() {
+        let ws = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        let args = ImportArgs {
+            workspace_root: ws.path().to_path_buf(),
+            home: home.path().to_path_buf(),
+            source: None,
+            apply: false,
+        };
+        let mut buf = Vec::new();
+        run(&args, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            output.contains("no MCP configs detected"),
+            "output: {output}"
+        );
+    }
+
+    #[test]
+    fn missing_single_source_reports_cleanly_not_error() {
+        let ws = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        let args = ImportArgs {
+            workspace_root: ws.path().to_path_buf(),
+            home: home.path().to_path_buf(),
+            source: Some(ImportSource::Kiro),
+            apply: false,
+        };
+        let mut buf = Vec::new();
+        let code = run(&args, &mut buf).unwrap();
+        assert_eq!(code, 0);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("no kiro config found"), "output: {output}");
+    }
+
+    #[test]
+    fn apply_with_existing_file_overwrites() {
+        let ws = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        write_file(
+            ws.path(),
+            ".mcp.json",
+            r#"{ "mcpServers": { "stale": { "command": "old" } } }"#,
+        );
+        write_file(
+            home.path(),
+            ".cursor/mcp.json",
+            r#"{ "mcpServers": { "fresh": { "command": "new" } } }"#,
+        );
+        let args = ImportArgs {
+            workspace_root: ws.path().to_path_buf(),
+            home: home.path().to_path_buf(),
+            source: Some(ImportSource::Cursor),
+            apply: true,
+        };
+        let mut buf = Vec::new();
+        run(&args, &mut buf).unwrap();
+        let written = fs::read_to_string(ws.path().join(".mcp.json")).unwrap();
+        assert!(!written.contains("stale"), "written: {written}");
+        assert!(written.contains("fresh"), "written: {written}");
+    }
+
+    #[test]
+    fn render_diff_is_empty_for_identical_strings() {
+        let d = render_diff("same\n", "same\n", Path::new("/tmp/.mcp.json"));
+        assert!(d.is_empty());
+    }
+}

--- a/crates/forge-cli/tests/cli_args.rs
+++ b/crates/forge-cli/tests/cli_args.rs
@@ -2,7 +2,10 @@
 /// These import the production `Cli` struct directly so any structural change
 /// to the real command hierarchy will break these tests.
 use clap::Parser;
-use forge_cli::{Cli, Commands, RunCommands, SessionCommands, SessionNewKind};
+use forge_cli::{
+    Cli, Commands, ImportSourceFlag, McpCommands, RunCommands, SessionCommands, SessionNewKind,
+};
+use forge_mcp::import::ImportSource;
 use std::path::PathBuf;
 
 #[test]
@@ -226,4 +229,75 @@ fn parse_run_agent_with_file_input() {
 fn unknown_command_returns_error() {
     let result = Cli::try_parse_from(["forge", "bogus"]);
     assert!(result.is_err(), "bogus command should fail to parse");
+}
+
+#[test]
+fn parse_mcp_import_defaults_to_auto_dry_run() {
+    let cli = Cli::try_parse_from(["forge", "mcp", "import"]).expect("should parse");
+    let Commands::Mcp {
+        cmd:
+            McpCommands::Import {
+                source,
+                apply,
+                workspace,
+            },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(source, ImportSourceFlag::Auto);
+    assert!(!apply);
+    assert_eq!(workspace, None);
+}
+
+#[test]
+fn parse_mcp_import_with_explicit_source_and_apply() {
+    let cli = Cli::try_parse_from([
+        "forge",
+        "mcp",
+        "import",
+        "--source=cursor",
+        "--apply",
+        "--workspace",
+        "/tmp/project",
+    ])
+    .expect("should parse");
+    let Commands::Mcp {
+        cmd:
+            McpCommands::Import {
+                source,
+                apply,
+                workspace,
+            },
+    } = cli.command
+    else {
+        panic!("wrong command shape");
+    };
+    assert_eq!(source, ImportSourceFlag::Source(ImportSource::Cursor));
+    assert!(apply);
+    assert_eq!(workspace, Some(PathBuf::from("/tmp/project")));
+}
+
+#[test]
+fn parse_mcp_import_rejects_bogus_source() {
+    let result = Cli::try_parse_from(["forge", "mcp", "import", "--source=bogus"]);
+    assert!(result.is_err(), "bogus source should fail to parse");
+}
+
+#[test]
+fn parse_mcp_import_accepts_all_six_source_slugs() {
+    for slug in ["vscode", "cursor", "claude", "continue", "kiro", "codex"] {
+        let cli = Cli::try_parse_from(["forge", "mcp", "import", &format!("--source={slug}")])
+            .unwrap_or_else(|e| panic!("failed to parse source={slug}: {e}"));
+        let Commands::Mcp {
+            cmd: McpCommands::Import { source, .. },
+        } = cli.command
+        else {
+            panic!("wrong command shape for {slug}");
+        };
+        let ImportSourceFlag::Source(got) = source else {
+            panic!("expected Source variant for {slug}");
+        };
+        assert_eq!(got.slug(), slug);
+    }
 }

--- a/crates/forge-mcp/Cargo.toml
+++ b/crates/forge-mcp/Cargo.toml
@@ -17,6 +17,8 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "str
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["process", "io-util", "sync", "macros", "rt", "rt-multi-thread", "time"] }
+# Codex source format (F-131) stores MCP servers in `~/.codex/config.toml`.
+toml = "0.8"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/forge-mcp/src/import.rs
+++ b/crates/forge-mcp/src/import.rs
@@ -1,0 +1,729 @@
+//! Source-format converters for `forge mcp import` (F-131).
+//!
+//! Each third-party tool stores its MCP server declarations in a slightly
+//! different on-disk layout. A converter module here reads the raw file
+//! contents from one such source and returns a `BTreeMap<String,
+//! McpServerSpec>` shaped for Forge's universal `.mcp.json` schema.
+//!
+//! The converters never touch the filesystem directly — callers feed them a
+//! string so they're trivially testable with fixtures.
+//!
+//! # Import sources
+//!
+//! | Source       | File path                                                         |
+//! |--------------|-------------------------------------------------------------------|
+//! | VS Code      | `.vscode/mcp.json` (top-level `servers`)                          |
+//! | Cursor       | `~/.cursor/mcp.json` (top-level `mcpServers`)                     |
+//! | Claude       | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+//! | Continue     | `~/.continue/config.json` (one key among many)                    |
+//! | Kiro         | `.kiro/mcp.json` (workspace) — mirrors Claude/Cursor              |
+//! | Codex        | `.codex/config.toml` (workspace) — TOML `[mcp_servers.<name>]`    |
+//!
+//! The import path uses a deliberately *lenient* top-level parse: unknown
+//! top-level keys are ignored (many sources nest `mcpServers` inside a
+//! larger app config). Server entries themselves are strict — unknown
+//! fields are dropped silently rather than rejected because source tools
+//! routinely add tool-specific metadata (`disabled`, `autoApprove`,
+//! `envFile`, `auth`, `supports_parallel_tool_calls`, ...) that have no
+//! universal-schema analogue.
+
+use crate::{McpServerSpec, ServerKind};
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+/// Identifiers for the six supported import sources. Matches the
+/// `ImportSource` enum declared in `docs/architecture/crate-architecture.md`
+/// §3.3.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportSource {
+    VsCode,
+    Cursor,
+    ClaudeDesktop,
+    Continue,
+    Kiro,
+    Codex,
+}
+
+impl ImportSource {
+    /// Human-readable slug used in CLI flags (`--source=<slug>`) and diff
+    /// headers.
+    pub fn slug(self) -> &'static str {
+        match self {
+            ImportSource::VsCode => "vscode",
+            ImportSource::Cursor => "cursor",
+            ImportSource::ClaudeDesktop => "claude",
+            ImportSource::Continue => "continue",
+            ImportSource::Kiro => "kiro",
+            ImportSource::Codex => "codex",
+        }
+    }
+
+    /// Every known source, in the order they're walked by auto-detect.
+    pub fn all() -> &'static [ImportSource] {
+        &[
+            ImportSource::VsCode,
+            ImportSource::Cursor,
+            ImportSource::ClaudeDesktop,
+            ImportSource::Continue,
+            ImportSource::Kiro,
+            ImportSource::Codex,
+        ]
+    }
+
+    /// Parse the `--source=<slug>` CLI flag value.
+    pub fn from_slug(slug: &str) -> Option<Self> {
+        Self::all().iter().copied().find(|s| s.slug() == slug)
+    }
+
+    /// Convert a raw file body into a `BTreeMap<String, McpServerSpec>`.
+    pub fn convert(self, raw: &str) -> Result<BTreeMap<String, McpServerSpec>> {
+        match self {
+            ImportSource::VsCode => vscode::convert(raw),
+            ImportSource::Cursor => cursor::convert(raw),
+            ImportSource::ClaudeDesktop => claude::convert(raw),
+            ImportSource::Continue => continue_::convert(raw),
+            ImportSource::Kiro => kiro::convert(raw),
+            ImportSource::Codex => codex::convert(raw),
+        }
+    }
+
+    /// Default on-disk location for this source, if one can be resolved
+    /// from the given workspace root and home directory. Returning `None`
+    /// means "can't locate without more info" — e.g. missing `$HOME`.
+    pub fn default_path(self, workspace_root: &Path, home: &Path) -> Option<PathBuf> {
+        match self {
+            ImportSource::VsCode => Some(workspace_root.join(".vscode").join("mcp.json")),
+            ImportSource::Cursor => Some(home.join(".cursor").join("mcp.json")),
+            ImportSource::ClaudeDesktop => {
+                // macOS canonical path per the MCP docs. Linux/Windows have
+                // their own locations; we pick the macOS one because it's
+                // the one the Issue cites verbatim and because Claude
+                // Desktop is macOS/Windows-only anyway.
+                Some(
+                    home.join("Library")
+                        .join("Application Support")
+                        .join("Claude")
+                        .join("claude_desktop_config.json"),
+                )
+            }
+            ImportSource::Continue => Some(home.join(".continue").join("config.json")),
+            ImportSource::Kiro => Some(workspace_root.join(".kiro").join("mcp.json")),
+            ImportSource::Codex => Some(workspace_root.join(".codex").join("config.toml")),
+        }
+    }
+}
+
+/// Auto-detection report: which sources were found on disk, and the
+/// converted server maps for each.
+#[derive(Debug, Default)]
+pub struct DetectionReport {
+    pub found: Vec<Detection>,
+}
+
+#[derive(Debug)]
+pub struct Detection {
+    pub source: ImportSource,
+    pub path: PathBuf,
+    pub servers: BTreeMap<String, McpServerSpec>,
+}
+
+/// Walk every known source location rooted at `workspace_root` / `home`.
+/// For each file that exists and parses, record a `Detection`. Parse
+/// failures surface as a hard error (we don't want to silently drop a
+/// config the user asked us to import).
+pub fn detect_all(workspace_root: &Path, home: &Path) -> Result<DetectionReport> {
+    let mut report = DetectionReport::default();
+    for &source in ImportSource::all() {
+        let Some(path) = source.default_path(workspace_root, home) else {
+            continue;
+        };
+        if !path.exists() {
+            continue;
+        }
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading {} source at {}", source.slug(), path.display()))?;
+        let servers = source.convert(&raw).with_context(|| {
+            format!("converting {} source at {}", source.slug(), path.display())
+        })?;
+        report.found.push(Detection {
+            source,
+            path,
+            servers,
+        });
+    }
+    Ok(report)
+}
+
+/// A server entry as it appears in most JSON-based sources (VS Code,
+/// Cursor, Claude Desktop, Kiro). Lenient about unknown fields so that
+/// source-specific extensions (`envFile`, `disabled`, `autoApprove`,
+/// `auth`, `sandbox`, `type: "sse"`, ...) don't blow up the import.
+#[derive(Debug, Default, Deserialize)]
+struct JsonServer {
+    #[serde(default, rename = "type")]
+    kind: Option<String>,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+}
+
+impl JsonServer {
+    fn into_spec(self) -> Result<McpServerSpec> {
+        let kind_str = self.kind.as_deref().map(normalize_kind);
+        let transport = match kind_str {
+            Some("stdio") => Transport::Stdio,
+            Some("http") => Transport::Http,
+            Some(other) => {
+                return Err(anyhow!(
+                    "unknown MCP server type {other:?}; expected \"stdio\" or \"http\""
+                ))
+            }
+            None => match (self.command.is_some(), self.url.is_some()) {
+                (true, false) => Transport::Stdio,
+                (false, true) => Transport::Http,
+                (true, true) => {
+                    return Err(anyhow!(
+                        "MCP server declares both `command` and `url`; set `type` explicitly"
+                    ))
+                }
+                (false, false) => {
+                    return Err(anyhow!(
+                    "MCP server missing transport fields: need `command` (stdio) or `url` (http)"
+                ))
+                }
+            },
+        };
+
+        let kind = match transport {
+            Transport::Stdio => ServerKind::Stdio {
+                command: self
+                    .command
+                    .ok_or_else(|| anyhow!("stdio MCP server missing `command`"))?,
+                args: self.args,
+                env: self.env,
+            },
+            Transport::Http => ServerKind::Http {
+                url: self
+                    .url
+                    .ok_or_else(|| anyhow!("http MCP server missing `url`"))?,
+                headers: self.headers,
+            },
+        };
+        Ok(McpServerSpec { kind })
+    }
+}
+
+/// Normalize source-specific transport strings onto the universal
+/// `"stdio"` / `"http"` pair. Continue uses `"sse"` and `"streamable-http"`
+/// for remote variants; we fold both onto `"http"` because the universal
+/// schema only stores the destination URL.
+fn normalize_kind(raw: &str) -> &str {
+    match raw {
+        "stdio" => "stdio",
+        "http" | "sse" | "streamable-http" | "streamable_http" => "http",
+        other => other,
+    }
+}
+
+enum Transport {
+    Stdio,
+    Http,
+}
+
+fn parse_json_map(raw: &str, key: &str) -> Result<BTreeMap<String, McpServerSpec>> {
+    let value: serde_json::Value =
+        serde_json::from_str(raw).context("source file is not valid JSON")?;
+    let map = match value.get(key) {
+        Some(serde_json::Value::Object(obj)) => obj.clone(),
+        Some(_) => return Err(anyhow!("{key:?} must be a JSON object")),
+        None => return Ok(BTreeMap::new()),
+    };
+
+    let mut out = BTreeMap::new();
+    for (name, entry) in map {
+        let raw: JsonServer = serde_json::from_value(entry)
+            .with_context(|| format!("invalid server entry {name:?}"))?;
+        let spec = raw
+            .into_spec()
+            .with_context(|| format!("invalid server entry {name:?}"))?;
+        out.insert(name, spec);
+    }
+    Ok(out)
+}
+
+pub mod vscode {
+    //! VS Code uses `.vscode/mcp.json` with a top-level `servers` object.
+    //! The schema also allows a sibling `inputs: []` array which we ignore
+    //! (it only matters for VS Code's own secret-prompt UI).
+    use super::*;
+
+    pub fn convert(raw: &str) -> Result<BTreeMap<String, McpServerSpec>> {
+        parse_json_map(raw, "servers")
+    }
+}
+
+pub mod cursor {
+    //! Cursor's `~/.cursor/mcp.json` is closest to the universal schema:
+    //! top-level `mcpServers`, stdio or http entries.
+    use super::*;
+
+    pub fn convert(raw: &str) -> Result<BTreeMap<String, McpServerSpec>> {
+        parse_json_map(raw, "mcpServers")
+    }
+}
+
+pub mod claude {
+    //! Claude Desktop's `claude_desktop_config.json` nests `mcpServers`
+    //! inside a larger config object. We ignore the sibling keys.
+    use super::*;
+
+    pub fn convert(raw: &str) -> Result<BTreeMap<String, McpServerSpec>> {
+        parse_json_map(raw, "mcpServers")
+    }
+}
+
+pub mod continue_ {
+    //! Continue stores MCP servers inside its larger `~/.continue/config.json`.
+    //! Older versions used an object under `mcpServers`; newer ones use an
+    //! array of `{ name, type, command, args, env, url, ... }`. We handle
+    //! both shapes. Other top-level keys (`models`, `contextProviders`, …)
+    //! are ignored.
+    use super::*;
+
+    pub fn convert(raw: &str) -> Result<BTreeMap<String, McpServerSpec>> {
+        let value: serde_json::Value =
+            serde_json::from_str(raw).context("source file is not valid JSON")?;
+        let mcp = match value.get("mcpServers") {
+            Some(v) => v,
+            None => return Ok(BTreeMap::new()),
+        };
+
+        let mut out = BTreeMap::new();
+        match mcp {
+            serde_json::Value::Object(obj) => {
+                for (name, entry) in obj {
+                    let raw: JsonServer = serde_json::from_value(entry.clone())
+                        .with_context(|| format!("invalid server entry {name:?}"))?;
+                    let spec = raw
+                        .into_spec()
+                        .with_context(|| format!("invalid server entry {name:?}"))?;
+                    out.insert(name.clone(), spec);
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for (idx, entry) in arr.iter().enumerate() {
+                    let obj = entry
+                        .as_object()
+                        .ok_or_else(|| anyhow!("Continue mcpServers[{idx}] must be an object"))?;
+                    let name = obj
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .ok_or_else(|| {
+                            anyhow!("Continue mcpServers[{idx}] missing required `name`")
+                        })?
+                        .to_string();
+                    let raw: JsonServer = serde_json::from_value(entry.clone())
+                        .with_context(|| format!("invalid server entry {name:?}"))?;
+                    let spec = raw
+                        .into_spec()
+                        .with_context(|| format!("invalid server entry {name:?}"))?;
+                    out.insert(name, spec);
+                }
+            }
+            _ => return Err(anyhow!("Continue `mcpServers` must be an object or array")),
+        }
+        Ok(out)
+    }
+}
+
+pub mod kiro {
+    //! Kiro's `.kiro/mcp.json` mirrors Claude Desktop's shape: top-level
+    //! `mcpServers`. Kiro-specific extensions (`disabled`, `autoApprove`,
+    //! `disabledTools`) are silently dropped.
+    use super::*;
+
+    pub fn convert(raw: &str) -> Result<BTreeMap<String, McpServerSpec>> {
+        parse_json_map(raw, "mcpServers")
+    }
+}
+
+pub mod codex {
+    //! Codex's `~/.codex/config.toml` stores MCP servers as
+    //! `[mcp_servers.<name>]` TOML tables. Codex-specific extensions
+    //! (`supports_parallel_tool_calls`, `default_tools_approval_mode`,
+    //! tool-level `approval_mode`, `startup_timeout_ms`, `env_vars`, ...)
+    //! have no universal-schema analogue and are silently dropped.
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct CodexConfig {
+        #[serde(default)]
+        mcp_servers: BTreeMap<String, CodexServer>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct CodexServer {
+        #[serde(default)]
+        command: Option<String>,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default)]
+        env: BTreeMap<String, String>,
+        #[serde(default)]
+        url: Option<String>,
+        #[serde(default)]
+        headers: BTreeMap<String, String>,
+    }
+
+    pub fn convert(raw: &str) -> Result<BTreeMap<String, McpServerSpec>> {
+        let cfg: CodexConfig = toml::from_str(raw).context("source file is not valid TOML")?;
+        let mut out = BTreeMap::new();
+        for (name, server) in cfg.mcp_servers {
+            let js = JsonServer {
+                kind: None,
+                command: server.command,
+                args: server.args,
+                env: server.env,
+                url: server.url,
+                headers: server.headers,
+            };
+            let spec = js
+                .into_spec()
+                .with_context(|| format!("invalid codex MCP server {name:?}"))?;
+            out.insert(name, spec);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_stdio<'a>(
+        servers: &'a BTreeMap<String, McpServerSpec>,
+        name: &str,
+    ) -> (&'a String, &'a [String], &'a BTreeMap<String, String>) {
+        let spec = servers
+            .get(name)
+            .unwrap_or_else(|| panic!("missing {name}"));
+        match &spec.kind {
+            ServerKind::Stdio { command, args, env } => (command, args.as_slice(), env),
+            other => panic!("expected Stdio, got {other:?}"),
+        }
+    }
+
+    fn assert_http<'a>(
+        servers: &'a BTreeMap<String, McpServerSpec>,
+        name: &str,
+    ) -> (&'a String, &'a BTreeMap<String, String>) {
+        let spec = servers
+            .get(name)
+            .unwrap_or_else(|| panic!("missing {name}"));
+        match &spec.kind {
+            ServerKind::Http { url, headers } => (url, headers),
+            other => panic!("expected Http, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slugs_round_trip() {
+        for &source in ImportSource::all() {
+            assert_eq!(ImportSource::from_slug(source.slug()), Some(source));
+        }
+        assert_eq!(ImportSource::from_slug("bogus"), None);
+    }
+
+    #[test]
+    fn vscode_parses_servers_key_stdio_and_http() {
+        let raw = r#"{
+            "inputs": [{"id": "tok", "type": "promptString"}],
+            "servers": {
+                "playwright": {
+                    "command": "npx",
+                    "args": ["-y", "@microsoft/mcp-server-playwright"]
+                },
+                "github": {
+                    "type": "http",
+                    "url": "https://api.githubcopilot.com/mcp"
+                }
+            }
+        }"#;
+        let servers = vscode::convert(raw).unwrap();
+        assert_eq!(servers.len(), 2);
+        let (cmd, args, _env) = assert_stdio(&servers, "playwright");
+        assert_eq!(cmd, "npx");
+        assert_eq!(args, ["-y", "@microsoft/mcp-server-playwright"]);
+        let (url, _h) = assert_http(&servers, "github");
+        assert_eq!(url, "https://api.githubcopilot.com/mcp");
+    }
+
+    #[test]
+    fn cursor_parses_mcp_servers_key_with_extensions() {
+        // `envFile`, `auth`, `${env:...}` interpolation — Cursor-specific
+        // extras that must not make the converter fail.
+        let raw = r#"{
+            "mcpServers": {
+                "local": {
+                    "type": "stdio",
+                    "command": "python",
+                    "args": ["mcp-server.py"],
+                    "env": { "API_KEY": "${env:API_KEY}" },
+                    "envFile": ".env"
+                },
+                "oauth": {
+                    "url": "https://api.example.com/mcp",
+                    "headers": { "Authorization": "Bearer tok" },
+                    "auth": { "CLIENT_ID": "${env:ID}" }
+                }
+            }
+        }"#;
+        let servers = cursor::convert(raw).unwrap();
+        assert_eq!(servers.len(), 2);
+        let (cmd, args, env) = assert_stdio(&servers, "local");
+        assert_eq!(cmd, "python");
+        assert_eq!(args, ["mcp-server.py"]);
+        assert_eq!(
+            env.get("API_KEY").map(String::as_str),
+            Some("${env:API_KEY}")
+        );
+        let (url, headers) = assert_http(&servers, "oauth");
+        assert_eq!(url, "https://api.example.com/mcp");
+        assert_eq!(
+            headers.get("Authorization").map(String::as_str),
+            Some("Bearer tok")
+        );
+    }
+
+    #[test]
+    fn claude_desktop_ignores_sibling_keys() {
+        let raw = r#"{
+            "globalShortcut": "Cmd+Shift+.",
+            "mcpServers": {
+                "filesystem": {
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+                }
+            }
+        }"#;
+        let servers = claude::convert(raw).unwrap();
+        let (cmd, args, _env) = assert_stdio(&servers, "filesystem");
+        assert_eq!(cmd, "npx");
+        assert_eq!(
+            args,
+            ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+        );
+    }
+
+    #[test]
+    fn continue_object_form_and_sse_type_maps_to_http() {
+        let raw = r#"{
+            "models": [],
+            "mcpServers": {
+                "docs": {
+                    "command": "docs-server",
+                    "args": ["--port", "42"],
+                    "env": { "LOG": "info" }
+                },
+                "remote": {
+                    "type": "sse",
+                    "url": "https://continue.example/mcp"
+                }
+            }
+        }"#;
+        let servers = continue_::convert(raw).unwrap();
+        assert_eq!(servers.len(), 2);
+        let (cmd, args, env) = assert_stdio(&servers, "docs");
+        assert_eq!(cmd, "docs-server");
+        assert_eq!(args, ["--port", "42"]);
+        assert_eq!(env.get("LOG").map(String::as_str), Some("info"));
+        let (url, _h) = assert_http(&servers, "remote");
+        assert_eq!(url, "https://continue.example/mcp");
+    }
+
+    #[test]
+    fn continue_array_form_uses_name_field() {
+        let raw = r#"{
+            "mcpServers": [
+                {
+                    "name": "sqlite",
+                    "type": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "mcp-sqlite", "/db.sqlite"]
+                }
+            ]
+        }"#;
+        let servers = continue_::convert(raw).unwrap();
+        let (cmd, args, _env) = assert_stdio(&servers, "sqlite");
+        assert_eq!(cmd, "npx");
+        assert_eq!(args, ["-y", "mcp-sqlite", "/db.sqlite"]);
+    }
+
+    #[test]
+    fn kiro_ignores_auto_approve_and_disabled() {
+        // Both are Kiro-specific and must not reach the universal schema.
+        let raw = r#"{
+            "mcpServers": {
+                "search": {
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-bravesearch"],
+                    "env": { "BRAVE_API_KEY": "xxx" },
+                    "disabled": false,
+                    "autoApprove": ["search"]
+                }
+            }
+        }"#;
+        let servers = kiro::convert(raw).unwrap();
+        let (cmd, args, env) = assert_stdio(&servers, "search");
+        assert_eq!(cmd, "npx");
+        assert_eq!(args, ["-y", "@modelcontextprotocol/server-bravesearch"]);
+        assert_eq!(env.get("BRAVE_API_KEY").map(String::as_str), Some("xxx"));
+    }
+
+    #[test]
+    fn codex_parses_toml_and_drops_extensions() {
+        let raw = r#"
+[mcp_servers.docs]
+command = "docs-server"
+args = ["--flag"]
+supports_parallel_tool_calls = true
+default_tools_approval_mode = "approve"
+
+[mcp_servers.docs.env]
+LOG_LEVEL = "info"
+
+[mcp_servers.docs.tools.search]
+approval_mode = "prompt"
+"#;
+        let servers = codex::convert(raw).unwrap();
+        let (cmd, args, env) = assert_stdio(&servers, "docs");
+        assert_eq!(cmd, "docs-server");
+        assert_eq!(args, ["--flag"]);
+        assert_eq!(env.get("LOG_LEVEL").map(String::as_str), Some("info"));
+    }
+
+    #[test]
+    fn convert_dispatches_on_source() {
+        let raw = r#"{ "mcpServers": { "x": { "command": "echo" } } }"#;
+        let servers = ImportSource::Cursor.convert(raw).unwrap();
+        let (cmd, _a, _e) = assert_stdio(&servers, "x");
+        assert_eq!(cmd, "echo");
+    }
+
+    #[test]
+    fn rejects_server_with_no_transport() {
+        let raw = r#"{ "servers": { "bad": { "type": "stdio" } } }"#;
+        let err = vscode::convert(raw).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("stdio MCP server missing `command`"),
+            "error: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_json() {
+        let err = cursor::convert("not json").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("valid JSON"), "error: {msg}");
+    }
+
+    #[test]
+    fn missing_servers_key_yields_empty_map() {
+        // Claude Desktop config without any mcpServers set still needs to
+        // parse cleanly.
+        let raw = r#"{ "globalShortcut": "Cmd+." }"#;
+        let servers = claude::convert(raw).unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn default_paths_are_rooted_correctly() {
+        let ws = Path::new("/work/project");
+        let home = Path::new("/home/user");
+        assert_eq!(
+            ImportSource::VsCode.default_path(ws, home).unwrap(),
+            PathBuf::from("/work/project/.vscode/mcp.json")
+        );
+        assert_eq!(
+            ImportSource::Cursor.default_path(ws, home).unwrap(),
+            PathBuf::from("/home/user/.cursor/mcp.json")
+        );
+        assert_eq!(
+            ImportSource::ClaudeDesktop.default_path(ws, home).unwrap(),
+            PathBuf::from(
+                "/home/user/Library/Application Support/Claude/claude_desktop_config.json"
+            )
+        );
+        assert_eq!(
+            ImportSource::Continue.default_path(ws, home).unwrap(),
+            PathBuf::from("/home/user/.continue/config.json")
+        );
+        assert_eq!(
+            ImportSource::Kiro.default_path(ws, home).unwrap(),
+            PathBuf::from("/work/project/.kiro/mcp.json")
+        );
+        assert_eq!(
+            ImportSource::Codex.default_path(ws, home).unwrap(),
+            PathBuf::from("/work/project/.codex/config.toml")
+        );
+    }
+
+    #[test]
+    fn detect_all_walks_all_sources_that_exist() {
+        let ws = tempfile::TempDir::new().unwrap();
+        let home = tempfile::TempDir::new().unwrap();
+        // VS Code present
+        let vsdir = ws.path().join(".vscode");
+        std::fs::create_dir_all(&vsdir).unwrap();
+        std::fs::write(
+            vsdir.join("mcp.json"),
+            r#"{ "servers": { "vs": { "command": "vs-cmd" } } }"#,
+        )
+        .unwrap();
+        // Cursor present
+        let cdir = home.path().join(".cursor");
+        std::fs::create_dir_all(&cdir).unwrap();
+        std::fs::write(
+            cdir.join("mcp.json"),
+            r#"{ "mcpServers": { "cursor": { "command": "cur-cmd" } } }"#,
+        )
+        .unwrap();
+        // Codex present
+        let codex_dir = ws.path().join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::write(
+            codex_dir.join("config.toml"),
+            r#"
+[mcp_servers.cx]
+command = "cx-cmd"
+"#,
+        )
+        .unwrap();
+
+        let report = detect_all(ws.path(), home.path()).unwrap();
+        let sources: Vec<_> = report.found.iter().map(|d| d.source).collect();
+        assert_eq!(
+            sources,
+            vec![
+                ImportSource::VsCode,
+                ImportSource::Cursor,
+                ImportSource::Codex
+            ]
+        );
+        assert!(report.found[0].servers.contains_key("vs"));
+        assert!(report.found[1].servers.contains_key("cursor"));
+        assert!(report.found[2].servers.contains_key("cx"));
+    }
+}

--- a/crates/forge-mcp/src/lib.rs
+++ b/crates/forge-mcp/src/lib.rs
@@ -9,10 +9,11 @@
 //! - [`transport`]: stdio (F-128) and http (F-129) connections.
 //! - Lifecycle manager (F-130) builds on top.
 
+pub mod import;
 pub mod transport;
 
 use anyhow::{anyhow, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
     fs,
@@ -126,6 +127,59 @@ fn resolve_transport(declared: Option<&str>, raw: &RawServer) -> Result<Transpor
             )),
         },
     }
+}
+
+/// Emit a universal `.mcp.json` document — `{ "mcpServers": { ... } }` —
+/// for a prepared server map. Used by `forge mcp import` to render both
+/// the proposed output file and the diff target.
+pub fn render_universal(servers: &BTreeMap<String, McpServerSpec>) -> Result<String> {
+    #[derive(Serialize)]
+    struct Doc<'a> {
+        #[serde(rename = "mcpServers")]
+        servers: BTreeMap<&'a str, Entry<'a>>,
+    }
+
+    #[derive(Serialize)]
+    #[serde(untagged)]
+    enum Entry<'a> {
+        Stdio {
+            command: &'a str,
+            #[serde(skip_serializing_if = "Vec::is_empty")]
+            args: Vec<&'a str>,
+            #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+            env: BTreeMap<&'a str, &'a str>,
+        },
+        Http {
+            url: &'a str,
+            #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+            headers: BTreeMap<&'a str, &'a str>,
+        },
+    }
+
+    let mut doc = Doc {
+        servers: BTreeMap::new(),
+    };
+    for (name, spec) in servers {
+        let entry = match &spec.kind {
+            ServerKind::Stdio { command, args, env } => Entry::Stdio {
+                command: command.as_str(),
+                args: args.iter().map(String::as_str).collect(),
+                env: env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect(),
+            },
+            ServerKind::Http { url, headers } => Entry::Http {
+                url: url.as_str(),
+                headers: headers
+                    .iter()
+                    .map(|(k, v)| (k.as_str(), v.as_str()))
+                    .collect(),
+            },
+        };
+        doc.servers.insert(name.as_str(), entry);
+    }
+
+    let mut out = serde_json::to_string_pretty(&doc).context("serializing universal .mcp.json")?;
+    out.push('\n');
+    Ok(out)
 }
 
 pub mod config {
@@ -378,6 +432,42 @@ mod tests {
             msg.contains("transport"),
             "error should explain missing transport: {msg}"
         );
+    }
+
+    #[test]
+    fn render_universal_round_trips_through_config_loader() {
+        use crate::render_universal;
+
+        let tmp = TempDir::new().unwrap();
+        let mut servers: BTreeMap<String, McpServerSpec> = BTreeMap::new();
+        servers.insert(
+            "stdio-srv".into(),
+            McpServerSpec {
+                kind: ServerKind::Stdio {
+                    command: "npx".into(),
+                    args: vec!["-y".into(), "@scope/server".into()],
+                    env: {
+                        let mut m = BTreeMap::new();
+                        m.insert("LOG".to_string(), "info".to_string());
+                        m
+                    },
+                },
+            },
+        );
+        servers.insert(
+            "http-srv".into(),
+            McpServerSpec {
+                kind: ServerKind::Http {
+                    url: "https://example.com/mcp".into(),
+                    headers: BTreeMap::new(),
+                },
+            },
+        );
+
+        let rendered = render_universal(&servers).unwrap();
+        write(&tmp.path().join(".mcp.json"), &rendered);
+        let parsed = config::load_workspace(tmp.path()).unwrap();
+        assert_eq!(parsed, servers);
     }
 
     #[test]

--- a/crates/forge-mcp/tests/fixtures/import/claude_desktop_config.json
+++ b/crates/forge-mcp/tests/fixtures/import/claude_desktop_config.json
@@ -1,0 +1,18 @@
+{
+  "globalShortcut": "Cmd+Shift+Space",
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/example/Desktop"
+      ]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_fake" }
+    }
+  }
+}

--- a/crates/forge-mcp/tests/fixtures/import/codex_config.toml
+++ b/crates/forge-mcp/tests/fixtures/import/codex_config.toml
@@ -1,0 +1,18 @@
+[mcp_servers.docs]
+command = "docs-server"
+args = ["--port", "4242"]
+supports_parallel_tool_calls = true
+default_tools_approval_mode = "approve"
+
+[mcp_servers.docs.env]
+LOG_LEVEL = "info"
+
+[mcp_servers.docs.tools.search]
+approval_mode = "prompt"
+
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[mcp_servers.github.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "ghp_fake"

--- a/crates/forge-mcp/tests/fixtures/import/continue_config.json
+++ b/crates/forge-mcp/tests/fixtures/import/continue_config.json
@@ -1,0 +1,15 @@
+{
+  "models": [{ "provider": "openai", "model": "gpt-4o" }],
+  "contextProviders": [],
+  "mcpServers": {
+    "sqlite": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "mcp-sqlite", "/tmp/app.db"]
+    },
+    "remote-sse": {
+      "type": "sse",
+      "url": "https://continue.example/mcp"
+    }
+  }
+}

--- a/crates/forge-mcp/tests/fixtures/import/cursor_mcp.json
+++ b/crates/forge-mcp/tests/fixtures/import/cursor_mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      "env": { "FS_ROOT": "/tmp" },
+      "envFile": ".env"
+    },
+    "remote": {
+      "url": "https://mcp.example.com/api",
+      "headers": { "Authorization": "Bearer ${env:MCP_TOKEN}" }
+    }
+  }
+}

--- a/crates/forge-mcp/tests/fixtures/import/kiro_mcp.json
+++ b/crates/forge-mcp/tests/fixtures/import/kiro_mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "web-search": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-bravesearch"],
+      "env": { "BRAVE_API_KEY": "${BRAVE_API_KEY}" },
+      "disabled": false,
+      "autoApprove": ["search"],
+      "disabledTools": []
+    }
+  }
+}

--- a/crates/forge-mcp/tests/fixtures/import/vscode_mcp.json
+++ b/crates/forge-mcp/tests/fixtures/import/vscode_mcp.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    { "type": "promptString", "id": "github-token", "description": "GitHub PAT" }
+  ],
+  "servers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@microsoft/mcp-server-playwright"]
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp"
+    }
+  }
+}

--- a/crates/forge-mcp/tests/import_fixtures.rs
+++ b/crates/forge-mcp/tests/import_fixtures.rs
@@ -1,0 +1,174 @@
+//! Fixture-based integration tests for `forge_mcp::import` (F-131).
+//!
+//! Each DoD-mandated source format gets a representative sample under
+//! `tests/fixtures/import/`. The test reads the fixture, runs it through
+//! the matching converter, and checks the converted `McpServerSpec` map
+//! against the universal-schema expected shape.
+
+use forge_mcp::{
+    import::{claude, codex, continue_, cursor, kiro, vscode},
+    McpServerSpec, ServerKind,
+};
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("import")
+}
+
+fn read(name: &str) -> String {
+    fs::read_to_string(fixtures_dir().join(name))
+        .unwrap_or_else(|e| panic!("reading fixture {name}: {e}"))
+}
+
+fn stdio_spec(command: &str, args: &[&str], env: &[(&str, &str)]) -> McpServerSpec {
+    McpServerSpec {
+        kind: ServerKind::Stdio {
+            command: command.into(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            env: env
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+        },
+    }
+}
+
+fn http_spec(url: &str, headers: &[(&str, &str)]) -> McpServerSpec {
+    McpServerSpec {
+        kind: ServerKind::Http {
+            url: url.into(),
+            headers: headers
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+        },
+    }
+}
+
+#[test]
+fn vscode_fixture_matches_expected_universal_shape() {
+    let got = vscode::convert(&read("vscode_mcp.json")).unwrap();
+
+    let mut want: BTreeMap<String, McpServerSpec> = BTreeMap::new();
+    want.insert(
+        "playwright".into(),
+        stdio_spec("npx", &["-y", "@microsoft/mcp-server-playwright"], &[]),
+    );
+    want.insert(
+        "github".into(),
+        http_spec("https://api.githubcopilot.com/mcp", &[]),
+    );
+
+    assert_eq!(got, want);
+}
+
+#[test]
+fn cursor_fixture_matches_expected_universal_shape() {
+    let got = cursor::convert(&read("cursor_mcp.json")).unwrap();
+
+    let mut want: BTreeMap<String, McpServerSpec> = BTreeMap::new();
+    want.insert(
+        "filesystem".into(),
+        stdio_spec(
+            "npx",
+            &["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            &[("FS_ROOT", "/tmp")],
+        ),
+    );
+    want.insert(
+        "remote".into(),
+        http_spec(
+            "https://mcp.example.com/api",
+            &[("Authorization", "Bearer ${env:MCP_TOKEN}")],
+        ),
+    );
+
+    assert_eq!(got, want);
+}
+
+#[test]
+fn claude_desktop_fixture_matches_expected_universal_shape() {
+    let got = claude::convert(&read("claude_desktop_config.json")).unwrap();
+
+    let mut want: BTreeMap<String, McpServerSpec> = BTreeMap::new();
+    want.insert(
+        "filesystem".into(),
+        stdio_spec(
+            "npx",
+            &[
+                "-y",
+                "@modelcontextprotocol/server-filesystem",
+                "/Users/example/Desktop",
+            ],
+            &[],
+        ),
+    );
+    want.insert(
+        "github".into(),
+        stdio_spec(
+            "npx",
+            &["-y", "@modelcontextprotocol/server-github"],
+            &[("GITHUB_PERSONAL_ACCESS_TOKEN", "ghp_fake")],
+        ),
+    );
+
+    assert_eq!(got, want);
+}
+
+#[test]
+fn continue_fixture_matches_expected_universal_shape() {
+    let got = continue_::convert(&read("continue_config.json")).unwrap();
+
+    let mut want: BTreeMap<String, McpServerSpec> = BTreeMap::new();
+    want.insert(
+        "sqlite".into(),
+        stdio_spec("npx", &["-y", "mcp-sqlite", "/tmp/app.db"], &[]),
+    );
+    want.insert(
+        "remote-sse".into(),
+        http_spec("https://continue.example/mcp", &[]),
+    );
+
+    assert_eq!(got, want);
+}
+
+#[test]
+fn kiro_fixture_matches_expected_universal_shape() {
+    let got = kiro::convert(&read("kiro_mcp.json")).unwrap();
+
+    let mut want: BTreeMap<String, McpServerSpec> = BTreeMap::new();
+    want.insert(
+        "web-search".into(),
+        stdio_spec(
+            "npx",
+            &["-y", "@modelcontextprotocol/server-bravesearch"],
+            &[("BRAVE_API_KEY", "${BRAVE_API_KEY}")],
+        ),
+    );
+
+    assert_eq!(got, want);
+}
+
+#[test]
+fn codex_fixture_matches_expected_universal_shape() {
+    let got = codex::convert(&read("codex_config.toml")).unwrap();
+
+    let mut want: BTreeMap<String, McpServerSpec> = BTreeMap::new();
+    want.insert(
+        "docs".into(),
+        stdio_spec("docs-server", &["--port", "4242"], &[("LOG_LEVEL", "info")]),
+    );
+    want.insert(
+        "github".into(),
+        stdio_spec(
+            "npx",
+            &["-y", "@modelcontextprotocol/server-github"],
+            &[("GITHUB_PERSONAL_ACCESS_TOKEN", "ghp_fake")],
+        ),
+    );
+
+    assert_eq!(got, want);
+}


### PR DESCRIPTION
Closes forge-ide/forge#245

## Summary

Adds the `forge mcp import` subcommand to `forge-cli` plus the six per-source converters that back it in `forge-mcp::import` (VS Code, Cursor, Claude Desktop, Continue, Kiro, Codex). Dry-run by default: prints a unified diff against the workspace's `.mcp.json`. `--apply` writes. Auto source (default) walks every known location and reports all detections, then merges with later sources overriding earlier ones.

Built on F-127 foundation (`McpServerSpec`, `ServerKind`, workspace/user `.mcp.json` loaders). Added `render_universal` to `forge-mcp` so both the diff target and the on-apply write produce the universal `{ "mcpServers": { ... } }` shape that `config::load_workspace` round-trips.

- `crates/forge-cli/src/mcp.rs`: subcommand implementation (`run_single`, `run_auto`, `finalize`, `render_diff`).
- `crates/forge-mcp/src/import.rs`: `ImportSource` enum, six converter modules, `detect_all` walker.
- Converters are lenient about unknown top-level keys (sources nest `mcpServers` inside larger app configs) and strict about transport shape for each entry.
- Continue accepts both object and array forms; `sse` and `streamable-http` transport strings fold onto universal `http`.
- Codex reads TOML `[mcp_servers.<name>]` and drops Codex-specific extensions (parallel-tool flag, per-tool approval modes, etc.).
- Claude Desktop default path is the macOS canonical location (`~/Library/Application Support/Claude/claude_desktop_config.json`) — matches the wording in the Issue and the docs.

## Test plan

- `just check-rust` passes locally (fmt, `cargo check --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`).
- `just test-rust` passes locally — 43 unit tests in `forge-mcp` (13 new `import::tests`, 1 new `render_universal` round-trip) + 6 new fixture-backed integration tests + 4 new CLI parse tests in `forge-cli`.
- Fixtures live under `crates/forge-mcp/tests/fixtures/import/` — one per source format — and are the concrete DoD evidence for the "one fixture per source format" checkbox.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code