### PR TITLE
docs(frontend): reconcile architecture §9.3 with monaco-host parent-relay (F-148)

### DIFF
--- a/docs/frontend/architecture.md
+++ b/docs/frontend/architecture.md
@@ -14,7 +14,7 @@
 - **CSS** — plain CSS variables from DESIGN.md tokens, no Tailwind (Tailwind fights the hand-tuned component system)
 - **Routing** — `@solidjs/router` or a minimal custom router (roughly 5 routes: Dashboard, Session, Catalog, Usage, Settings)
 - **Monaco** — loaded in an iframe (see §9.3)
-- **LSP client** — `monaco-languageclient` runs directly in the iframe alongside Monaco, talking to the language servers over stdio (Tauri gives us process spawn APIs)
+- **LSP client** — `monaco-languageclient` runs inside the Monaco iframe but never talks to Tauri directly. It forwards JSON-RPC over `postMessage` to the parent webview, which owns the IPC bridge to `forge-lsp` (see §9.3)
 - **Terminal** — xterm.js-compatible rendering driven by byte streams over Tauri events (from `forge-term`)
 
 ### 9.2 State model
@@ -64,10 +64,11 @@ export const [usageReport, setUsageReport] = createSignal<UsageReport | null>(nu
 Components subscribe by calling the signal as a function (Solid idiom): `{sessions[id].messages.map(m => ...)}`.
 
 ### 9.3 Monaco hosting
-- Monaco runs in `<iframe src="/monaco-host.html">` inside the session pane
-- Communicates with the Solid app via `window.postMessage` using a typed protocol (mirrors IPC types)
-- LSP lives in this iframe too, via `monaco-languageclient` — the iframe spawns language server processes through Tauri-exposed APIs
-- Reasons: Monaco's AMD loader, web workers, and global scope assumptions don't play well with modern bundlers, and keeping it isolated makes it replaceable later
+- Monaco runs in `<iframe src="/monaco-host.html">` inside the session pane. The iframe is renderer-only; it never talks to Tauri directly
+- Communicates with the Solid app via `window.postMessage` using a typed protocol (mirrors IPC types). See [`web/packages/monaco-host/README.md`](../../web/packages/monaco-host/README.md) for the full `kind`-tagged message table
+- `monaco-languageclient` runs inside the iframe but the **parent webview owns the LSP bridge**. The iframe emits outbound LSP frames as `client.message` / `client.notification` postMessage envelopes; the parent relays them to `forge-lsp` via the `lsp_send` Tauri command and pipes inbound frames back as `client.message` (bound to the owner webview via the `lsp_message` event — F-062 discipline). Lifecycle is driven from the parent through `lsp_start` / `lsp_stop` in `crates/forge-shell/src/ipc.rs` (F-123; PR #286)
+- Reasons: Monaco's AMD loader, web workers, and global scope assumptions don't play well with modern bundlers, and keeping it isolated makes the editor replaceable later. Sandbox-wise, routing LSP through the parent keeps Tauri capabilities off the iframe origin so server output can never touch the filesystem
+- **Considered alternatives.** Spawning language servers directly from the iframe (as an earlier draft of this section described) would save one hop of latency, but it requires exposing Tauri process-spawn capability inside the iframe sandbox. That violates the isolation rationale above, so the parent-relay model won
 
 ### 9.4 Design token pipeline
 - `web/packages/design/src/tokens.css` is the single source of CSS vars

--- a/web/packages/monaco-host/README.md
+++ b/web/packages/monaco-host/README.md
@@ -39,12 +39,13 @@ The iframe signals readiness with `ready`; the parent should queue `open` messag
 
 ### LSP lifecycle
 
-`MonacoLanguageClient` is instantiated at boot but **not started**. F-123 is responsible for:
+`MonacoLanguageClient` is instantiated at boot but **not started**. The parent webview drives the lifecycle via the F-123 IPC surface in `crates/forge-shell/src/ipc.rs` (PR #286):
 
-1. Wiring the parent side to `forge-lsp` over Tauri IPC.
-2. Telling the iframe when a language is ready so the client can `.start()`.
+1. Parent calls `lsp_start` to launch a `forge-lsp`-supervised server for the active language.
+2. Parent tells the iframe the language is ready so the client can `.start()`. Outbound frames flow as iframe `client.message` / `client.notification` → parent → `lsp_send`; inbound frames flow as the `lsp_message` Tauri event → parent → iframe `client.message`.
+3. Parent calls `lsp_stop` on teardown (owner-label authz rejects cross-session stops).
 
-Until F-123 lands the language client is idle: it holds the postMessage transport so that the construction path is verified on every boot, but no LSP traffic flows.
+When no parent has started a server the language client is idle: the postMessage transport is still wired so the construction path is verified on every boot, but no LSP traffic flows.
 
 ## Test harness
 
@@ -69,5 +70,5 @@ To add coverage that exercises Monaco, write a Playwright test in the parent `ap
 
 - [Build approach — Editor: Monaco in iframe](../../../docs/build/approach.md)
 - [Architecture overview §7](../../../docs/architecture/overview.md)
-- [Frontend architecture §9.3](../../../docs/frontend/architecture.md) — note: §9.3 currently describes direct Tauri process spawn from the iframe; F-121 follows the parent-relay model from the issue scope. Reconcile in a follow-up.
+- [Frontend architecture §9.3](../../../docs/frontend/architecture.md) — parent-relay LSP model matching this package's postMessage contract.
 - [Color system](../../../docs/design/color-system.md)


### PR DESCRIPTION
Closes forge-ide/forge#271

## Summary
- `docs/frontend/architecture.md` §9.1 and §9.3 previously described the Monaco iframe spawning LSP processes directly via Tauri. F-121 (#270) shipped the iframe as renderer-only and F-123 (#286) wired the parent-side IPC bridge to `forge-lsp`. Rewrite both sections to describe the parent-relay model: iframe emits `client.message` / `client.notification` over postMessage; parent relays via `lsp_send`; inbound frames flow back as the `lsp_message` Tauri event; lifecycle is driven by `lsp_start` / `lsp_stop` in `crates/forge-shell/src/ipc.rs`.
- Cross-reference `web/packages/monaco-host/README.md` and the F-123 IPC surface from §9.3.
- Preserve the direct-spawn rationale as a **considered alternatives** note (one-hop latency win rejected because it would require Tauri capability inside the iframe sandbox).
- Update the monaco-host README to drop the stale "§9.3 currently describes direct Tauri process spawn…reconcile in a follow-up" pointer and rewrite the LSP-lifecycle section to describe the now-merged F-123 flow concretely (no more "until F-123 lands" phrasing).

## Scope guard
Pure doc reconcile. No code changes. Two files touched: `docs/frontend/architecture.md`, `web/packages/monaco-host/README.md`.

## Test plan
- [x] `just check-rust` passes (fmt, cargo check, clippy -D warnings, rustdoc)
- [x] `just check-web` passes (typecheck + token drift)
- [x] Cross-reference link from `docs/frontend/architecture.md` to `web/packages/monaco-host/README.md` resolves on disk

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)