### PR TITLE
feat(forge-shell,web): activity bar + files sidebar + rename/delete IPC (F-126)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,6 +1189,7 @@ dependencies = [
  "criterion",
  "glob",
  "hex",
+ "ignore",
  "sha2",
  "similar",
  "tempfile",
@@ -1684,6 +1695,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2140,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/crates/forge-fs/Cargo.toml
+++ b/crates/forge-fs/Cargo.toml
@@ -7,6 +7,11 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 glob = "0.3"
 hex = "0.4"
+# F-126: gitignore-aware directory walking for the FilesSidebar. Respects
+# `.gitignore`, `.ignore`, global gitignore, and parent chains, matching the
+# behavior VS Code's file explorer has out of the box. The non-ignored
+# `list_tree` is retained for callers that want raw `read_dir` semantics.
+ignore = "0.4"
 sha2 = "0.10"
 similar = "2"
 tempfile = "3"

--- a/crates/forge-fs/src/lib.rs
+++ b/crates/forge-fs/src/lib.rs
@@ -8,8 +8,13 @@ mod limits;
 mod mutate;
 mod tree;
 pub use limits::Limits;
-pub use mutate::{edit, edit_preview, write, write_bytes, write_preview, ApprovalPreview, FsError};
-pub use tree::{list_tree, list_tree_with_limit, NodeKind, TreeNode, DEFAULT_MAX_ENTRIES};
+pub use mutate::{
+    delete, edit, edit_preview, rename, write, write_bytes, write_preview, ApprovalPreview, FsError,
+};
+pub use tree::{
+    list_tree, list_tree_gitignored, list_tree_gitignored_with_limit, list_tree_with_limit,
+    NodeKind, TreeNode, DEFAULT_MAX_ENTRIES,
+};
 
 /// Internal entry points exposed solely for the `benches/mutate.rs` allocation
 /// guard. Not part of the public API — do not depend on anything in here.

--- a/crates/forge-fs/src/mutate.rs
+++ b/crates/forge-fs/src/mutate.rs
@@ -165,6 +165,116 @@ pub fn write_bytes(
     Ok(())
 }
 
+/// F-126: atomically rename `from` to `to`, validating both paths against
+/// `allowed_paths`. Supports files and directories. Symlink rejection applies
+/// to both paths (via `canonicalize_no_symlink`) and the allowlist glob match
+/// is performed on both resolved canonical paths so a rename cannot relocate
+/// an entry outside the sandbox (or move an outside entry in).
+///
+/// `from` must exist; `to` must not exist, and its parent must be a directory
+/// — mirroring the same conservative policy as [`write()`]. Crossing
+/// filesystems is rejected with the platform's `std::fs::rename` error (we
+/// do not fall back to copy+delete — that would break atomicity and the
+/// approval audit trail).
+pub fn rename(
+    from: &str,
+    to: &str,
+    allowed_paths: &[String],
+    _limits: &Limits,
+) -> Result<(), FsError> {
+    let from_input = Path::new(from);
+    let to_input = Path::new(to);
+
+    // `from` must exist and canonicalize strictly — a rename of a
+    // not-yet-existing file is a bug at the caller, not a valid operation.
+    let canonical_from = canonicalize_no_symlink(from_input)?;
+    if !canonical_from.exists() {
+        return Err(FsError::TargetMissing {
+            path: canonical_from,
+        });
+    }
+    enforce_allowed(&canonical_from, allowed_paths)?;
+
+    // `to` uses the lenient canonicalizer (parent must exist, leaf may not).
+    let canonical_to = canonicalize_no_symlink(to_input)?;
+    enforce_allowed(&canonical_to, allowed_paths)?;
+
+    let parent = canonical_to
+        .parent()
+        .ok_or_else(|| FsError::ParentMissing {
+            path: canonical_to.clone(),
+        })?;
+    if !parent.is_dir() {
+        return Err(FsError::ParentMissing {
+            path: canonical_to.clone(),
+        });
+    }
+
+    // Refuse to clobber an existing destination. The UI-level rename action
+    // collects a fresh name up-front; if the user picks a colliding one the
+    // right behavior is to surface the error, not silently overwrite.
+    if canonical_to.exists() {
+        return Err(FsError::Io {
+            path: canonical_to.clone(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "rename destination already exists",
+            ),
+        });
+    }
+
+    std::fs::rename(&canonical_from, &canonical_to).map_err(|e| FsError::Io {
+        path: canonical_from,
+        source: e,
+    })
+}
+
+/// F-126: delete the entry at `path`. Files are removed via
+/// `std::fs::remove_file`; directories are removed recursively via
+/// `std::fs::remove_dir_all`. The FilesSidebar's context menu hits both, so
+/// branching on [`std::fs::FileType`] keeps the call site a single Tauri
+/// command.
+///
+/// Policy mirrors [`write()`]: `canonicalize_no_symlink` rejects any
+/// symlinked component along the path, and `enforce_allowed` glob-matches
+/// the canonical result against the caller's allowlist. `..` traversal is
+/// rejected by the canonicalization itself.
+///
+/// A compromised webview cannot delete outside its workspace, and a
+/// directory-delete cannot "escape" via a symlink inside the tree because
+/// `remove_dir_all` walks link targets by default — **BUT** we pre-reject
+/// symlinked path components so the walk begins inside the sandbox.
+pub fn delete(path: &str, allowed_paths: &[String], _limits: &Limits) -> Result<(), FsError> {
+    let input = Path::new(path);
+    let canonical = canonicalize_no_symlink(input)?;
+    enforce_allowed(&canonical, allowed_paths)?;
+
+    if !canonical.exists() {
+        return Err(FsError::TargetMissing { path: canonical });
+    }
+
+    let metadata = std::fs::symlink_metadata(&canonical).map_err(|e| FsError::Io {
+        path: canonical.clone(),
+        source: e,
+    })?;
+    if metadata.file_type().is_symlink() {
+        // Belt-and-braces: the canonicalize_no_symlink walk should have
+        // caught this, but leaf symlinks created via a race between check
+        // and delete are possible on slow filesystems. Refuse loudly.
+        return Err(FsError::SymlinkDenied { path: canonical });
+    }
+
+    let result = if metadata.is_dir() {
+        std::fs::remove_dir_all(&canonical)
+    } else {
+        std::fs::remove_file(&canonical)
+    };
+    result.map_err(|e| FsError::Io {
+        path: canonical,
+        source: e,
+    })
+}
+
 /// Apply a unified-diff `patch` to the file at `path` after validating the
 /// path. Rejects source files larger than `limits.max_read_bytes` before
 /// reading them into RAM, and delegates post-patch size enforcement to
@@ -438,5 +548,132 @@ mod tests {
     fn apply_unified_diff_rejects_non_patch_input() {
         let err = apply_unified_diff("a\n", "garbage\n").unwrap_err();
         assert!(matches!(err, FsError::MalformedPatch { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // F-126: rename / delete tests
+    // -----------------------------------------------------------------------
+
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn allow(root: &std::path::Path) -> Vec<String> {
+        let base = fs::canonicalize(root).unwrap();
+        vec![format!("{}/**", base.display()), base.display().to_string()]
+    }
+
+    #[test]
+    fn rename_moves_file_within_allowlist() {
+        let tmp = TempDir::new().unwrap();
+        let from = tmp.path().join("a.txt");
+        let to = tmp.path().join("b.txt");
+        fs::write(&from, "hi").unwrap();
+
+        rename(
+            from.to_str().unwrap(),
+            to.to_str().unwrap(),
+            &allow(tmp.path()),
+            &Limits::default(),
+        )
+        .expect("rename must succeed");
+        assert!(!from.exists());
+        assert_eq!(fs::read_to_string(&to).unwrap(), "hi");
+    }
+
+    #[test]
+    fn rename_rejects_destination_outside_allowlist() {
+        let workspace = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let from = workspace.path().join("a.txt");
+        fs::write(&from, "hi").unwrap();
+        let to = outside.path().join("exfil.txt");
+
+        let err = rename(
+            from.to_str().unwrap(),
+            to.to_str().unwrap(),
+            &allow(workspace.path()),
+            &Limits::default(),
+        )
+        .expect_err("rename outside allowlist must fail");
+        assert!(matches!(err, FsError::PathDenied { .. }));
+        assert!(from.exists(), "from must not have been moved");
+    }
+
+    #[test]
+    fn rename_refuses_to_clobber_existing() {
+        let tmp = TempDir::new().unwrap();
+        let from = tmp.path().join("a.txt");
+        let to = tmp.path().join("b.txt");
+        fs::write(&from, "one").unwrap();
+        fs::write(&to, "two").unwrap();
+
+        let err = rename(
+            from.to_str().unwrap(),
+            to.to_str().unwrap(),
+            &allow(tmp.path()),
+            &Limits::default(),
+        )
+        .expect_err("rename over existing must fail");
+        assert!(matches!(err, FsError::Io { .. }));
+        assert_eq!(fs::read_to_string(&to).unwrap(), "two");
+    }
+
+    #[test]
+    fn delete_removes_file_within_allowlist() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("a.txt");
+        fs::write(&target, "hi").unwrap();
+        delete(
+            target.to_str().unwrap(),
+            &allow(tmp.path()),
+            &Limits::default(),
+        )
+        .expect("delete must succeed");
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn delete_removes_directory_recursively() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("sub");
+        fs::create_dir(&dir).unwrap();
+        fs::write(dir.join("inner.txt"), "x").unwrap();
+        delete(
+            dir.to_str().unwrap(),
+            &allow(tmp.path()),
+            &Limits::default(),
+        )
+        .expect("recursive delete must succeed");
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn delete_rejects_path_outside_allowlist() {
+        let workspace = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let victim = outside.path().join("keep.txt");
+        fs::write(&victim, "important").unwrap();
+
+        let err = delete(
+            victim.to_str().unwrap(),
+            &allow(workspace.path()),
+            &Limits::default(),
+        )
+        .expect_err("delete outside allowlist must fail");
+        assert!(matches!(err, FsError::PathDenied { .. }));
+        assert!(victim.exists(), "victim must not be deleted");
+    }
+
+    #[test]
+    fn delete_missing_target_returns_target_missing() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("ghost.txt");
+        let err = delete(
+            missing.to_str().unwrap(),
+            &allow(tmp.path()),
+            &Limits::default(),
+        )
+        .expect_err("missing target must error");
+        assert!(matches!(err, FsError::TargetMissing { .. }));
     }
 }

--- a/crates/forge-fs/src/tree.rs
+++ b/crates/forge-fs/src/tree.rs
@@ -110,6 +110,152 @@ pub fn list_tree_with_limit(
     Ok(root_node)
 }
 
+/// F-126: `list_tree` variant that honors `.gitignore`, `.ignore`, global
+/// gitignore and parent `.gitignore` files via the `ignore` crate. Hidden
+/// files (`.git/`, dotfiles) are skipped — matching VS Code's files sidebar
+/// defaults. The non-ignored [`list_tree`] is retained for callers that want
+/// raw `read_dir` semantics (e.g. agent `fs.tree` tool calls that may need
+/// to show gitignored files for debugging).
+///
+/// The allowlist and entry-budget / depth-cap contracts are identical to
+/// [`list_tree`]. Symlinks are reported as leaves and never recursed into
+/// (the `ignore` crate has `follow_links(false)` by default, which we rely
+/// on for sandbox safety).
+pub fn list_tree_gitignored(
+    root: &str,
+    allowed_paths: &[String],
+    max_depth: u32,
+) -> Result<TreeNode, FsError> {
+    list_tree_gitignored_with_limit(root, allowed_paths, max_depth, DEFAULT_MAX_ENTRIES)
+}
+
+/// As [`list_tree_gitignored`] but with a caller-chosen entry cap.
+pub fn list_tree_gitignored_with_limit(
+    root: &str,
+    allowed_paths: &[String],
+    max_depth: u32,
+    max_entries: usize,
+) -> Result<TreeNode, FsError> {
+    let canonical = std::fs::canonicalize(root).map_err(|e| FsError::Io {
+        path: PathBuf::from(root),
+        source: e,
+    })?;
+    enforce_allowed(&canonical, allowed_paths)?;
+
+    let name = canonical
+        .file_name()
+        .map(|o| o.to_string_lossy().into_owned())
+        .unwrap_or_else(|| canonical.to_string_lossy().into_owned());
+
+    if !canonical.is_dir() {
+        return Ok(TreeNode {
+            name,
+            kind: classify(&canonical),
+            path: canonical,
+            children: None,
+        });
+    }
+
+    // Bridge `ignore::Walk`'s flat stream into our recursive `TreeNode` shape.
+    // We keep a per-directory bucket keyed by the canonical parent path so
+    // each entry slots into its parent's `children` vec as we see it. `Walk`
+    // yields parents before children when `max_depth` is set, so the first
+    // time a child lands its parent already exists in the map.
+    use std::collections::HashMap;
+
+    let mut builder = ignore::WalkBuilder::new(&canonical);
+    // max_depth on `ignore::WalkBuilder` counts from the root as depth 0
+    // (root itself), which matches `list_tree`'s contract.
+    builder
+        .max_depth(Some(max_depth as usize))
+        .follow_links(false)
+        .hidden(true)
+        .git_global(true)
+        .git_ignore(true)
+        .git_exclude(true)
+        .parents(true)
+        .require_git(false);
+
+    let mut buckets: HashMap<PathBuf, Vec<TreeNode>> = HashMap::new();
+    buckets.insert(canonical.clone(), Vec::new());
+    let mut seen_entries: usize = 0;
+
+    for entry in builder.build() {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let entry_path = entry.path().to_path_buf();
+        if entry_path == canonical {
+            continue;
+        }
+        if seen_entries >= max_entries {
+            break;
+        }
+        seen_entries += 1;
+
+        let file_type = entry.file_type();
+        let kind = match file_type {
+            Some(ft) if ft.is_symlink() => NodeKind::Symlink,
+            Some(ft) if ft.is_dir() => NodeKind::Dir,
+            Some(ft) if ft.is_file() => NodeKind::File,
+            _ => NodeKind::Other,
+        };
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let node = TreeNode {
+            name,
+            path: entry_path.clone(),
+            kind,
+            children: if matches!(kind, NodeKind::Dir) {
+                Some(Vec::new())
+            } else {
+                None
+            },
+        };
+        if matches!(kind, NodeKind::Dir) {
+            // `entry(_).or_insert_with(Vec::new)` is intentional over `.insert`:
+            // if the walker ever yields a child before its parent (parallel
+            // mode, future `ignore` changes, or edge cases with parent
+            // `.gitignore` traversal), the earlier children already live in
+            // `buckets[entry_path]`. A blind `.insert` would overwrite and
+            // silently lose them; the entry-API preserves them.
+            buckets.entry(entry_path.clone()).or_default();
+        }
+        let parent = entry_path
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| canonical.clone());
+        buckets.entry(parent).or_default().push(node);
+    }
+
+    // Second pass: hoist each directory's bucket into its own `children`
+    // vec. Walk depth-first from the root; sort children by lowercase name
+    // for stable output matching `walk_dir`.
+    fn assemble(
+        node: TreeNode,
+        buckets: &mut std::collections::HashMap<PathBuf, Vec<TreeNode>>,
+    ) -> TreeNode {
+        if !matches!(node.kind, NodeKind::Dir) {
+            return node;
+        }
+        let mut children = buckets.remove(&node.path).unwrap_or_default();
+        children.sort_by_key(|c| c.name.to_lowercase());
+        let assembled = children.into_iter().map(|c| assemble(c, buckets)).collect();
+        TreeNode {
+            children: Some(assembled),
+            ..node
+        }
+    }
+
+    let root_node = TreeNode {
+        name,
+        path: canonical.clone(),
+        kind: NodeKind::Dir,
+        children: Some(Vec::new()),
+    };
+    Ok(assemble(root_node, &mut buckets))
+}
+
 /// Walk a single directory, recursing into subdirectories while
 /// `remaining_depth > 0`. Budget is decremented per emitted node. Symlinks
 /// appear as leaves and are never recursed into.
@@ -274,5 +420,89 @@ mod tests {
         let err = list_tree(missing.to_str().unwrap(), &allow(tmp.path()), 4)
             .expect_err("missing path is an Io error");
         assert!(matches!(err, FsError::Io { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // F-126: gitignore-aware walker
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn gitignored_walker_excludes_ignored_paths() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join(".gitignore"),
+            "node_modules/\nbuild/\n*.log\n",
+        )
+        .unwrap();
+        fs::write(tmp.path().join("app.ts"), "").unwrap();
+        fs::write(tmp.path().join("keep.md"), "").unwrap();
+        fs::write(tmp.path().join("debug.log"), "").unwrap();
+        fs::create_dir(tmp.path().join("node_modules")).unwrap();
+        fs::write(tmp.path().join("node_modules/junk.js"), "").unwrap();
+        fs::create_dir(tmp.path().join("build")).unwrap();
+        fs::write(tmp.path().join("build/out.o"), "").unwrap();
+
+        let tree = list_tree_gitignored(tmp.path().to_str().unwrap(), &allow(tmp.path()), 4)
+            .expect("gitignored walk ok");
+        let children = tree.children.expect("root has children");
+        let names: Vec<_> = children.iter().map(|n| n.name.as_str()).collect();
+        // .gitignore itself is hidden (starts with dot) so it's excluded by
+        // the `hidden(true)` default, matching VS Code's default. `debug.log`
+        // and `node_modules` and `build` must all be excluded.
+        assert!(
+            names.contains(&"app.ts"),
+            "app.ts must be present: {names:?}"
+        );
+        assert!(
+            names.contains(&"keep.md"),
+            "keep.md must be present: {names:?}"
+        );
+        assert!(
+            !names.contains(&"debug.log"),
+            "*.log must be excluded: {names:?}"
+        );
+        assert!(
+            !names.contains(&"node_modules"),
+            "node_modules/ must be excluded: {names:?}"
+        );
+        assert!(
+            !names.contains(&"build"),
+            "build/ must be excluded: {names:?}"
+        );
+    }
+
+    #[test]
+    fn gitignored_walker_denies_paths_outside_allowlist() {
+        let tmp = TempDir::new().unwrap();
+        let other = TempDir::new().unwrap();
+        let err = list_tree_gitignored(other.path().to_str().unwrap(), &allow(tmp.path()), 4)
+            .expect_err("must deny out-of-allowlist root");
+        assert!(matches!(err, FsError::PathDenied { .. }));
+    }
+
+    #[test]
+    fn gitignored_walker_lists_nested_dirs() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), "ignored.txt\n").unwrap();
+        fs::create_dir(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "").unwrap();
+        fs::write(tmp.path().join("ignored.txt"), "").unwrap();
+
+        let tree = list_tree_gitignored(tmp.path().to_str().unwrap(), &allow(tmp.path()), 4)
+            .expect("walk ok");
+        let children = tree.children.expect("has children");
+        let src = children
+            .iter()
+            .find(|n| n.name == "src")
+            .expect("src dir present");
+        assert_eq!(src.kind, NodeKind::Dir);
+        let src_children = src.children.as_ref().unwrap();
+        assert_eq!(src_children.len(), 1);
+        assert_eq!(src_children[0].name, "main.rs");
+        let names: Vec<_> = children.iter().map(|n| n.name.as_str()).collect();
+        assert!(
+            !names.contains(&"ignored.txt"),
+            "ignored.txt must be excluded: {names:?}"
+        );
     }
 }

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -390,6 +390,8 @@ pub fn build_invoke_handler<R: Runtime>() -> Box<dyn Fn(tauri::ipc::Invoke<R>) -
         lsp_start,
         lsp_stop,
         lsp_send,
+        rename_path,
+        delete_path,
     ])
 }
 
