### PR TITLE
[F-144] Re-run Branch variant: branch_parent threading + BranchSelected

### DIFF
--- a/crates/forge-core/src/transcript.rs
+++ b/crates/forge-core/src/transcript.rs
@@ -29,11 +29,11 @@ use crate::{ForgeError, Result};
 /// only `ToolCallStarted` would leave orphan completion events with no
 /// matching start. Filtering the full cluster requires tracking
 /// `ToolCallId`s from the started events we hide — a larger change
-/// deferred to F-144 (Branch variant needs the same bookkeeping).
-/// For F-143 (Replace, no-tool-call scenarios are the common case) we
-/// accept that a superseded turn's tool events remain visible in replay;
-/// the UI can interpret them in context of the surviving
-/// `AssistantMessage` for `new_id`.
+/// deferred to a future pass. F-144 (Branch / Fresh) inherits the same
+/// limitation: for `RerunVariant::Fresh` a superseded turn's tool-call
+/// events remain visible in replay alongside the regenerated turn. The
+/// UI interprets them in the context of the surviving `AssistantMessage`
+/// for `new_id`.
 ///
 /// Consumers in other contexts (e.g. rebuilding a provider request from
 /// history) can call this same helper to walk a coherent, non-superseded
@@ -61,7 +61,8 @@ fn is_hidden_by(event: &Event, superseded: &HashSet<MessageId>) -> bool {
         }
         // See doc-comment on `apply_superseded`: filtering `ToolCallStarted`
         // alone would leave orphaned `ToolCallCompleted` events (keyed by
-        // `ToolCallId`, not `MessageId`). Deferred to F-144.
+        // `ToolCallId`, not `MessageId`). Full-cluster filtering is a
+        // future pass; F-144 inherits the limitation.
         // Hide the markers themselves: consumers see a clean transcript.
         Event::MessageSuperseded { .. } => true,
         _ => false,

--- a/crates/forge-ipc/src/lib.rs
+++ b/crates/forge-ipc/src/lib.rs
@@ -23,17 +23,33 @@ pub enum IpcMessage {
     ToolCallRejected(ToolCallRejected),
     /// F-143: client → session request to re-run an assistant message.
     RerunMessage(RerunMessage),
+    /// F-144: client → session request to activate a specific branch variant.
+    SelectBranch(SelectBranch),
 }
 
 /// Client → session: re-run the assistant message with `msg_id` using the
-/// given `variant`. Phase 1 only dispatches [`RerunVariant::Replace`]; Branch
-/// and Fresh return an error until F-144/F-145 land.
+/// given `variant`. All three variants (`Replace`, `Branch`, `Fresh`) are
+/// wired as of F-144.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RerunMessage {
     /// Target assistant message to re-run. Wire shape is the canonical
     /// `MessageId` string to stay symmetric with `ToolCallApproved.id`.
     pub msg_id: String,
     pub variant: RerunVariant,
+}
+
+/// Client → session: activate a specific branch variant for replay / UI.
+///
+/// `parent` is the branch-point message id (the root variant's own id). The
+/// daemon resolves `variant_index` against the event log: `0` refers to the
+/// root itself; `N >= 1` refers to the `AssistantMessage` with
+/// `branch_parent == Some(parent)` and `branch_variant_index == N`. On a
+/// successful resolve, the daemon emits `Event::BranchSelected { parent,
+/// selected }` where `selected` is the resolved MessageId.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SelectBranch {
+    pub parent_id: String,
+    pub variant_index: u32,
 }
 
 /// Client → session: send a user message to start a new turn.

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -157,6 +157,8 @@ pub async fn run_turn<P: Provider>(
         provider,
         initial_req,
         msg_id,
+        None, // branch_parent — top-level turns are never a branch variant
+        0,    // branch_variant_index — root position
         pending_approvals,
         &dispatcher,
         &ctx,
@@ -173,12 +175,21 @@ pub async fn run_turn<P: Provider>(
 /// `pub(crate)` so rerun paths (F-143+) can reuse the loop with a pre-built
 /// `ChatRequest` and a pre-chosen `msg_id`, instead of going through
 /// [`run_turn`] which synthesizes a fresh `UserMessage` event.
+///
+/// `branch_parent` / `branch_variant_index` (F-144) are threaded onto every
+/// `AssistantMessage` event this loop emits for `msg_id`:
+///   * `None` / `0` — top-level turn or the root variant of a branch point.
+///   * `Some(root_id)` / `N >= 1` — a Branch-rerun generation; both the
+///     original and this new message co-exist in the transcript. Consumers
+///     choose which to display via `BranchSelected`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_request_loop<P: Provider>(
     session: Arc<Session>,
     provider: Arc<P>,
     mut req: ChatRequest,
     msg_id: MessageId,
+    branch_parent: Option<MessageId>,
+    branch_variant_index: u32,
     pending_approvals: PendingApprovals,
     dispatcher: &ToolDispatcher,
     ctx: &ToolCtx,
@@ -220,8 +231,8 @@ pub(crate) async fn run_request_loop<P: Provider>(
                 stream_finalised: false,
                 // F-112: empty Arc<str> — no allocation (matches `Arc::<str>::from("")`).
                 text: Arc::from(""),
-                branch_parent: None,
-                branch_variant_index: 0,
+                branch_parent: branch_parent.clone(),
+                branch_variant_index,
             })
             .await?;
 
@@ -346,8 +357,8 @@ pub(crate) async fn run_request_loop<P: Provider>(
                                                 stream_finalised: true,
                                                 // F-112: wrap at boundary.
                                                 text: Arc::from(assistant_text.as_str()),
-                                                branch_parent: None,
-                                                branch_variant_index: 0,
+                                                branch_parent: branch_parent.clone(),
+                                                branch_variant_index,
                                             })
                                             .await?;
                                         // Close the Model step too so the
@@ -496,8 +507,8 @@ pub(crate) async fn run_request_loop<P: Provider>(
                             stream_finalised: true,
                             // F-112: wrap at boundary.
                             text: Arc::from(assistant_text.as_str()),
-                            branch_parent: None,
-                            branch_variant_index: 0,
+                            branch_parent: branch_parent.clone(),
+                            branch_variant_index,
                         })
                         .await?;
 
@@ -535,8 +546,8 @@ pub(crate) async fn run_request_loop<P: Provider>(
                             stream_finalised: true,
                             // F-112: wrap at boundary.
                             text: Arc::from(assistant_text.as_str()),
-                            branch_parent: None,
-                            branch_variant_index: 0,
+                            branch_parent: branch_parent.clone(),
+                            branch_variant_index,
                         })
                         .await?;
                     // F-139: close the Model step with an Error outcome
@@ -570,8 +581,8 @@ pub(crate) async fn run_request_loop<P: Provider>(
                     stream_finalised: true,
                     // F-112: wrap at boundary.
                     text: Arc::from(assistant_text.as_str()),
-                    branch_parent: None,
-                    branch_variant_index: 0,
+                    branch_parent: branch_parent.clone(),
+                    branch_variant_index,
                 })
                 .await?;
             // F-139: close Model step on the no-Done exit path too.
@@ -621,25 +632,30 @@ impl Orchestrator {
         Self
     }
 
-    /// F-143: re-run an existing assistant message.
+    /// Re-run an existing assistant message.
     ///
