### PR TITLE
feat(web): SubAgentBanner inline orchestrator-spawn rendering (F-136)

### DIFF
--- a/web/packages/app/src/components/SubAgentBanner.css
+++ b/web/packages/app/src/components/SubAgentBanner.css
@@ -1,0 +1,156 @@
+/*
+ * F-136 SubAgentBanner — inline orchestrator-spawn banner rendered in the
+ * parent's ChatPane. Token palette per `docs/ui-specs/sub-agent-banner.md`
+ * §6 and reuses the `PaneHeader.css` ember accent + surface-1/surface-2
+ * token pair. No opacity on state changes (component-principles.md).
+ */
+
+.sub-agent-banner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-1);
+  /* Spec: 2px left border in `--color-ember-400`. */
+  border-left: 2px solid var(--color-ember-400);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-primary);
+}
+
+.sub-agent-banner__header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  cursor: pointer;
+  user-select: none;
+  /* Remove button default visuals while keeping keyboard activation. */
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  width: 100%;
+}
+
+.sub-agent-banner__header:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+  border-radius: var(--r-sm);
+}
+
+.sub-agent-banner__glyph {
+  color: var(--color-ember-400);
+  flex: 0 0 auto;
+}
+
+.sub-agent-banner__label {
+  color: var(--color-text-primary);
+  flex: 0 0 auto;
+}
+
+.sub-agent-banner__name {
+  color: var(--color-text-primary);
+}
+
+.sub-agent-banner__timestamp {
+  color: var(--color-text-tertiary);
+  font-size: 10px;
+  margin-left: var(--sp-2);
+  flex: 0 0 auto;
+}
+
+.sub-agent-banner__state-chip {
+  margin-left: auto;
+  padding: 0 var(--sp-2);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--color-border-1);
+  background: var(--color-surface-3);
+  color: var(--color-text-secondary);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  flex: 0 0 auto;
+}
+
+/*
+ * State chip semantic palette — spec §6:
+ *   running → warn   done → ok   queued → text-secondary
+ *   error   → err    killed → text-tertiary
+ * No opacity changes; colors are tokenised.
+ */
+.sub-agent-banner__state-chip[data-state='running'] {
+  color: var(--color-warning);
+  border-color: var(--color-warning-border);
+}
+
+.sub-agent-banner__state-chip[data-state='done'] {
+  color: var(--color-ok, #33d17a);
+  border-color: var(--color-ok-border, rgba(51, 209, 122, 0.22));
+}
+
+.sub-agent-banner__state-chip[data-state='error'] {
+  color: var(--color-error);
+  border-color: var(--color-error-border);
+}
+
+.sub-agent-banner__state-chip[data-state='queued'] {
+  color: var(--color-text-secondary);
+}
+
+.sub-agent-banner__state-chip[data-state='killed'] {
+  color: var(--color-text-tertiary);
+}
+
+.sub-agent-banner__chevron {
+  color: var(--color-text-tertiary);
+  flex: 0 0 auto;
+  font-size: 10px;
+}
+
+.sub-agent-banner__summary {
+  color: var(--color-text-tertiary);
+  font-size: 10px;
+  padding-left: var(--sp-4);
+}
+
+.sub-agent-banner__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  padding-left: var(--sp-4);
+  border-top: 1px solid var(--color-border-1);
+  padding-top: var(--sp-2);
+  margin-top: var(--sp-1);
+}
+
+.sub-agent-banner__empty {
+  margin: 0;
+  color: var(--color-text-tertiary);
+  font-size: 10px;
+}
+
+.sub-agent-banner__open-monitor {
+  align-self: flex-start;
+  padding: var(--sp-1) var(--sp-3);
+  background: transparent;
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.sub-agent-banner__open-monitor:hover {
+  border-color: var(--color-ember-400);
+  color: var(--color-ember-400);
+}
+
+.sub-agent-banner__open-monitor:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}