@@ -1374,7 +1376,14 @@ pub async fn tree<R: Runtime>(
     // workspaces Forge targets; the entry budget inside `forge-fs` is the
     // second line of defense.
     let requested = depth.unwrap_or(6).min(16);
-    let node = forge_fs::list_tree(&root, &allowed, requested).map_err(|e| e.to_string())?;
+    // F-126: the FilesSidebar uses `tree` to render the workspace; honor
+    // `.gitignore` (plus `.ignore`, global gitignore, parent chains, and
+    // hidden files) via the `ignore` crate so the sidebar matches what a
+    // developer sees in VS Code. The non-ignored `list_tree` is retained
+    // in `forge-fs` for other callers (e.g. agent tool paths that may need
+    // to inspect gitignored files).
+    let node =
+        forge_fs::list_tree_gitignored(&root, &allowed, requested).map_err(|e| e.to_string())?;
     Ok(TreeNodeDto::from(node))
 }
 
@@ -1633,4 +1642,68 @@ pub async fn lsp_send<R: Runtime>(
     let caller_label = webview.label().to_string();
     let transport = state.owned_transport(&server, &caller_label)?;
     transport.send(message).await.map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// F-126: filesystem mutation commands for the FilesSidebar context menu.
+//
+// `rename_path` and `delete_path` are siblings of F-122's `read_file` /
+// `write_file` / `tree`. They inherit the same authz + sandbox posture:
+//
+// 1. Session-scoped `require_window_label` gate — the FilesSidebar only
+//    renders inside a session window.
+// 2. Server-side cached `workspace_root` lookup (via `cached_workspace_root`,
+//    the same helper F-122's commands use). The webview does NOT supply a
+//    `workspace_root` parameter — a lying webview cannot widen its sandbox.
+// 3. Path sandbox enforced by `forge-fs::rename` / `forge-fs::delete`, which
+//    glob-match canonicalized inputs against the workspace allowlist.
+//
+// Appended at EOF per the concurrent-worktree convention (F-137 / F-144 are
+// touching adjacent code simultaneously; keeping new additions at the bottom
+// minimizes rebase conflicts).
+// ---------------------------------------------------------------------------
+
+/// Rename / move `from` → `to` inside the session's workspace. Both paths
+/// go through the `forge-fs` allowlist; a rename that would move an entry
+/// outside the workspace (or move an outside entry in) is rejected with a
+/// path-denied error.
+///
+/// Clobbering an existing destination is refused — the UI collects a fresh
+/// name up-front, and a silent overwrite would break the audit trail.
+#[tauri::command]
+pub async fn rename_path<R: Runtime>(
+    session_id: String,
+    from: String,
+    to: String,
+    webview: Webview<R>,
+    state: State<'_, BridgeState>,
+) -> Result<(), String> {
+    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_size("from", &from, MAX_FS_PATH_BYTES)?;
+    require_size("to", &to, MAX_FS_PATH_BYTES)?;
+
+    let workspace = cached_workspace_root(&state, &session_id).await?;
+    let allowed = workspace_allowlist(&workspace);
+    let limits = forge_fs::Limits::default();
+    forge_fs::rename(&from, &to, &allowed, &limits).map_err(|e| e.to_string())
+}
+
+/// Delete the entry at `path` inside the session's workspace. Files are
+/// removed via `remove_file`; directories are removed recursively via
+/// `remove_dir_all`. Symlinked path components are rejected before any
+/// filesystem mutation happens.
+#[tauri::command]
+pub async fn delete_path<R: Runtime>(
+    session_id: String,
+    path: String,
+    webview: Webview<R>,
+    state: State<'_, BridgeState>,
+) -> Result<(), String> {
+    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_size("path", &path, MAX_FS_PATH_BYTES)?;
+
+    let workspace = cached_workspace_root(&state, &session_id).await?;
+    let allowed = workspace_allowlist(&workspace);
+    let limits = forge_fs::Limits::default();
+    forge_fs::delete(&path, &allowed, &limits).map_err(|e| e.to_string())
 }

--- a/crates/forge-shell/tests/ipc_fs.rs
+++ b/crates/forge-shell/tests/ipc_fs.rs
@@ -465,3 +465,226 @@ async fn tree_rejects_mismatched_session_label() {
         "cross-session invoke must be rejected, got: {err}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tree_excludes_gitignored_entries() {
+    let workspace = TempDir::new().unwrap();
+    let canonical_ws = fs::canonicalize(workspace.path()).unwrap();
+    fs::write(canonical_ws.join(".gitignore"), "node_modules/\n*.log\n").unwrap();
+    fs::write(canonical_ws.join("app.ts"), "").unwrap();
+    fs::write(canonical_ws.join("err.log"), "leak").unwrap();
+    fs::create_dir(canonical_ws.join("node_modules")).unwrap();
+    fs::write(canonical_ws.join("node_modules/pkg.js"), "").unwrap();
+
+    let (app, _conn) = make_app_with_workspace(workspace.path(), TEST_SESSION).await;
+    let window = make_session_window(&app, TEST_SESSION);
+
+    let result = invoke_ok(
+        &window,
+        "tree",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "root": canonical_ws,
+            "depth": 4,
+        }),
+    );
+    let children = result["children"].as_array().expect("children array");
+    let names: Vec<&str> = children
+        .iter()
+        .map(|n| n["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"app.ts"), "app.ts must remain: {names:?}");
+    assert!(
+        !names.contains(&"err.log"),
+        "*.log must be excluded from sidebar tree: {names:?}"
+    );
+    assert!(
+        !names.contains(&"node_modules"),
+        "node_modules/ must be excluded: {names:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// rename_path (F-126)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rename_path_moves_file_within_workspace() {
+    let workspace = TempDir::new().unwrap();
+    let canonical_ws = fs::canonicalize(workspace.path()).unwrap();
+    let from = canonical_ws.join("old.txt");
+    let to = canonical_ws.join("new.txt");
+    fs::write(&from, "contents").unwrap();
+
+    let (app, _conn) = make_app_with_workspace(workspace.path(), TEST_SESSION).await;
+    let window = make_session_window(&app, TEST_SESSION);
+
+    invoke_ok(
+        &window,
+        "rename_path",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "from": from,
+            "to": to,
+        }),
+    );
+    assert!(!from.exists());
+    assert_eq!(fs::read_to_string(&to).unwrap(), "contents");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rename_path_rejects_destination_outside_workspace() {
+    let workspace = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let canonical_ws = fs::canonicalize(workspace.path()).unwrap();
+    let canonical_outside = fs::canonicalize(outside.path()).unwrap();
+    let from = canonical_ws.join("inside.txt");
+    let to = canonical_outside.join("escape.txt");
+    fs::write(&from, "x").unwrap();
+
+    let (app, _conn) = make_app_with_workspace(workspace.path(), TEST_SESSION).await;
+    let window = make_session_window(&app, TEST_SESSION);
+
+    let err = invoke_err(
+        &window,
+        "rename_path",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "from": from,
+            "to": to,
+        }),
+    );
+    assert!(
+        err.contains("not allowed") || err.contains("PathDenied"),
+        "must reject out-of-workspace destination: {err}"
+    );
+    assert!(from.exists(), "source must remain when rename denied");
+    assert!(!to.exists(), "destination must not be created on denial");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rename_path_rejects_dashboard_window() {
+    let workspace = TempDir::new().unwrap();
+    let canonical_ws = fs::canonicalize(workspace.path()).unwrap();
+    let from = canonical_ws.join("a.txt");
+    let to = canonical_ws.join("b.txt");
+    fs::write(&from, "x").unwrap();
+
+    let (app, _conn) = make_app_with_workspace(workspace.path(), TEST_SESSION).await;
+    let window = make_dashboard_window(&app);
+
+    let err = invoke_err(
+        &window,
+        "rename_path",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "from": from,
+            "to": to,
+        }),
+    );
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "dashboard must not invoke rename_path: {err}"
+    );
+    assert!(from.exists(), "source must remain");
+}
+
+// ---------------------------------------------------------------------------
+// delete_path (F-126)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_path_removes_file_inside_workspace() {
+    let workspace = TempDir::new().unwrap();
+    let canonical_ws = fs::canonicalize(workspace.path()).unwrap();
+    let target = canonical_ws.join("doomed.txt");
+    fs::write(&target, "x").unwrap();
+
+    let (app, _conn) = make_app_with_workspace(workspace.path(), TEST_SESSION).await;
+    let window = make_session_window(&app, TEST_SESSION);
+
+    invoke_ok(
+        &window,
+        "delete_path",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "path": target,
+        }),
+    );
+    assert!(!target.exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_path_rejects_paths_outside_workspace() {
+    let workspace = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let canonical_outside = fs::canonicalize(outside.path()).unwrap();
+    let victim = canonical_outside.join("keep.txt");
+    fs::write(&victim, "important").unwrap();
+
+    let (app, _conn) = make_app_with_workspace(workspace.path(), TEST_SESSION).await;
+    let window = make_session_window(&app, TEST_SESSION);
+
+    let err = invoke_err(
+        &window,
+        "delete_path",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "path": victim,
+        }),
+    );
+    assert!(
+        err.contains("not allowed") || err.contains("PathDenied"),
+        "must reject out-of-workspace path: {err}"
+    );
+    assert!(victim.exists(), "victim must remain when delete denied");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_path_rejects_dashboard_window() {
+    let workspace = TempDir::new().unwrap();
+    let canonical_ws = fs::canonicalize(workspace.path()).unwrap();
+    let target = canonical_ws.join("forbidden.txt");
+    fs::write(&target, "x").unwrap();
+
+    let (app, _conn) = make_app_with_workspace(workspace.path(), TEST_SESSION).await;
+    let window = make_dashboard_window(&app);
+
+    let err = invoke_err(
+        &window,
+        "delete_path",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "path": target,
+        }),
+    );
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "dashboard must not invoke delete_path: {err}"
+    );
+    assert!(target.exists(), "target must remain");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_path_returns_not_connected_when_cache_is_empty() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("hi.txt");
+    fs::write(&file, "hi").unwrap();
+
+    let app = make_app_empty_cache();
+    let window = make_session_window(&app, TEST_SESSION);
+
+    let err = invoke_err(
+        &window,
+        "delete_path",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "path": file,
+        }),
+    );
+    assert!(
+        err.contains("not connected") && err.contains("session_hello"),
+        "expected 'not connected' error, got: {err}"
+    );
+    assert!(file.exists(), "file must remain on not-connected");
+}

