### PR TITLE
[F-147] Reconcile context-picker spec §7 placement prose with viewport-aware flip

### DIFF
--- a/docs/ui-specs/context-picker.md
+++ b/docs/ui-specs/context-picker.md
@@ -10,7 +10,9 @@
 
 **Trigger.** Typing `@` in any chat composer.
 
-**Size.** 360–480px wide, up to 360px tall (scrolls), popped *above* the composer (never below — the composer must remain visible).
+**Size.** 360–480px wide, up to 360px tall (scrolls).
+
+**Placement.** Viewport-aware and computed by the pure `computePopupPlacement` helper in `web/packages/app/src/components/ContextPicker.tsx`. The popup prefers anchoring *below* the caret/composer when there is room — specifically, when `viewportHeight − anchorBottom − gap ≥ popupHeight` (gap defaults to 4px, popup height is capped at 360px). When that space is not available, placement flips to *above* the anchor so the popup is never clipped by the viewport bottom. In the standard chat layout the composer is pinned to the bottom of its pane, so the flip-above branch is the one that renders in practice; the below branch is what keeps the popup from being clipped when the composer is embedded in pickers or other non-bottom-pinned hosts. Either way the composer itself remains visible.
 
 **Structure.**
 ```


### PR DESCRIPTION
Closes forge-ide/forge#269

## Summary

Pure doc-reconcile. `docs/ui-specs/context-picker.md` §7 prose previously described placement as *"popped above the composer (never below)"*, but F-141 (#268) shipped `computePopupPlacement` — a pure, viewport-aware helper that prefers anchoring **below** when there is room and **flips above** when the popup would clip the viewport bottom. The spec text now matches the shipped behavior.

## Changes

- `docs/ui-specs/context-picker.md` — replaced the single inline "popped above" clause with a dedicated **Placement** paragraph that:
  - States the heuristic explicitly (`viewportHeight − anchorBottom − gap ≥ popupHeight`)
  - Cites the 4px default gap and the 360px popup-height cap
  - Points readers to `computePopupPlacement` in `web/packages/app/src/components/ContextPicker.tsx` as the source of truth
  - Frames the flip-above branch as what renders in practice under the standard chat layout (composer pinned to pane bottom), preserving the old "composer remains visible" intent

## DoD

- [x] §7 placement prose describes viewport-aware flip behavior
- [x] §7.1 placement-diagram checkbox — **N/A**. The §7 *Structure* diagram depicts the popup's internal layout (search bar + category list), not placement relative to the composer. No placement diagram exists to annotate.
- [x] No code changes (single-file edit in `docs/`)
- [x] Tests pass — verified locally via `just check-web` (pnpm typecheck + check-tokens) and `just test-web` (578/578 app tests pass); CI will re-run on this PR.

## Heads-up for reviewer

The issue body paraphrases the implementation's heuristic as *"anchor above when there's room, otherwise flip below"*. That paraphrase is **inverted** relative to the real code — `computePopupPlacement` returns `'below'` first when space is available and only flips to `'above'` otherwise. This PR documents the implementation (primary source), not the issue's paraphrase, so F-141's shipped behavior and the spec are now aligned on the same rule.

## Test plan

- [x] `just check-web` — typecheck + token reference check pass
- [x] `just test-web` — 578 tests pass (docs-only change; no behavior affected)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)