### PR TITLE
feat(web): context category resolvers + provider adaptation (F-142)

### DIFF
--- a/web/packages/app/src/components/ContextChip.css
+++ b/web/packages/app/src/components/ContextChip.css
@@ -45,3 +45,48 @@
 .ctx-chip__dismiss:hover {
   color: var(--color-error);
 }
+
+/* ---------------------------------------------------------------------------
+   F-142 — lazy file preview popover (hover-expanded, read-only)
+   --------------------------------------------------------------------------- */
+
+.ctx-chip {
+  position: relative;
+}
+
+.ctx-chip__preview {
+  position: absolute;
+  bottom: calc(100% + var(--sp-1));
+  left: 0;
+  z-index: 10;
+  max-width: 480px;
+  max-height: 320px;
+  overflow: auto;
+  padding: var(--sp-2);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-primary);
+  white-space: pre;
+  pointer-events: none;
+}
+
+.ctx-chip__preview-body {
+  margin: 0;
+  white-space: pre;
+}
+
+.ctx-chip__preview-loading,
+.ctx-chip__preview-error {
+  display: block;
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}
+
+.ctx-chip__preview-error {
+  color: var(--color-error);
+  font-style: normal;
+}

--- a/web/packages/app/src/components/ContextChip.test.tsx
+++ b/web/packages/app/src/components/ContextChip.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, fireEvent } from '@solidjs/testing-library';
+import { render, fireEvent, waitFor } from '@solidjs/testing-library';
 import { ContextChip } from './ContextChip';
 
 // F-141: ContextChip is the pill that lands in the `ctx-chips` row when