--- a/web/packages/app/src/ipc/fs.ts
+++ b/web/packages/app/src/ipc/fs.ts
@@ -68,3 +68,37 @@ export async function tree(
     depth,
   });
 }
+
+/**
+ * F-126: atomically rename / move `from` → `to`. Both paths must resolve
+ * inside the session's cached workspace root; the shell-side `forge-fs`
+ * allowlist rejects any out-of-sandbox path. The webview does NOT pass
+ * `workspace_root` — same server-side-cache security model as F-122's
+ * `read_file` / `write_file` / `tree`.
+ */
+export async function renamePath(
+  sessionId: SessionId,
+  from: string,
+  to: string,
+): Promise<void> {
+  await invoke('rename_path', {
+    sessionId,
+    from,
+    to,
+  });
+}
+
+/**
+ * F-126: delete the entry at `path`. Files are removed via `remove_file`;
+ * directories are removed recursively via `remove_dir_all`. Symlink
+ * components are rejected before any filesystem mutation.
+ */
+export async function deletePath(
+  sessionId: SessionId,
+  path: string,
+): Promise<void> {
+  await invoke('delete_path', {
+    sessionId,
+    path,
+  });
+}

--- a/web/packages/app/src/routes/Session/SessionWindow.css
+++ b/web/packages/app/src/routes/Session/SessionWindow.css
@@ -7,6 +7,13 @@
   font-family: var(--font-body);
 }
 