--- a/web/packages/app/src/components/SubAgentBanner.test.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.test.tsx
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import { SubAgentBanner } from './SubAgentBanner';
+import type { ChatTurn } from '../stores/messages';
+
+// F-136 component tests — the DoD pins expand/collapse, nested rendering for
+// sub-of-sub banners, and completion state. Tests pass a `turn` fixture +
+// optional `children`/`onOpenInMonitor` overrides; no store wiring required.
+
+function makeTurn(
+  overrides: Partial<Extract<ChatTurn, { type: 'sub_agent_banner' }>> = {},
+): Extract<ChatTurn, { type: 'sub_agent_banner' }> {
+  return {
+    type: 'sub_agent_banner',
+    child_instance_id: 'child-1',
+    parent_instance_id: 'parent-1',
+    status: 'running',
+    started_at: Date.UTC(2026, 3, 20, 14, 37, 0),
+    ...overrides,
+  };
+}
+
+describe('SubAgentBanner — header + default state', () => {
+  it('renders the spawned glyph and agent name in the header', () => {
+    const { getByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn({ agent_name: 'test-writer' })} />
+    ));
+    const header = getByTestId('sub-agent-banner-header-child-1');
+    expect(header).toHaveTextContent('spawned');
+    expect(header).toHaveTextContent('test-writer');
+  });
+
+  it('falls back to a short prefix of the child id when no agent_name is set', () => {
+    const { getByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn({ child_instance_id: 'abcd1234-efgh-5678' })} />
+    ));
+    const header = getByTestId('sub-agent-banner-header-abcd1234-efgh-5678');
+    // Short prefix (first 8 chars) is visible; the full id is not.
+    expect(header).toHaveTextContent('abcd1234');
+    expect(header).not.toHaveTextContent('efgh-5678');
+  });
+
+  it('renders a "delegated at HH:MM" timestamp from started_at', () => {
+    // Build a fixture whose local-time HH:MM we can predict independent
+    // of the runner's TZ by reading the same Date back.
+    const at = new Date();
+    at.setHours(9, 5, 0, 0);
+    const { getByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn({ started_at: at.getTime() })} />
+    ));
+    const ts = getByTestId('sub-agent-banner-timestamp-child-1');
+    expect(ts).toHaveTextContent(/delegated at \d{2}:\d{2}/);
+  });
+
+  it('mounts collapsed by default — summary visible, body hidden', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn()} />
+    ));
+    expect(getByTestId('sub-agent-banner-child-1')).toHaveAttribute(
+      'data-expanded',
+      'false',
+    );
+    expect(getByTestId('sub-agent-banner-summary-child-1')).toBeInTheDocument();
+    expect(queryByTestId('sub-agent-banner-body-child-1')).not.toBeInTheDocument();
+  });
+});
+
+describe('SubAgentBanner — expand/collapse', () => {
+  it('toggles to expanded on header click and back to collapsed on second click', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn()} />
+    ));
+    const header = getByTestId('sub-agent-banner-header-child-1');
+
+    fireEvent.click(header);
+    expect(getByTestId('sub-agent-banner-child-1')).toHaveAttribute(
+      'data-expanded',
+      'true',
+    );
+    expect(getByTestId('sub-agent-banner-body-child-1')).toBeInTheDocument();
+    expect(queryByTestId('sub-agent-banner-summary-child-1')).not.toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(getByTestId('sub-agent-banner-child-1')).toHaveAttribute(
+      'data-expanded',
+      'false',
+    );
+  });
+
+  it('expands when Enter is pressed on the focused header', () => {
+    const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    const header = getByTestId('sub-agent-banner-header-child-1');
+    fireEvent.keyDown(header, { key: 'Enter' });
+    expect(getByTestId('sub-agent-banner-child-1')).toHaveAttribute(
+      'data-expanded',
+      'true',
+    );
+  });
+
+  it('expands when Space is pressed on the focused header', () => {
+    const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    const header = getByTestId('sub-agent-banner-header-child-1');
+    fireEvent.keyDown(header, { key: ' ' });
+    expect(getByTestId('sub-agent-banner-child-1')).toHaveAttribute(
+      'data-expanded',
+      'true',
+    );
+  });
+
+  it('renders the "No step events yet" placeholder when expanded with no children', () => {
+    const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    fireEvent.click(getByTestId('sub-agent-banner-header-child-1'));
+    expect(getByTestId('sub-agent-banner-empty-child-1')).toBeInTheDocument();
+  });
+});
+
+describe('SubAgentBanner — nested rendering for sub-of-sub', () => {
+  it('renders a nested SubAgentBanner when an expanded body carries a sub_agent_banner child turn', () => {
+    const grandchild: Extract<ChatTurn, { type: 'sub_agent_banner' }> = {
+      type: 'sub_agent_banner',
+      child_instance_id: 'grandchild-1',
+      parent_instance_id: 'child-1',
+      status: 'running',
+      started_at: Date.now(),
+      agent_name: 'deep-helper',
+    };
+    const { getByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn()} children={[grandchild]} />
+    ));
+    fireEvent.click(getByTestId('sub-agent-banner-header-child-1'));
+
+    // Nested banner is rendered inside the parent body.
+    expect(getByTestId('sub-agent-banner-grandchild-1')).toBeInTheDocument();
+    const nestedHeader = getByTestId('sub-agent-banner-header-grandchild-1');
+    expect(nestedHeader).toHaveTextContent('deep-helper');
+  });
+
+  it('replaces nested inline children with an "Open in new window" button past max depth (3)', () => {
+    const grandchild: Extract<ChatTurn, { type: 'sub_agent_banner' }> = {
+      type: 'sub_agent_banner',
+      child_instance_id: 'too-deep-1',
+      parent_instance_id: 'child-1',
+      status: 'running',
+      started_at: Date.now(),
+    };
+    const { getByTestId, queryByTestId } = render(() => (
+      <SubAgentBanner
+        turn={makeTurn()}
+        children={[grandchild]}
+        depth={3}
+      />
+    ));
+    fireEvent.click(getByTestId('sub-agent-banner-header-child-1'));
+    // At depth ≥ 3 the body renders the open-monitor fallback, not the
+    // nested banner — its testid must be absent.
+    expect(queryByTestId('sub-agent-banner-too-deep-1')).not.toBeInTheDocument();
+    expect(getByTestId('sub-agent-banner-open-monitor-child-1')).toBeInTheDocument();
+  });
+});
+
+describe('SubAgentBanner — completion state', () => {
+  it('renders the state chip with data-state="running" while the child is live', () => {
+    const { getByTestId, container } = render(() => (
+      <SubAgentBanner turn={makeTurn({ status: 'running' })} />
+    ));
+    const chip = getByTestId('sub-agent-banner-state-child-1');
+    expect(chip).toHaveAttribute('data-state', 'running');
+    expect(chip).toHaveTextContent('running');
+    // The outer section also mirrors the status via data-status so CSS can
+    // target completed vs. running styling without prop plumbing.
+    const section = container.querySelector('.sub-agent-banner');
+    expect(section).toHaveAttribute('data-status', 'running');
+  });
+
+  it('renders the state chip with data-state="done" on completion', () => {
+    const { getByTestId, container } = render(() => (
+      <SubAgentBanner turn={makeTurn({ status: 'done' })} />
+    ));
+    const chip = getByTestId('sub-agent-banner-state-child-1');
+    expect(chip).toHaveAttribute('data-state', 'done');
+    expect(chip).toHaveTextContent('done');
+    const section = container.querySelector('.sub-agent-banner');
+    expect(section).toHaveAttribute('data-status', 'done');
+  });
+
+  it('summary line shows step count + last step when provided', () => {
+    const { getByTestId } = render(() => (
+      <SubAgentBanner
+        turn={makeTurn({ step_count: 6, last_step_summary: 'wrote validate.test.ts' })}
+      />
+    ));
+    const summary = getByTestId('sub-agent-banner-summary-child-1');
+    expect(summary).toHaveTextContent('6 steps');
+    expect(summary).toHaveTextContent('wrote validate.test.ts');
+  });
+
+  it('summary line falls back to "waiting for first step" before any step event', () => {
+    const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    expect(getByTestId('sub-agent-banner-summary-child-1')).toHaveTextContent(
+      'waiting for first step',
+    );
+  });
+});
+
+describe('SubAgentBanner — double-click to Agent Monitor (F-140)', () => {
+  it('calls onOpenInMonitor with the child instance id on header double-click', () => {
+    const open = vi.fn();
+    const { getByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn()} onOpenInMonitor={open} />
+    ));
+    fireEvent.dblClick(getByTestId('sub-agent-banner-header-child-1'));
+    expect(open).toHaveBeenCalledWith('child-1');
+  });
+
+  it('invokes the "Open in new window" button when depth exceeds the inline cap', () => {
+    const open = vi.fn();
+    const grandchild: Extract<ChatTurn, { type: 'sub_agent_banner' }> = {
+      type: 'sub_agent_banner',
+      child_instance_id: 'too-deep-2',
+      parent_instance_id: 'child-1',
+      status: 'running',
+      started_at: Date.now(),
+    };
+    const { getByTestId } = render(() => (
+      <SubAgentBanner
+        turn={makeTurn()}
+        children={[grandchild]}
+        depth={3}
+        onOpenInMonitor={open}
+      />
+    ));
+    fireEvent.click(getByTestId('sub-agent-banner-header-child-1'));
+    fireEvent.click(getByTestId('sub-agent-banner-open-monitor-child-1'));
+    expect(open).toHaveBeenCalledWith('child-1');
+  });
+});