-    /// For [`RerunVariant::Replace`]:
-    ///   1. Read the event log and filter prior supersede markers so reruns
-    ///      don't compound.
-    ///   2. Reconstruct the provider request from events up to — but not
-    ///      including — `msg_id`'s assistant turn.
-    ///   3. Drive `run_request_loop` with a fresh `new_id` to regenerate
-    ///      the response.
-    ///   4. After the regenerated assistant message is finalised, emit
-    ///      `Event::MessageSuperseded { old_id: msg_id, new_id }` so
-    ///      replay consumers hide the original.
+    /// Three variants (see [`RerunVariant`]):
     ///
-    /// Ordering matters: the `MessageSuperseded` marker is emitted *after*
-    /// the new assistant message is finalised. If regeneration errors
-    /// mid-stream, the marker is never written and the original message
-    /// stays visible — we don't point the UI at a half-written new_id.
+    /// * [`RerunVariant::Replace`] (F-143) — truncate logically at `msg_id`'s
+    ///   assistant turn, regenerate, and emit `MessageSuperseded` so replay
+    ///   hides the original.
+    /// * [`RerunVariant::Branch`] (F-144) — keep both versions. Spawns a
+    ///   new `AssistantMessage` with `branch_parent` threaded to the target's
+    ///   branch root and `branch_variant_index = prev_max + 1`. Both the
+    ///   original and the new message remain visible in replay; consumers
+    ///   pick which to display via `BranchSelected`.
+    /// * [`RerunVariant::Fresh`] (F-144) — truncate back to the originating
+    ///   user message (discarding intermediate turns / tool calls) and
+    ///   regenerate from that user message alone. The new AssistantMessage
+    ///   is a new root (`branch_parent = None`); the original turn is
+    ///   superseded via `MessageSuperseded`.
     ///
-    /// Branch / Fresh return an error today; they land in F-144 / F-145.
+    /// Ordering matters for Replace / Fresh: the `MessageSuperseded` marker
+    /// is emitted *after* the new assistant message is finalised. If
+    /// regeneration errors mid-stream the marker is never written and the
+    /// original message stays authoritative — we don't point the UI at a
+    /// half-written new_id. For Branch the original is never hidden, so
+    /// no supersede marker is emitted.
     #[allow(clippy::too_many_arguments)]
     pub async fn rerun_message<P: Provider>(
         &self,
@@ -669,12 +685,34 @@ impl Orchestrator {
                 )
                 .await
             }
-            RerunVariant::Branch => Err(anyhow!(
-                "rerun_message: Branch variant not implemented (F-144)"
-            )),
-            RerunVariant::Fresh => Err(anyhow!(
-                "rerun_message: Fresh variant not implemented (F-145)"
-            )),
+            RerunVariant::Branch => {
+                self.rerun_branch(
+                    session,
+                    provider,
+                    msg_id,
+                    pending_approvals,
+                    allowed_paths,
+                    auto_approve,
+                    workspace_root,
+                    child_registry,
+                    byte_budget,
+                )
+                .await
+            }
+            RerunVariant::Fresh => {
+                self.rerun_fresh(
+                    session,
+                    provider,
+                    msg_id,
+                    pending_approvals,
+                    allowed_paths,
+                    auto_approve,
+                    workspace_root,
+                    child_registry,
+                    byte_budget,
+                )
+                .await
+            }
         }
     }
 