+/* F-126: chrome row — activity bar + optional sidebar + main pane column. */
+.session-window__chrome {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .session-window__pane {
   display: flex;
   flex-direction: column;

--- a/web/packages/app/src/routes/Session/SessionWindow.test.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.test.tsx
@@ -50,6 +50,16 @@ describe('SessionWindow', () => {
     resetMessagesStore();
     invokeMock.mockImplementation(async (cmd: string) => {
       if (cmd === 'session_hello') return helloAck;
+      // F-126: the FilesSidebar calls `tree` when the sidebar opens; return
+      // a minimal empty-root shape so the component mounts cleanly.
+      if (cmd === 'tree') {
+        return {
+          name: 'ws',
+          path: '/ws',
+          kind: 'Dir',
+          children: [],
+        };
+      }
       return undefined;
     });
     setInvokeForTesting(invokeMock as never);
@@ -213,5 +223,59 @@ describe('SessionWindow', () => {
 
     const list = await findByTestId('message-list');
     await waitFor(() => expect(list.textContent).toContain('hello from the wire'));
+  });
+
+  // -----------------------------------------------------------------------
+  // F-126: activity bar + files sidebar
+  // -----------------------------------------------------------------------
+
+  it('renders the activity bar alongside the pane', async () => {
+    const { findByTestId } = renderAt('/session/abc123');
+    const bar = await findByTestId('activity-bar');
+    expect(bar).toBeInTheDocument();
+    expect(await findByTestId('activity-bar-files')).toBeInTheDocument();
+  });
+
+  it('keeps the files sidebar hidden by default', async () => {
+    const { findByTestId, queryByTestId } = renderAt('/session/abc123');
+    await findByTestId('activity-bar');
+    expect(queryByTestId('files-sidebar')).toBeNull();
+  });
+
+  it('toggles the files sidebar when Cmd+Shift+E fires after the workspace is known', async () => {
+    const { findByTestId, queryByTestId } = renderAt('/session/abc123');
+    // Wait for session_hello → activeWorkspaceRoot populated, and the
+    // activity bar rendered.
+    await findByTestId('activity-bar');
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('session_hello', {
+        sessionId: 'abc123',
+      }),
+    );
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'E', metaKey: true, shiftKey: true }),
+    );
+    await findByTestId('files-sidebar');
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'E', metaKey: true, shiftKey: true }),
+    );
+    await waitFor(() => expect(queryByTestId('files-sidebar')).toBeNull());
+  });
+
+  it('toggles the files sidebar when the activity bar Files button is clicked', async () => {
+    const { findByTestId, queryByTestId } = renderAt('/session/abc123');
+    await findByTestId('activity-bar');
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('session_hello', {
+        sessionId: 'abc123',
+      }),
+    );
+    const files = await findByTestId('activity-bar-files');
+    files.click();
+    await findByTestId('files-sidebar');
+    files.click();
+    await waitFor(() => expect(queryByTestId('files-sidebar')).toBeNull());
   });
 });

--- a/web/packages/app/src/routes/Session/SessionWindow.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.tsx
@@ -1,4 +1,4 @@
-import { type Component, createSignal, onCleanup, onMount } from 'solid-js';
+import { type Component, Show, createSignal, onCleanup, onMount } from 'solid-js';
 import { useParams } from '@solidjs/router';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import type { ProviderId, SessionId } from '@forge/ipc';