--- a/web/packages/app/src/components/SubAgentBanner.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.tsx
@@ -1,0 +1,217 @@
+import { type Component, createSignal, For, Show } from 'solid-js';
+import type { ChatTurn, SubAgentStatus } from '../stores/messages';
+import './SubAgentBanner.css';
+
+// ---------------------------------------------------------------------------
+// SubAgentBanner — inline representation of a spawned sub-agent in the
+// parent's ChatPane (F-136). Matches `docs/ui-specs/sub-agent-banner.md` §6:
+// 2px ember left-border accent, header row (`↳ spawned · <name>`), model +
+// step-count + state chips, click header to toggle collapse. Double-click
+// navigates to the Agent Monitor (F-140) with the child instance pre-selected
+// — the route 404s until F-140 lands.
+//
+// Backend gap (flagged in the PR body): today no step events ride the
+// child's `instance_id` so live step streaming is wired through props but
+// stays empty in production. The banner still flips `running → done` when
+// `BackgroundAgentCompleted` arrives for the child (F-137 already forwards
+// that event onto the session bus).
+// ---------------------------------------------------------------------------
+
+export type SubAgentBannerTurn = Extract<ChatTurn, { type: 'sub_agent_banner' }>;
+
+export interface SubAgentBannerProps {
+  turn: SubAgentBannerTurn;
+  /**
+   * Child turns to render inside the banner when expanded. Empty today —
+   * the wire is here for when instance-tagged step/assistant events start
+   * flowing through the orchestrator's step executor (post-F-140).
+   */
+  children?: ChatTurn[];
+  /**
+   * Optional custom navigator used by tests. Production uses
+   * `window.location.href = '/agent-monitor?instance=<id>'` which 404s
+   * until F-140 registers the route.
+   */
+  onOpenInMonitor?: (childInstanceId: string) => void;
+  /**
+   * F-136 §6 "Max depth: 3. Beyond that, child banners render collapsed by
+   * default and 'Open in new window' appears." Defaults to 0 at the root.
+   */
+  depth?: number;
+}
+
+const MAX_INLINE_DEPTH = 3;
+
+function shortId(id: string): string {
+  // Instance ids are UUIDs; the short 8-char prefix keeps the header
+  // readable when no agent_name was enriched.
+  return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+function formatStartedAt(ms: number): string {
+  const d = new Date(ms);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+function statusLabel(status: SubAgentStatus): string {
+  return status;
+}
+
+export const SubAgentBanner: Component<SubAgentBannerProps> = (props) => {
+  // Spec §6 "Collapsed state" — default collapsed; user expands to inspect.
+  const [expanded, setExpanded] = createSignal(false);
+
+  const depth = (): number => props.depth ?? 0;
+  const beyondMaxDepth = (): boolean => depth() >= MAX_INLINE_DEPTH;
+
+  const displayName = (): string =>
+    props.turn.agent_name ?? shortId(props.turn.child_instance_id);
+
+  const toggle = (): void => {
+    setExpanded((v) => !v);
+  };
+
+  const openInMonitor = (): void => {
+    if (props.onOpenInMonitor) {
+      props.onOpenInMonitor(props.turn.child_instance_id);
+      return;
+    }
+    // Route 404s until F-140 lands; flagged in the PR body.
+    if (typeof window !== 'undefined') {
+      window.location.href = `/agent-monitor?instance=${encodeURIComponent(props.turn.child_instance_id)}`;
+    }
+  };
+
+  const summaryLine = (): string => {
+    const last = props.turn.last_step_summary;
+    const count = props.turn.step_count;
+    if (count !== undefined && count > 0) {
+      const stepWord = count === 1 ? 'step' : 'steps';
+      return last ? `${count} ${stepWord} · last: ${last}` : `${count} ${stepWord}`;
+    }
+    // Pre-step-executor phase — nothing to summarise yet.
+    return 'waiting for first step';
+  };
+
+  return (
+    <section
+      class="sub-agent-banner"
+      data-testid={`sub-agent-banner-${props.turn.child_instance_id}`}
+      data-status={props.turn.status}
+      data-expanded={expanded() ? 'true' : 'false'}
+      aria-label={`Sub-agent ${displayName()} (${statusLabel(props.turn.status)})`}
+    >
+      {/* Header — click to toggle, double-click jumps to Agent Monitor. */}
+      <header
+        class="sub-agent-banner__header"
+        data-testid={`sub-agent-banner-header-${props.turn.child_instance_id}`}
+        onClick={toggle}
+        onDblClick={openInMonitor}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e: KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+      >
+        <span class="sub-agent-banner__glyph" aria-hidden="true">↳</span>
+        <span class="sub-agent-banner__label">
+          spawned · <span class="sub-agent-banner__name">{displayName()}</span>
+        </span>
+        <span
+          class="sub-agent-banner__timestamp"
+          data-testid={`sub-agent-banner-timestamp-${props.turn.child_instance_id}`}
+        >
+          delegated at {formatStartedAt(props.turn.started_at)}
+        </span>
+        <span
+          class="sub-agent-banner__state-chip"
+          data-testid={`sub-agent-banner-state-${props.turn.child_instance_id}`}
+          data-state={props.turn.status}
+        >
+          {statusLabel(props.turn.status)}
+        </span>
+        <span
+          class="sub-agent-banner__chevron"
+          data-testid={`sub-agent-banner-chevron-${props.turn.child_instance_id}`}
+          aria-hidden="true"
+        >
+          {expanded() ? 'v' : '>'}
+        </span>
+      </header>
+
+      {/* Collapsed body — one-line summary per spec §6 "Collapsed state". */}
+      <Show when={!expanded()}>
+        <div
+          class="sub-agent-banner__summary"
+          data-testid={`sub-agent-banner-summary-${props.turn.child_instance_id}`}
+        >
+          {summaryLine()}
+        </div>
+      </Show>
+
+      {/* Expanded body — nested turn render. Beyond MAX_INLINE_DEPTH we
+          render the "Open in new window" affordance instead of inlining
+          grandchildren, per spec §6 "Max depth: 3". */}
+      <Show when={expanded()}>
+        <div
+          class="sub-agent-banner__body"
+          data-testid={`sub-agent-banner-body-${props.turn.child_instance_id}`}
+        >
+          <Show
+            when={!beyondMaxDepth()}
+            fallback={
+              <button
+                type="button"
+                class="sub-agent-banner__open-monitor"
+                data-testid={`sub-agent-banner-open-monitor-${props.turn.child_instance_id}`}
+                onClick={openInMonitor}
+              >
+                Open in new window
+              </button>
+            }
+          >
+            <Show
+              when={(props.children ?? []).length > 0}
+              fallback={
+                <p
+                  class="sub-agent-banner__empty"
+                  data-testid={`sub-agent-banner-empty-${props.turn.child_instance_id}`}
+                >
+                  No step events yet.
+                </p>
+              }
+            >
+              <For each={props.children ?? []}>
+                {(child) => <NestedTurnRenderer turn={child} depth={depth() + 1} />}
+              </For>
+            </Show>
+          </Show>
+        </div>
+      </Show>
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// NestedTurnRenderer — renders a nested sub-agent banner when a child turn
+// of type `sub_agent_banner` shows up inside an expanded banner body. Other
+// turn types are intentionally excluded here: the parent ChatPane owns the
+// cross-turn switch (user/assistant/tool/error), so nested banners only
+// need to know how to recurse into themselves.
+// ---------------------------------------------------------------------------
+
+const NestedTurnRenderer: Component<{ turn: ChatTurn; depth: number }> = (props) => {
+  return (
+    <Show when={props.turn.type === 'sub_agent_banner'}>
+      <SubAgentBanner
+        turn={props.turn as SubAgentBannerTurn}
+        depth={props.depth}
+      />
+    </Show>
+  );
+};

--- a/web/packages/app/src/ipc/events.test.ts
+++ b/web/packages/app/src/ipc/events.test.ts
@@ -48,9 +48,10 @@ describe('fromRustEvent — non-rendering variants return null', () => {
     },
     { type: 'session_ended', at: '2026-04-18T10:00:00Z', reason: 'UserExit', archived: true },
     { type: 'branch_selected', parent: 'a', selected: 'b' },
-    { type: 'sub_agent_spawned', parent: 'p', child: 'c', from_msg: 'm' },
+    // F-136: sub_agent_spawned + background_agent_completed are now mapped
+    // into renderable SessionEvents (banner mount + terminal flip); they're
+    // asserted in their own positive describes below.
     { type: 'background_agent_started', id: 'ba-1', agent: 'a', at: '2026-04-18T10:00:00Z' },
-    { type: 'background_agent_completed', id: 'ba-1', at: '2026-04-18T10:00:00Z' },
     {
       type: 'usage_tick',
       provider: 'p',
@@ -375,6 +376,84 @@ describe('fromRustEvent — narrowing drops malformed required fields', () => {
         stream_finalised: true,
         text: null,
       }),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-136: sub_agent_spawned + background_agent_completed — ChatPane banner
+// wire-up. The Rust shape matches `forge_core::Event::SubAgentSpawned` /
+// `BackgroundAgentCompleted`; event_wire_shape.rs pins it serverside.
+// ---------------------------------------------------------------------------
+
+describe('fromRustEvent — sub_agent_spawned (F-136)', () => {
+  it('maps to SubAgentSpawned with parent/child/from_msg carried through', () => {
+    const rust = {
+      type: 'sub_agent_spawned',
+      parent: 'parent-inst-1',
+      child: 'child-inst-1',
+      from_msg: 'msg-7',
+    };
+    expect(fromRustEvent(rust)).toEqual({
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'parent-inst-1',
+      child_instance_id: 'child-inst-1',
+      from_msg: 'msg-7',
+    });
+  });
+
+  it('forwards an optional agent_name when the shell enriches the payload', () => {
+    const rust = {
+      type: 'sub_agent_spawned',
+      parent: 'p',
+      child: 'c',
+      from_msg: 'm',
+      agent_name: 'test-writer',
+    };
+    expect(fromRustEvent(rust)).toEqual({
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'p',
+      child_instance_id: 'c',
+      from_msg: 'm',
+      agent_name: 'test-writer',
+    });
+  });
+
+  it('drops payloads with a non-string parent', () => {
+    expect(
+      fromRustEvent({ type: 'sub_agent_spawned', parent: 7, child: 'c', from_msg: 'm' }),
+    ).toBeNull();
+  });
+
+  it('drops payloads with a non-string child', () => {
+    expect(
+      fromRustEvent({ type: 'sub_agent_spawned', parent: 'p', child: null, from_msg: 'm' }),
+    ).toBeNull();
+  });
+
+  it('drops payloads with a non-string from_msg', () => {
+    expect(
+      fromRustEvent({ type: 'sub_agent_spawned', parent: 'p', child: 'c' }),
+    ).toBeNull();
+  });
+});
+
+describe('fromRustEvent — background_agent_completed (F-136)', () => {
+  it('maps to BackgroundAgentCompleted keyed by instance id', () => {
+    const rust = {
+      type: 'background_agent_completed',
+      id: 'child-inst-1',
+      at: '2026-04-20T10:00:00Z',
+    };
+    expect(fromRustEvent(rust)).toEqual({
+      kind: 'BackgroundAgentCompleted',
+      instance_id: 'child-inst-1',
+    });
+  });
+
+  it('drops payloads missing the id', () => {
+    expect(
+      fromRustEvent({ type: 'background_agent_completed', at: '2026-04-20T10:00:00Z' }),
     ).toBeNull();
   });
 });

--- a/web/packages/app/src/ipc/events.ts
+++ b/web/packages/app/src/ipc/events.ts
@@ -154,6 +154,50 @@ export function fromRustEvent(rustEvent: unknown): SessionEvent | null {
     return { kind: 'AssistantDelta', message_id: id, delta };
   }
 
+  // F-136: sub-agent spawn — the orchestrator emitted `SubAgentSpawned`
+  // from the session's event log. Carries parent/child `AgentInstanceId`s
+  // and the originating `MessageId`. Optional `agent_name` is accepted if
+  // present so a future shell-side enrichment can surface it without
+  // another round-trip; absent today.
+  if (type === 'sub_agent_spawned') {
+    const parent = ev['parent'];
+    const child = ev['child'];
+    const fromMsg = ev['from_msg'];
+    if (!isString(parent)) {
+      warnDrop('sub_agent_spawned', 'parent missing or not a string');
+      return null;
+    }
+    if (!isString(child)) {
+      warnDrop('sub_agent_spawned', 'child missing or not a string');
+      return null;
+    }
+    if (!isString(fromMsg)) {
+      warnDrop('sub_agent_spawned', 'from_msg missing or not a string');
+      return null;
+    }
+    const agentName = ev['agent_name'];
+    const out: SessionEvent = {
+      kind: 'SubAgentSpawned',
+      parent_instance_id: parent,
+      child_instance_id: child,
+      from_msg: fromMsg,
+    };
+    if (isString(agentName)) out.agent_name = agentName;
+    return out;
+  }
+
+  // F-136: sub-agent terminal — `BackgroundAgentRegistry` (F-137) forwards
+  // this onto the session bus when the child's orchestrator lifecycle hits
+  // `Completed` or `Failed`. Flips the matching banner to `done`.
+  if (type === 'background_agent_completed') {
+    const id = ev['id'];
+    if (!isString(id)) {
+      warnDrop('background_agent_completed', 'id missing or not a string');
+      return null;
+    }
+    return { kind: 'BackgroundAgentCompleted', instance_id: id };
+  }
+
   if (type === 'assistant_message') {
     // The orchestrator emits AssistantMessage twice per turn:
     //   1. at stream-open: stream_finalised: false, text: ""

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -1135,3 +1135,100 @@ describe('ChatPane — persistent approvals (F-036)', () => {
     ).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// F-136: SubAgentBanner inline mount via SubAgentSpawned store event
+// ---------------------------------------------------------------------------
+//
+// The DoD requires ChatPane to listen for `SubAgentSpawned` events and mount
+// a `SubAgentBanner` inline at the message position. The banner also flips
+// running → done when a matching `BackgroundAgentCompleted` arrives (F-137
+// already forwards that event onto the session bus).
+describe('ChatPane — sub-agent banner inline mount (F-136)', () => {
+  it('mounts a SubAgentBanner turn when SubAgentSpawned is pushed to the store', () => {
+    pushEvent(SID, {
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'parent-inst-1',
+      child_instance_id: 'child-inst-1',
+      from_msg: 'msg-7',
+      agent_name: 'test-writer',
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('sub-agent-banner-child-inst-1')).toBeInTheDocument();
+    expect(
+      getByTestId('sub-agent-banner-header-child-inst-1'),
+    ).toHaveTextContent('test-writer');
+  });
+
+  it('renders the banner inline between surrounding turns in order of arrival', () => {
+    pushEvent(SID, { kind: 'UserMessage', text: 'USER-MARKER', message_id: 'u-1' });
+    pushEvent(SID, {
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'parent-inst-1',
+      child_instance_id: 'child-inst-2',
+      from_msg: 'u-1',
+      agent_name: 'reviewer',
+    });
+    pushEvent(SID, {
+      kind: 'AssistantMessage',
+      text: 'ASSIST-MARKER',
+      message_id: 'a-1',
+    });
+    const { getByTestId, getByText } = render(() => <ChatPane />);
+    const list = getByTestId('message-list');
+    const banner = getByTestId('sub-agent-banner-child-inst-2');
+    expect(list).toContainElement(banner);
+    // Order: user text precedes banner; assistant text follows it.
+    // Markers are unique so `.textContent` matching doesn't cross-match
+    // the banner's "spawned · reviewer" header.
+    const nodes = Array.from(list.children);
+    const userIdx = nodes.findIndex((n) => n.textContent?.includes('USER-MARKER'));
+    const bannerIdx = nodes.findIndex((n) => n === banner || n.contains(banner));
+    const assistantIdx = nodes.findIndex((n) =>
+      n.textContent?.includes('ASSIST-MARKER'),
+    );
+    expect(userIdx).toBeGreaterThanOrEqual(0);
+    expect(bannerIdx).toBeGreaterThan(userIdx);
+    expect(assistantIdx).toBeGreaterThan(bannerIdx);
+    // Sanity: the assistant text still rendered, so the banner didn't
+    // swallow or replace subsequent turns.
+    expect(getByText('ASSIST-MARKER')).toBeInTheDocument();
+  });
+
+  it('flips a banner from running → done when BackgroundAgentCompleted arrives for the same child id', () => {
+    pushEvent(SID, {
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'parent-inst-1',
+      child_instance_id: 'child-inst-3',
+      from_msg: 'msg-x',
+      agent_name: 'reviewer',
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    const chip = getByTestId('sub-agent-banner-state-child-inst-3');
+    expect(chip).toHaveAttribute('data-state', 'running');
+
+    pushEvent(SID, {
+      kind: 'BackgroundAgentCompleted',
+      instance_id: 'child-inst-3',
+    });
+    expect(chip).toHaveAttribute('data-state', 'done');
+  });
+
+  it('is idempotent — a duplicate SubAgentSpawned for the same child does not stack banners', () => {
+    pushEvent(SID, {
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'parent-inst-1',
+      child_instance_id: 'child-inst-4',
+      from_msg: 'msg-a',
+    });
+    pushEvent(SID, {
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'parent-inst-1',
+      child_instance_id: 'child-inst-4',
+      from_msg: 'msg-a',
+    });
+    const { getAllByTestId } = render(() => <ChatPane />);
+    const banners = getAllByTestId('sub-agent-banner-child-inst-4');
+    expect(banners).toHaveLength(1);
+  });
+});

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -31,6 +31,7 @@ import {
   type ContextCategory,
 } from '../../components/ContextPicker';
 import { ContextChip } from '../../components/ContextChip';
+import { SubAgentBanner } from '../../components/SubAgentBanner';
 import type { ProviderId } from '@forge/ipc';
 import {
   buildRegistry,
@@ -821,6 +822,12 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
                 return <ToolCallCard turn={turn} />;
               case 'error':
                 return <ErrorTurn turn={turn} />;
+              case 'sub_agent_banner':
+                // F-136: inline banner for a spawned child agent. Nested
+                // child turns (future work post-F-140) are threaded through
+                // the banner's `children` prop when they arrive with a
+                // matching `instance_id`; today the list is empty.
+                return <SubAgentBanner turn={turn} />;
             }
           }}
         </For>

--- a/web/packages/app/src/stores/messages.test.ts
+++ b/web/packages/app/src/stores/messages.test.ts
@@ -345,4 +345,64 @@ describe('messages store', () => {
       expect(getMessagesState(SID).turns[0]!.type).toBe('user');
     });
   });
+
+  // F-136: banner-turn lifecycle inside the store. ChatPane integration
+  // lives in ChatPane.test.tsx; these cases pin the pure reducer semantics.
+  describe('SubAgentSpawned + BackgroundAgentCompleted (F-136)', () => {
+    it('appends a sub_agent_banner turn in running state', () => {
+      pushEvent(SID, {
+        kind: 'SubAgentSpawned',
+        parent_instance_id: 'p-1',
+        child_instance_id: 'c-1',
+        from_msg: 'm-1',
+        agent_name: 'writer',
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+      const turn = state.turns[0]!;
+      if (turn.type !== 'sub_agent_banner') {
+        throw new Error(`expected sub_agent_banner turn, got ${turn.type}`);
+      }
+      expect(turn.child_instance_id).toBe('c-1');
+      expect(turn.parent_instance_id).toBe('p-1');
+      expect(turn.agent_name).toBe('writer');
+      expect(turn.status).toBe('running');
+      expect(typeof turn.started_at).toBe('number');
+    });
+
+    it('does not stack duplicate banners when the same SubAgentSpawned arrives twice', () => {
+      pushEvent(SID, {
+        kind: 'SubAgentSpawned',
+        parent_instance_id: 'p',
+        child_instance_id: 'c-dup',
+        from_msg: 'm',
+      });
+      pushEvent(SID, {
+        kind: 'SubAgentSpawned',
+        parent_instance_id: 'p',
+        child_instance_id: 'c-dup',
+        from_msg: 'm',
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns).toHaveLength(1);
+    });
+
+    it('flips the matching banner to done on BackgroundAgentCompleted', () => {
+      pushEvent(SID, {
+        kind: 'SubAgentSpawned',
+        parent_instance_id: 'p',
+        child_instance_id: 'c-term',
+        from_msg: 'm',
+      });
+      pushEvent(SID, { kind: 'BackgroundAgentCompleted', instance_id: 'c-term' });
+      const turn = getMessagesState(SID).turns[0]!;
+      if (turn.type !== 'sub_agent_banner') throw new Error('expected banner');
+      expect(turn.status).toBe('done');
+    });
+
+    it('BackgroundAgentCompleted for an unknown instance id is a no-op', () => {
+      pushEvent(SID, { kind: 'BackgroundAgentCompleted', instance_id: 'nobody' });
+      expect(getMessagesState(SID).turns).toHaveLength(0);
+    });
+  });
 });

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -25,13 +25,36 @@ export type SessionEvent =
   | { kind: 'ToolCallFailed'; tool_call_id: string; error: string }
   | { kind: 'Error'; message: string }
   | { kind: 'StreamingStarted' }
-  | { kind: 'StreamingStopped' };
+  | { kind: 'StreamingStopped' }
+  // F-136: orchestrator spawned a sub-agent; ChatPane mounts a SubAgentBanner
+  // inline at the spawn position. `agent_name` is optional because the Rust
+  // `SubAgentSpawned` wire event carries only parent/child/from_msg. When the
+  // name is known (F-137 stores it on the orchestrator instance, but it does
+  // not ride the event today), the shell may enrich the payload; otherwise
+  // the banner falls back to `child` id as the label.
+  | {
+      kind: 'SubAgentSpawned';
+      parent_instance_id: string;
+      child_instance_id: string;
+      from_msg: string;
+      agent_name?: string;
+    }
+  // F-136: sub-agent background lifecycle reached a terminal state. Flips any
+  // banner whose child id matches from `running` → `done`. Emitted by
+  // `forge_session::BackgroundAgentRegistry` (F-137).
+  | {
+      kind: 'BackgroundAgentCompleted';
+      instance_id: string;
+    };
 
 // ---------------------------------------------------------------------------
 // Chat turn shapes (derived, used for rendering)
 // ---------------------------------------------------------------------------
 
 export type ToolCallStatus = 'in-progress' | 'awaiting-approval' | 'completed' | 'errored';
+
+/** F-136: sub-agent banner lifecycle state as rendered in the ChatPane. */
+export type SubAgentStatus = 'queued' | 'running' | 'done' | 'error' | 'killed';
 
 export type ChatTurn =
   | { type: 'user'; text: string; message_id: string }
@@ -49,6 +72,23 @@ export type ChatTurn =
       error?: string;
       /** Populated when status is 'awaiting-approval'. */
       preview?: ApprovalPreview;
+    }
+  | {
+      type: 'sub_agent_banner';
+      /** Child `AgentInstanceId` the banner tracks. */
+      child_instance_id: string;
+      /** Emitting parent agent instance id (often the session itself today). */
+      parent_instance_id: string;
+      /** Optional display name — falls back to the child id's short prefix. */
+      agent_name?: string;
+      /** Live state. Starts `running` on spawn; flips to `done` on terminal. */
+      status: SubAgentStatus;
+      /** ms epoch at which the banner was mounted (spawn event seen). */
+      started_at: number;
+      /** Last observed step summary. Populated by future step-routing work. */
+      last_step_summary?: string;
+      /** Count of steps seen so far — reserved for future step-routing work. */
+      step_count?: number;
     }
   | { type: 'error'; message: string };
 
@@ -250,6 +290,59 @@ export function pushEvent(sessionId: SessionId, event: SessionEvent): void {
           state.turns.push({ type: 'error', message: event.message });
           state.awaitingResponse = false;
           state.streamingMessageId = null;
+        }),
+      );
+      break;
+    }
+
+    // F-136: orchestrator spawn — mount a banner turn inline at the current
+    // position. Duplicates (same child_instance_id twice in a row) are
+    // ignored so a replay or event re-delivery doesn't stack multiple
+    // banners for one child.
+    case 'SubAgentSpawned': {
+      setMessagesStore(
+        produce((s) => {
+          const state = s[sessionId]!;
+          const existing = state.turns.find(
+            (t) =>
+              t.type === 'sub_agent_banner' &&
+              t.child_instance_id === event.child_instance_id,
+          );
+          if (existing) return;
+          const banner: Extract<ChatTurn, { type: 'sub_agent_banner' }> = {
+            type: 'sub_agent_banner',
+            child_instance_id: event.child_instance_id,
+            parent_instance_id: event.parent_instance_id,
+            status: 'running',
+            started_at: Date.now(),
+          };
+          if (event.agent_name !== undefined) {
+            banner.agent_name = event.agent_name;
+          }
+          state.turns.push(banner);
+        }),
+      );
+      break;
+    }
+
+    // F-136: child lifecycle terminal — flip matching banner to `done`.
+    // Unknown child_instance_id is a no-op (replay or out-of-order delivery).
+    case 'BackgroundAgentCompleted': {
+      setMessagesStore(
+        produce((s) => {
+          const state = s[sessionId]!;
+          const idx = state.turns.findIndex(
+            (t) =>
+              t.type === 'sub_agent_banner' &&
+              t.child_instance_id === event.instance_id,
+          );
+          if (idx >= 0) {
+            const turn = state.turns[idx] as Extract<
+              ChatTurn,
+              { type: 'sub_agent_banner' }
+            >;
+            turn.status = 'done';
+          }
         }),
       );
       break;


### PR DESCRIPTION
## Summary

- Adds `SubAgentBanner` to `web/packages/app/src/components/` per `docs/ui-specs/sub-agent-banner.md` §6: 2px ember left-border, `↳ spawned · <name>` header, `delegated at HH:MM` timestamp, semantic state chip, click-to-toggle collapse, double-click to open Agent Monitor.
- Wires `SubAgentSpawned` and `BackgroundAgentCompleted` through `fromRustEvent` → `SessionEvent` store variants → new `sub_agent_banner` `ChatTurn` → `ChatPane` inline render. Banner flips `running → done` on child lifecycle completion (F-137 already forwards that event onto the session bus).
- Component tests cover expand/collapse (click + Enter/Space), nested rendering for sub-of-sub banners, max-depth cap at 3 with an "Open in new window" fallback, timestamp formatting, state-chip transitions, and double-click navigation. ChatPane integration tests pin the banner mount on `SubAgentSpawned`, in-order placement between surrounding turns, duplicate-spawn idempotence, and the terminal-flip behavior.

Closes #250.

## Partial DoD flag — live step streaming

The DoD asks the banner to "stream live steps (running → completed) from the orchestrator event stream." Today the banner's streaming plumbing is wired, but the backend does not yet emit instance-tagged events for child agents:

- `crates/forge-session/src/tools/agent_spawn.rs` registers the child in the orchestrator but does not run it through `run_turn` (F-137 stores the prompt on `AgentInstance.initial_prompt`; a real step executor lands post-F-140).
- F-139 `StepStarted`/`StepFinished` events are emitted by the session turn loop with `instance_id: None`, per the comment at `crates/forge-core/src/event.rs:157-160` — "F-140 wires the AgentMonitor through `run_turn` and will populate the field."

So the banner today:

- Renders the spawn header and timestamp immediately on `SubAgentSpawned`.
- Stays in `running` while the child is live.
- Flips to `done` on `BackgroundAgentCompleted { id: child }` (via `BackgroundAgentRegistry` F-137).
- Exposes `step_count` / `last_step_summary` props so when the step executor starts emitting instance-tagged events, no frontend change is required — just routing `StepStarted`/`StepFinished` events whose `instance_id` matches a mounted banner.

## Notes for reviewer

- The Agent Monitor route (F-140) is shipping concurrently. Per the issue, double-click uses `window.location.href = '/agent-monitor?instance=<id>'`; the route 404s until F-140 merges.
- F-145 (#259) is in flight and also touches `ChatPane.tsx` (BranchSelected subscription). No real-time conflict — separate worktrees — but the second-merged PR will need a trivial rebase around the new `case 'sub_agent_banner':` branch in the turn switch.
- The implementation avoids opacity-as-disabled per `component-principles.md` and reuses the `--color-ember-400` + `--color-surface-1` + `--r-sm` token palette from `PaneHeader.css`.
- Adds one new semantic token reference (`--color-ok` / `--color-ok-border`) with inline hex fallbacks so the banner's `done` state is legible even where the token hasn't been declared; the semantic palette can replace the fallbacks as part of a follow-up token pass without a component change.

## Verification

- `just check-rust` — passed (fmt, check, clippy -D warnings, rustdoc).
- `just test-rust` — passed (no Rust code changed, regression gate only).
- `just check-web` — passed (pnpm typecheck + token drift gate).
- `just test-web` — 539 tests pass across 48 files; 16 new SubAgentBanner tests, 4 new ChatPane integration tests, 4 new messages-store tests, 7 new events-adapter tests.

## Test plan

- [ ] CI green on `forge-ide/forge`
- [ ] Manual: session with `agent.spawn` tool call produces a banner turn inline with the assistant stream; banner collapses/expands on click; double-click tries to navigate (404 until F-140)
- [ ] Manual: child terminal flips the state chip `running → done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)