@@ -739,6 +777,10 @@ impl Orchestrator {
             provider,
             req,
             new_id.clone(),
+            // Replace does not create a branch — the regenerated message
+            // takes the original's place rather than sitting alongside it.
+            None,
+            0,
             pending_approvals,
             &dispatcher,
             &ctx,
@@ -757,6 +799,224 @@ impl Orchestrator {
             .await?;
 
         Ok(new_id)
+    }
+
+    /// F-144: re-run producing a new Branch sibling of `target`.
+    ///
+    /// Semantics (per `docs/ui-specs/branching.md §15.1` and CONCEPT.md
+    /// §10.3 "Branch"):
+    ///   1. Read + filter history. Compute the branch root:
+    ///      `root = target.branch_parent.unwrap_or(target)`. This coalesces
+    ///      "branch of a branch" so every variant of the same original
+    ///      response threads to the same root id (otherwise chained branches
+    ///      would form a tree rather than a flat list of siblings).
+    ///   2. Walk the filtered history to find `prev_max`, the highest
+    ///      `branch_variant_index` among any `AssistantMessage` with
+    ///      `branch_parent.unwrap_or(id) == root`. The root itself sits at
+    ///      variant 0; the first Branch re-run produces variant 1.
+    ///   3. Rebuild the provider request up to `target` via the same
+    ///      `build_request_up_to` helper Replace uses — a branch is a
+    ///      sibling generation from the same prompt state.
+    ///   4. Drive `run_request_loop` with `branch_parent = Some(root)` and
+    ///      `branch_variant_index = prev_max + 1`. No supersede marker is
+    ///      emitted — both the original and the new sibling stay visible
+    ///      in replay; consumers choose which to display via
+    ///      `BranchSelected` (emitted separately by `select_branch`).
+    #[allow(clippy::too_many_arguments)]
+    async fn rerun_branch<P: Provider>(
+        &self,
+        session: Arc<crate::session::Session>,
+        provider: Arc<P>,
+        target: MessageId,
+        pending_approvals: PendingApprovals,
+        allowed_paths: Vec<String>,
+        auto_approve: bool,
+        workspace_root: Option<std::path::PathBuf>,
+        child_registry: Option<crate::sandbox::ChildRegistry>,
+        byte_budget: Option<Arc<crate::byte_budget::ByteBudget>>,
+    ) -> Result<MessageId> {
+        let history = read_since(&session.log_path, 0)
+            .await
+            .map_err(|e| anyhow!("rerun_branch: read event log: {e}"))?;
+        let history = apply_superseded(history);
+
+        // Resolve the branch root. `target.branch_parent ?? target.id` —
+        // spec §15.1. Also capture `prev_max`, the highest variant index
+        // already at this branch point (root sits at 0 implicitly).
+        let (root, prev_max) = find_branch_root_and_max(&history, &target)?;
+        let next_index = prev_max
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("rerun_branch: branch_variant_index overflow"))?;
+
+        let req = build_request_up_to(&history, &target)?;
+
+        let mut dispatcher = crate::tools::ToolDispatcher::new();
+        dispatcher
+            .register(Box::new(crate::tools::FsReadTool))
+            .expect("fs.read must register on a fresh dispatcher");
+        dispatcher
+            .register(Box::new(crate::tools::FsWriteTool))
+            .expect("fs.write must register on a fresh dispatcher");
+        dispatcher
+            .register(Box::new(crate::tools::FsEditTool))
+            .expect("fs.edit must register on a fresh dispatcher");
+        dispatcher
+            .register(Box::new(crate::tools::ShellExecTool))
+            .expect("shell.exec must register on a fresh dispatcher");
+        dispatcher
+            .register(Box::new(crate::tools::AgentSpawnTool))
+            .expect("agent.spawn must register on a fresh dispatcher");
+        let ctx = crate::tools::ToolCtx {
+            allowed_paths,
+            workspace_root,
+            child_registry,
+            byte_budget,
+            agent_ctx: None,
+        };
+
+        let new_id = MessageId::new();
+        run_request_loop(
+            Arc::clone(&session),
+            provider,
+            req,
+            new_id.clone(),
+            Some(root),
+            next_index,
+            pending_approvals,
+            &dispatcher,
+            &ctx,
+            auto_approve,
+        )
+        .await?;
+
+        // Branch does not emit MessageSuperseded: both versions co-exist.
+        Ok(new_id)
+    }
+
+    /// F-144: re-run discarding intermediate turns — the "Fresh" variant.
+    ///
+    /// Semantics (per CONCEPT.md §10.3 "Fresh"): regenerate from the
+    /// originating user message alone, losing all intermediate tool calls
+    /// and sub-agent context. The new AssistantMessage is a new root
+    /// (`branch_parent = None`); the original target assistant turn is
+    /// logically superseded via `MessageSuperseded` so replay consumers
+    /// hide it.
+    ///
+    /// Steps:
+    ///   1. Read + filter history.
+    ///   2. Locate the `UserMessage` that immediately precedes `target`'s
+    ///      assistant turn; build a one-message `ChatRequest` from it.
+    ///      This is the key behavioural difference from Replace (which
+    ///      carries *all* prior turns) — Fresh discards everything between
+    ///      the user message and the target.
+    ///   3. Drive `run_request_loop` with root branch metadata (None / 0).
+    ///   4. Emit `MessageSuperseded { old_id: target, new_id }` on success
+    ///      so a fresh subscriber sees only the regenerated message.
+    ///
+    /// Ordering invariant matches Replace: if the regenerated stream errors
+    /// mid-flight, the supersede marker is never emitted and the original
+    /// message stays authoritative.
+    #[allow(clippy::too_many_arguments)]
+    async fn rerun_fresh<P: Provider>(
+        &self,
+        session: Arc<crate::session::Session>,
+        provider: Arc<P>,
+        target: MessageId,
+        pending_approvals: PendingApprovals,
+        allowed_paths: Vec<String>,
+        auto_approve: bool,
+        workspace_root: Option<std::path::PathBuf>,
+        child_registry: Option<crate::sandbox::ChildRegistry>,
+        byte_budget: Option<Arc<crate::byte_budget::ByteBudget>>,
+    ) -> Result<MessageId> {
+        let history = read_since(&session.log_path, 0)
+            .await
+            .map_err(|e| anyhow!("rerun_fresh: read event log: {e}"))?;
+        let history = apply_superseded(history);
+
+        let req = build_fresh_request_for(&history, &target)?;
+
+        let mut dispatcher = crate::tools::ToolDispatcher::new();
+        dispatcher
+            .register(Box::new(crate::tools::FsReadTool))
+            .expect("fs.read must register on a fresh dispatcher");
+        dispatcher
+            .register(Box::new(crate::tools::FsWriteTool))
+            .expect("fs.write must register on a fresh dispatcher");
+        dispatcher
+            .register(Box::new(crate::tools::FsEditTool))
+            .expect("fs.edit must register on a fresh dispatcher");
+        dispatcher
+            .register(Box::new(crate::tools::ShellExecTool))
+            .expect("shell.exec must register on a fresh dispatcher");
+        dispatcher
+            .register(Box::new(crate::tools::AgentSpawnTool))
+            .expect("agent.spawn must register on a fresh dispatcher");
+        let ctx = crate::tools::ToolCtx {
+            allowed_paths,
+            workspace_root,
+            child_registry,
+            byte_budget,
+            agent_ctx: None,
+        };
+
+        let new_id = MessageId::new();
+        run_request_loop(
+            Arc::clone(&session),
+            provider,
+            req,
+            new_id.clone(),
+            None,
+            0,
+            pending_approvals,
+            &dispatcher,
+            &ctx,
+            auto_approve,
+        )
+        .await?;
+
+        session
+            .emit(Event::MessageSuperseded {
+                old_id: target,
+                new_id: new_id.clone(),
+            })
+            .await?;
+
+        Ok(new_id)
+    }
+
+    /// F-144: activate a specific branch variant for replay / UI.
+    ///
+    /// Resolves `variant_index` against the filtered event log and emits
+    /// `Event::BranchSelected { parent, selected }`.
+    ///
+    /// Resolution rules:
+    ///   * `variant_index == 0` — `selected` is `parent` itself (the root's
+    ///     own id).
+    ///   * `variant_index >= 1` — `selected` is the `AssistantMessage` with
+    ///     `branch_parent == Some(parent)` and matching
+    ///     `branch_variant_index`.
+    ///
+    /// An unknown variant index returns `Err` and does **not** emit
+    /// `BranchSelected`. Emitting for a nonexistent variant would corrupt
+    /// the event log — downstream consumers reasonably assume every
+    /// `BranchSelected.selected` points at a real message.
+    pub async fn select_branch(
+        &self,
+        session: Arc<crate::session::Session>,
+        parent: MessageId,
+        variant_index: u32,
+    ) -> Result<()> {
+        let history = read_since(&session.log_path, 0)
+            .await
+            .map_err(|e| anyhow!("select_branch: read event log: {e}"))?;
+        let history = apply_superseded(history);
+
+        let selected = resolve_branch_variant(&history, &parent, variant_index)?;
+        session
+            .emit(Event::BranchSelected { parent, selected })
+            .await?;
+        Ok(())
     }
 }
 
@@ -845,6 +1105,158 @@ fn finalise_request(messages: Vec<ChatMessage>) -> Result<ChatRequest> {
         system: None,
         messages,
     })