@@ -9,6 +9,7 @@ import {
   sessionSubscribe,
 } from '../../ipc/session';
 import {
+  activeWorkspaceRoot,
   setActiveSessionId,
   setActiveWorkspaceRoot,
   setSessionEvents,
@@ -20,6 +21,8 @@ import { seedPersistentApprovals } from '../../stores/approvals';
 import { PaneHeader } from './PaneHeader';
 import { ChatPane } from './ChatPane';
 import { usePaneWidth } from '../../layout/usePaneWidth';
+import { ActivityBar, type ActivityId } from '../../shell/ActivityBar';
+import { FilesSidebar } from '../../shell/FilesSidebar';
 import './SessionWindow.css';
 
 /**
@@ -118,25 +121,78 @@ export const SessionWindow: Component = () => {
   const [paneEl, setPaneEl] = createSignal<HTMLElement | null>(null);
   const { compactness } = usePaneWidth(paneEl);
 
+  // F-126: activity-bar + files-sidebar chrome. `activeActivity` is `null`
+  // when the sidebar is hidden (default) and an activity id when visible.
+  // `Cmd/Ctrl+Shift+E` toggles the files sidebar without routing through
+  // the activity bar click handler so the shortcut works even when the
+  // activity bar is keyboard-focused elsewhere.
+  const [activeActivity, setActiveActivity] = createSignal<ActivityId | null>(null);
+
+  const toggleFiles = (): void => {
+    setActiveActivity((prev) => (prev === 'files' ? null : 'files'));
+  };
+
+  const onActivitySelect = (id: ActivityId): void => {
+    // Only 'files' is wired in F-126. Search/Git are placeholders.
+    if (id !== 'files') return;
+    toggleFiles();
+  };
+
+  const onShortcut = (e: KeyboardEvent): void => {
+    // Cmd/Ctrl+Shift+E toggles the files sidebar. Match Mac's `Meta` and
+    // Windows/Linux `Ctrl` on the same binding, matching the issue's
+    // platform-agnostic spec.
+    const mod = e.metaKey || e.ctrlKey;
+    if (mod && e.shiftKey && (e.key === 'E' || e.key === 'e')) {
+      e.preventDefault();
+      toggleFiles();
+    }
+  };
+
+  onMount(() => {
+    window.addEventListener('keydown', onShortcut);
+  });
+  onCleanup(() => {
+    window.removeEventListener('keydown', onShortcut);
+  });
+
   return (
     <main class="session-window">
-      <section
-        class="session-window__pane"
-        aria-label="Session pane"
-        ref={setPaneEl}
-      >
-        <PaneHeader
-          subject={subject()}
-          providerId={providerId()}
-          providerLabel={providerLabel()}
-          costLabel={costLabel()}
-          compactness={compactness()}
-          onClose={handleClose}
+      <div class="session-window__chrome">
+        <ActivityBar
+          active={activeActivity()}
+          onSelect={onActivitySelect}
         />
-        <div class="session-window__pane-body">
-          <ChatPane />
-        </div>
-      </section>
+        <Show when={activeActivity() === 'files' && activeWorkspaceRoot() !== null}>
+          <FilesSidebar
+            sessionId={sessionId()}
+            workspaceRoot={activeWorkspaceRoot() as string}
+            onOpen={(_path) => {
+              // F-126 scope lands the wiring; F-126+ will route through the
+              // layout store to open an EditorPane in the main area. For
+              // now we close the sidebar to signal the action registered.
+              setActiveActivity(null);
+            }}
+          />
+        </Show>
+        <section
+          class="session-window__pane"
+          aria-label="Session pane"
+          ref={setPaneEl}
+        >
+          <PaneHeader
+            subject={subject()}
+            providerId={providerId()}
+            providerLabel={providerLabel()}
+            costLabel={costLabel()}
+            compactness={compactness()}
+            onClose={handleClose}
+          />
+          <div class="session-window__pane-body">
+            <ChatPane />
+          </div>
+        </section>
+      </div>
     </main>
   );
 };

--- a/web/packages/app/src/shell/ActivityBar.css
+++ b/web/packages/app/src/shell/ActivityBar.css
@@ -1,0 +1,61 @@
+/* F-126: 44px activity bar chrome per docs/ui-specs/shell.md §2. */
+
+.activity-bar {
+  display: flex;
+  flex-direction: column;
+  width: 44px;
+  flex: 0 0 44px;
+  background: var(--color-surface-0, #0d0d0d);
+  border-right: 1px solid var(--color-border-1, #1f1f1f);
+  padding: 6px 0;
+  gap: 2px;
+  align-items: stretch;
+}
+
+.activity-bar__item {
+  all: unset;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  cursor: pointer;
+  color: var(--color-text-tertiary, #888);
+  position: relative;
+  transition: color 80ms linear, background 80ms linear;
+}
+
+.activity-bar__item:hover:not(:disabled) {
+  color: var(--color-text-primary, #eee);
+  background: var(--color-surface-1, #161616);
+}
+
+.activity-bar__item:focus-visible {
+  outline: 2px solid var(--color-accent-ember, #ff4a12);
+  outline-offset: -2px;
+}
+
+.activity-bar__item:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.activity-bar__item--active {
+  color: var(--color-text-primary, #eee);
+}
+
+/* Active marker on the left edge, per the VS Code-style activity bar. */
+.activity-bar__item--active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--color-accent-ember, #ff4a12);
+}
+
+.activity-bar__icon {
+  width: 20px;
+  height: 20px;
+}

--- a/web/packages/app/src/shell/ActivityBar.test.tsx
+++ b/web/packages/app/src/shell/ActivityBar.test.tsx
@@ -1,0 +1,66 @@
+// F-126: ActivityBar render + click behavior.
+//
+// The bar is purely presentational — it emits `onSelect` for enabled items
+// and respects the `active` prop for visual state. Placeholder items
+// (search, git) must render but not invoke `onSelect` so the chrome is
+// visually complete before F-127/F-128 wire them up.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@solidjs/testing-library';
+import { ActivityBar } from './ActivityBar';
+
+afterEach(() => cleanup());
+
+describe('ActivityBar', () => {
+  it('renders files, search, git buttons with accessible labels', () => {
+    const { getByTestId } = render(() => (
+      <ActivityBar active="files" onSelect={vi.fn()} />
+    ));
+    expect(getByTestId('activity-bar-files')).toBeInTheDocument();
+    expect(getByTestId('activity-bar-search')).toBeInTheDocument();
+    expect(getByTestId('activity-bar-git')).toBeInTheDocument();
+  });
+
+  it('marks the active item with aria-pressed=true', () => {
+    const { getByTestId } = render(() => (
+      <ActivityBar active="files" onSelect={vi.fn()} />
+    ));
+    expect(getByTestId('activity-bar-files').getAttribute('aria-pressed')).toBe('true');
+    expect(getByTestId('activity-bar-search').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('invokes onSelect when the Files button is clicked', () => {
+    const onSelect = vi.fn();
+    const { getByTestId } = render(() => (
+      <ActivityBar active={null} onSelect={onSelect} />
+    ));
+    fireEvent.click(getByTestId('activity-bar-files'));
+    expect(onSelect).toHaveBeenCalledWith('files');
+  });
+
+  it('disables the search and git placeholders', () => {
+    const onSelect = vi.fn();
+    const { getByTestId } = render(() => (
+      <ActivityBar active={null} onSelect={onSelect} />
+    ));
+    const search = getByTestId('activity-bar-search') as HTMLButtonElement;
+    const git = getByTestId('activity-bar-git') as HTMLButtonElement;
+    expect(search.disabled).toBe(true);
+    expect(git.disabled).toBe(true);
+    // Disabled buttons should not fire click handlers even if the user
+    // manages to trigger them programmatically — browsers already enforce
+    // this, the assertion below is belt-and-braces.
+    fireEvent.click(search);
+    fireEvent.click(git);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('shows the Files shortcut in the button tooltip', () => {
+    const { getByTestId } = render(() => (
+      <ActivityBar active={null} onSelect={vi.fn()} />
+    ));
+    const title = getByTestId('activity-bar-files').getAttribute('title') ?? '';
+    expect(title.toLowerCase()).toContain('shift');
+    expect(title.toLowerCase()).toContain('e');
+  });
+});

--- a/web/packages/app/src/shell/ActivityBar.tsx
+++ b/web/packages/app/src/shell/ActivityBar.tsx
@@ -1,0 +1,106 @@
+// F-126: 44px left-edge activity bar. Per `docs/ui-specs/shell.md` §2 the
+// bar hosts a vertical stack of icon buttons that toggle activity-bar
+// content in the adjacent sidebar slot. `shell.md` only extracts §2; the
+// finer §2.1 icon-set is not yet copied into the repo, so for this landing
+// we render three buttons — Files (active), Search, Git — with the latter
+// two as visible-but-disabled placeholders. F-127/F-128 will wire Search
+// and Git to their own sidebars.
+//
+// The component is a controlled visual — it emits `onSelect(activity)` and
+// accepts `active` from the parent. The parent (SessionWindow) owns the
+// sidebar-visibility signal so a keyboard shortcut (`Cmd/Ctrl+Shift+E`)
+// can toggle it without reaching through a ref.
+
+import type { Component } from 'solid-js';
+import { For } from 'solid-js';
+import './ActivityBar.css';
+
+export type ActivityId = 'files' | 'search' | 'git';
+
+export interface ActivityBarProps {
+  /** Currently selected activity, or `null` when no sidebar is open. */
+  active: ActivityId | null;
+  /** Emitted when a user clicks an activity icon. Parent decides whether
+   *  the click opens, toggles, or no-ops the sidebar. */
+  onSelect: (activity: ActivityId) => void;
+}
+
+interface ActivityDef {
+  id: ActivityId;
+  label: string;
+  /** Keyboard shortcut shown in the tooltip. Files is Cmd/Ctrl+Shift+E per
+   *  the issue. Search / Git shortcuts land with F-127 / F-128. */
+  shortcut?: string;
+  /** Placeholder until the sidebar is wired. Disabled buttons keep the
+   *  visual chrome intact so the 44px grid renders correctly. */
+  disabled?: boolean;
+  /** Inline SVG path data. Tiny hand-rolled icons that match the linework
+   *  weight in `docs/forge-mocks.html` (1.7px stroke). Replaced with a
+   *  shared icon set when F-148 lands the chrome pass. */
+  svg: string;
+}
+
+const ACTIVITIES: ActivityDef[] = [
+  {
+    id: 'files',
+    label: 'Files',
+    shortcut: 'Cmd/Ctrl+Shift+E',
+    svg: 'M3 4h6l2 2h10v12a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z',
+  },
+  {
+    id: 'search',
+    label: 'Search (coming soon)',
+    disabled: true,
+    svg: 'M11 19a8 8 0 1 0-5.3-14.1A8 8 0 0 0 11 19zm10 2-4.3-4.3',
+  },
+  {
+    id: 'git',
+    label: 'Source control (coming soon)',
+    disabled: true,
+    svg: 'M5 3v10a4 4 0 0 0 4 4h6M5 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm14 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4z',
+  },
+];
+
+export const ActivityBar: Component<ActivityBarProps> = (props) => {
+  return (
+    <nav
+      class="activity-bar"
+      aria-label="Activity bar"
+      data-testid="activity-bar"
+    >
+      <For each={ACTIVITIES}>
+        {(item) => {
+          const isActive = () => props.active === item.id;
+          const title = () =>
+            item.shortcut ? `${item.label} (${item.shortcut})` : item.label;
+          return (
+            <button
+              type="button"
+              class="activity-bar__item"
+              classList={{ 'activity-bar__item--active': isActive() }}
+              aria-label={item.label}
+              aria-pressed={isActive()}
+              title={title()}
+              disabled={item.disabled}
+              data-testid={`activity-bar-${item.id}`}
+              onClick={() => props.onSelect(item.id)}
+            >
+              <svg
+                class="activity-bar__icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.7"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d={item.svg} />
+              </svg>
+            </button>
+          );
+        }}
+      </For>
+    </nav>
+  );
+};

--- a/web/packages/app/src/shell/FilesSidebar.css
+++ b/web/packages/app/src/shell/FilesSidebar.css
@@ -1,0 +1,114 @@
+/* F-126: files sidebar chrome. Width is parent-controlled (SessionWindow
+ * keeps a remembered width); this component only fills its slot. */
+
+.files-sidebar {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 240px;
+  min-width: 180px;
+  background: var(--color-surface-0, #0d0d0d);
+  border-right: 1px solid var(--color-border-1, #1f1f1f);
+  color: var(--color-text-primary, #eee);
+  font-family: var(--font-body);
+  font-size: 12px;
+  overflow: hidden;
+}
+
+.files-sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 28px;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--color-border-1, #1f1f1f);
+  color: var(--color-text-tertiary, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 10px;
+}
+
+.files-sidebar__refresh {
+  all: unset;
+  cursor: pointer;
+  color: var(--color-text-tertiary, #888);
+  padding: 2px;
+  border-radius: 2px;
+}
+
+.files-sidebar__refresh:hover {
+  color: var(--color-text-primary, #eee);
+  background: var(--color-surface-1, #161616);
+}
+
+.files-sidebar__error {
+  padding: 6px 10px;
+  color: var(--color-accent-ember, #ff4a12);
+  font-size: 11px;
+  border-bottom: 1px solid var(--color-border-1, #1f1f1f);
+}
+
+.files-sidebar__tree {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.files-sidebar__row {
+  display: flex;
+  align-items: center;
+  height: 22px;
+  padding-right: 8px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.files-sidebar__row:hover {
+  background: var(--color-surface-1, #161616);
+}
+
+.files-sidebar__chevron {
+  width: 14px;
+  display: inline-block;
+  text-align: center;
+  color: var(--color-text-tertiary, #888);
+  font-size: 10px;
+}
+
+.files-sidebar__name {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.files-sidebar__menu {
+  position: fixed;
+  z-index: 100;
+  list-style: none;
+  padding: 4px 0;
+  margin: 0;
+  background: var(--color-surface-1, #161616);
+  border: 1px solid var(--color-border-1, #1f1f1f);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  min-width: 140px;
+  font-size: 12px;
+}
+
+.files-sidebar__menu button {
+  all: unset;
+  display: block;
+  width: 100%;
+  padding: 6px 14px;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.files-sidebar__menu button:hover:not(:disabled) {
+  background: var(--color-accent-ember, #ff4a12);
+  color: #000;
+}
+
+.files-sidebar__menu button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}

--- a/web/packages/app/src/shell/FilesSidebar.test.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.test.tsx
@@ -1,0 +1,263 @@
+// F-126: FilesSidebar render + context-menu behavior.
+//
+// Tree-load is injected via `loadTree` so tests run without Tauri. The
+// component is expected to:
+//  1. Render the children of the loaded root (not the root itself — the
+//     header owns the workspace label slot).
+//  2. Toggle directory expansion on click; render recursive children when
+//     open.
+//  3. Surface a context menu with Open/Rename/Delete on right-click.
+//  4. Route Open → `props.onOpen(path)`.
+//  5. Route Rename → `props.renamePath(sessionId, from, to)` with the
+//     new path computed by swapping the leaf name.
+//  6. Route Delete → `props.deletePath(sessionId, path)`.
+//  7. Display gitignore-filtered trees correctly (the filtering itself is
+//     exercised in the Rust integration test; here we just confirm the
+//     component renders whatever the tree call returns).
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@solidjs/testing-library';
+import type { SessionId, TreeNodeDto } from '@forge/ipc';
+import { FilesSidebar } from './FilesSidebar';
+
+const SID = 'session-sidebar-test' as SessionId;
+const WS = '/workspace/demo';
+
+function node(
+  name: string,
+  path: string,
+  kind: 'File' | 'Dir',
+  children?: TreeNodeDto[],
+): TreeNodeDto {
+  return {
+    name,
+    path,
+    kind,
+    children: kind === 'Dir' ? children ?? [] : null,
+  } as TreeNodeDto;
+}
+
+function demoTree(): TreeNodeDto {
+  return node(
+    'demo',
+    WS,
+    'Dir',
+    [
+      node('README.md', `${WS}/README.md`, 'File'),
+      node('src', `${WS}/src`, 'Dir', [
+        node('main.ts', `${WS}/src/main.ts`, 'File'),
+      ]),
+    ],
+  );
+}
+
+function treeWithoutIgnored(): TreeNodeDto {
+  // Simulates the post-gitignore-filter tree: `node_modules/` and `*.log`
+  // are absent because the shell-side `tree` command now uses the
+  // gitignored walker. The component renders whatever it receives — the
+  // key invariant is that gitignored entries never appear.
+  return node(
+    'demo',
+    WS,
+    'Dir',
+    [
+      node('app.ts', `${WS}/app.ts`, 'File'),
+      node('keep.md', `${WS}/keep.md`, 'File'),
+    ],
+  );
+}
+
+afterEach(() => cleanup());
+
+describe('FilesSidebar render', () => {
+  it('renders EXPLORER header and the root children on mount', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const { findByText, getByText } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    await findByText('README.md');
+    expect(getByText('EXPLORER')).toBeInTheDocument();
+    expect(getByText('src')).toBeInTheDocument();
+    expect(loadTree).toHaveBeenCalledWith(SID, WS);
+  });
+
+  it('expands and collapses a directory on click', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const { findByText, queryByText } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    const srcRow = await findByText('src');
+    // Not expanded yet — main.ts is hidden.
+    expect(queryByText('main.ts')).toBeNull();
+    fireEvent.click(srcRow);
+    await waitFor(() => expect(queryByText('main.ts')).not.toBeNull());
+    fireEvent.click(srcRow);
+    await waitFor(() => expect(queryByText('main.ts')).toBeNull());
+  });
+
+  it('opens a file on double-click', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const onOpen = vi.fn();
+    const { findByText } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={onOpen}
+        loadTree={loadTree}
+      />
+    ));
+    const readme = await findByText('README.md');
+    fireEvent.dblClick(readme);
+    expect(onOpen).toHaveBeenCalledWith(`${WS}/README.md`);
+  });
+
+  it('renders only the gitignore-filtered tree the IPC layer returns', async () => {
+    const loadTree = vi.fn().mockResolvedValue(treeWithoutIgnored());
+    const { findByText, queryByText } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    await findByText('app.ts');
+    expect(queryByText('node_modules')).toBeNull();
+    expect(queryByText('err.log')).toBeNull();
+  });
+
+  it('surfaces a load error in an alert region', async () => {
+    const loadTree = vi
+      .fn()
+      .mockRejectedValue(new Error('tauri invoke unavailable (command=tree)'));
+    const { findByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    const err = await findByTestId('files-sidebar-error');
+    expect(err.textContent).toMatch(/tauri invoke unavailable/);
+  });
+});
+
+describe('FilesSidebar context menu', () => {
+  it('opens a context menu on right-click with Open/Rename/Delete', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const { findByText, findByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    const readme = await findByText('README.md');
+    fireEvent.contextMenu(readme);
+    const menu = await findByTestId('files-sidebar-menu');
+    expect(menu).toBeInTheDocument();
+    expect(await findByTestId('files-sidebar-menu-open')).toBeInTheDocument();
+    expect(await findByTestId('files-sidebar-menu-rename')).toBeInTheDocument();
+    expect(await findByTestId('files-sidebar-menu-delete')).toBeInTheDocument();
+  });
+
+  it('routes Rename through the rename_path wrapper with the new absolute path', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const renamePath = vi.fn().mockResolvedValue(undefined);
+    const { findByText, findByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+        renamePath={renamePath}
+        promptForRename={() => 'renamed.md'}
+      />
+    ));
+    const readme = await findByText('README.md');
+    fireEvent.contextMenu(readme);
+    const rename = await findByTestId('files-sidebar-menu-rename');
+    fireEvent.click(rename);
+    await waitFor(() =>
+      expect(renamePath).toHaveBeenCalledWith(
+        SID,
+        `${WS}/README.md`,
+        `${WS}/renamed.md`,
+      ),
+    );
+    // Tree reloads on success.
+    expect(loadTree).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips rename when the prompt returns null (cancel)', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const renamePath = vi.fn().mockResolvedValue(undefined);
+    const { findByText, findByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+        renamePath={renamePath}
+        promptForRename={() => null}
+      />
+    ));
+    const readme = await findByText('README.md');
+    fireEvent.contextMenu(readme);
+    fireEvent.click(await findByTestId('files-sidebar-menu-rename'));
+    expect(renamePath).not.toHaveBeenCalled();
+  });
+
+  it('routes Delete through the delete_path wrapper on confirm', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const deletePath = vi.fn().mockResolvedValue(undefined);
+    const { findByText, findByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+        deletePath={deletePath}
+        confirmDelete={() => true}
+      />
+    ));
+    const readme = await findByText('README.md');
+    fireEvent.contextMenu(readme);
+    fireEvent.click(await findByTestId('files-sidebar-menu-delete'));
+    await waitFor(() =>
+      expect(deletePath).toHaveBeenCalledWith(SID, `${WS}/README.md`),
+    );
+    expect(loadTree).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips delete when the confirm returns false', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const deletePath = vi.fn().mockResolvedValue(undefined);
+    const { findByText, findByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+        deletePath={deletePath}
+        confirmDelete={() => false}
+      />
+    ));
+    const readme = await findByText('README.md');
+    fireEvent.contextMenu(readme);
+    fireEvent.click(await findByTestId('files-sidebar-menu-delete'));
+    expect(deletePath).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/app/src/shell/FilesSidebar.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.tsx
@@ -1,0 +1,353 @@
+// F-126: files sidebar — tree view bound to the `tree` Tauri command.
+//
+// Per docs/ui-specs/layout-panes.md §3.2, the files sidebar is NOT a pane
+// type. It lives in the activity-bar-driven sidebar slot. Toggle lives in
+// the parent (SessionWindow) so a keyboard shortcut can show/hide without
+// reaching through a ref.
+//
+// The tree is loaded on mount from the session's workspace root via the
+// F-122 `tree` command (which now honors `.gitignore` via F-126's
+// gitignored walker in `forge-fs`). Context-menu actions dispatch to:
+//   - `open` → `props.onOpen(path)`; SessionWindow is expected to route
+//     the path to a new/existing EditorPane.
+//   - `rename` → `rename_path` Tauri command; reloads the tree on success.
+//   - `delete` → `delete_path` Tauri command; reloads the tree on success.
+//
+// The tree-load surface is injectable (`loadTree` prop) for tests, matching
+// EditorPane's style.
+
+import {
+  type Component,
+  For,
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  on,
+  onCleanup,
+  onMount,
+} from 'solid-js';
+import type { SessionId, TreeNodeDto } from '@forge/ipc';
+import {
+  tree as defaultTree,
+  renamePath as defaultRenamePath,
+  deletePath as defaultDeletePath,
+} from '../ipc/fs';
+import './FilesSidebar.css';
+
+export interface FilesSidebarProps {
+  sessionId: SessionId;
+  /** Absolute workspace root; passed as the `tree(root)` argument. */
+  workspaceRoot: string;
+  /** Called when the user activates a file (double-click or context-menu
+   *  "Open"). SessionWindow is expected to open an EditorPane on the path. */
+  onOpen: (path: string) => void;
+  /** Injection seam for tests. */
+  loadTree?: typeof defaultTree;
+  renamePath?: typeof defaultRenamePath;
+  deletePath?: typeof defaultDeletePath;
+  /** Injection seam for user-facing confirms. Tests inject deterministic
+   *  stubs; production resolves to `window.prompt` / `window.confirm`. */
+  promptForRename?: (currentName: string) => string | null;
+  confirmDelete?: (name: string) => boolean;
+}
+
+type ContextMenuTarget = {
+  path: string;
+  name: string;
+  isDir: boolean;
+  x: number;
+  y: number;
+};
+
+export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
+  const load = () => props.loadTree ?? defaultTree;
+  const rename = () => props.renamePath ?? defaultRenamePath;
+  const remove = () => props.deletePath ?? defaultDeletePath;
+  const askRename = () =>
+    props.promptForRename ?? ((name: string) => window.prompt('Rename to:', name));
+  const askDelete = () =>
+    props.confirmDelete ?? ((name: string) => window.confirm(`Delete ${name}?`));
+
+  const [rootNode, setRootNode] = createSignal<TreeNodeDto | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+  const [expanded, setExpanded] = createSignal<Set<string>>(new Set());
+  const [menu, setMenu] = createSignal<ContextMenuTarget | null>(null);
+
+  const refresh = async (): Promise<void> => {
+    try {
+      const next = await load()(props.sessionId, props.workspaceRoot);
+      setRootNode(next);
+      // Auto-expand the root so the first level of children is visible.
+      const rootPath = next.path;
+      setExpanded((prev) => {
+        const copy = new Set(prev);
+        copy.add(rootPath);
+        return copy;
+      });
+      setError(null);
+    } catch (err) {
+      setError(errorToString(err));
+    }
+  };
+
+  onMount(() => {
+    void refresh();
+  });
+
+  createEffect(
+    on(
+      () => [props.sessionId, props.workspaceRoot] as const,
+      () => {
+        void refresh();
+      },
+      { defer: true },
+    ),
+  );
+
+  const dismissMenu = (): void => {
+    setMenu(null);
+  };
+
+  const onEscape = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') dismissMenu();
+  };
+
+  onMount(() => {
+    window.addEventListener('click', dismissMenu);
+    window.addEventListener('keydown', onEscape);
+  });
+  onCleanup(() => {
+    window.removeEventListener('click', dismissMenu);
+    window.removeEventListener('keydown', onEscape);
+  });
+
+  const toggle = (path: string): void => {
+    setExpanded((prev) => {
+      const copy = new Set(prev);
+      if (copy.has(path)) copy.delete(path);
+      else copy.add(path);
+      return copy;
+    });
+  };
+
+  const handleContextMenu = (
+    e: MouseEvent,
+    node: TreeNodeDto,
+  ): void => {
+    e.preventDefault();
+    setMenu({
+      path: node.path,
+      name: node.name,
+      isDir: node.kind === 'Dir',
+      x: e.clientX,
+      y: e.clientY,
+    });
+  };
+
+  const doOpen = (path: string): void => {
+    dismissMenu();
+    props.onOpen(path);
+  };
+
+  const doRename = async (): Promise<void> => {
+    const target = menu();
+    dismissMenu();
+    if (!target) return;
+    const fresh = askRename()(target.name);
+    if (fresh === null || fresh === '' || fresh === target.name) return;
+    const parent = target.path.slice(0, target.path.lastIndexOf('/'));
+    const nextPath = `${parent}/${fresh}`;
+    try {
+      await rename()(props.sessionId, target.path, nextPath);
+      await refresh();
+    } catch (err) {
+      setError(errorToString(err));
+    }
+  };
+
+  const doDelete = async (): Promise<void> => {
+    const target = menu();
+    dismissMenu();
+    if (!target) return;
+    if (!askDelete()(target.name)) return;
+    try {
+      await remove()(props.sessionId, target.path);
+      await refresh();
+    } catch (err) {
+      setError(errorToString(err));
+    }
+  };
+
+  const rootChildren = createMemo<TreeNodeDto[]>(() => {
+    const r = rootNode();
+    if (r === null) return [];
+    return r.children ?? [];
+  });
+
+  return (
+    <aside
+      class="files-sidebar"
+      aria-label="Files sidebar"
+      data-testid="files-sidebar"
+    >
+      <header class="files-sidebar__header">
+        <span class="files-sidebar__title">EXPLORER</span>
+        <button
+          type="button"
+          class="files-sidebar__refresh"
+          aria-label="Refresh file tree"
+          title="Refresh"
+          onClick={() => {
+            void refresh();
+          }}
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M4 4v5h5" />
+            <path d="M20 20v-5h-5" />
+            <path d="M5 9a9 9 0 0 1 14-3l1 3M19 15a9 9 0 0 1-14 3l-1-3" />
+          </svg>
+        </button>
+      </header>
+      <Show when={error() !== null}>
+        <div class="files-sidebar__error" role="alert" data-testid="files-sidebar-error">
+          {error()}
+        </div>
+      </Show>
+      <div class="files-sidebar__tree" role="tree">
+        <For each={rootChildren()}>
+          {(child) => (
+            <TreeRow
+              node={child}
+              depth={0}
+              expanded={expanded()}
+              onToggle={toggle}
+              onOpen={doOpen}
+              onContext={handleContextMenu}
+            />
+          )}
+        </For>
+      </div>
+      <Show when={menu()}>
+        {(target) => (
+          <ul
+            class="files-sidebar__menu"
+            role="menu"
+            data-testid="files-sidebar-menu"
+            style={{ top: `${target().y}px`, left: `${target().x}px` }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <li role="none">
+              <button
+                type="button"
+                role="menuitem"
+                data-testid="files-sidebar-menu-open"
+                disabled={target().isDir}
+                onClick={() => doOpen(target().path)}
+              >
+                Open
+              </button>
+            </li>
+            <li role="none">
+              <button
+                type="button"
+                role="menuitem"
+                data-testid="files-sidebar-menu-rename"
+                onClick={() => {
+                  void doRename();
+                }}
+              >
+                Rename…
+              </button>
+            </li>
+            <li role="none">
+              <button
+                type="button"
+                role="menuitem"
+                data-testid="files-sidebar-menu-delete"
+                onClick={() => {
+                  void doDelete();
+                }}
+              >
+                Delete
+              </button>
+            </li>
+          </ul>
+        )}
+      </Show>
+    </aside>
+  );
+};
+
+interface TreeRowProps {
+  node: TreeNodeDto;
+  depth: number;
+  expanded: Set<string>;
+  onToggle: (path: string) => void;
+  onOpen: (path: string) => void;
+  onContext: (e: MouseEvent, node: TreeNodeDto) => void;
+}
+
+const TreeRow: Component<TreeRowProps> = (props) => {
+  const isDir = (): boolean => props.node.kind === 'Dir';
+  const isOpen = (): boolean => props.expanded.has(props.node.path);
+  const indent = (): string => `${props.depth * 12}px`;
+
+  const onClick = (): void => {
+    if (isDir()) {
+      props.onToggle(props.node.path);
+    }
+  };
+
+  const onDoubleClick = (): void => {
+    if (!isDir()) {
+      props.onOpen(props.node.path);
+    }
+  };
+
+  return (
+    <>
+      <div
+        class="files-sidebar__row"
+        classList={{ 'files-sidebar__row--dir': isDir() }}
+        role="treeitem"
+        aria-expanded={isDir() ? isOpen() : undefined}
+        data-testid="files-sidebar-row"
+        data-path={props.node.path}
+        style={{ 'padding-left': indent() }}
+        onClick={onClick}
+        onDblClick={onDoubleClick}
+        onContextMenu={(e) => props.onContext(e, props.node)}
+      >
+        <span class="files-sidebar__chevron" aria-hidden="true">
+          {isDir() ? (isOpen() ? '▾' : '▸') : ''}
+        </span>
+        <span class="files-sidebar__name">{props.node.name}</span>
+      </div>
+      <Show when={isDir() && isOpen()}>
+        <For each={props.node.children ?? []}>
+          {(child) => (
+            <TreeRow
+              node={child}
+              depth={props.depth + 1}
+              expanded={props.expanded}
+              onToggle={props.onToggle}
+              onOpen={props.onOpen}
+              onContext={props.onContext}
+            />
+          )}
+        </For>
+      </Show>
+    </>
+  );
+};
+
+function errorToString(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}


### PR DESCRIPTION
Closes #240.

## Summary

- New left-edge 44px activity bar (`web/packages/app/src/shell/ActivityBar.tsx`) with Files / Search / Git slots (Search + Git are visible-but-disabled placeholders — F-127 / F-128 will wire them up).
- New files sidebar (`web/packages/app/src/shell/FilesSidebar.tsx`) bound to the F-122 `tree` Tauri command, with click-to-expand directories, double-click-to-open files, and a right-click context menu (Open / Rename / Delete).
- `Cmd/Ctrl+Shift+E` toggles sidebar visibility from anywhere in the session window.
- `tree` command now walks via `ignore::WalkBuilder` so `.gitignore`, `.ignore`, global gitignore, and parent-chain excludes are respected (plus hidden-file skipping to match VS Code's default files explorer). Added `list_tree_gitignored` / `list_tree_gitignored_with_limit` in `forge-fs`; the non-ignored `list_tree` is retained for agent-side callers that need raw `read_dir` semantics.
- New `rename_path(session_id, from, to)` and `delete_path(session_id, path)` Tauri commands — both follow F-122's server-side cached-workspace-root pattern (webview never supplies `workspace_root`), both reuse `require_window_label` + `forge-fs` path allowlist, both appended at EOF of `crates/forge-shell/src/ipc.rs` per the concurrent-worktree convention (F-137 / F-144 touch adjacent code).
- `forge-fs::rename` and `forge-fs::delete` added in `mutate.rs`; rename refuses to clobber an existing destination and glob-matches both source and destination; delete recursively removes directories via `remove_dir_all` and re-rejects leaf-symlink races.

## Reasonable assumptions (flag for reviewer)

- `docs/ui-specs/shell.md` extracts only §2 of the activity-bar spec; §2.1 is referenced by the issue but not yet copied into the repo. Rendered three icons (Files active, Search + Git disabled placeholders). Icon linework matches the 1.7px stroke style in `docs/forge-mocks.html`.
- **DoD deviation on 'open' action:** The DoD says context-menu Open should dispatch to `read_file` / EditorPane. This PR routes Open through a `props.onOpen(path)` callback and leaves the SessionWindow handler as a placeholder that closes the sidebar — the EditorPane routing needs the layout-store to grow a "open file in editor pane" reducer, which is F-126+ scope. Rename and Delete fully dispatch. File a follow-up issue to wire Open once the layout store supports programmatic pane creation.
- `tree` Tauri command behavior change: existing callers will now receive gitignore-filtered results. The only caller in the repo is the web `ipc/fs.ts` wrapper (which is the caller this issue owns); agent-side `fs.tree` tool paths continue to use `forge_fs::list_tree` directly and are unaffected.

## Test plan
- [x] `just check-rust` — fmt, clippy, rustdoc all pass
- [x] `just check-web` — typecheck + design-token drift gate pass
- [x] `just test-rust` — 350+ tests pass including new forge-fs rename / delete / gitignored-walker unit tests
- [x] `just test-rust-webview` — 19 ipc_fs tests pass including new rename_path / delete_path / tree-gitignore cases; dashboard + cross-session label-mismatch rejection verified for both new commands
- [x] `just test-web` — 529 tests pass including 5 new ActivityBar tests, 10 new FilesSidebar tests, and 3 new SessionWindow tests covering keyboard shortcut and activity-bar click toggling the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)