@@ -37,5 +37,62 @@ describe('ContextChip', () => {
     expect(getByTestId('ctx-chip-dismiss').getAttribute('aria-label')).toBe(
       'Remove src/app.ts',
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // F-142 — lazy file preview popover
+  // -------------------------------------------------------------------------
+
+  it('shows a preview popover on hover for a file chip with loadPreview', async () => {
+    const loadPreview = vi.fn().mockResolvedValue('console.log("hi");');
+    const { getByTestId, queryByTestId } = render(() => (
+      <ContextChip
+        category="file"
+        label="app.ts"
+        value="/ws/app.ts"
+        loadPreview={loadPreview}
+        onDismiss={() => {}}
+      />
+    ));
+    expect(queryByTestId('ctx-chip-preview')).toBeNull();
+    fireEvent.mouseEnter(getByTestId('ctx-chip'));
+    expect(loadPreview).toHaveBeenCalledWith('/ws/app.ts');
+    await waitFor(() =>
+      expect(getByTestId('ctx-chip-preview')).toHaveTextContent(
+        'console.log("hi");',
+      ),
+    );
+  });
+
+  it('does not load a preview for a non-file chip', () => {
+    const loadPreview = vi.fn().mockResolvedValue('ignored');
+    const { getByTestId, queryByTestId } = render(() => (
+      <ContextChip
+        category="terminal"
+        label="last 20 lines"
+        loadPreview={loadPreview}
+        onDismiss={() => {}}
+      />
+    ));
+    fireEvent.mouseEnter(getByTestId('ctx-chip'));
+    expect(loadPreview).not.toHaveBeenCalled();
+    expect(queryByTestId('ctx-chip-preview')).toBeNull();
+  });
+
+  it('hides the preview again on mouse leave', async () => {
+    const loadPreview = vi.fn().mockResolvedValue('body');
+    const { getByTestId, queryByTestId } = render(() => (
+      <ContextChip
+        category="file"
+        label="app.ts"
+        value="/ws/app.ts"
+        loadPreview={loadPreview}
+        onDismiss={() => {}}
+      />
+    ));
+    fireEvent.mouseEnter(getByTestId('ctx-chip'));
+    await waitFor(() => expect(getByTestId('ctx-chip-preview')).toBeDefined());
+    fireEvent.mouseLeave(getByTestId('ctx-chip'));
+    expect(queryByTestId('ctx-chip-preview')).toBeNull();
   });
 });

--- a/web/packages/app/src/components/ContextChip.tsx
+++ b/web/packages/app/src/components/ContextChip.tsx
@@ -1,18 +1,36 @@
-import { type Component } from 'solid-js';
+import {
+  type Component,
+  createSignal,
+  onCleanup,
+  Show,
+} from 'solid-js';
 import type { ContextCategory } from './ContextPicker';
 import './ContextChip.css';
 
 // ---------------------------------------------------------------------------
 // ContextChip — pill shown in the composer's `ctx-chips` row once a picker
 // result is inserted (F-141). The chip is intentionally minimal: icon +
-// label + dismiss-×. Full resolution (opening the file preview on hover,
-// expanding a directory tree, etc.) is out of scope for F-141.
+// label + dismiss-×.
+//
+// F-142 adds the "lazy file preview" per the DoD: hovering a file chip
+// expands a read-only preview popover with the file's content. Non-file
+// chips show only their label — the preview is category-gated so a selection
+// or terminal chip does not try to load something.
 // ---------------------------------------------------------------------------
 
 export interface ContextChipProps {
   category: ContextCategory;
   label: string;
   onDismiss: () => void;
+  /**
+   * Optional loader for the preview popover. Called with the chip's
+   * identifier (`value`); expected to return the preview text. The chip only
+   * shows a preview when `category === 'file'` AND `loadPreview` is provided
+   * — other categories display only the chip label.
+   */
+  loadPreview?: (value: string) => Promise<string>;
+  /** Chip identifier passed to `loadPreview`. Defaults to label. */
+  value?: string;
 }
 
 function iconFor(category: ContextCategory): string {
@@ -34,12 +52,65 @@ function iconFor(category: ContextCategory): string {
   }
 }
 
+/** Clip preview bodies so the popover never grows past a manageable size. */
+const PREVIEW_MAX_CHARS = 4000;
+
 export const ContextChip: Component<ContextChipProps> = (props) => {
+  const [preview, setPreview] = createSignal<string | null>(null);
+  const [hovered, setHovered] = createSignal(false);
+  const [loading, setLoading] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  let loadToken = 0;
+
+  const canPreview = (): boolean =>
+    props.category === 'file' && props.loadPreview !== undefined;
+
+  const handleEnter = (): void => {
+    if (!canPreview()) return;
+    setHovered(true);
+    if (preview() !== null || loading()) return;
+    const token = ++loadToken;
+    const value = props.value ?? props.label;
+    setLoading(true);
+    setError(null);
+    props
+      .loadPreview!(value)
+      .then((body) => {
+        if (token !== loadToken) return;
+        const clipped =
+          body.length > PREVIEW_MAX_CHARS
+            ? `${body.slice(0, PREVIEW_MAX_CHARS - 1)}…`
+            : body;
+        setPreview(clipped);
+      })
+      .catch((err: unknown) => {
+        if (token !== loadToken) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (token === loadToken) setLoading(false);
+      });
+  };
+
+  const handleLeave = (): void => {
+    setHovered(false);
+  };
+
+  onCleanup(() => {
+    // Invalidate any in-flight loader on unmount.
+    loadToken++;
+  });
+
   return (
     <span
       class="ctx-chip"
       data-testid="ctx-chip"
       data-category={props.category}
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+      onFocus={handleEnter}
+      onBlur={handleLeave}
     >
       <span class="ctx-chip__icon" aria-hidden="true">
         {iconFor(props.category)}
@@ -54,6 +125,25 @@ export const ContextChip: Component<ContextChipProps> = (props) => {
       >
         ×
       </button>
+      <Show when={canPreview() && hovered()}>
+        <div
+          class="ctx-chip__preview"
+          data-testid="ctx-chip-preview"
+          role="tooltip"
+        >
+          <Show when={loading()}>
+            <span class="ctx-chip__preview-loading">loading…</span>
+          </Show>
+          <Show when={error() !== null}>
+            <span class="ctx-chip__preview-error" role="alert">
+              {error()}
+            </span>
+          </Show>
+          <Show when={preview() !== null}>
+            <pre class="ctx-chip__preview-body">{preview()}</pre>
+          </Show>
+        </div>
+      </Show>
     </span>
   );
 };

--- a/web/packages/app/src/components/toast.ts
+++ b/web/packages/app/src/components/toast.ts
@@ -1,0 +1,43 @@
+// F-142: minimal toast queue.
+//
+// A real toast system is out of scope — the context picker only needs a
+// single "disallowed URL" user-visible notification today. This file exposes
+// a signal-backed queue + `pushToast(kind, message)` helper. A `<ToastHost>`
+// renderer is a follow-up; tests observe `toasts()` directly, and the
+// ephemeral nature of the queue means nothing breaks while the renderer is
+// absent (notifications just don't surface visually yet).
+
+import { createSignal } from 'solid-js';
+
+export type ToastKind = 'info' | 'warning' | 'error';
+
+export interface Toast {
+  id: number;
+  kind: ToastKind;
+  message: string;
+  createdAt: number;
+}
+
+const [toasts, setToasts] = createSignal<Toast[]>([]);
+let nextId = 1;
+
+/** Reactive accessor for mounted renderers and tests. */
+export { toasts };
+
+/** Append a toast and return its id. */
+export function pushToast(kind: ToastKind, message: string): number {
+  const id = nextId++;
+  setToasts((prev) => [...prev, { id, kind, message, createdAt: Date.now() }]);
+  return id;
+}
+
+/** Remove a toast by id. Used by the host component on dismiss/timeout. */
+export function dismissToast(id: number): void {
+  setToasts((prev) => prev.filter((t) => t.id !== id));
+}
+
+/** Test helper — clear the queue between tests. */
+export function clearToastsForTesting(): void {
+  setToasts([]);
+  nextId = 1;
+}

--- a/web/packages/app/src/context/agent.test.ts
+++ b/web/packages/app/src/context/agent.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@forge/ipc';
+import {
+  createAgentResolver,
+  summarizeTranscript,
+  type TranscriptEntry,
+} from './agent';
+
+describe('summarizeTranscript', () => {
+  it('keeps only the last 20 turns', () => {
+    const entries: TranscriptEntry[] = Array.from({ length: 30 }, (_, i) => ({
+      role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+      text: `turn ${i}`,
+    }));
+    const out = summarizeTranscript(entries);
+    expect(out.split('\n')).toHaveLength(20);
+    expect(out.split('\n')[0]).toMatch(/turn 10/);
+  });
+
+  it('truncates long messages with an ellipsis', () => {
+    const long = 'x'.repeat(200);
+    const out = summarizeTranscript([{ role: 'user', text: long }]);
+    expect(out.length).toBeLessThan(long.length + 10);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});
+
+describe('createAgentResolver.list', () => {
+  it('lists known agents and filters by query', async () => {
+    const resolver = createAgentResolver({
+      listAgents: () => [
+        { id: 's-1' as SessionId, label: 'refactor-bot' },
+        { id: 's-2' as SessionId, label: 'design-reviewer' },
+      ],
+    });
+    const out = await resolver.list('refactor');
+    expect(out).toEqual([
+      { category: 'agent', label: 'refactor-bot', value: 's-1' },
+    ]);
+  });
+
+  it('falls back to the session id when no label is given', async () => {
+    const resolver = createAgentResolver({
+      listAgents: () => [{ id: 'sess-xyz' as SessionId }],
+    });
+    const out = await resolver.list('');
+    expect(out[0]!.label).toBe('sess-xyz');
+  });
+});
+
+describe('createAgentResolver.resolve', () => {
+  it('calls getTranscript and summarizes the result', async () => {
+    const getTranscript = vi
+      .fn<(id: SessionId) => Promise<TranscriptEntry[]>>()
+      .mockResolvedValue([
+        { role: 'user', text: 'Fix the bug' },
+        { role: 'assistant', text: 'Patch applied.' },
+      ]);
+    const resolver = createAgentResolver({
+      listAgents: () => [],
+      getTranscript,
+    });
+    const block = await resolver.resolve('s-42');
+    expect(getTranscript).toHaveBeenCalledWith('s-42');
+    expect(block.type).toBe('agent');
+    expect(block.content).toBe('user: Fix the bug\nassistant: Patch applied.');
+    expect(block.meta).toEqual({ agentSessionId: 's-42' });
+  });
+});

--- a/web/packages/app/src/context/agent.ts
+++ b/web/packages/app/src/context/agent.ts
@@ -1,0 +1,85 @@
+// F-142: agent resolver.
+//
+// The spec (§7.6) says an agent reference should insert "a summary + inline
+// references, not full copy" of the other agent's transcript. The full
+// compaction pipeline lives in forge-session (not shipped here); the resolver
+// therefore accepts an injected `getTranscript(sessionId)` closure and a
+// `summarize(turns)` helper. For v1 the default summarizer takes the last
+// 20 turns' first 120 chars each — terse, but enough to prove the shape.
+//
+// Candidates come from the `sessions` store (populated by the shell bridge).
+// Filtering on `query` is substring-match on the session id or label.
+
+import type { SessionId } from '@forge/ipc';
+import type { Candidate, ContextBlock, Resolver } from './types';
+import { fuzzyMatch } from './types';
+
+export interface AgentCandidateSource {
+  id: SessionId;
+  /** Human-readable label. Falls back to the session id. */
+  label?: string;
+}
+
+/** Simple transcript shape — each entry is a role-tagged line. */
+export interface TranscriptEntry {
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+export interface AgentResolverDeps {
+  /** Returns currently-known agent sessions (excluding the caller). */
+  listAgents: () => AgentCandidateSource[];
+  /** Fetches a transcript. Default never-available — inject for tests. */
+  getTranscript?: (id: SessionId) => Promise<TranscriptEntry[]>;
+}
+
+/**
+ * Default transcript summarizer — last 20 turns, each trimmed to 120 chars.
+ * Exported so tests can drive the summarizer directly without an IPC stub.
+ */
+export function summarizeTranscript(entries: TranscriptEntry[]): string {
+  const MAX_TURNS = 20;
+  const MAX_CHARS = 120;
+  const recent = entries.slice(-MAX_TURNS);
+  return recent
+    .map((e) => {
+      const truncated =
+        e.text.length > MAX_CHARS
+          ? `${e.text.slice(0, MAX_CHARS - 1)}…`
+          : e.text;
+      return `${e.role}: ${truncated}`;
+    })
+    .join('\n');
+}
+
+export function createAgentResolver(deps: AgentResolverDeps): Resolver<string> {
+  const getTranscript =
+    deps.getTranscript ?? (async (_id: SessionId) => [] as TranscriptEntry[]);
+
+  return {
+    async list(query: string): Promise<Candidate[]> {
+      const all = deps.listAgents();
+      const withLabels = all.map((a) => ({
+        id: a.id,
+        label: a.label ?? String(a.id),
+      }));
+      const matched = withLabels.filter(
+        (a) => fuzzyMatch(query, a.label) || fuzzyMatch(query, String(a.id)),
+      );
+      return matched.map((a) => ({
+        category: 'agent' as const,
+        label: a.label,
+        value: String(a.id),
+      }));
+    },
+
+    async resolve(id: string): Promise<ContextBlock> {
+      const entries = await getTranscript(id as SessionId);
+      return {
+        type: 'agent',
+        content: summarizeTranscript(entries),
+        meta: { agentSessionId: id },
+      };
+    },
+  };
+}

--- a/web/packages/app/src/context/context-adapter.test.ts
+++ b/web/packages/app/src/context/context-adapter.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  adaptContextBlocks,
+  providerFlavour,
+  toAnthropicXml,
+  toOpenAiFunctionContext,
+  type ContextBlock,
+  type ProviderId,
+} from '@forge/ipc';
+
+describe('context-adapter — single block serializers', () => {
+  it('toAnthropicXml wraps a file block with type + path attributes', () => {
+    const block: ContextBlock = {
+      type: 'file',
+      path: 'src/app.ts',
+      content: "console.log('hi');",
+    };
+    expect(toAnthropicXml(block)).toBe(
+      `<context type="file" path="src/app.ts">\nconsole.log('hi');\n</context>`,
+    );
+  });
+
+  it('toAnthropicXml omits the path attribute when path is empty', () => {
+    const block: ContextBlock = { type: 'selection', content: 'snippet' };
+    expect(toAnthropicXml(block)).toBe(
+      `<context type="selection">\nsnippet\n</context>`,
+    );
+  });
+
+  it('toAnthropicXml escapes quote and angle-bracket chars in path', () => {
+    const block: ContextBlock = {
+      type: 'file',
+      path: 'weird "name"<.ts>',
+      content: 'x',
+    };
+    expect(toAnthropicXml(block)).toContain(
+      'path="weird &quot;name&quot;&lt;.ts&gt;"',
+    );
+  });
+
+  it('toOpenAiFunctionContext wraps with function-call-style delimiters', () => {
+    const block: ContextBlock = {
+      type: 'directory',
+      path: 'tests/payments',
+      content: 'a.ts\nb.ts',
+    };
+    expect(toOpenAiFunctionContext(block)).toBe(
+      `[context(type="directory", path="tests/payments")]\na.ts\nb.ts\n[/context]`,
+    );
+  });
+
+  it('toOpenAiFunctionContext omits path for pointer-style blocks', () => {
+    const block: ContextBlock = { type: 'skill', content: 'ref:typescript-review' };
+    expect(toOpenAiFunctionContext(block)).toBe(
+      `[context(type="skill")]\nref:typescript-review\n[/context]`,
+    );
+  });
+});
+
+describe('context-adapter — providerFlavour', () => {
+  it('maps known Anthropic ids', () => {
+    expect(providerFlavour('anthropic' as ProviderId)).toBe('anthropic');
+    expect(providerFlavour('claude-3-5' as ProviderId)).toBe('anthropic');
+  });
+
+  it('maps known OpenAI and compatible ids', () => {
+    expect(providerFlavour('openai' as ProviderId)).toBe('openai');
+    expect(providerFlavour('gpt-4o' as ProviderId)).toBe('openai');
+    expect(providerFlavour('groq' as ProviderId)).toBe('openai');
+    expect(providerFlavour('ollama-local' as ProviderId)).toBe('openai');
+    expect(providerFlavour('deepseek' as ProviderId)).toBe('openai');
+  });
+
+  it('falls back to anthropic for null / unknown ids', () => {
+    expect(providerFlavour(null)).toBe('anthropic');
+    expect(providerFlavour(undefined)).toBe('anthropic');
+    expect(providerFlavour('some-proprietary-model' as ProviderId)).toBe(
+      'anthropic',
+    );
+  });
+});
+
+describe('context-adapter — adaptContextBlocks', () => {
+  const blocks: ContextBlock[] = [
+    { type: 'file', path: 'src/app.ts', content: 'body-a' },
+    { type: 'directory', path: 'tests', content: 'tests/a.ts\ntests/b.ts' },
+  ];
+
+  it('returns empty string for empty blocks', () => {
+    expect(adaptContextBlocks([], 'anthropic')).toBe('');
+    expect(adaptContextBlocks([], 'openai')).toBe('');
+  });
+
+  it('Anthropic: XML tags joined with newlines', () => {
+    const out = adaptContextBlocks(blocks, 'anthropic');
+    expect(out).toContain('<context type="file" path="src/app.ts">');
+    expect(out).toContain('<context type="directory" path="tests">');
+    expect(out.split('</context>').length).toBe(3); // 2 closes + trailing
+  });
+
+  it('OpenAI: function-call-style blocks joined with newlines', () => {
+    const out = adaptContextBlocks(blocks, 'openai');
+    expect(out).toContain('[context(type="file", path="src/app.ts")]');
+    expect(out).toContain('[context(type="directory", path="tests")]');
+    expect(out).toContain('[/context]');
+    expect(out.indexOf('<context')).toBe(-1);
+  });
+
+  it('accepts a raw ProviderId and resolves flavour', () => {
+    const a = adaptContextBlocks(blocks, 'anthropic' as ProviderId);
+    const o = adaptContextBlocks(blocks, 'gpt-4o' as ProviderId);
+    expect(a).toContain('<context');
+    expect(o).toContain('[context(');
+  });
+});

--- a/web/packages/app/src/context/directory.test.ts
+++ b/web/packages/app/src/context/directory.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@forge/ipc';
+import type { TreeNodeDto } from '../ipc/fs';
+import {
+  createDirectoryResolver,
+  flattenAllPaths,
+  flattenDirectories,
+  DIRECTORY_RESOLVER_MAX_PATHS,
+} from './directory';
+
+const SESSION: SessionId = 'session-1' as SessionId;
+const ROOT = '/tmp/ws';
+
+function fileNode(path: string, name: string): TreeNodeDto {
+  return { path, name, kind: 'File', children: null };
+}
+function dirNode(path: string, name: string, children: TreeNodeDto[]): TreeNodeDto {
+  return { path, name, kind: 'Dir', children };
+}
+
+describe('flattenDirectories', () => {
+  it('collects directory nodes (including root) and skips files', () => {
+    const tree = dirNode('/ws', 'ws', [
+      fileNode('/ws/a.ts', 'a.ts'),
+      dirNode('/ws/tests', 'tests', [fileNode('/ws/tests/a.test.ts', 'a.test.ts')]),
+    ]);
+    expect(flattenDirectories(tree).map((d) => d.path)).toEqual([
+      '/ws',
+      '/ws/tests',
+    ]);
+  });
+});
+
+describe('flattenAllPaths', () => {
+  it('emits every path in DFS order', () => {
+    const tree = dirNode('/ws', 'ws', [
+      fileNode('/ws/a.ts', 'a.ts'),
+      dirNode('/ws/sub', 'sub', [fileNode('/ws/sub/b.ts', 'b.ts')]),
+    ]);
+    expect(flattenAllPaths(tree)).toEqual([
+      '/ws',
+      '/ws/a.ts',
+      '/ws/sub',
+      '/ws/sub/b.ts',
+    ]);
+  });
+});
+
+describe('createDirectoryResolver.list', () => {
+  it('surfaces directory nodes and filters by query', async () => {
+    const treeFn = vi.fn().mockResolvedValue(
+      dirNode('/ws', 'ws', [
+        dirNode('/ws/tests', 'tests', [
+          dirNode('/ws/tests/payments', 'payments', []),
+        ]),
+        dirNode('/ws/src', 'src', []),
+      ]),
+    );
+    const resolver = createDirectoryResolver({
+      sessionId: SESSION,
+      workspaceRoot: ROOT,
+      tree: treeFn,
+    });
+    const out = await resolver.list('pay');
+    expect(out.map((c) => c.value)).toEqual(['/ws/tests/payments']);
+  });
+});
+
+describe('createDirectoryResolver.resolve', () => {
+  it('walks the picked directory and returns a path snapshot', async () => {
+    const treeFn = vi
+      .fn()
+      .mockResolvedValue(
+        dirNode('/ws/src', 'src', [
+          fileNode('/ws/src/a.ts', 'a.ts'),
+          fileNode('/ws/src/b.ts', 'b.ts'),
+        ]),
+      );
+    const resolver = createDirectoryResolver({
+      sessionId: SESSION,
+      workspaceRoot: ROOT,
+      tree: treeFn,
+    });
+    const block = await resolver.resolve('/ws/src');
+    expect(treeFn).toHaveBeenCalledWith(SESSION, '/ws/src');
+    expect(block.type).toBe('directory');
+    expect(block.path).toBe('/ws/src');
+    expect(block.content).toBe('/ws/src\n/ws/src/a.ts\n/ws/src/b.ts');
+  });
+
+  it('caps at DIRECTORY_RESOLVER_MAX_PATHS and notes truncation', async () => {
+    const children = Array.from({ length: 300 }, (_, i) =>
+      fileNode(`/ws/f${i}.ts`, `f${i}.ts`),
+    );
+    const treeFn = vi.fn().mockResolvedValue(dirNode('/ws', 'ws', children));
+    const resolver = createDirectoryResolver({
+      sessionId: SESSION,
+      workspaceRoot: ROOT,
+      tree: treeFn,
+    });
+    const block = await resolver.resolve('/ws');
+    const lines = block.content.split('\n');
+    // First DIRECTORY_RESOLVER_MAX_PATHS lines are the truncated paths,
+    // followed by a "+N more — truncated" marker line.
+    expect(lines.length).toBe(DIRECTORY_RESOLVER_MAX_PATHS + 1);
+    expect(lines[lines.length - 1]).toMatch(/\+\d+ more — truncated/);
+  });
+});

--- a/web/packages/app/src/context/directory.ts
+++ b/web/packages/app/src/context/directory.ts
@@ -1,0 +1,92 @@
+// F-142: directory resolver.
+//
+// `list(query)` shares the tree IPC with the file resolver but emits directory
+// nodes instead. `resolve(ref)` inserts a tree snapshot — paths only, no file
+// contents, capped at 200 entries per the spec (§7.4 "max 200 paths in v1").
+
+import type { SessionId } from '@forge/ipc';
+import {
+  tree as defaultTree,
+  type TreeNodeDto,
+} from '../ipc/fs';
+import type { Candidate, ContextBlock, Resolver } from './types';
+import { fuzzyMatch } from './types';
+
+/** Spec-mandated cap: directory snapshots include at most this many paths. */
+export const DIRECTORY_RESOLVER_MAX_PATHS = 200;
+
+/** UI-side paging for the candidate list. */
+export const DIRECTORY_RESOLVER_MAX_RESULTS = 50;
+
+export interface DirectoryResolverDeps {
+  sessionId: SessionId;
+  workspaceRoot: string;
+  tree?: typeof defaultTree;
+}
+
+/** Emit `[path, name]` pairs for directory nodes only (root included). */
+export function flattenDirectories(
+  node: TreeNodeDto,
+  out: Array<{ path: string; name: string }> = [],
+): Array<{ path: string; name: string }> {
+  // `kind` is the Rust-side enum 'File' | 'Dir' | 'Symlink' | 'Other'.
+  if (node.kind === 'Dir') {
+    out.push({ path: node.path, name: node.name });
+  }
+  if (node.children) {
+    for (const child of node.children) flattenDirectories(child, out);
+  }
+  return out;
+}
+
+/**
+ * Flatten every path (file or directory) beneath `node`. Used by `resolve` to
+ * produce the 200-path snapshot. The cap is applied by the caller so the
+ * helper stays generic.
+ */
+export function flattenAllPaths(
+  node: TreeNodeDto,
+  out: string[] = [],
+): string[] {
+  out.push(node.path);
+  if (node.children) {
+    for (const child of node.children) flattenAllPaths(child, out);
+  }
+  return out;
+}
+
+export function createDirectoryResolver(deps: DirectoryResolverDeps): Resolver<string> {
+  const treeFn = deps.tree ?? defaultTree;
+
+  return {
+    async list(query: string): Promise<Candidate[]> {
+      const node = await treeFn(deps.sessionId, deps.workspaceRoot);
+      const dirs = flattenDirectories(node);
+      const matched = dirs.filter((d) => fuzzyMatch(query, d.path));
+      return matched.slice(0, DIRECTORY_RESOLVER_MAX_RESULTS).map((d) => ({
+        category: 'directory' as const,
+        label: d.name || d.path,
+        value: d.path,
+      }));
+    },
+
+    async resolve(dirPath: string): Promise<ContextBlock> {
+      // Walk from the picked directory specifically — not the workspace root —
+      // so the snapshot reflects the directory the user @-mentioned.
+      const node = await treeFn(deps.sessionId, dirPath);
+      const all = flattenAllPaths(node);
+      const truncated = all.length > DIRECTORY_RESOLVER_MAX_PATHS;
+      const shown = all.slice(0, DIRECTORY_RESOLVER_MAX_PATHS);
+      const body =
+        shown.join('\n') +
+        (truncated
+          ? `\n… (+${all.length - DIRECTORY_RESOLVER_MAX_PATHS} more — truncated)`
+          : '');
+      return {
+        type: 'directory',
+        path: dirPath,
+        content: body,
+      };
+    },
+  };
+}

--- a/web/packages/app/src/context/file.test.ts
+++ b/web/packages/app/src/context/file.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@forge/ipc';
+import type { TreeNodeDto, FileContent } from '../ipc/fs';
+import {
+  createFileResolver,
+  flattenFiles,
+  truncateToBytes,
+  FILE_RESOLVER_MAX_BYTES,
+  FILE_RESOLVER_MAX_RESULTS,
+} from './file';
+
+const SESSION: SessionId = 'session-1' as SessionId;
+const ROOT = '/tmp/ws';
+
+function fileNode(path: string, name: string): TreeNodeDto {
+  return { path, name, kind: 'File', children: null };
+}
+function dirNode(path: string, name: string, children: TreeNodeDto[]): TreeNodeDto {
+  return { path, name, kind: 'Dir', children };
+}
+
+describe('flattenFiles', () => {
+  it('collects only file entries and descends into directories', () => {
+    const tree: TreeNodeDto = dirNode('/ws', 'ws', [
+      fileNode('/ws/a.ts', 'a.ts'),
+      dirNode('/ws/sub', 'sub', [
+        fileNode('/ws/sub/b.ts', 'b.ts'),
+        { path: '/ws/sub/link', name: 'link', kind: 'Symlink', children: null },
+      ]),
+    ]);
+    const out = flattenFiles(tree);
+    expect(out.map((f) => f.path)).toEqual(['/ws/a.ts', '/ws/sub/b.ts']);
+  });
+});
+
+describe('truncateToBytes', () => {
+  it('returns the original content when under budget', () => {
+    expect(truncateToBytes('hello', 32)).toBe('hello');
+  });
+
+  it('appends a truncation marker when over budget', () => {
+    const long = 'x'.repeat(1000);
+    const out = truncateToBytes(long, 100);
+    expect(out.endsWith('(truncated at 100 bytes)')).toBe(true);
+    expect(new TextEncoder().encode(out.split('\n… ')[0]!).length).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('createFileResolver.list', () => {
+  it('calls tree with (sessionId, workspaceRoot) and filters by query', async () => {
+    const treeFn = vi.fn().mockResolvedValue(
+      dirNode('/ws', 'ws', [
+        fileNode('/ws/app.ts', 'app.ts'),
+        fileNode('/ws/lib.ts', 'lib.ts'),
+        fileNode('/ws/README.md', 'README.md'),
+      ]),
+    );
+    const resolver = createFileResolver({
+      sessionId: SESSION,
+      workspaceRoot: ROOT,
+      tree: treeFn,
+    });
+    const out = await resolver.list('lib');
+    expect(treeFn).toHaveBeenCalledWith(SESSION, ROOT);
+    expect(out).toEqual([
+      { category: 'file', label: 'lib.ts', value: '/ws/lib.ts' },
+    ]);
+  });
+
+  it('returns all files on empty query, up to the cap', async () => {
+    const many = Array.from({ length: 100 }, (_, i) =>
+      fileNode(`/ws/f${i}.ts`, `f${i}.ts`),
+    );
+    const treeFn = vi.fn().mockResolvedValue(dirNode('/ws', 'ws', many));
+    const resolver = createFileResolver({
+      sessionId: SESSION,
+      workspaceRoot: ROOT,
+      tree: treeFn,
+    });
+    const out = await resolver.list('');
+    expect(out).toHaveLength(FILE_RESOLVER_MAX_RESULTS);
+  });
+});
+
+describe('createFileResolver.resolve', () => {
+  it('reads the file and returns a file ContextBlock', async () => {
+    const readFn = vi.fn<(s: SessionId, p: string) => Promise<FileContent>>()
+      .mockResolvedValue({
+        path: '/ws/app.ts',
+        content: 'export const x = 1;',
+        bytes: 19,
+        sha256: 'deadbeef',
+      });
+    const resolver = createFileResolver({
+      sessionId: SESSION,
+      workspaceRoot: ROOT,
+      tree: vi.fn(),
+      readFile: readFn,
+    });
+    const block = await resolver.resolve('/ws/app.ts');
+    expect(readFn).toHaveBeenCalledWith(SESSION, '/ws/app.ts');
+    expect(block).toEqual({
+      type: 'file',
+      path: '/ws/app.ts',
+      content: 'export const x = 1;',
+    });
+  });
+
+  it('truncates oversize file content', async () => {
+    const readFn = vi.fn<(s: SessionId, p: string) => Promise<FileContent>>()
+      .mockResolvedValue({
+        path: '/ws/big.ts',
+        content: 'x'.repeat(FILE_RESOLVER_MAX_BYTES * 2),
+        bytes: FILE_RESOLVER_MAX_BYTES * 2,
+        sha256: 'aa',
+      });
+    const resolver = createFileResolver({
+      sessionId: SESSION,
+      workspaceRoot: ROOT,
+      tree: vi.fn(),
+      readFile: readFn,
+    });
+    const block = await resolver.resolve('/ws/big.ts');
+    expect(block.content).toMatch(/\(truncated at \d+ bytes\)$/);
+  });
+});

--- a/web/packages/app/src/context/file.ts
+++ b/web/packages/app/src/context/file.ts
@@ -1,0 +1,99 @@
+// F-142: file resolver.
+//
+// `list(query)` walks the session's workspace via the F-122 `tree` IPC, flattens
+// the result to file-only entries, and applies a substring match against
+// `query`. The shell enforces gitignore semantics inside `forge-fs::tree` so
+// the webview does not re-implement that filter.
+//
+// `resolve(ref)` reads the file via `read_file`. `ref` is the absolute path
+// round-tripped through the picker result's `value`. File contents are
+// truncated to a byte budget so a single @-file cannot dominate the prompt.
+
+import type { SessionId } from '@forge/ipc';
+import {
+  readFile as defaultReadFile,
+  tree as defaultTree,
+  type TreeNodeDto,
+  type FileContent,
+} from '../ipc/fs';
+import type { Candidate, ContextBlock, Resolver } from './types';
+import { fuzzyMatch } from './types';
+
+/** Maximum bytes included in a resolved file block. Larger files are
+ *  truncated with a trailing marker so the model can see the cut happened. */
+export const FILE_RESOLVER_MAX_BYTES = 32 * 1024;
+
+/** Ceiling on candidates surfaced to the picker. The tree IPC already caps
+ *  entries server-side; this is a UI-side paging guard. */
+export const FILE_RESOLVER_MAX_RESULTS = 50;
+
+export interface FileResolverDeps {
+  sessionId: SessionId;
+  /** Workspace root path. Pass the session's cached root (`activeWorkspaceRoot`). */
+  workspaceRoot: string;
+  /** Injection seam — defaults to the real Tauri invoker. */
+  tree?: typeof defaultTree;
+  readFile?: typeof defaultReadFile;
+}
+
+/**
+ * Flatten a tree node into `[path, name]` pairs for file entries only.
+ * Directories are descended but not emitted. Exported for test visibility.
+ */
+export function flattenFiles(
+  node: TreeNodeDto,
+  out: Array<{ path: string; name: string }> = [],
+): Array<{ path: string; name: string }> {
+  // `kind` is the Rust-side enum: 'File' | 'Dir' | 'Symlink' | 'Other'. Only
+  // plain files go into the picker — symlinks and special files are skipped
+  // so the resolver cannot accidentally tunnel outside the gitignore filter.
+  if (node.kind === 'File') {
+    out.push({ path: node.path, name: node.name });
+  }
+  if (node.children) {
+    for (const child of node.children) flattenFiles(child, out);
+  }
+  return out;
+}
+
+/** Truncate content to `maxBytes` UTF-8 bytes. Appends a visible marker when
+ *  truncation occurs so the model can see the cut. */
+export function truncateToBytes(content: string, maxBytes: number): string {
+  const encoded = new TextEncoder().encode(content);
+  if (encoded.length <= maxBytes) return content;
+  const decoder = new TextDecoder();
+  // Truncate at a codepoint boundary by passing `{ stream: false }` and
+  // slicing enough bytes to give the decoder room to resync on invalid
+  // trailing bytes.
+  const slice = encoded.slice(0, maxBytes);
+  const truncated = decoder.decode(slice, { stream: false });
+  return `${truncated}\n… (truncated at ${maxBytes} bytes)`;
+}
+
+export function createFileResolver(deps: FileResolverDeps): Resolver<string> {
+  const treeFn = deps.tree ?? defaultTree;
+  const readFn = deps.readFile ?? defaultReadFile;
+
+  return {
+    async list(query: string): Promise<Candidate[]> {
+      const node = await treeFn(deps.sessionId, deps.workspaceRoot);
+      const files = flattenFiles(node);
+      const matched = files.filter((f) => fuzzyMatch(query, f.path));
+      return matched.slice(0, FILE_RESOLVER_MAX_RESULTS).map((f) => ({
+        category: 'file' as const,
+        label: f.name,
+        value: f.path,
+      }));
+    },
+
+    async resolve(path: string): Promise<ContextBlock> {
+      const file: FileContent = await readFn(deps.sessionId, path);
+      const content = truncateToBytes(file.content, FILE_RESOLVER_MAX_BYTES);
+      return {
+        type: 'file',
+        path,
+        content,
+      };
+    },
+  };
+}

--- a/web/packages/app/src/context/resolvers.test.ts
+++ b/web/packages/app/src/context/resolvers.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@forge/ipc';
+import type { TreeNodeDto } from '../ipc/fs';
+import { buildRegistry, listCandidates, resolveChips } from './resolvers';
+
+const SESSION: SessionId = 'session-1' as SessionId;
+const ROOT = '/tmp/ws';
+
+function file(path: string, name: string): TreeNodeDto {
+  return { path, name, kind: 'File', children: null };
+}
+function dir(path: string, name: string, children: TreeNodeDto[]): TreeNodeDto {
+  return { path, name, kind: 'Dir', children };
+}
+
+describe('buildRegistry', () => {
+  it('includes only categories whose deps were passed', () => {
+    const reg = buildRegistry({
+      skill: { listSkills: () => [] },
+    });
+    expect(reg.skill).toBeDefined();
+    expect(reg.file).toBeUndefined();
+    expect(reg.url).toBeUndefined();
+  });
+});
+
+describe('listCandidates', () => {
+  it('fans out across resolvers and drops empty tabs', async () => {
+    const treeFn = vi
+      .fn()
+      .mockResolvedValue(dir('/ws', 'ws', [file('/ws/app.ts', 'app.ts')]));
+    const reg = buildRegistry({
+      file: { sessionId: SESSION, workspaceRoot: ROOT, tree: treeFn },
+      skill: { listSkills: () => [{ name: 'ts-review' }] },
+    });
+    const items = await listCandidates(reg, '');
+    expect(items.file).toHaveLength(1);
+    expect(items.skill).toHaveLength(1);
+    // Categories without registered resolvers are absent
+    expect(items.agent).toBeUndefined();
+    expect(items.url).toBeUndefined();
+  });
+
+  it('a failing resolver yields an empty tab, not a thrown promise', async () => {
+    const treeFn = vi.fn().mockRejectedValue(new Error('tree failed'));
+    const reg = buildRegistry({
+      file: { sessionId: SESSION, workspaceRoot: ROOT, tree: treeFn },
+    });
+    await expect(listCandidates(reg, '')).resolves.toEqual({});
+  });
+});
+
+describe('resolveChips', () => {
+  it('resolves each chip to a block and serializes for Anthropic', async () => {
+    const treeFn = vi.fn();
+    const readFn = vi.fn().mockResolvedValue({
+      path: '/ws/a.ts',
+      content: 'A',
+      bytes: 1,
+      sha256: 'x',
+    });
+    const reg = buildRegistry({
+      file: {
+        sessionId: SESSION,
+        workspaceRoot: ROOT,
+        tree: treeFn,
+        readFile: readFn,
+      },
+    });
+    const out = await resolveChips(
+      reg,
+      [{ category: 'file', label: 'a.ts', value: '/ws/a.ts' }],
+      'anthropic',
+    );
+    expect(out).toContain('<context type="file" path="/ws/a.ts">');
+    expect(out).toContain('A');
+  });
+
+  it('uses OpenAI function-context shape for openai provider id', async () => {
+    const reg = buildRegistry({ skill: { listSkills: () => [] } });
+    const out = await resolveChips(
+      reg,
+      [{ category: 'skill', label: 'ts', value: 'ts' }],
+      'gpt-4o',
+    );
+    expect(out).toContain('[context(type="skill")]');
+  });
+
+  it('returns empty string when no chips', async () => {
+    expect(await resolveChips({}, [], 'anthropic')).toBe('');
+  });
+
+  it('drops chips whose category has no registered resolver', async () => {
+    // file chip, no file resolver -> dropped silently -> empty adapter output
+    const reg = buildRegistry({ skill: { listSkills: () => [] } });
+    const out = await resolveChips(
+      reg,
+      [{ category: 'file', label: 'x.ts', value: '/ws/x.ts' }],
+      'anthropic',
+    );
+    expect(out).toBe('');
+  });
+});

--- a/web/packages/app/src/context/resolvers.ts
+++ b/web/packages/app/src/context/resolvers.ts
@@ -1,0 +1,128 @@
+// F-142: resolver registry + helpers.
+//
+// The Composer talks to this module rather than to each resolver directly:
+//
+//   - `listCandidates(query)` fans out to all active resolvers and returns a
+//     `Partial<Record<ContextCategory, PickerResult[]>>` shape the existing
+//     ContextPicker `items` prop consumes.
+//   - `resolveChips(chips, providerId)` routes each chip to its resolver,
+//     collects the `ContextBlock[]`, and serializes via `adaptContextBlocks`.
+//
+// Registry is built from injected deps so the Composer keeps its simple
+// constructor seam (tests pass stubs; production passes real stores).
+
+import { adaptContextBlocks, type ContextBlock, type ProviderId } from '@forge/ipc';
+import type { ContextCategory, PickerResult } from '../components/ContextPicker';
+import type { Candidate, Resolver } from './types';
+import { createFileResolver, type FileResolverDeps } from './file';
+import { createDirectoryResolver, type DirectoryResolverDeps } from './directory';
+import { createSelectionResolver, type SelectionResolverDeps } from './selection';
+import { createTerminalResolver, type TerminalResolverDeps } from './terminal';
+import { createAgentResolver, type AgentResolverDeps } from './agent';
+import { createSkillResolver, type SkillResolverDeps } from './skill';
+import { createUrlResolver, type UrlResolverDeps } from './url';
+
+/** A chip as it lives in the composer: the picker result round-tripped. */
+export interface Chip {
+  category: ContextCategory;
+  label: string;
+  value: string;
+}
+
+export interface ResolverRegistry {
+  file?: Resolver<string>;
+  directory?: Resolver<string>;
+  selection?: Resolver<string>;
+  terminal?: Resolver<string>;
+  agent?: Resolver<string>;
+  skill?: Resolver<string>;
+  url?: Resolver<string>;
+}
+
+export interface BuildRegistryDeps {
+  file?: FileResolverDeps;
+  directory?: DirectoryResolverDeps;
+  selection?: SelectionResolverDeps;
+  terminal?: TerminalResolverDeps;
+  agent?: AgentResolverDeps;
+  skill?: SkillResolverDeps;
+  url?: UrlResolverDeps;
+}
+
+/** Construct a resolver registry from per-category deps. Any category whose
+ *  deps are omitted is left absent — its picker tab will show "No results". */
+export function buildRegistry(deps: BuildRegistryDeps): ResolverRegistry {
+  const registry: ResolverRegistry = {};
+  if (deps.file) registry.file = createFileResolver(deps.file);
+  if (deps.directory) registry.directory = createDirectoryResolver(deps.directory);
+  if (deps.selection) registry.selection = createSelectionResolver(deps.selection);
+  if (deps.terminal) registry.terminal = createTerminalResolver(deps.terminal);
+  if (deps.agent) registry.agent = createAgentResolver(deps.agent);
+  if (deps.skill) registry.skill = createSkillResolver(deps.skill);
+  if (deps.url) registry.url = createUrlResolver(deps.url);
+  return registry;
+}
+
+/**
+ * Fan out `list(query)` across every active resolver. Returns the shape the
+ * ContextPicker's `items` prop expects. Resolvers that throw produce an
+ * empty list for their tab rather than short-circuiting the whole fan-out —
+ * one misbehaving source should not dismiss the picker.
+ */
+export async function listCandidates(
+  registry: ResolverRegistry,
+  query: string,
+): Promise<Partial<Record<ContextCategory, PickerResult[]>>> {
+  const entries = Object.entries(registry) as Array<[
+    ContextCategory,
+    Resolver<string> | undefined,
+  ]>;
+  const settled = await Promise.all(
+    entries.map(async ([cat, resolver]): Promise<[ContextCategory, PickerResult[]]> => {
+      if (!resolver) return [cat, []];
+      try {
+        const list = await resolver.list(query);
+        return [cat, candidatesToPickerResults(list)];
+      } catch {
+        return [cat, []];
+      }
+    }),
+  );
+  const out: Partial<Record<ContextCategory, PickerResult[]>> = {};
+  for (const [cat, list] of settled) {
+    if (list.length > 0) out[cat] = list;
+  }
+  return out;
+}
+
+function candidatesToPickerResults(list: Candidate[]): PickerResult[] {
+  return list.map((c) => ({
+    category: c.category,
+    label: c.label,
+    value: c.value,
+  }));
+}
+
+/**
+ * Resolve every chip into a `ContextBlock` and serialize for the active
+ * provider. Chips whose category has no registered resolver are dropped
+ * silently — the composer should not have allowed them to be picked, but
+ * dropping is safer than injecting an unresolved reference at send time.
+ */
+export async function resolveChips(
+  registry: ResolverRegistry,
+  chips: Chip[],
+  provider: ProviderId | null | undefined,
+): Promise<string> {
+  const blocks: ContextBlock[] = [];
+  for (const chip of chips) {
+    const resolver = registry[chip.category];
+    if (!resolver) continue;
+    try {
+      blocks.push(await resolver.resolve(chip.value));
+    } catch {
+      // Drop a failed resolve — the user's typed text still sends.
+    }
+  }
+  return adaptContextBlocks(blocks, provider);
+}

--- a/web/packages/app/src/context/selection.test.ts
+++ b/web/packages/app/src/context/selection.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSelectionResolver,
+  type SelectionSnapshot,
+} from './selection';
+
+const SNAP: SelectionSnapshot = {
+  path: '/ws/src/app.ts',
+  startLine: 14,
+  endLine: 22,
+  text: 'const x = 1;\nconst y = 2;',
+};
+
+describe('createSelectionResolver.list', () => {
+  it('returns an empty list when no selection is active', async () => {
+    const resolver = createSelectionResolver({ getSelection: () => null });
+    expect(await resolver.list('')).toEqual([]);
+  });
+
+  it('returns one candidate whose label names the file and line range', async () => {
+    const resolver = createSelectionResolver({ getSelection: () => SNAP });
+    const out = await resolver.list('');
+    expect(out).toHaveLength(1);
+    expect(out[0]!.category).toBe('selection');
+    expect(out[0]!.label).toBe('app.ts @ ln 14-22');
+  });
+});
+
+describe('createSelectionResolver.resolve', () => {
+  it('round-trips the snapshot through the ref JSON', async () => {
+    const resolver = createSelectionResolver({ getSelection: () => SNAP });
+    const [candidate] = await resolver.list('');
+    const block = await resolver.resolve(candidate!.value);
+    expect(block.type).toBe('selection');
+    expect(block.path).toBe('/ws/src/app.ts');
+    expect(block.content).toBe(SNAP.text);
+    expect(block.meta).toEqual({ startLine: 14, endLine: 22 });
+  });
+});

--- a/web/packages/app/src/context/selection.ts
+++ b/web/packages/app/src/context/selection.ts
@@ -1,0 +1,61 @@
+// F-142: selection resolver.
+//
+// The active editor's current selection is supplied by F-122's EditorPane
+// (future integration) or an injected provider for tests today. The picker
+// surfaces at most one entry — "current selection" — whose label reflects
+// the active file and line range. Returns `[]` when there is no selection
+// to keep the tab coherent with the spec ("otherwise absent").
+//
+// No IPC call is involved. The selection snapshot lives entirely in the
+// webview — EditorPane (or a future selection bus) owns it.
+
+import type { Candidate, ContextBlock, Resolver } from './types';
+
+export interface SelectionSnapshot {
+  /** Absolute path of the file the selection was taken from. */
+  path: string;
+  /** 1-based inclusive start line. */
+  startLine: number;
+  /** 1-based inclusive end line. */
+  endLine: number;
+  /** The selected text (already sliced by the editor). */
+  text: string;
+}
+
+export interface SelectionResolverDeps {
+  /** Returns the current selection snapshot, or `null` when none. */
+  getSelection: () => SelectionSnapshot | null;
+}
+
+/**
+ * Selection refs are the snapshot itself, serialized as JSON in the picker's
+ * `value` field. This keeps `resolve` self-contained — the snapshot at
+ * list-time is the one the user sees, even if the editor's live selection
+ * changes between @-pick and send.
+ */
+export function createSelectionResolver(deps: SelectionResolverDeps): Resolver<string> {
+  return {
+    async list(_query: string): Promise<Candidate[]> {
+      const snap = deps.getSelection();
+      if (!snap) return [];
+      const leaf = snap.path.split('/').pop() ?? snap.path;
+      return [
+        {
+          category: 'selection' as const,
+          label: `${leaf} @ ln ${snap.startLine}-${snap.endLine}`,
+          value: JSON.stringify(snap),
+        },
+      ];
+    },
+
+    async resolve(ref: string): Promise<ContextBlock> {
+      const snap = JSON.parse(ref) as SelectionSnapshot;
+      return {
+        type: 'selection',
+        path: snap.path,
+        content: snap.text,
+        meta: { startLine: snap.startLine, endLine: snap.endLine },
+      };
+    },
+  };
+}

--- a/web/packages/app/src/context/settings.test.ts
+++ b/web/packages/app/src/context/settings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  allowedHosts,
+  setAllowedHosts,
+  isUrlAllowed,
+  resetAllowedHostsForTesting,
+} from './settings';
+
+describe('allowedHosts signal', () => {
+  beforeEach(() => {
+    resetAllowedHostsForTesting();
+  });
+
+  it('starts empty', () => {
+    expect(allowedHosts()).toEqual([]);
+  });
+
+  it('setAllowedHosts updates the signal', () => {
+    setAllowedHosts(['example.com']);
+    expect(allowedHosts()).toEqual(['example.com']);
+  });
+});
+
+describe('isUrlAllowed', () => {
+  it('rejects non-http(s) schemes', () => {
+    expect(isUrlAllowed('file:///etc/passwd', ['passwd'])).toBe(false);
+    expect(isUrlAllowed('data:text/plain,hi', [])).toBe(false);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(isUrlAllowed('not a url', ['example.com'])).toBe(false);
+  });
+
+  it('rejects hosts not on the list', () => {
+    expect(isUrlAllowed('https://blocked.example.com', ['allowed.example.com'])).toBe(false);
+  });
+
+  it('accepts exact hostname matches', () => {
+    expect(isUrlAllowed('https://docs.rs/tokio', ['docs.rs'])).toBe(true);
+    expect(isUrlAllowed('http://example.com:8080/x', ['example.com'])).toBe(true);
+  });
+
+  it('does not match subdomains implicitly', () => {
+    expect(isUrlAllowed('https://api.example.com', ['example.com'])).toBe(false);
+  });
+});

--- a/web/packages/app/src/context/settings.ts
+++ b/web/packages/app/src/context/settings.ts
@@ -1,0 +1,41 @@
+// F-142: minimal settings surface for the URL resolver's allowed-hosts list.
+//
+// A full settings store is out of scope for this task. We expose a signal
+// that defaults to an empty list (strictest — every URL is rejected until a
+// host is added) and a setter for both tests and a future settings panel.
+//
+// The URL resolver imports `allowedHosts()` lazily so a host update is
+// observed the next time a user types a URL in the picker.
+
+import { createSignal } from 'solid-js';
+
+/**
+ * Allowed hosts for the URL context resolver. Exact hostname match — no
+ * wildcard or suffix semantics. Keep this tiny; a real settings panel
+ * (follow-up) will populate it from `~/.forge/config.toml`.
+ */
+const [allowedHosts, setAllowedHosts] = createSignal<string[]>([]);
+
+export { allowedHosts, setAllowedHosts };
+
+/**
+ * Check whether a URL string is allowed. Returns `false` for malformed URLs
+ * or hosts absent from `allowedHosts()`.
+ */
+export function isUrlAllowed(url: string, hosts: readonly string[] = allowedHosts()): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  // Only http(s) — file:// and data: URLs should never be fetched from the
+  // webview on a user's behalf.
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+  return hosts.includes(parsed.hostname);
+}
+
+/** Test helper — reset to a clean empty list. */
+export function resetAllowedHostsForTesting(): void {
+  setAllowedHosts([]);
+}

--- a/web/packages/app/src/context/skill.test.ts
+++ b/web/packages/app/src/context/skill.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createSkillResolver } from './skill';
+
+describe('createSkillResolver.list', () => {
+  it('filters by name and description substring', async () => {
+    const resolver = createSkillResolver({
+      listSkills: () => [
+        { name: 'typescript-review', description: 'TS lint pass' },
+        { name: 'rust-audit', description: 'Check cargo-deny' },
+      ],
+    });
+    expect((await resolver.list('typescript')).map((c) => c.value)).toEqual([
+      'typescript-review',
+    ]);
+    expect((await resolver.list('cargo')).map((c) => c.value)).toEqual([
+      'rust-audit',
+    ]);
+  });
+
+  it('labels skills with their description when present', async () => {
+    const resolver = createSkillResolver({
+      listSkills: () => [
+        { name: 'typescript-review', description: 'TS lint pass' },
+      ],
+    });
+    const [candidate] = await resolver.list('');
+    expect(candidate!.label).toBe('typescript-review — TS lint pass');
+  });
+});
+
+describe('createSkillResolver.resolve', () => {
+  it('returns a pointer block, not the skill body', async () => {
+    const resolver = createSkillResolver({
+      listSkills: () => [],
+    });
+    const block = await resolver.resolve('typescript-review');
+    expect(block).toEqual({
+      type: 'skill',
+      content: 'skill:typescript-review',
+      meta: { skillName: 'typescript-review', pointer: true },
+    });
+  });
+});

--- a/web/packages/app/src/context/skill.ts
+++ b/web/packages/app/src/context/skill.ts
@@ -1,0 +1,53 @@
+// F-142: skill resolver.
+//
+// Skills are inserted *by reference*, not by content — the picker attaches a
+// pointer and the agent loads the skill definition when it needs to. This
+// keeps the prompt lean and lets the session-side skill registry choose its
+// own loading shape (lazy fetch, caching, etc.).
+//
+// The `catalog.skills` store (seeded by the shell bridge) is the candidate
+// source. `resolve` returns a pointer block — the `content` field is a
+// compact `skill:<name>` reference that the receiving provider treats as a
+// tool-context indicator.
+
+import type { Candidate, ContextBlock, Resolver } from './types';
+import { fuzzyMatch } from './types';
+
+export interface SkillCandidateSource {
+  name: string;
+  /** Optional one-line description. Surfaced in the candidate label. */
+  description?: string;
+}
+
+export interface SkillResolverDeps {
+  listSkills: () => SkillCandidateSource[];
+}
+
+export function createSkillResolver(deps: SkillResolverDeps): Resolver<string> {
+  return {
+    async list(query: string): Promise<Candidate[]> {
+      const skills = deps.listSkills();
+      const matched = skills.filter(
+        (s) =>
+          fuzzyMatch(query, s.name) ||
+          (s.description !== undefined && fuzzyMatch(query, s.description)),
+      );
+      return matched.map((s) => ({
+        category: 'skill' as const,
+        label:
+          s.description !== undefined && s.description.length > 0
+            ? `${s.name} — ${s.description}`
+            : s.name,
+        value: s.name,
+      }));
+    },
+
+    async resolve(name: string): Promise<ContextBlock> {
+      return {
+        type: 'skill',
+        content: `skill:${name}`,
+        meta: { skillName: name, pointer: true },
+      };
+    },
+  };
+}

--- a/web/packages/app/src/context/terminal.test.ts
+++ b/web/packages/app/src/context/terminal.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTerminalResolver,
+  type TerminalSnapshot,
+} from './terminal';
+
+const SNAP: TerminalSnapshot = {
+  terminalId: 'abc123',
+  shellName: 'zsh',
+  text: 'line-1\nline-2\nline-3',
+  lineCount: 3,
+};
+
+describe('createTerminalResolver.list', () => {
+  it('returns [] when no terminal is focused', async () => {
+    const resolver = createTerminalResolver({ getSnapshot: () => null });
+    expect(await resolver.list('')).toEqual([]);
+  });
+
+  it('returns one candidate with shell + line count', async () => {
+    const resolver = createTerminalResolver({ getSnapshot: () => SNAP });
+    const out = await resolver.list('');
+    expect(out).toHaveLength(1);
+    expect(out[0]!.label).toBe('zsh — last 3 lines');
+  });
+});
+
+describe('createTerminalResolver.resolve', () => {
+  it('carries the text through and annotates meta', async () => {
+    const resolver = createTerminalResolver({ getSnapshot: () => SNAP });
+    const [candidate] = await resolver.list('');
+    const block = await resolver.resolve(candidate!.value);
+    expect(block.type).toBe('terminal');
+    expect(block.content).toBe(SNAP.text);
+    expect(block.meta).toEqual({ terminalId: 'abc123', shellName: 'zsh' });
+  });
+});

--- a/web/packages/app/src/context/terminal.ts
+++ b/web/packages/app/src/context/terminal.ts
@@ -1,0 +1,53 @@
+// F-142: terminal resolver.
+//
+// The spec calls for the "last N lines of the focused terminal pane". F-125
+// owns the xterm.js byte buffer; F-142 does not tap into it directly — the
+// resolver instead accepts an injected `getTerminalSnapshot()` closure, which
+// the ChatPane wires to the focused TerminalPane at mount time (or supplies
+// a null provider when no terminal is mounted).
+//
+// This keeps the resolver pure and the coupling to F-125 one-directional:
+// TerminalPane exposes a `snapshot()` method upstream, not downstream.
+
+import type { Candidate, ContextBlock, Resolver } from './types';
+
+export interface TerminalSnapshot {
+  /** Identifier of the focused terminal (for labelling only). */
+  terminalId: string;
+  /** Display name: usually the shell path's final segment (`zsh`, `bash`). */
+  shellName: string;
+  /** Lines already joined with `\n`. The picker labels the count. */
+  text: string;
+  /** Number of lines `text` covers — used in the candidate label. */
+  lineCount: number;
+}
+
+export interface TerminalResolverDeps {
+  /** Returns the focused terminal's recent output, or `null` when none. */
+  getSnapshot: () => TerminalSnapshot | null;
+}
+
+export function createTerminalResolver(deps: TerminalResolverDeps): Resolver<string> {
+  return {
+    async list(_query: string): Promise<Candidate[]> {
+      const snap = deps.getSnapshot();
+      if (!snap) return [];
+      return [
+        {
+          category: 'terminal' as const,
+          label: `${snap.shellName} — last ${snap.lineCount} lines`,
+          value: JSON.stringify(snap),
+        },
+      ];
+    },
+
+    async resolve(ref: string): Promise<ContextBlock> {
+      const snap = JSON.parse(ref) as TerminalSnapshot;
+      return {
+        type: 'terminal',
+        content: snap.text,
+        meta: { terminalId: snap.terminalId, shellName: snap.shellName },
+      };
+    },
+  };
+}

--- a/web/packages/app/src/context/types.ts
+++ b/web/packages/app/src/context/types.ts
@@ -1,0 +1,46 @@
+// F-142: shared resolver contracts.
+//
+// Each category under `context/` exports a module with two functions:
+//
+//   list(query) -> Promise<Candidate[]>      // populate picker results
+//   resolve(ref) -> Promise<ContextBlock>    // materialize at send time
+//
+// `Candidate` is the shape the picker already consumes via `PickerResult`.
+// The `ref` type is category-specific — we keep each resolver narrowly
+// typed and rely on the picker's `value` field (round-tripped as an opaque
+// string) to transport the category-specific identifier at send time.
+//
+// Keeping this file dependency-light: no imports from the picker component
+// (avoids pulling solid-js into otherwise pure resolver modules).
+
+import type { ContextBlock } from '@forge/ipc';
+import type { ContextCategory } from '../components/ContextPicker';
+
+export type { ContextBlock };
+
+/** A single picker result. Matches `PickerResult` in the picker component. */
+export interface Candidate {
+  category: ContextCategory;
+  label: string;
+  value: string;
+}
+
+/**
+ * Category resolver shape. `TRef` is the category-specific reference the
+ * resolver needs at send time. Each concrete resolver narrows this type —
+ * callers typically go through the picker (`value: string`) and route to
+ * the right resolver by chip category.
+ */
+export interface Resolver<TRef = string> {
+  list(query: string): Promise<Candidate[]>;
+  resolve(ref: TRef): Promise<ContextBlock>;
+}
+
+/**
+ * Substring-match case-insensitive. Common helper for candidate list filters.
+ * Empty query matches everything.
+ */
+export function fuzzyMatch(query: string, value: string): boolean {
+  if (!query) return true;
+  return value.toLowerCase().includes(query.toLowerCase());
+}

--- a/web/packages/app/src/context/url.test.ts
+++ b/web/packages/app/src/context/url.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createUrlResolver, URL_RESOLVER_MAX_BYTES } from './url';
+
+describe('createUrlResolver.list', () => {
+  it('returns [] when the query is not a URL', async () => {
+    const resolver = createUrlResolver({ allowedHosts: () => [] });
+    expect(await resolver.list('not a url')).toEqual([]);
+  });
+
+  it('raises a toast and returns [] for a disallowed host', async () => {
+    const pushToast = vi.fn();
+    const resolver = createUrlResolver({
+      allowedHosts: () => ['allowed.example.com'],
+      pushToast,
+    });
+    const out = await resolver.list('https://blocked.example.com/page');
+    expect(out).toEqual([]);
+    expect(pushToast).toHaveBeenCalledWith(
+      'warning',
+      expect.stringContaining('not allowed'),
+    );
+  });
+
+  it('returns one candidate for an allowed URL', async () => {
+    const resolver = createUrlResolver({
+      allowedHosts: () => ['docs.rs'],
+    });
+    const out = await resolver.list('https://docs.rs/tokio');
+    expect(out).toEqual([
+      { category: 'url', label: 'docs.rs/tokio', value: 'https://docs.rs/tokio' },
+    ]);
+  });
+});
+
+describe('createUrlResolver.resolve', () => {
+  it('refuses disallowed URLs at send time and toasts the user', async () => {
+    const pushToast = vi.fn();
+    const fetchImpl = vi.fn();
+    const resolver = createUrlResolver({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      allowedHosts: () => ['only.example.com'],
+      pushToast,
+    });
+    const block = await resolver.resolve('https://evil.example.com/x');
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(pushToast).toHaveBeenCalledWith('error', expect.stringContaining('Refusing'));
+    expect(block.content).toContain('refused');
+    expect(block.meta).toEqual({ refused: true });
+  });
+
+  it('fetches an allowed URL and returns its body', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('<html>hi</html>'),
+    });
+    const resolver = createUrlResolver({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      allowedHosts: () => ['example.com'],
+    });
+    const block = await resolver.resolve('https://example.com/page');
+    expect(fetchImpl).toHaveBeenCalledWith('https://example.com/page');
+    expect(block.content).toBe('<html>hi</html>');
+    expect(block.type).toBe('url');
+    expect(block.path).toBe('https://example.com/page');
+  });
+
+  it('truncates large response bodies', async () => {
+    const big = 'x'.repeat(URL_RESOLVER_MAX_BYTES * 2);
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(big),
+    });
+    const resolver = createUrlResolver({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      allowedHosts: () => ['example.com'],
+    });
+    const block = await resolver.resolve('https://example.com/big');
+    expect(block.content).toMatch(/\(truncated at \d+ bytes\)$/);
+  });
+
+  it('surfaces non-2xx responses', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(''),
+    });
+    const resolver = createUrlResolver({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      allowedHosts: () => ['example.com'],
+    });
+    const block = await resolver.resolve('https://example.com/missing');
+    expect(block.content).toBe('[fetch failed: HTTP 404]');
+    expect(block.meta).toEqual({ status: 404 });
+  });
+
+  it('catches fetch errors gracefully', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('offline'));
+    const resolver = createUrlResolver({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      allowedHosts: () => ['example.com'],
+    });
+    const block = await resolver.resolve('https://example.com/page');
+    expect(block.content).toBe('[fetch failed: offline]');
+    expect(block.meta).toEqual({ error: 'offline' });
+  });
+});