+}
+
+/// F-144: given a filtered history and a rerun target, return the branch
+/// root id and the highest `branch_variant_index` already present at that
+/// root. Used by `rerun_branch` to thread the new variant as
+/// `(root, prev_max + 1)`.
+///
+/// Root resolution follows spec §15.1:
+///   * If `target.branch_parent == Some(root)` — target is already a
+///     branch variant; the new sibling shares the same root.
+///   * If `target.branch_parent == None` — target is a root message; the
+///     new sibling's root is `target.id` itself.
+///
+/// `prev_max` starts at 0 (the root's implicit variant). Any sibling with
+/// `branch_parent == Some(root)` bumps it to at least its own
+/// `branch_variant_index`.
+///
+/// Walks the filtered `(seq, Event)` list twice: once to find `target`'s
+/// own AssistantMessage (to read its `branch_parent`), once to scan for
+/// siblings. Both passes are O(n) in history size — single-threaded reruns
+/// are not a hot path.
+fn find_branch_root_and_max(
+    history: &[(u64, Event)],
+    target: &MessageId,
+) -> Result<(MessageId, u32)> {
+    // Pass 1: locate target's own `branch_parent`.
+    let target_branch_parent = history
+        .iter()
+        .find_map(|(_, ev)| match ev {
+            Event::AssistantMessage {
+                id, branch_parent, ..
+            } if id == target => Some(branch_parent.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            anyhow!("rerun_branch: target message {target:?} not found in session log")
+        })?;
+
+    let root = target_branch_parent.unwrap_or_else(|| target.clone());
+
+    // Pass 2: scan siblings. `prev_max` is the highest `branch_variant_index`
+    // seen for any AssistantMessage whose branch_parent coalesces to `root`.
+    // `id == root` covers the root itself (which is the implicit variant 0
+    // but we tolerate any value its own variant field may carry).
+    let mut prev_max: u32 = 0;
+    for (_, ev) in history {
+        if let Event::AssistantMessage {
+            id,
+            branch_parent,
+            branch_variant_index,
+            ..
+        } = ev
+        {
+            let belongs_to_root = match branch_parent {
+                Some(p) => p == &root,
+                None => id == &root,
+            };
+            if belongs_to_root && *branch_variant_index > prev_max {
+                prev_max = *branch_variant_index;
+            }
+        }
+    }
+
+    Ok((root, prev_max))
+}
+
+/// F-144: build the single-message `ChatRequest` for the Fresh re-run
+/// variant.
+///
+/// Behaviourally distinct from `build_request_up_to`: where Replace /
+/// Branch carry *all* prior turns into the request, Fresh discards
+/// everything between the originating user message and `target`. The
+/// returned request contains exactly one message — the last `UserMessage`
+/// before `target`'s assistant turn.
+///
+/// If `target` is not found, or no `UserMessage` precedes it, returns an
+/// informative error.
+fn build_fresh_request_for(history: &[(u64, Event)], target: &MessageId) -> Result<ChatRequest> {
+    let mut last_user: Option<String> = None;
+
+    for (_, ev) in history {
+        match ev {
+            Event::UserMessage { text, .. } => {
+                last_user = Some(text.to_string());
+            }
+            Event::AssistantMessage { id, .. } if id == target => {
+                let text = last_user.ok_or_else(|| {
+                    anyhow!("rerun_fresh: no user message precedes target {target:?}")
+                })?;
+                return Ok(ChatRequest {
+                    system: None,
+                    messages: vec![ChatMessage {
+                        role: ChatRole::User,
+                        content: vec![ChatBlock::Text(text)],
+                    }],
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Err(anyhow!(
+        "rerun_fresh: target message {target:?} not found in session log"
+    ))
+}
+
+/// F-144: resolve `(parent, variant_index)` to the MessageId to report in
+/// `BranchSelected.selected`.
+///
+/// * `variant_index == 0` returns `parent` directly — the root variant is
+///   represented by the original message id itself.
+/// * `variant_index >= 1` scans `history` for an `AssistantMessage` with
+///   `branch_parent == Some(parent)` and `branch_variant_index` equal to
+///   the requested index.
+///
+/// Unknown variants return `Err`. Callers **must** propagate rather than
+/// emit `BranchSelected { parent, selected: parent }` as a fallback —
+/// replay consumers assume every selected id is live.
+fn resolve_branch_variant(
+    history: &[(u64, Event)],
+    parent: &MessageId,
+    variant_index: u32,
+) -> Result<MessageId> {
+    if variant_index == 0 {
+        // Sanity-check that a root with this id actually exists. A random
+        // parent id should not be silently accepted — the UI would gate
+        // display of a nonexistent message.
+        let exists = history
+            .iter()
+            .any(|(_, ev)| matches!(ev, Event::AssistantMessage { id, .. } if id == parent));
+        if !exists {
+            return Err(anyhow!(
+                "select_branch: parent message {parent:?} not found in session log"
+            ));
+        }
+        return Ok(parent.clone());
+    }
+
+    history
+        .iter()
+        .find_map(|(_, ev)| match ev {
+            Event::AssistantMessage {
+                id,
+                branch_parent: Some(bp),
+                branch_variant_index,
+                ..
+            } if bp == parent && *branch_variant_index == variant_index => Some(id.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            anyhow!("select_branch: no variant with index {variant_index} under parent {parent:?}")
+        })
 }
 
 #[cfg(test)]
@@ -978,5 +1390,118 @@ mod tests {
             reqs[0].system.is_none(),
             "no cache → no injection, system stays None"
         );
+    }
+
+    // F-144: branch-of-a-branch re-runs must thread to the same root. Spec
+    // §15.1: `branch_parent_id = M.branch_parent_id ?? M.id`. If the target
+    // is already a branch variant, the new sibling shares target's parent
+    // (not target itself). This is what keeps variants flat — without
+    // coalescing, chained Branch reruns would form a tree of parents and
+    // `prev_max + 1` couldn't resolve sibling order.
+    #[test]
+    fn find_branch_root_coalesces_when_target_is_itself_a_variant() {
+        use chrono::Utc;
+
+        let root = MessageId::new();
+        let variant1 = MessageId::new();
+        let variant2 = MessageId::new();
+
+        fn assistant_with_branch(id: &MessageId, parent: Option<&MessageId>, idx: u32) -> Event {
+            Event::AssistantMessage {
+                id: id.clone(),
+                provider: ProviderId::new(),
+                model: "mock".into(),
+                at: Utc::now(),
+                stream_finalised: true,
+                text: Arc::from(""),
+                branch_parent: parent.cloned(),
+                branch_variant_index: idx,
+            }
+        }
+
+        let history = vec![
+            (1, assistant_with_branch(&root, None, 0)),
+            (2, assistant_with_branch(&variant1, Some(&root), 1)),
+            (3, assistant_with_branch(&variant2, Some(&root), 2)),
+        ];
+
+        // Branch-ing `variant1` must coalesce to `root`, and prev_max must
+        // reflect variant2 (index 2) — not just variant1's own index.
+        let (resolved_root, prev_max) =
+            find_branch_root_and_max(&history, &variant1).expect("resolve");
+        assert_eq!(
+            resolved_root, root,
+            "branch-of-a-branch must resolve to root"
+        );
+        assert_eq!(
+            prev_max, 2,
+            "prev_max must scan all siblings, not just target's own variant_index"
+        );
+
+        // Branch-ing the root directly lands at the same root and the same
+        // prev_max — the family of variants does not grow by targeting the
+        // root.
+        let (root_again, same_max) =
+            find_branch_root_and_max(&history, &root).expect("resolve root");
+        assert_eq!(root_again, root);
+        assert_eq!(same_max, 2);
+    }
+
+    // F-144: resolve_branch_variant must refuse unknown variant indices.
+    // A well-meaning bug that emits `BranchSelected { parent, selected:
+    // parent }` as a fallback on unknown index would corrupt replay —
+    // downstream UIs assume every selected id is a live message.
+    #[test]
+    fn resolve_branch_variant_rejects_unknown_index() {
+        use chrono::Utc;
+
+        let root = MessageId::new();
+        let variant1 = MessageId::new();
+        let history = vec![
+            (
+                1,
+                Event::AssistantMessage {
+                    id: root.clone(),
+                    provider: ProviderId::new(),
+                    model: "mock".into(),
+                    at: Utc::now(),
+                    stream_finalised: true,
+                    text: Arc::from(""),
+                    branch_parent: None,
+                    branch_variant_index: 0,
+                },
+            ),
+            (
+                2,
+                Event::AssistantMessage {
+                    id: variant1.clone(),
+                    provider: ProviderId::new(),
+                    model: "mock".into(),
+                    at: Utc::now(),
+                    stream_finalised: true,
+                    text: Arc::from(""),
+                    branch_parent: Some(root.clone()),
+                    branch_variant_index: 1,
+                },
+            ),
+        ];
+
+        // Known variants resolve.
+        assert_eq!(
+            resolve_branch_variant(&history, &root, 0).expect("root resolves"),
+            root
+        );
+        assert_eq!(
+            resolve_branch_variant(&history, &root, 1).expect("variant 1 resolves"),
+            variant1
+        );
+
+        // Unknown indexes return Err without silently falling back.
+        assert!(resolve_branch_variant(&history, &root, 99).is_err());
+        // Parent id that doesn't exist in the log is also rejected —
+        // even at variant_index 0, where the naïve implementation would
+        // return the parent unchanged.
+        let orphan = MessageId::new();
+        assert!(resolve_branch_variant(&history, &orphan, 0).is_err());
     }
 }

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -38,6 +38,7 @@ fn ipc_message_kind(msg: &IpcMessage) -> &'static str {
         IpcMessage::ToolCallApproved(_) => "ToolCallApproved",
         IpcMessage::ToolCallRejected(_) => "ToolCallRejected",
         IpcMessage::RerunMessage(_) => "RerunMessage",
+        IpcMessage::SelectBranch(_) => "SelectBranch",
     }
 }
 
@@ -554,10 +555,12 @@ async fn handle_connection<P: Provider + 'static>(
                     }
 
                     Some(IpcMessage::RerunMessage(r)) => {
-                        // F-143: dispatch rerun through the `Orchestrator`.
-                        // Spawn the re-run off the event loop so concurrent
-                        // tool approvals still flow through the same
-                        // connection while regeneration streams.
+                        // F-143 / F-144: dispatch rerun through the
+                        // `Orchestrator`. All three variants (Replace,
+                        // Branch, Fresh) are wired. Spawn off the event
+                        // loop so concurrent tool approvals still flow
+                        // through the same connection while regeneration
+                        // streams.
                         let session = Arc::clone(&session);
                         let provider = Arc::clone(&provider);
                         let approvals = Arc::clone(&pending_approvals);
@@ -589,6 +592,24 @@ async fn handle_connection<P: Provider + 'static>(
                                 .await
                             {
                                 eprintln!("rerun error: {e}");
+                            }
+                        });
+                    }
+
+                    Some(IpcMessage::SelectBranch(s)) => {
+                        // F-144: activate a specific branch variant. Spawned
+                        // off the event loop like rerun so the connection
+                        // stays responsive if the log scan is slow on a
+                        // large session.
+                        let session = Arc::clone(&session);
+                        let parent = MessageId::from_string(s.parent_id.clone());
+                        let variant_index = s.variant_index;
+                        tokio::spawn(async move {
+                            let orch = Orchestrator::new();
+                            if let Err(e) =
+                                orch.select_branch(session, parent, variant_index).await
+                            {
+                                eprintln!("select_branch error: {e}");
                             }
                         });
                     }

--- a/crates/forge-session/tests/rerun_branch.rs
+++ b/crates/forge-session/tests/rerun_branch.rs
@@ -1,0 +1,346 @@
+//! F-144: Re-run Branch variant — both versions co-exist, BranchSelected gates display.
+//!
+//! Scenario:
+//!   1. Client drives a user→assistant turn, capturing the original message id `A`.
+//!   2. Client fires `RerunMessage { msg_id: A, variant: Branch }`. The daemon
+//!      regenerates and emits a second `AssistantMessage` with
+//!      `branch_parent = Some(A)` and `branch_variant_index = 1`. No
+//!      `MessageSuperseded` marker — both versions co-exist.
+//!   3. Client fires `SelectBranch { parent: A, variant_index: 1 }`; daemon
+//!      emits `BranchSelected { parent: A, selected: A_branch }`.
+//!   4. A fresh subscriber sees both `AssistantMessage`s in the replay and a
+//!      trailing `BranchSelected` event tying them together.
+//!
+//! The invariant: Branch is the *only* rerun shape where both versions stay
+//! visible. Tool-call filtering limitations documented on `apply_superseded`
+//! are out of scope for this happy-path coverage.
+
+use forge_core::{ids::MessageId, Event, RerunVariant};
+use forge_ipc::{
+    ClientInfo, Hello, IpcEvent, IpcMessage, RerunMessage, SelectBranch, SendUserMessage,
+    Subscribe, PROTO_VERSION,
+};
+use forge_providers::MockProvider;
+use forge_session::{server::serve_with_session, session::Session};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+const SCRIPT_FIRST: &str = r#"{"delta":"original answer"}
+{"done":"end_turn"}
+"#;
+
+const SCRIPT_BRANCH: &str = r#"{"delta":"branch answer"}
+{"done":"end_turn"}
+"#;
+
+async fn connect_with_retry(path: &std::path::PathBuf) -> UnixStream {
+    for _ in 0..20 {
+        match UnixStream::connect(path).await {
+            Ok(s) => return s,
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+        }
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("server did not start in time")
+}
+
+async fn do_handshake(stream: &mut UnixStream) {
+    let hello = IpcMessage::Hello(Hello {
+        proto: PROTO_VERSION,
+        client: ClientInfo {
+            kind: "test".into(),
+            pid: std::process::id(),
+            user: "tester".into(),
+        },
+    });
+    forge_ipc::write_frame(stream, &hello).await.unwrap();
+    let response = forge_ipc::read_frame(stream).await.unwrap();
+    assert!(
+        matches!(response, IpcMessage::HelloAck(_)),
+        "expected HelloAck, got {response:?}"
+    );
+}
+
+fn extract_event(msg: &IpcMessage) -> Option<Event> {
+    if let IpcMessage::Event(IpcEvent { event, .. }) = msg {
+        Some(event.clone())
+    } else {
+        None
+    }
+}
+
+#[tokio::test]
+async fn rerun_branch_keeps_both_variants_and_branch_selected_gates_display() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("rerun-branch.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(
+        MockProvider::from_responses(vec![SCRIPT_FIRST.into(), SCRIPT_BRANCH.into()]).unwrap(),
+    );
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            server_session,
+            server_provider,
+            true,
+            false,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    });
+
+    // ── Turn 1: original assistant response ───────────────────────────
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage { text: "ask".into() }),
+    )
+    .await
+    .unwrap();
+
+    let (mut reader, mut writer) = stream.into_split();
+    let original_msg_id: MessageId = loop {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::AssistantMessage {
+            id,
+            stream_finalised: true,
+            branch_parent,
+            branch_variant_index,
+            ..
+        } = event
+        {
+            // Sanity: first turn is a root, not a branch.
+            assert_eq!(
+                branch_parent, None,
+                "first assistant message must be a branch root"
+            );
+            assert_eq!(branch_variant_index, 0);
+            break id;
+        }
+    };
+
+    // ── Branch re-run on the same connection ──────────────────────────
+    forge_ipc::write_frame(
+        &mut writer,
+        &IpcMessage::RerunMessage(RerunMessage {
+            msg_id: original_msg_id.to_string(),
+            variant: RerunVariant::Branch,
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Drain until we see the finalised Branch variant (distinguished by
+    // branch_parent == Some(original)).
+    let branch_msg_id: MessageId = loop {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::AssistantMessage {
+            id,
+            stream_finalised: true,
+            branch_parent: Some(parent),
+            branch_variant_index,
+            ..
+        } = &event
+        {
+            assert_eq!(
+                parent, &original_msg_id,
+                "branch variant must point at the original as its root"
+            );
+            assert_eq!(
+                *branch_variant_index, 1,
+                "first branch re-run must land at variant_index 1"
+            );
+            break id.clone();
+        }
+    };
+    assert_ne!(
+        branch_msg_id, original_msg_id,
+        "variant must have a fresh id"
+    );
+
+    // ── select_branch: activate the sibling ───────────────────────────
+    forge_ipc::write_frame(
+        &mut writer,
+        &IpcMessage::SelectBranch(SelectBranch {
+            parent_id: original_msg_id.to_string(),
+            variant_index: 1,
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Drain until we see the BranchSelected event.
+    loop {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::BranchSelected { parent, selected } = &event {
+            assert_eq!(parent, &original_msg_id);
+            assert_eq!(
+                selected, &branch_msg_id,
+                "BranchSelected must resolve variant_index=1 to the branch message id"
+            );
+            break;
+        }
+    }
+
+    drop(reader);
+    drop(writer);
+
+    // ── Fresh subscriber: both variants MUST replay + BranchSelected ──
+    let mut stream2 = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream2).await;
+    forge_ipc::write_frame(&mut stream2, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+
+    let mut replay: Vec<Event> = Vec::new();
+    let (mut reader2, _writer2) = stream2.into_split();
+    while let Ok(Ok(frame)) = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        forge_ipc::read_frame(&mut reader2),
+    )
+    .await
+    {
+        if let Some(ev) = extract_event(&frame) {
+            replay.push(ev);
+        }
+    }
+
+    let original_present = replay.iter().any(|e| {
+        matches!(
+            e,
+            Event::AssistantMessage { id, stream_finalised: true, .. } if *id == original_msg_id
+        )
+    });
+    assert!(
+        original_present,
+        "fresh replay must keep the original variant visible — Branch does not supersede"
+    );
+
+    let branch_present = replay.iter().any(|e| {
+        matches!(
+            e,
+            Event::AssistantMessage { id, stream_finalised: true, branch_parent: Some(p), .. }
+                if *id == branch_msg_id && *p == original_msg_id
+        )
+    });
+    assert!(
+        branch_present,
+        "fresh replay must include the Branch variant with branch_parent threaded"
+    );
+
+    let selected_present = replay.iter().any(|e| {
+        matches!(
+            e,
+            Event::BranchSelected { parent, selected }
+                if *parent == original_msg_id && *selected == branch_msg_id
+        )
+    });
+    assert!(
+        selected_present,
+        "fresh replay must include BranchSelected so the UI knows which variant to display"
+    );
+}
+
+#[tokio::test]
+async fn select_branch_with_variant_zero_resolves_to_parent() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("select-root.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(MockProvider::from_responses(vec![SCRIPT_FIRST.into()]).unwrap());
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            server_session,
+            server_provider,
+            true,
+            false,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage { text: "ask".into() }),
+    )
+    .await
+    .unwrap();
+
+    let (mut reader, mut writer) = stream.into_split();
+    let original_msg_id: MessageId = loop {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::AssistantMessage {
+            id,
+            stream_finalised: true,
+            ..
+        } = event
+        {
+            break id;
+        }
+    };
+
+    // variant_index=0 resolves to parent itself.
+    forge_ipc::write_frame(
+        &mut writer,
+        &IpcMessage::SelectBranch(SelectBranch {
+            parent_id: original_msg_id.to_string(),
+            variant_index: 0,
+        }),
+    )
+    .await
+    .unwrap();
+
+    loop {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::BranchSelected { parent, selected } = &event {
+            assert_eq!(parent, &original_msg_id);
+            assert_eq!(
+                selected, &original_msg_id,
+                "variant_index=0 must resolve to the root message itself"
+            );
+            break;
+        }
+    }
+}

--- a/crates/forge-session/tests/rerun_fresh.rs
+++ b/crates/forge-session/tests/rerun_fresh.rs
@@ -1,0 +1,263 @@
+//! F-144: Re-run Fresh variant — truncate to the originating user message,
+//! regenerate from there (new root), and supersede the original turn.
+//!
+//! Scenario:
+//!   1. Client drives two user→assistant turns. Turn 1 asks a question and
+//!      gets answer A. Turn 2 asks a follow-up and gets answer B.
+//!   2. Client fires `RerunMessage { msg_id: B, variant: Fresh }`. Fresh
+//!      semantics (CONCEPT.md §10.3): regenerate from turn 2's user message
+//!      *alone* — intermediate tool calls and prior turns are discarded.
+//!      The mock provider's second response (`SCRIPT_FRESH`) is asserted
+//!      to have been dispatched a request containing exactly one user
+//!      message with turn 2's text.
+//!   3. `MessageSuperseded { old_id: B, new_id: B' }` hides the original B
+//!      in replay; B' is a new root (`branch_parent = None`).
+
+use forge_core::{ids::MessageId, Event, RerunVariant};
+use forge_ipc::{
+    ClientInfo, Hello, IpcEvent, IpcMessage, RerunMessage, SendUserMessage, Subscribe,
+    PROTO_VERSION,
+};
+use forge_providers::MockProvider;
+use forge_session::{server::serve_with_session, session::Session};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+const SCRIPT_TURN1: &str = r#"{"delta":"answer one"}
+{"done":"end_turn"}
+"#;
+
+const SCRIPT_TURN2: &str = r#"{"delta":"answer two"}
+{"done":"end_turn"}
+"#;
+
+const SCRIPT_FRESH: &str = r#"{"delta":"fresh answer"}
+{"done":"end_turn"}
+"#;
+
+async fn connect_with_retry(path: &std::path::PathBuf) -> UnixStream {
+    for _ in 0..20 {
+        match UnixStream::connect(path).await {
+            Ok(s) => return s,
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+        }
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("server did not start in time")
+}
+
+async fn do_handshake(stream: &mut UnixStream) {
+    let hello = IpcMessage::Hello(Hello {
+        proto: PROTO_VERSION,
+        client: ClientInfo {
+            kind: "test".into(),
+            pid: std::process::id(),
+            user: "tester".into(),
+        },
+    });
+    forge_ipc::write_frame(stream, &hello).await.unwrap();
+    let response = forge_ipc::read_frame(stream).await.unwrap();
+    assert!(matches!(response, IpcMessage::HelloAck(_)));
+}
+
+fn extract_event(msg: &IpcMessage) -> Option<Event> {
+    if let IpcMessage::Event(IpcEvent { event, .. }) = msg {
+        Some(event.clone())
+    } else {
+        None
+    }
+}
+
+async fn drive_turn(
+    reader: &mut tokio::net::unix::OwnedReadHalf,
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    text: &str,
+) -> MessageId {
+    forge_ipc::write_frame(
+        writer,
+        &IpcMessage::SendUserMessage(SendUserMessage { text: text.into() }),
+    )
+    .await
+    .unwrap();
+    loop {
+        let frame = forge_ipc::read_frame(reader).await.unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::AssistantMessage {
+            id,
+            stream_finalised: true,
+            ..
+        } = event
+        {
+            return id;
+        }
+    }
+}
+
+#[tokio::test]
+async fn rerun_fresh_regenerates_from_user_message_root_and_supersedes_original() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("rerun-fresh.sock");
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(
+        MockProvider::from_responses(vec![
+            SCRIPT_TURN1.into(),
+            SCRIPT_TURN2.into(),
+            SCRIPT_FRESH.into(),
+        ])
+        .unwrap(),
+    );
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            server_session,
+            server_provider,
+            true,
+            false,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+
+    let (mut reader, mut writer) = stream.into_split();
+    let _turn1_id = drive_turn(&mut reader, &mut writer, "first question").await;
+    let turn2_id = drive_turn(&mut reader, &mut writer, "follow up question").await;
+
+    // ── Fresh rerun on turn 2 ──────────────────────────────────────────
+    forge_ipc::write_frame(
+        &mut writer,
+        &IpcMessage::RerunMessage(RerunMessage {
+            msg_id: turn2_id.to_string(),
+            variant: RerunVariant::Fresh,
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Drain until we see the supersede marker.
+    let fresh_id: MessageId = loop {
+        let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::MessageSuperseded { old_id, new_id } = &event {
+            assert_eq!(
+                old_id, &turn2_id,
+                "Fresh must supersede the targeted turn-2 assistant message"
+            );
+            break new_id.clone();
+        }
+    };
+
+    // The regenerated message must be a new root (branch_parent: None,
+    // branch_variant_index: 0) — this is the "new root" criterion in the DoD.
+    let events = provider.recorded_requests();
+    // Three requests dispatched: turn 1, turn 2, fresh-rerun.
+    assert_eq!(
+        events.len(),
+        3,
+        "Fresh must dispatch a new provider request (turn1, turn2, fresh)"
+    );
+
+    // The fresh request MUST contain exactly one message — the originating
+    // user message for turn 2. Prior turns are discarded (this is what
+    // distinguishes Fresh from Replace). The assertion on content verifies
+    // turn 2's user text, not turn 1's.
+    let fresh_req = &events[2];
+    assert_eq!(
+        fresh_req.messages.len(),
+        1,
+        "Fresh request must have exactly one message (the originating user turn only)"
+    );
+    let msg = &fresh_req.messages[0];
+    assert!(
+        matches!(msg.role, forge_providers::ChatRole::User),
+        "Fresh's single message must be a user message"
+    );
+    let text_ok = msg
+        .content
+        .iter()
+        .any(|b| matches!(b, forge_providers::ChatBlock::Text(t) if t == "follow up question"));
+    assert!(
+        text_ok,
+        "Fresh must regenerate from turn 2's user message verbatim, got: {:?}",
+        msg.content
+    );
+
+    drop(reader);
+    drop(writer);
+
+    // ── Fresh subscriber: original turn-2 assistant is hidden, new one visible ──
+    let mut stream2 = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream2).await;
+    forge_ipc::write_frame(&mut stream2, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+
+    let mut replay: Vec<Event> = Vec::new();
+    let (mut reader2, _writer2) = stream2.into_split();
+    while let Ok(Ok(frame)) = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        forge_ipc::read_frame(&mut reader2),
+    )
+    .await
+    {
+        if let Some(ev) = extract_event(&frame) {
+            replay.push(ev);
+        }
+    }
+
+    let superseded_present = replay.iter().any(|e| {
+        matches!(
+            e,
+            Event::AssistantMessage { id, stream_finalised: true, .. } if *id == turn2_id
+        )
+    });
+    assert!(
+        !superseded_present,
+        "Fresh must supersede the original turn-2 assistant message on replay"
+    );
+
+    let regenerated = replay
+        .iter()
+        .find(|e| {
+            matches!(
+                e,
+                Event::AssistantMessage { id, stream_finalised: true, .. } if *id == fresh_id
+            )
+        })
+        .expect("regenerated Fresh assistant message must appear in replay");
+
+    if let Event::AssistantMessage {
+        branch_parent,
+        branch_variant_index,
+        ..
+    } = regenerated
+    {
+        assert_eq!(
+            *branch_parent, None,
+            "Fresh regeneration must be a new root (branch_parent = None)"
+        );
+        assert_eq!(
+            *branch_variant_index, 0,
+            "Fresh regeneration must have branch_variant_index = 0 (root position)"
+        );
+    }
+}

--- a/crates/forge-shell/src/bridge.rs
+++ b/crates/forge-shell/src/bridge.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context, Result};
 use forge_core::{ApprovalScope, RerunVariant};
 use forge_ipc::{
-    read_frame, write_frame, ClientInfo, Hello, HelloAck, IpcMessage, RerunMessage,
+    read_frame, write_frame, ClientInfo, Hello, HelloAck, IpcMessage, RerunMessage, SelectBranch,
     SendUserMessage, Subscribe, ToolCallApproved, ToolCallRejected, PROTO_VERSION,
 };
 use serde::Serialize;
@@ -372,9 +372,9 @@ impl SessionBridge {
         write_frame(&mut *writer, &frame).await
     }
 
-    /// F-143: forward a `rerun_message` request to the session daemon.
-    /// Branch/Fresh variants will be wired in F-144/F-145 — the daemon
-    /// rejects them today, so callers should gate on `variant == Replace`.
+    /// F-143 / F-144: forward a `rerun_message` request to the session
+    /// daemon. All three variants (Replace, Branch, Fresh) are dispatched
+    /// server-side.
     pub async fn rerun_message(
         &self,
         session_id: &str,
@@ -384,6 +384,27 @@ impl SessionBridge {
         let writer = self.writer_for(session_id).await?;
         let mut writer = writer.lock().await;
         let frame = IpcMessage::RerunMessage(RerunMessage { msg_id, variant });
+        write_frame(&mut *writer, &frame).await
+    }
+
+    /// F-144: forward a `select_branch` request to the session daemon.
+    /// Triggers the daemon to emit `Event::BranchSelected { parent,
+    /// selected }` after resolving `variant_index` against the event log.
+    /// Unknown variants are surfaced daemon-side as log lines; the Tauri
+    /// command returns `Ok(())` once the frame is written (the emission
+    /// arrives through the event stream).
+    pub async fn select_branch(
+        &self,
+        session_id: &str,
+        parent_id: String,
+        variant_index: u32,
+    ) -> Result<()> {
+        let writer = self.writer_for(session_id).await?;
+        let mut writer = writer.lock().await;
+        let frame = IpcMessage::SelectBranch(SelectBranch {
+            parent_id,
+            variant_index,
+        });
         write_frame(&mut *writer, &frame).await
     }
 

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -311,10 +311,10 @@ pub async fn session_approve_tool<R: Runtime>(
         .map_err(|e| e.to_string())
 }
 
-/// F-143: re-run an assistant message. Phase 1 dispatches only
-/// `RerunVariant::Replace`; `Branch` (F-144) and `Fresh` (F-145) return an
-/// error today rather than silently no-op, so a UI that ships Branch before
-/// the daemon supports it learns fast.
+/// F-143 / F-144: re-run an assistant message. All three `RerunVariant`s
+/// (`Replace`, `Branch`, `Fresh`) are dispatched through the bridge. The
+/// `variant` parameter is typed so serde rejects any non-variant at the
+/// Tauri arg-deserialization layer — no byte cap is useful here.
 #[tauri::command]
 pub async fn rerun_message<R: Runtime>(
     session_id: String,
@@ -324,22 +324,39 @@ pub async fn rerun_message<R: Runtime>(
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
     require_window_label(&webview, &format!("session-{session_id}"))?;
-    // F-068 / L4: bound `msg_id` before the bridge allocates a frame. The
-    // variant is typed (forge_core::RerunVariant) — serde rejects any
-    // non-variant at Tauri arg deserialization, so no byte cap is needed.
+    // F-068 / L4: bound `msg_id` before the bridge allocates a frame.
     require_size("msg_id", &msg_id, MAX_MESSAGE_ID_BYTES)?;
-    match variant {
-        RerunVariant::Replace => state
-            .bridge
-            .rerun_message(&session_id, msg_id, variant)
-            .await
-            .map_err(|e| e.to_string()),
-        // Branch / Fresh return errors here (not silent no-ops) so a UI that
-        // invokes them before F-144/F-145 ship gets a loud signal instead of
-        // a hanging command.
-        RerunVariant::Branch => Err("rerun_message: Branch variant not implemented (F-144)".into()),
-        RerunVariant::Fresh => Err("rerun_message: Fresh variant not implemented (F-145)".into()),
-    }
+    state
+        .bridge
+        .rerun_message(&session_id, msg_id, variant)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// F-144: activate a branch variant for replay / UI display. Resolves
+/// `variant_index` against the session log and (on success) emits
+/// `Event::BranchSelected { parent, selected }`. The emission arrives
+/// through the session event stream; this command returns `Ok(())` once
+/// the frame is written to the daemon.
+///
+/// Authz + size caps mirror `rerun_message` — only the owning session's
+/// webview may drive its branch selection; `parent_id` is bounded by
+/// `MAX_MESSAGE_ID_BYTES`.
+#[tauri::command]
+pub async fn select_branch<R: Runtime>(
+    session_id: String,
+    parent_id: String,
+    variant_index: u32,
+    webview: Webview<R>,
+    state: State<'_, BridgeState>,
+) -> Result<(), String> {
+    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_size("parent_id", &parent_id, MAX_MESSAGE_ID_BYTES)?;
+    state
+        .bridge
+        .select_branch(&session_id, parent_id, variant_index)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -375,6 +392,7 @@ pub fn build_invoke_handler<R: Runtime>() -> Box<dyn Fn(tauri::ipc::Invoke<R>) -
         session_approve_tool,
         session_reject_tool,
         rerun_message,
+        select_branch,
         get_persistent_approvals,
         save_approval,
         remove_approval,

--- a/crates/forge-shell/tests/ipc_authz.rs
+++ b/crates/forge-shell/tests/ipc_authz.rs
@@ -211,6 +211,32 @@ fn session_a_window_invoking_rerun_message_for_session_b_is_rejected() {
     );
 }
 
+/// F-144: `select_branch` is session-scoped. A session-A webview must not be
+/// able to switch branch variants inside session-B's transcript — the
+/// resulting `BranchSelected` event would forge UI state in another
+/// session's stream.
+#[test]
+fn session_a_window_invoking_select_branch_for_session_b_is_rejected() {
+    let app = make_app_with_session_bridge();
+    let window = build_window(&app, "session-A");
+
+    let err = invoke(
+        &window,
+        "select_branch",
+        serde_json::json!({
+            "sessionId": "B",
+            "parentId": "deadbeefdeadbeef",
+            "variantIndex": 1,
+        }),
+    )
+    .expect_err("session-A must not select a branch in session B");
+
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}
+
 #[test]
 fn session_a_window_invoking_session_hello_for_session_b_is_rejected() {
     let app = make_app_with_session_bridge();


### PR DESCRIPTION
Closes forge-ide/forge#258

## Summary

Builds on F-143 (Replace). Wires the remaining two `RerunVariant` arms plus the `select_branch` Tauri command so the three-option re-run menu (Replace, Branch, Fresh) dispatches end-to-end.

Concretely:

- `forge_core::Event::BranchSelected` is already on the enum (F-032); no event-log shape changes here. Stale F-143 doc comments on `apply_superseded` updated — the tool-call-filtering carry-forward is no longer owned by F-144.
- `forge_ipc::IpcMessage::SelectBranch { parent_id, variant_index }` — new client→daemon frame; `RerunMessage` unchanged. `ipc_message_kind`'s exhaustive match extended.
- `forge_session::Orchestrator::rerun_message` now dispatches all three variants (no more "Branch not implemented" error).
  - `rerun_branch` — threads `branch_parent = Some(root)` and `branch_variant_index = prev_max + 1` onto the regenerated `AssistantMessage`; does **not** emit `MessageSuperseded` (both versions co-exist).
  - `rerun_fresh` — builds a `ChatRequest` with *only* the originating `UserMessage` (discarding all intermediate turns), runs it as a new root, and emits `MessageSuperseded` after the regenerated turn finalises.
- `forge_session::Orchestrator::select_branch(parent, variant_index)` — resolves `variant_index` against the filtered event log and emits `Event::BranchSelected { parent, selected }`. Unknown indices return `Err` without emitting — callers must not silently corrupt the log with a fallback.
- `run_request_loop` now takes `branch_parent: Option<MessageId>` + `branch_variant_index: u32` so the same loop serves per-turn, Replace, Branch, and Fresh emissions.
- `forge-shell::ipc::rerun_message` drops the `Branch`/`Fresh` stub errors — all three now forward to the bridge.
- `forge-shell::ipc::select_branch` — new `#[tauri::command]`, `require_window_label` + `require_size("parent_id", MAX_MESSAGE_ID_BYTES)` guards. Registered in `build_invoke_handler!`.
- Integration tests:
  - `tests/rerun_branch.rs` — both variants remain in replay; `branch_parent` threaded; `BranchSelected` resolves `variant_index=1` to the new message id; `variant_index=0` resolves to parent itself.
  - `tests/rerun_fresh.rs` — mock provider records exactly one `ChatRequest` for the fresh rerun, with a single `User` `ChatBlock::Text` equal to the originating turn's user text (prior turns discarded). Fresh replay hides the original turn and surfaces the regenerated root.
- Unit tests in `orchestrator::tests`:
  - `find_branch_root_coalesces_when_target_is_itself_a_variant` — Branch of variant 1 (with variant 2 also present) resolves root correctly, `prev_max = 2`.
  - `resolve_branch_variant_rejects_unknown_index` — unknown variants / unknown parents return `Err`; known ones resolve.
- `forge-shell/tests/ipc_authz.rs` — new `session_a_window_invoking_select_branch_for_session_b_is_rejected` matching the F-143 template (11 authz tests pass).

## Interpretations / Deferred items (flag for reviewer)

- **`branch_parent` wording.** The DoD says `branch_parent = msg_id`. Spec §15.1 says `branch_parent_id = M.branch_parent_id ?? M.id`. Implemented the spec version (coalesce): branch-of-a-branch threads all variants back to the same root id, otherwise `prev_max + 1` can't compute sibling ordering. Flagged here rather than silently diverged.
- **`select_branch` signature.** `docs/architecture/ipc-contracts.md` declares `select_branch(session, parent, variant: MessageId)`. The F-144 DoD says `(session, parent_id, variant_index: u32)`. Followed the DoD. The doc drift is a follow-up (not fixed here — scope creep). The server still resolves `variant_index` to a MessageId internally before emitting `BranchSelected.selected`.
- **ts-rs generated bindings.** `SelectBranch` is a wire-internal IPC frame (no `#[derive(TS)]`, matches `RerunMessage`). The Tauri command's args are all primitives (`String`, `u32`) — Tauri invoke plumbing doesn't need new bindings. Existing `generated/RerunVariant.ts` already covers the only exported type used by the rerun command surface. DoD's reference to `generated.ts` is the same stale wording F-143 flagged.
- **Tool-call filtering on supersede.** F-143's carry-forward. `apply_superseded` filters `AssistantMessage`/`AssistantDelta` events whose id is superseded but leaves the associated `ToolCall*` cluster in place (completion events are keyed by `ToolCallId`, not `MessageId`, so filtering `ToolCallStarted` alone would leave orphan completions). Fresh inherits this same limitation. Doc comment updated to drop the "deferred to F-144" language.
- **`build_request_up_to` fidelity gap.** F-143 noted tool-call blocks aren't round-tripped into the regenerated request. Branch reuses the same helper and inherits the same gap; Fresh sidesteps it entirely by building a one-message request.
- **Coalesce arm unit-tested, not integration-tested.** The Branch integration test covers a single Branch on a root. The branch-of-a-branch coalesce case is covered by `find_branch_root_coalesces_when_target_is_itself_a_variant`. Integration coverage of chained branches is a follow-up.

## Test plan

- `just check-rust` — fmt, check, clippy `-D warnings`, rustdoc `-D warnings` all pass
- `just test-rust` — 0 failures across the workspace including 3 integration tests (rerun_replace, rerun_branch, rerun_fresh) and 4 orchestrator unit tests
- `just test-rust-webview` — 11 ipc_authz tests pass (F-143's 10 + new F-144 `select_branch` authz regression)

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)