--- a/web/packages/app/src/context/url.ts
+++ b/web/packages/app/src/context/url.ts
@@ -1,0 +1,105 @@
+// F-142: URL resolver.
+//
+// A URL is accepted as a candidate only if its hostname is on the
+// `allowedHosts` list (see `./settings.ts`). At resolve time we fetch the
+// URL with `fetch()` from the webview — no new IPC command was added for
+// this task. Disallowed URLs raise a user-visible toast and return an empty
+// string candidate list so the picker shows "No url results".
+//
+// Truncation mirrors the file resolver's 32 KiB budget: a fetched page's
+// body beyond that is dropped with a visible marker.
+
+import type { Candidate, ContextBlock, Resolver } from './types';
+import { allowedHosts as defaultAllowedHosts, isUrlAllowed } from './settings';
+import { pushToast as defaultPushToast } from '../components/toast';
+import { truncateToBytes } from './file';
+
+export const URL_RESOLVER_MAX_BYTES = 32 * 1024;
+
+export interface UrlResolverDeps {
+  /** Injection seam — defaults to the browser `fetch`. Tests pass stubs. */
+  fetchImpl?: typeof fetch;
+  /** Override the allowed-hosts source (tests). Defaults to the live signal. */
+  allowedHosts?: () => readonly string[];
+  /** Override the toast sink (tests). Defaults to the global queue. */
+  pushToast?: (kind: 'info' | 'warning' | 'error', message: string) => void;
+}
+
+export function createUrlResolver(deps: UrlResolverDeps = {}): Resolver<string> {
+  const fetchFn = deps.fetchImpl ?? fetch.bind(globalThis);
+  const hostsFn = deps.allowedHosts ?? (() => defaultAllowedHosts());
+  const toast = deps.pushToast ?? defaultPushToast;
+
+  return {
+    async list(query: string): Promise<Candidate[]> {
+      // The picker treats a `url` candidate as present only when the query
+      // parses as an http(s) URL. Otherwise the tab is empty.
+      const trimmed = query.trim();
+      if (trimmed.length === 0) return [];
+      if (!/^https?:\/\//i.test(trimmed)) return [];
+      const hosts = hostsFn();
+      if (!isUrlAllowed(trimmed, hosts)) {
+        toast(
+          'warning',
+          `URL host not allowed — add it to settings → allowed hosts before @-referencing it.`,
+        );
+        return [];
+      }
+      let parsed: URL;
+      try {
+        parsed = new URL(trimmed);
+      } catch {
+        return [];
+      }
+      return [
+        {
+          category: 'url' as const,
+          label: parsed.hostname + parsed.pathname,
+          value: trimmed,
+        },
+      ];
+    },
+
+    async resolve(url: string): Promise<ContextBlock> {
+      // Re-check the allowed-hosts list at send time — the setting could
+      // have changed between pick and send.
+      if (!isUrlAllowed(url, hostsFn())) {
+        toast(
+          'error',
+          `Refusing to fetch ${url}: host not on allowed-hosts list.`,
+        );
+        return {
+          type: 'url',
+          path: url,
+          content: `[refused: host not allowed]`,
+          meta: { refused: true },
+        };
+      }
+      try {
+        const res = await fetchFn(url);
+        if (!res.ok) {
+          return {
+            type: 'url',
+            path: url,
+            content: `[fetch failed: HTTP ${res.status}]`,
+            meta: { status: res.status },
+          };
+        }
+        const body = await res.text();
+        return {
+          type: 'url',
+          path: url,
+          content: truncateToBytes(body, URL_RESOLVER_MAX_BYTES),
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          type: 'url',
+          path: url,
+          content: `[fetch failed: ${message}]`,
+          meta: { error: message },
+        };
+      }
+    },
+  };
+}

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -809,6 +809,90 @@ describe('Composer @-trigger and ContextPicker integration (F-141)', () => {
     expect(queryByTestId('context-picker')).not.toBeInTheDocument();
     expect(queryByTestId('ctx-chip')).not.toBeInTheDocument();
   });
+
+  // F-142 DoD item 4: ChatPane wires the resolver registry + provider adapter
+  // into the send path — a file chip emits a prepended `<context ...>` block
+  // above the user text on the IPC call. Injects a stub registry so the test
+  // doesn't need a running Rust backend.
+  it('F-142 integration: chip at send time prepends an Anthropic-shaped block to text', async () => {
+    const stubRegistry = {
+      file: {
+        list: async () => [
+          { category: 'file' as const, label: 'app.ts', value: '/ws/app.ts' },
+        ],
+        resolve: async () => ({
+          type: 'file' as const,
+          path: '/ws/app.ts',
+          content: 'body-of-app',
+        }),
+      },
+    };
+    const { getByTestId } = render(() => (
+      <ChatPane registry={stubRegistry} providerId={'anthropic'} />
+    ));
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    // Open the picker, pick the only file candidate, type a message, send.
+    textarea.value = '@app';
+    textarea.selectionStart = 4;
+    textarea.selectionEnd = 4;
+    fireEvent.input(textarea);
+    // `list(query)` runs async; wait a tick for the picker items to populate.
+    await new Promise((r) => setTimeout(r, 0));
+    fireEvent.mouseDown(getByTestId('context-picker-result-0'));
+    fireEvent.input(textarea, { target: { value: 'explain' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    // resolveChips is async — wait a microtask for the prefix path.
+    await new Promise((r) => setTimeout(r, 0));
+    const call = invokeMock.mock.calls.find(
+      (c) => c[0] === 'session_send_message',
+    );
+    expect(call).toBeDefined();
+    const sentText = (call![1] as { text: string }).text;
+    expect(sentText).toContain('<context type="file" path="/ws/app.ts">');
+    expect(sentText).toContain('body-of-app');
+    expect(sentText).toContain('explain');
+    // The user text follows the context block, separated by a blank line.
+    expect(sentText.trim().endsWith('explain')).toBe(true);
+  });
+
+  // F-142 DoD item 2: send flow routes chips through the resolver registry
+  // and prepends a provider-shaped block to the user text. Uses a Composer
+  // directly with a stub `onSend` so the assertion stays scoped to the
+  // composer's chip-forwarding contract.
+  it('F-142: onSend receives the currently-attached chips and clears them', () => {
+    const items = {
+      file: [
+        { category: 'file' as const, label: 'app.ts', value: '/ws/app.ts' },
+      ],
+    };
+    const onSend = vi.fn();
+    const { getByTestId, queryByTestId } = render(() => (
+      <Composer disabled={false} onSend={onSend} items={items} />
+    ));
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    textarea.value = '@app';
+    textarea.selectionStart = 4;
+    textarea.selectionEnd = 4;
+    fireEvent.input(textarea);
+    fireEvent.mouseDown(getByTestId('context-picker-result-0'));
+    // One chip is now attached.
+    expect(getByTestId('ctx-chip')).toHaveTextContent('app.ts');
+    // Type a message and send with Enter.
+    fireEvent.input(textarea, { target: { value: 'please review' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledWith(
+      'please review',
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: 'file',
+          label: 'app.ts',
+          value: '/ws/app.ts',
+        }),
+      ]),
+    );
+    // Chips are consumed on send.
+    expect(queryByTestId('ctx-chip')).not.toBeInTheDocument();
+  });
 });
 
 describe('args_json boundary contract (F-080)', () => {

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -31,6 +31,15 @@ import {
   type ContextCategory,
 } from '../../components/ContextPicker';
 import { ContextChip } from '../../components/ContextChip';
+import type { ProviderId } from '@forge/ipc';
+import {
+  buildRegistry,
+  listCandidates,
+  resolveChips,
+  type BuildRegistryDeps,
+  type ResolverRegistry,
+} from '../../context/resolvers';
+import { readFile as defaultReadFile } from '../../ipc/fs';
 import './ChatPane.css';
 
 // ---------------------------------------------------------------------------
@@ -339,7 +348,7 @@ function utf8ByteLength(text: string): number {
   return new TextEncoder().encode(text).length;
 }
 
-interface InsertedChip {
+export interface InsertedChip {
   /** Stable id so SolidJS can reconcile chip list updates. */
   id: string;
   category: ContextCategory;
@@ -369,14 +378,31 @@ export function removeAtSpan(
 
 export interface ComposerProps {
   disabled: boolean;
-  onSend: (text: string) => void;
   /**
-   * Optional category-indexed items forwarded to the ContextPicker. F-141
-   * ships with this undefined (the picker shows empty tabs). F-142 will
-   * wire a resolver on top of this prop. Exposed now so component tests
-   * can drive the end-to-end "type @ → pick → chip appears" flow.
+   * Send handler. Receives the trimmed text and the currently-attached chips.
+   * F-142 routes chips through a resolver registry (`onSend` in `ChatPane`
+   * builds the provider-shaped context prefix) — callers that want the raw
+   * string path can ignore `chips`.
+   */
+  onSend: (text: string, chips: InsertedChip[]) => void;
+  /**
+   * Optional category-indexed items forwarded to the ContextPicker. Exposed
+   * for tests that drive the end-to-end "type @ → pick → chip appears" flow
+   * without booting the resolver registry.
    */
   items?: Partial<Record<ContextCategory, PickerResult[]>>;
+  /**
+   * F-142: resolver registry. When present, the composer fetches live picker
+   * results from `listCandidates(registry, query)` on every query change.
+   * `items` (if also present) wins — tests can pin the list without stubbing
+   * the registry.
+   */
+  registry?: ResolverRegistry;
+  /**
+   * F-142: hover preview loader for file chips. Injected into `ContextChip`;
+   * production passes `readFile(sessionId, path)`, tests pass a stub.
+   */
+  loadFilePreview?: (path: string) => Promise<string>;
 }
 
 export const Composer: Component<ComposerProps> = (props) => {
@@ -414,6 +440,31 @@ export const Composer: Component<ComposerProps> = (props) => {
   const trimmedByteLength = createMemo(() => utf8ByteLength(text().trim()));
   const overCap = createMemo(() => trimmedByteLength() > MAX_COMPOSER_BYTES);
 
+  // F-142: live items populated from the resolver registry. Every query
+  // change fires a fan-out through `listCandidates`; the latest successful
+  // result wins. When no registry is wired, `items()` stays `undefined` and
+  // the picker renders empty tabs (or consumes `props.items` for tests).
+  const [registryItems, setRegistryItems] = createSignal<
+    Partial<Record<ContextCategory, PickerResult[]>> | undefined
+  >(undefined);
+  // Guard against races: the newest query wins when multiple in-flight
+  // promises resolve out of order.
+  let listToken = 0;
+
+  createEffect(() => {
+    const registry = props.registry;
+    if (!registry) return;
+    const match = trigger();
+    const query = match ? match.query : '';
+    const token = ++listToken;
+    void listCandidates(registry, query).then((items) => {
+      if (token !== listToken) return;
+      setRegistryItems(items);
+    });
+  });
+
+  const effectiveItems = createMemo(() => props.items ?? registryItems());
+
   const measureAnchor = () => {
     if (!composerRef) return;
     const r = composerRef.getBoundingClientRect();
@@ -443,11 +494,13 @@ export const Composer: Component<ComposerProps> = (props) => {
     const value = text().trim();
     if (!value) return;
     if (utf8ByteLength(value) > MAX_COMPOSER_BYTES) return;
-    props.onSend(value);
+    const attached = chips();
+    props.onSend(value, attached);
     setText('');
     setCaret(0);
-    // Chips persist across sends intentionally — clearing them on send is
-    // F-142 territory once backend context blocks wire up.
+    // F-142: chips are consumed on send. The caller (ChatPane) resolves and
+    // prepends them to the message text through the provider adapter.
+    setChips([]);
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -551,6 +604,10 @@ export const Composer: Component<ComposerProps> = (props) => {
             <ContextChip
               category={chip.category}
               label={chip.label}
+              value={chip.value}
+              {...(props.loadFilePreview !== undefined
+                ? { loadPreview: props.loadFilePreview }
+                : {})}
               onDismiss={() => dismissChip(chip.id)}
             />
           )}
@@ -575,7 +632,7 @@ export const Composer: Component<ComposerProps> = (props) => {
         <ContextPicker
           query={trigger()!.query}
           anchorRect={anchorRect()}
-          {...(props.items ? { items: props.items } : {})}
+          {...(effectiveItems() ? { items: effectiveItems()! } : {})}
           onPick={replaceAtSpan}
           onDismiss={dismissPicker}
         />
@@ -620,13 +677,54 @@ export const Composer: Component<ComposerProps> = (props) => {
 // ChatPane root
 // ---------------------------------------------------------------------------
 
-export const ChatPane: Component = () => {
+/**
+ * ChatPane props — the default component reads the active session + provider
+ * from stores, but tests can inject a fixed registry / provider to avoid
+ * touching global state.
+ */
+export interface ChatPaneProps {
+  /** F-142: override the default resolver registry built from active-session
+   *  state. Tests pass a stub; production leaves it undefined. */
+  registry?: ResolverRegistry;
+  /** F-142: active provider for `adaptContextBlocks`. Production passes the
+   *  user's selected provider id; tests can pin a flavour. */
+  providerId?: ProviderId | null;
+}
+
+export const ChatPane: Component<ChatPaneProps> = (props) => {
   const sessionId = () => activeSessionId();
   const state = createMemo(() => {
     const id = sessionId();
     if (!id) return { turns: [], awaitingResponse: false, streamingMessageId: null };
     return getMessagesState(id);
   });
+
+  // F-142: default registry — builds resolvers lazily from the active session
+  // and workspace root. Resolvers that need data we don't have (active
+  // selection, focused terminal, transcripts of sibling agents) are absent
+  // for v1 and their tabs show "No results"; spec §7.2-§7.7 allows this.
+  const defaultRegistry = createMemo<ResolverRegistry>(() => {
+    const id = sessionId();
+    const root = activeWorkspaceRoot();
+    if (!id || !root) return {};
+    const deps: BuildRegistryDeps = {
+      file: { sessionId: id, workspaceRoot: root },
+      directory: { sessionId: id, workspaceRoot: root },
+      url: {},
+    };
+    return buildRegistry(deps);
+  });
+  const registry = (): ResolverRegistry => props.registry ?? defaultRegistry();
+
+  // F-142: lazy file preview loader. Chips are free-standing, so we
+  // snapshot the session at preview time rather than closing over the live
+  // signal — a stale sessionId is preferable to a null crash mid-hover.
+  const loadFilePreview = async (path: string): Promise<string> => {
+    const id = sessionId();
+    if (!id) return '';
+    const file = await defaultReadFile(id, path);
+    return file.content;
+  };
 
   let listRef: HTMLDivElement | undefined;
   // Track whether the user has scrolled up (released auto-pin)
@@ -656,18 +754,35 @@ export const ChatPane: Component = () => {
     setUserScrolledUp(!atBottom);
   };
 
-  const handleSend = (text: string) => {
+  const handleSend = (text: string, chips: InsertedChip[]) => {
     const id = sessionId();
     if (!id) return;
     setAwaitingResponse(id, true);
     // Re-pin on new user message
     setUserScrolledUp(false);
-    // On rejection, the Error event handler in the messages store rolls back
-    // both `awaitingResponse` and `streamingMessageId`, re-enabling the
-    // composer and surfacing the failure as an inline error turn.
-    invoke('session_send_message', { sessionId: id, text }).catch((err) =>
-      reportInvokeError(id, 'session_send_message', err),
-    );
+
+    const sendText = (body: string): void => {
+      invoke('session_send_message', { sessionId: id, text: body }).catch(
+        (err) => reportInvokeError(id, 'session_send_message', err),
+      );
+    };
+
+    // F-142: resolve chips through the registry and prepend the provider-
+    // shaped context to the user's text. The current IPC boundary
+    // (`session_send_message`) takes a single `text` string; compact shape
+    // above that boundary is the pragmatic v1 wire until a structured
+    // `context_blocks` field lands server-side.
+    if (chips.length === 0) {
+      // Fast path — keep the no-chip send synchronous so callers that dispatch
+      // an Enter and check `invoke` on the next tick (the existing composer
+      // contract) observe the call without awaiting a promise chain.
+      sendText(text);
+      return;
+    }
+    const providerId = props.providerId ?? null;
+    void resolveChips(registry(), chips, providerId).then((prefix) => {
+      sendText(prefix.length > 0 ? `${prefix}\n\n${text}` : text);
+    });
   };
 
   return (
@@ -719,6 +834,8 @@ export const ChatPane: Component = () => {
       <Composer
         disabled={state().awaitingResponse || state().streamingMessageId !== null}
         onSend={handleSend}
+        registry={registry()}
+        loadFilePreview={loadFilePreview}
       />
     </section>
   );

--- a/web/packages/ipc/src/context-adapter.ts
+++ b/web/packages/ipc/src/context-adapter.ts
@@ -1,0 +1,152 @@
+// F-142: provider-shaped serialization for resolved context blocks.
+//
+// The @-context picker (F-141) produces `ContextBlock[]` at send time via the
+// F-142 resolvers. Different providers expect different prompt shapes:
+//
+//   - Anthropic messages: inline XML tags Claude's training rewards, one per
+//     block, stacked above the user's typed text.
+//   - OpenAI chat: function-style `[context(...)]` tool-context blocks — the
+//     shape Codex / Cursor / gpt-4 system prompts conventionally use.
+//
+// Both serializers are pure (string-in / string-out) so they're trivially
+// testable and can run equally well from the send-time code path or from a
+// future server-side compactor. Shape lives in `@forge/ipc` because both the
+// app package and (eventually) the shell-side IPC plumbing for `fetch_url`
+// may need it; keeping it in the IPC package avoids a cycle.
+
+import type { ProviderId } from './generated/ProviderId';
+
+/**
+ * Category of a resolved context block. Mirrors `ContextCategory` in the
+ * picker (`web/packages/app/src/components/ContextPicker.tsx`) — duplicated
+ * here so the IPC package has no dependency on the app package.
+ */
+export type ContextBlockType =
+  | 'file'
+  | 'directory'
+  | 'selection'
+  | 'terminal'
+  | 'agent'
+  | 'skill'
+  | 'url';
+
+/**
+ * A resolved context block. Produced by a resolver's `resolve(ref)` call at
+ * send time. Consumed by `adaptContextBlocks` to produce provider-specific
+ * text that is prepended to the user's composer text.
+ *
+ * `content` is always populated (even if empty). `path` is set for blocks
+ * whose location is meaningful to the model (file, directory, url) and omitted
+ * for blocks whose location is ephemeral (selection, terminal, agent, skill).
+ * `meta` is optional and only used by specialised serializers; the default
+ * Anthropic/OpenAI shapes ignore it.
+ */
+export interface ContextBlock {
+  type: ContextBlockType;
+  /** Optional path / URL / identifier shown to the model. */
+  path?: string;
+  /** Textual content of the block. May be empty for pointer-style blocks. */
+  content: string;
+  /** Free-form extra metadata. Not serialized by default adapters. */
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Serialize a block as an Anthropic XML tag. Attributes are limited to `type`
+ * and `path` (when present); quotes in the path are escaped — Claude is happy
+ * with non-strict XML but the serializer keeps its output parseable so
+ * downstream log scrapers don't trip on embedded quotes.
+ *
+ * Example:
+ *   <context type="file" path="src/app.ts">
+ *   …file contents…
+ *   </context>
+ */
+export function toAnthropicXml(block: ContextBlock): string {
+  const attrs: string[] = [`type="${escapeAttr(block.type)}"`];
+  if (block.path !== undefined && block.path.length > 0) {
+    attrs.push(`path="${escapeAttr(block.path)}"`);
+  }
+  const open = `<context ${attrs.join(' ')}>`;
+  const close = `</context>`;
+  return `${open}\n${block.content}\n${close}`;
+}
+
+/**
+ * Serialize a block as an OpenAI-style function-context shape. The format is
+ * a pseudo function call the model recognises as tool-injected context:
+ *
+ *   [context(type="file", path="src/app.ts")]
+ *   …file contents…
+ *   [/context]
+ *
+ * This is the convention Cursor/Continue/Codex use when lowering attached
+ * files into a gpt-4-class chat turn. It is not a wire-level function-calling
+ * payload — serialization stays in-text so the message shape matches the
+ * Anthropic path and the Rust send path can prepend it verbatim.
+ */
+export function toOpenAiFunctionContext(block: ContextBlock): string {
+  const attrs: string[] = [`type="${escapeAttr(block.type)}"`];
+  if (block.path !== undefined && block.path.length > 0) {
+    attrs.push(`path="${escapeAttr(block.path)}"`);
+  }
+  const open = `[context(${attrs.join(', ')})]`;
+  const close = `[/context]`;
+  return `${open}\n${block.content}\n${close}`;
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Active provider flavour for adapter selection. `openai` covers the Codex /
+ * gpt-4 family; `anthropic` covers Claude. Unknown providers fall back to the
+ * Anthropic shape — it degrades better (the XML reads as text to non-Claude
+ * models) than the function-call shape.
+ */
+export type ProviderFlavour = 'anthropic' | 'openai';
+
+/**
+ * Coerce a `ProviderId` into the flavour the adapter understands. Keeps the
+ * mapping explicit and testable — the raw id is free-form (`ProviderId =
+ * string`) so the caller shouldn't guess.
+ */
+export function providerFlavour(id: ProviderId | null | undefined): ProviderFlavour {
+  if (id === null || id === undefined) return 'anthropic';
+  const lower = String(id).toLowerCase();
+  if (lower.includes('openai')) return 'openai';
+  if (lower.includes('anthropic') || lower.includes('claude')) return 'anthropic';
+  // OpenAI-compatible endpoints often use names like `groq`, `together`,
+  // `mistral`, `ollama` — fall back to the OpenAI shape for those since they
+  // expose the same chat-completions contract.
+  if (
+    lower.includes('groq') ||
+    lower.includes('together') ||
+    lower.includes('mistral') ||
+    lower.includes('ollama') ||
+    lower.includes('deepseek') ||
+    lower.includes('gpt')
+  ) {
+    return 'openai';
+  }
+  return 'anthropic';
+}
+
+/**
+ * Serialize a list of resolved context blocks into a single string, shaped
+ * for the active provider. Returns an empty string when `blocks` is empty —
+ * callers can prepend the result unconditionally without needing a guard.
+ */
+export function adaptContextBlocks(
+  blocks: ContextBlock[],
+  provider: ProviderId | ProviderFlavour | null | undefined,
+): string {
+  if (blocks.length === 0) return '';
+  const flavour =
+    provider === 'anthropic' || provider === 'openai'
+      ? provider
+      : providerFlavour(provider);
+  const serialize = flavour === 'openai' ? toOpenAiFunctionContext : toAnthropicXml;
+  return blocks.map(serialize).join('\n');
+}

--- a/web/packages/ipc/src/index.ts
+++ b/web/packages/ipc/src/index.ts
@@ -28,3 +28,18 @@ export type { ToolCallId } from './generated/ToolCallId';
 export type { TreeKindDto } from './generated/TreeKindDto';
 export type { TreeNodeDto } from './generated/TreeNodeDto';
 export type { WorkspaceId } from './generated/WorkspaceId';
+
+// F-142: context-adapter lives in the IPC package so both the app's send-time
+// wiring and any future shell-side compactor share a single serialization
+// contract for `ContextBlock[]`.
+export {
+  adaptContextBlocks,
+  providerFlavour,
+  toAnthropicXml,
+  toOpenAiFunctionContext,
+} from './context-adapter';
+export type {
+  ContextBlock,
+  ContextBlockType,
+  ProviderFlavour,
+} from './context-adapter';


### PR DESCRIPTION
## Summary

Populates the ContextPicker (F-141) with live data and adapts resolved chips into provider-specific context blocks at send time.

- Seven resolver modules under `web/packages/app/src/context/` — `file`, `directory`, `selection`, `terminal`, `agent`, `skill`, `url` — each exporting `list(query)` and `resolve(ref)` with injected deps for testing.
- File/directory resolvers walk the F-122 `tree` IPC using the server-side cached workspace root; directory snapshots cap at 200 paths per spec.
- URL resolver honors an allowed-hosts list from settings; disallowed URLs raise a user-visible toast instead of fetching. Fetched bodies are truncated to 32 KiB.
- Provider adapter in `@forge/ipc` (`context-adapter.ts`) serializes `ContextBlock[]` as Anthropic XML tags or OpenAI function-context blocks based on the active provider.
- Lazy file-preview popover on `ContextChip` hover (read-only, clipped to 4 KiB).
- Composer fans out live picker items from the resolver registry as the query changes; chips are consumed on send and prepended to the user text as provider-shaped context.
- Minimal toast queue scaffolded; the on-screen renderer is a follow-up — the URL-host warning fires correctly and is observable by tests today.

## Spec / DoD

Closes #256 — satisfies every DoD item in the issue:
- [x] Seven resolver modules in the specified location
- [x] Each exports `list(query) -> Candidate[]` and `resolve(ref) -> ContextBlock`
- [x] URL resolver honors allowed-hosts; disallowed URL raises a toast
- [x] Provider adapter serializes for Anthropic and OpenAI
- [x] Lazy file preview on chip hover
- [x] Unit tests per resolver + adapter
- [x] CI gates pass (`just check-rust`, `just check-web`, `just test-rust`, `just test-web`)

## Test plan

- [x] `just check-rust` — fmt, clippy, rustdoc pass
- [x] `just check-web` — typecheck + token-drift gate pass
- [x] `just test-rust` — full Rust suite passes (no Rust changes; regression gate)
- [x] `just test-web` — 510 tests pass (47 files, +9 new test files, +1 integration test in ChatPane)

## Follow-ups (out of scope)

- `<ToastHost>` renderer to surface queued toasts visually (queue is wired).
- Server-side `session_send_message` boundary extension for structured `context_blocks` — today the adapter prepends a serialized string above the user text, which matches the current IPC surface.
- Real selection / terminal providers (EditorPane exposing live selection, TerminalPane exposing byte-buffer snapshot) — the resolvers accept injected closures so producers land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)