### PR TITLE
[F-150] Integrate EditorPane into GridContainer tree

### DIFF
--- a/web/packages/app/src/layout/DropZoneOverlay.test.tsx
+++ b/web/packages/app/src/layout/DropZoneOverlay.test.tsx
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@solidjs/testing-library';
-import type { LayoutNode } from './GridContainer';
-import { GridContainer } from './GridContainer';
+import type { LayoutTree } from '@forge/ipc';
+import { GridContainer, type LayoutLeaf } from './GridContainer';
 import { DropZoneOverlay } from './DropZoneOverlay';
 
 afterEach(() => {
   cleanup();
 });
+
+function renderByPaneType(leaf: LayoutLeaf) {
+  return <div data-testid={leaf.id}>{leaf.id}</div>;
+}
 
 describe('DropZoneOverlay — standalone', () => {
   it('renders all five zones, none active when `activeZone` is null', () => {
@@ -27,18 +31,23 @@ describe('DropZoneOverlay — standalone', () => {
 });
 
 describe('GridContainer — drag overlay threading', () => {
-  const tree: LayoutNode = {
+  const tree: LayoutTree = {
     kind: 'split',
     id: 'root',
     direction: 'v',
     ratio: 0.5,
-    a: { kind: 'leaf', id: 'a', render: () => <div data-testid="a">a</div> },
-    b: { kind: 'leaf', id: 'b', render: () => <div data-testid="b">b</div> },
+    a: { kind: 'leaf', id: 'a', pane_type: 'chat' },
+    b: { kind: 'leaf', id: 'b', pane_type: 'chat' },
   };
 
   it('renders no overlay when dragState is null', () => {
     const { queryByTestId } = render(() => (
-      <GridContainer tree={tree} onRatioChange={() => {}} dragState={null} />
+      <GridContainer
+        tree={tree}
+        renderLeaf={renderByPaneType}
+        onRatioChange={() => {}}
+        dragState={null}
+      />
     ));
     expect(queryByTestId('drop-zone-overlay')).toBeNull();
   });
@@ -47,6 +56,7 @@ describe('GridContainer — drag overlay threading', () => {
     render(() => (
       <GridContainer
         tree={tree}
+        renderLeaf={renderByPaneType}
         onRatioChange={() => {}}
         dragState={{ sourceId: 'a', targetId: 'b', zone: 'right' }}
       />

--- a/web/packages/app/src/layout/GridContainer.test.tsx
+++ b/web/packages/app/src/layout/GridContainer.test.tsx
@@ -1,22 +1,30 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from '@solidjs/testing-library';
-import { GridContainer, type LayoutNode } from './GridContainer';
+import type { LayoutTree } from '@forge/ipc';
+import { GridContainer, type LayoutLeaf } from './GridContainer';
 
 afterEach(() => {
   cleanup();
 });
 
+// F-150: GridContainer now consumes the persisted `LayoutTree` shape. Tests
+// drive it with a `renderLeaf` prop that dispatches on `pane_type` the same
+// way SessionWindow does in production.
+function renderByPaneType(leaf: LayoutLeaf) {
+  return <div data-testid={`leaf-${leaf.id}`}>{leaf.pane_type}-{leaf.id}</div>;
+}
+
 describe('GridContainer — leaf rendering', () => {
-  it('renders a single leaf tree by calling its render callback', () => {
-    const tree: LayoutNode = {
-      kind: 'leaf',
-      id: 'chat-1',
-      render: () => <div data-testid="leaf-content">hello</div>,
-    };
+  it('renders a single leaf tree by calling renderLeaf', () => {
+    const tree: LayoutTree = { kind: 'leaf', id: 'chat-1', pane_type: 'chat' };
     const { getByTestId } = render(() => (
-      <GridContainer tree={tree} onRatioChange={vi.fn()} />
+      <GridContainer
+        tree={tree}
+        renderLeaf={renderByPaneType}
+        onRatioChange={vi.fn()}
+      />
     ));
-    expect(getByTestId('leaf-content').textContent).toBe('hello');
+    expect(getByTestId('leaf-chat-1').textContent).toBe('chat-chat-1');
     expect(getByTestId('grid-leaf-chat-1')).toBeTruthy();
   });
 });
@@ -24,41 +32,33 @@ describe('GridContainer — leaf rendering', () => {
 describe('GridContainer — recursive split tree', () => {
   it('renders nested H/V splits with the correct leaves', () => {
     // Shape: v-split [ chat | h-split [ editor / terminal ] ]
-    const tree: LayoutNode = {
+    const tree: LayoutTree = {
       kind: 'split',
       id: 'root',
       direction: 'v',
       ratio: 0.5,
-      a: {
-        kind: 'leaf',
-        id: 'chat',
-        render: () => <div data-testid="chat">chat</div>,
-      },
+      a: { kind: 'leaf', id: 'chat', pane_type: 'chat' },
       b: {
         kind: 'split',
         id: 'right',
         direction: 'h',
         ratio: 0.6,
-        a: {
-          kind: 'leaf',
-          id: 'editor',
-          render: () => <div data-testid="editor">editor</div>,
-        },
-        b: {
-          kind: 'leaf',
-          id: 'terminal',
-          render: () => <div data-testid="terminal">terminal</div>,
-        },
+        a: { kind: 'leaf', id: 'editor', pane_type: 'editor' },
+        b: { kind: 'leaf', id: 'terminal', pane_type: 'terminal' },
       },
     };
 
     const { getAllByTestId, getByTestId } = render(() => (
-      <GridContainer tree={tree} onRatioChange={vi.fn()} />
+      <GridContainer
+        tree={tree}
+        renderLeaf={renderByPaneType}
+        onRatioChange={vi.fn()}
+      />
     ));
 
-    expect(getByTestId('chat')).toBeTruthy();
-    expect(getByTestId('editor')).toBeTruthy();
-    expect(getByTestId('terminal')).toBeTruthy();
+    expect(getByTestId('leaf-chat')).toBeTruthy();
+    expect(getByTestId('leaf-editor')).toBeTruthy();
+    expect(getByTestId('leaf-terminal')).toBeTruthy();
 
     const splits = getAllByTestId('split-pane');
     // Two SplitPane nodes: the root v-split and the nested h-split.
@@ -70,7 +70,7 @@ describe('GridContainer — recursive split tree', () => {
 
   it('propagates onRatioChange with the originating split node id', () => {
     const onRatioChange = vi.fn();
-    const tree: LayoutNode = {
+    const tree: LayoutTree = {
       kind: 'split',
       id: 'root',
       direction: 'v',
@@ -80,14 +80,18 @@ describe('GridContainer — recursive split tree', () => {
         id: 'left',
         direction: 'h',
         ratio: 0.5,
-        a: { kind: 'leaf', id: 'a1', render: () => <div>a1</div> },
-        b: { kind: 'leaf', id: 'a2', render: () => <div>a2</div> },
+        a: { kind: 'leaf', id: 'a1', pane_type: 'chat' },
+        b: { kind: 'leaf', id: 'a2', pane_type: 'chat' },
       },
-      b: { kind: 'leaf', id: 'b1', render: () => <div>b1</div> },
+      b: { kind: 'leaf', id: 'b1', pane_type: 'chat' },
     };
 
     const { getAllByTestId } = render(() => (
-      <GridContainer tree={tree} onRatioChange={onRatioChange} />
+      <GridContainer
+        tree={tree}
+        renderLeaf={renderByPaneType}
+        onRatioChange={onRatioChange}
+      />
     ));
 
     const splits = getAllByTestId('split-pane') as HTMLElement[];

--- a/web/packages/app/src/layout/GridContainer.tsx
+++ b/web/packages/app/src/layout/GridContainer.tsx
@@ -1,37 +1,30 @@
 import { type Component, type JSX, Match, Show, Switch } from 'solid-js';
+import type { LayoutTree } from '@forge/ipc';
 import { SplitPane } from './SplitPane';
 import { DropZoneOverlay } from './DropZoneOverlay';
 import type { DragState } from './useDragToDock';
 
 /**
- * A terminal node in the layout tree. `render` produces the pane body for
- * the leaf — F-117 stays agnostic about pane type (chat, terminal, editor,
- * files, agent monitor); the caller supplies the renderer.
+ * F-150: GridContainer now consumes the serialized `LayoutTree` shape from
+ * the IPC package directly. A leaf carries `pane_type`, which drives the
+ * caller-supplied `renderLeaf` dispatcher. Previously each leaf embedded a
+ * `render` closure, but closures can't be persisted and made the tree
+ * non-serializable, forcing an adapter layer that had to be rebuilt for
+ * every tree mutation. Moving to the persisted shape lets drag-to-dock,
+ * layoutStore, and GridContainer share one data structure end-to-end.
  */
-export interface LeafNode {
-  kind: 'leaf';
-  id: string;
-  render: () => JSX.Element;
-}
-
-/**
- * An internal node that splits its area between `a` and `b`. `ratio` is the
- * fraction of the container occupied by `a` (0..1).
- */
-export interface SplitNode {
-  kind: 'split';
-  id: string;
-  direction: 'h' | 'v';
-  ratio: number;
-  a: LayoutNode;
-  b: LayoutNode;
-}
-
-export type LayoutNode = LeafNode | SplitNode;
+export type LayoutLeaf = LayoutTree & { kind: 'leaf' };
 
 export interface GridContainerProps {
   /** The root of the layout tree. Arbitrarily deep H/V combinations. */
-  tree: LayoutNode;
+  tree: LayoutTree;
+  /**
+   * Produce the pane body for a leaf. GridContainer stays pane-agnostic —
+   * the dispatch on `pane_type` lives in the caller's renderer so chat /
+   * terminal / editor / files / agent-monitor panes all mount through a
+   * single code path. Re-invoked whenever the tree identity changes.
+   */
+  renderLeaf: (leaf: LayoutLeaf) => JSX.Element;
   /**
    * Emitted when a split node's ratio changes (drag or double-click
    * reset). `id` is the split node's id; the parent owns persistence
@@ -49,8 +42,8 @@ export interface GridContainerProps {
 
 /**
  * Recursive N-ary layout renderer over `SplitPane`. Each split node maps to
- * one `SplitPane`; each leaf renders via its callback. GridContainer is a
- * pure function of its props — the tree walks parent-side, which keeps
+ * one `SplitPane`; each leaf renders via `renderLeaf(leaf)`. GridContainer
+ * is a pure function of its props — the tree walks parent-side, which keeps
  * persistence (F-120) and drag-to-dock (F-118) trivial to layer on later.
  *
  * F-118 layered the optional `dragState` prop here so the drop-zone overlay
@@ -62,6 +55,7 @@ export const GridContainer: Component<GridContainerProps> = (props) => {
   return (
     <GridNode
       node={props.tree}
+      renderLeaf={props.renderLeaf}
       onRatioChange={props.onRatioChange}
       dragState={() => props.dragState ?? null}
     />
@@ -69,13 +63,14 @@ export const GridContainer: Component<GridContainerProps> = (props) => {
 };
 
 const GridNode: Component<{
-  node: LayoutNode;
+  node: LayoutTree;
+  renderLeaf: (leaf: LayoutLeaf) => JSX.Element;
   onRatioChange: (id: string, next: number) => void;
   dragState: () => DragState | null;
 }> = (props) => {
   return (
     <Switch>
-      <Match when={props.node.kind === 'leaf' && (props.node as LeafNode)}>
+      <Match when={props.node.kind === 'leaf' && (props.node as LayoutLeaf)}>
         {(leaf) => {
           const activeZone = () => {
             const s = props.dragState();
@@ -89,7 +84,7 @@ const GridNode: Component<{
               data-leaf-id={leaf().id}
               style={{ width: '100%', height: '100%', position: 'relative' }}
             >
-              {leaf().render()}
+              {props.renderLeaf(leaf())}
               <Show when={showOverlay()}>
                 <DropZoneOverlay activeZone={activeZone()} />
               </Show>
@@ -97,7 +92,12 @@ const GridNode: Component<{
           );
         }}
       </Match>
-      <Match when={props.node.kind === 'split' && (props.node as SplitNode)}>
+      <Match
+        when={
+          props.node.kind === 'split' &&
+          (props.node as LayoutTree & { kind: 'split' })
+        }
+      >
         {(split) => (
           <SplitPane
             direction={split().direction}
@@ -106,11 +106,13 @@ const GridNode: Component<{
           >
             <GridNode
               node={split().a}
+              renderLeaf={props.renderLeaf}
               onRatioChange={props.onRatioChange}
               dragState={props.dragState}
             />
             <GridNode
               node={split().b}
+              renderLeaf={props.renderLeaf}
               onRatioChange={props.onRatioChange}
               dragState={props.dragState}
             />

--- a/web/packages/app/src/layout/dockDrop.ts
+++ b/web/packages/app/src/layout/dockDrop.ts
@@ -1,4 +1,12 @@
-import type { LayoutNode, LeafNode, SplitNode } from './GridContainer';
+import type { LayoutTree } from '@forge/ipc';
+
+// F-150: `dockDrop` operates on the persisted `LayoutTree` shape. Renderer
+// closures live on the caller (GridContainer's `renderLeaf` prop) and don't
+// leak into tree mutation. Local type aliases keep the rest of the module
+// readable — a "leaf" and a "split" are just `LayoutTree` narrowed by kind.
+type LeafNode = LayoutTree & { kind: 'leaf' };
+type SplitNode = LayoutTree & { kind: 'split' };
+type LayoutNode = LayoutTree;
 
 /**
  * Which edge (or center) of a target pane is being hovered. Matches the five

--- a/web/packages/app/src/layout/layoutStore.test.ts
+++ b/web/packages/app/src/layout/layoutStore.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Layouts } from '@forge/ipc';
+import type { LayoutTree, Layouts } from '@forge/ipc';
 import {
   createLayoutStore,
   DEFAULT_DEBOUNCE_MS,
@@ -214,73 +214,187 @@ describe('layoutStore', () => {
     expect(Object.keys(writes[0]?.named ?? {})).toEqual(['default']);
   });
 
-  // F-126: openFile + activeEditorFile cover the FilesSidebar -> EditorPane
-  // routing. The reducer writes `pane_state[EDITOR_LEAF_ID].active_file`
-  // on the active layout; the getter reads the same slot.
-  it('openFile sets active_file on the active layout and exposes it via activeEditorFile', async () => {
+  // F-150: openFile now writes into a real editor leaf in the GridContainer
+  // tree. The reducer walks the tree DFS and either updates an existing
+  // editor leaf's `pane_state[<id>].active_file`, or splits the root right
+  // with a freshly-minted editor leaf when no editor is present.
+  it('openFile splits the root right with a fresh editor leaf when no editor exists', async () => {
     const { scheduler, tick } = makeFakeScheduler();
     const store = createLayoutStore(WORKSPACE, { read, write, scheduler });
     await store.load();
-    expect(store.activeEditorFile()).toBeNull();
 
     store.openFile('/ws/src/main.ts');
-    expect(store.activeEditorFile()).toBe('/ws/src/main.ts');
+
+    const tree = store.layouts.named.default?.tree;
+    // Root is now a v-split (chat left, editor right).
+    expect(tree?.kind).toBe('split');
+    if (tree?.kind !== 'split') throw new Error('expected split');
+    expect(tree.direction).toBe('v');
+    expect(tree.ratio).toBeCloseTo(0.5);
+    expect(tree.a.kind).toBe('leaf');
+    if (tree.a.kind !== 'leaf') throw new Error('expected leaf');
+    expect(tree.a.pane_type).toBe('chat');
+    expect(tree.b.kind).toBe('leaf');
+    if (tree.b.kind !== 'leaf') throw new Error('expected leaf');
+    expect(tree.b.pane_type).toBe('editor');
+
+    // The editor leaf's active_file is wired via pane_state keyed on the
+    // leaf's own id.
+    const editorId = tree.b.id;
+    expect(
+      store.layouts.named.default?.pane_state[editorId]?.active_file,
+    ).toBe('/ws/src/main.ts');
 
     tick(DEFAULT_DEBOUNCE_MS);
     await store.flush();
-    expect(writes[0]?.named.default?.pane_state.editor?.active_file).toBe(
+    expect(writes[0]?.named.default?.pane_state[editorId]?.active_file).toBe(
       '/ws/src/main.ts',
     );
   });
 
-  it('openFile updates the existing editor slot when called with a new path', async () => {
+  it('openFile reuses the first editor leaf in DFS order when one exists', async () => {
+    // Pre-load a layout that already has an editor leaf mid-tree.
+    const seed: LayoutTree = {
+      kind: 'split',
+      id: 'root',
+      direction: 'v',
+      ratio: 0.5,
+      a: { kind: 'leaf', id: 'chat-1', pane_type: 'chat' },
+      b: { kind: 'leaf', id: 'editor-1', pane_type: 'editor' },
+    };
+    read.mockResolvedValueOnce({
+      active: 'default',
+      named: {
+        default: {
+          tree: seed,
+          pane_state: { 'editor-1': { active_file: '/ws/old.ts' } },
+        },
+      },
+    });
     const { scheduler, tick } = makeFakeScheduler();
     const store = createLayoutStore(WORKSPACE, { read, write, scheduler });
     await store.load();
 
-    store.openFile('/ws/first.ts');
-    store.openFile('/ws/second.ts');
-    expect(store.activeEditorFile()).toBe('/ws/second.ts');
+    store.openFile('/ws/new.ts');
 
-    tick(DEFAULT_DEBOUNCE_MS);
-    await store.flush();
-    // Only one write because both mutations land inside the debounce window.
-    expect(writes).toHaveLength(1);
-    expect(writes[0]?.named.default?.pane_state.editor?.active_file).toBe(
-      '/ws/second.ts',
-    );
-  });
-
-  it('openFile(null) clears the active editor file', async () => {
-    const { scheduler, tick } = makeFakeScheduler();
-    const store = createLayoutStore(WORKSPACE, { read, write, scheduler });
-    await store.load();
-
-    store.openFile('/ws/a.ts');
-    store.openFile(null);
-    expect(store.activeEditorFile()).toBeNull();
+    // Tree structure is unchanged (same leaf count, same ids).
+    const tree = store.layouts.named.default?.tree;
+    expect(tree).toEqual(seed);
+    // active_file on the existing leaf swapped to the new path.
+    expect(
+      store.layouts.named.default?.pane_state['editor-1']?.active_file,
+    ).toBe('/ws/new.ts');
 
     tick(DEFAULT_DEBOUNCE_MS);
     await store.flush();
     expect(
-      writes[writes.length - 1]?.named.default?.pane_state.editor?.active_file,
-    ).toBeNull();
+      writes[0]?.named.default?.pane_state['editor-1']?.active_file,
+    ).toBe('/ws/new.ts');
   });
 
-  it('openFile is idempotent on identical path (no extra write scheduled)', async () => {
+  it('openFile assigns a fresh id for each new editor leaf so multiple editors can coexist', async () => {
+    // Start from the singleton chat layout; openFile once to create editor-1.
+    // Then closeLeaf(editor-1) to restore the singleton, then openFile again —
+    // the new editor must not collide with the first id even after removal.
+    const { scheduler } = makeFakeScheduler();
+    const store = createLayoutStore(WORKSPACE, { read, write, scheduler });
+    await store.load();
+
+    store.openFile('/ws/a.ts');
+    const firstTree = store.layouts.named.default?.tree;
+    if (firstTree?.kind !== 'split') throw new Error('expected split');
+    if (firstTree.b.kind !== 'leaf') throw new Error('expected leaf');
+    const firstEditorId = firstTree.b.id;
+
+    store.closeLeaf(firstEditorId);
+    store.openFile('/ws/b.ts');
+    const secondTree = store.layouts.named.default?.tree;
+    if (secondTree?.kind !== 'split') throw new Error('expected split');
+    if (secondTree.b.kind !== 'leaf') throw new Error('expected leaf');
+    const secondEditorId = secondTree.b.id;
+
+    expect(secondEditorId).not.toBe(firstEditorId);
+  });
+
+  it('closeLeaf removes a leaf, promotes its sibling, and reclaims pane_state', async () => {
+    const seed: LayoutTree = {
+      kind: 'split',
+      id: 'root',
+      direction: 'v',
+      ratio: 0.5,
+      a: { kind: 'leaf', id: 'chat-1', pane_type: 'chat' },
+      b: { kind: 'leaf', id: 'editor-1', pane_type: 'editor' },
+    };
+    read.mockResolvedValueOnce({
+      active: 'default',
+      named: {
+        default: {
+          tree: seed,
+          pane_state: {
+            'editor-1': { active_file: '/ws/gone.ts' },
+            'chat-1': {},
+          },
+        },
+      },
+    });
     const { scheduler, tick } = makeFakeScheduler();
     const store = createLayoutStore(WORKSPACE, { read, write, scheduler });
     await store.load();
 
-    store.openFile('/ws/x.ts');
-    tick(DEFAULT_DEBOUNCE_MS);
-    await store.flush();
-    expect(writes).toHaveLength(1);
+    store.closeLeaf('editor-1');
 
-    // Second call with the same path: no state change, no scheduled write.
-    store.openFile('/ws/x.ts');
+    const tree = store.layouts.named.default?.tree;
+    // Sibling promoted — root becomes the chat leaf.
+    expect(tree?.kind).toBe('leaf');
+    if (tree?.kind !== 'leaf') throw new Error('expected leaf');
+    expect(tree.id).toBe('chat-1');
+    expect(tree.pane_type).toBe('chat');
+
+    // pane_state for the removed leaf is gone; the surviving leaf's state
+    // is preserved.
+    const paneState = store.layouts.named.default?.pane_state ?? {};
+    expect('editor-1' in paneState).toBe(false);
+    expect('chat-1' in paneState).toBe(true);
+
     tick(DEFAULT_DEBOUNCE_MS);
     await store.flush();
-    expect(writes).toHaveLength(1);
+    expect('editor-1' in (writes[0]?.named.default?.pane_state ?? {})).toBe(
+      false,
+    );
+  });
+
+  it('closeLeaf on the sole remaining leaf resets to the default chat layout', async () => {
+    const { scheduler } = makeFakeScheduler();
+    const store = createLayoutStore(WORKSPACE, { read, write, scheduler });
+    await store.load();
+
+    // Default seed is a single `root`/`chat` leaf.
+    store.closeLeaf('root');
+
+    const tree = store.layouts.named.default?.tree;
+    expect(tree?.kind).toBe('leaf');
+    if (tree?.kind !== 'leaf') throw new Error('expected leaf');
+    expect(tree.pane_type).toBe('chat');
+  });
+
+  it('setLayoutTree replaces the active layout\'s tree and schedules a write', async () => {
+    const { scheduler, tick } = makeFakeScheduler();
+    const store = createLayoutStore(WORKSPACE, { read, write, scheduler });
+    await store.load();
+
+    const next: LayoutTree = {
+      kind: 'split',
+      id: 'root',
+      direction: 'h',
+      ratio: 0.3,
+      a: { kind: 'leaf', id: 'chat-1', pane_type: 'chat' },
+      b: { kind: 'leaf', id: 'terminal-1', pane_type: 'terminal' },
+    };
+    store.setLayoutTree('default', next);
+    expect(store.layouts.named.default?.tree).toEqual(next);
+
+    tick(DEFAULT_DEBOUNCE_MS);
+    await store.flush();
+    expect(writes[0]?.named.default?.tree).toEqual(next);
   });
 });

--- a/web/packages/app/src/layout/layoutStore.ts
+++ b/web/packages/app/src/layout/layoutStore.ts
@@ -1,5 +1,5 @@
 import { createStore, reconcile } from 'solid-js/store';
-import type { Layout, Layouts, PaneState } from '@forge/ipc';
+import type { Layout, LayoutTree, Layouts, PaneState, PaneType } from '@forge/ipc';
 import { readLayouts, writeLayouts } from '../ipc/layouts';
 
 /**
@@ -11,6 +11,14 @@ import { readLayouts, writeLayouts } from '../ipc/layouts';
  * burst collapses into one disk write. A missing or corrupt file produces
  * the default single-pane layout at the shell layer — this store never has
  * to branch on "did the file exist".
+ *
+ * F-150: openFile / closeLeaf now operate on the real GridContainer tree
+ * rather than a synthetic singleton slot. `openFile(path)` either reuses
+ * the first editor leaf (DFS order) or splits the root right with a newly
+ * minted `editor-<n>` leaf. `closeLeaf(id)` removes a leaf, promotes its
+ * sibling, and garbage-collects the matching `pane_state` entry; closing
+ * the sole remaining leaf snaps back to the default single-chat layout so
+ * the tree is never empty.
  *
  * Testability. The debounce and the write transport are parameterizable: a
  * test can pass a synchronous write hook and a `setTimeout`-like scheduler
@@ -63,16 +71,13 @@ export interface LayoutStoreOptions {
   scheduler?: Scheduler;
   /** Error hook for failed writes. Defaults to `console.error`. */
   onWriteError?: (err: unknown) => void;
+  /**
+   * Injection seam for leaf-id generation. Production uses a module-local
+   * monotonic counter; tests can substitute a deterministic generator to
+   * keep assertions legible. Called once per freshly-split editor leaf.
+   */
+  nextEditorId?: () => string;
 }
-
-/**
- * F-126: the fixed synthetic leaf id used to carry the "currently open file"
- * in `pane_state`. The FilesSidebar's Open action and the EditorPane slot in
- * SessionWindow both key off this id. Once a follow-up lands full GridContainer
- * wiring, this id can be replaced with a real editor-leaf id walked out of the
- * layout tree.
- */
-export const EDITOR_LEAF_ID = 'editor';
 
 export interface LayoutStore {
   /** The reactive snapshot. Wrap reads in effects to track changes. */
@@ -83,27 +88,42 @@ export interface LayoutStore {
   setLayouts: (next: Layouts) => void;
   /** Replace one named layout's tree. Schedules a debounced write. */
   setLayout: (name: string, layout: Layout) => void;
+  /** Replace just the tree of a named layout. Schedules a debounced write. */
+  setLayoutTree: (name: string, tree: LayoutTree) => void;
   /** Upsert pane state for a leaf. Schedules a debounced write. */
   setPaneState: (layoutName: string, leafId: string, state: PaneState) => void;
   /** Change the active named layout. Schedules a debounced write. */
   setActive: (name: string) => void;
   /**
-   * F-126: record `path` as the file to mount in the EditorPane. Writes
-   * `pane_state[EDITOR_LEAF_ID].active_file = path` on the active layout
-   * and schedules a debounced persist. Idempotent — calling with the same
-   * path is a no-op write. Reset by calling with `null`.
+   * F-150: open `path` in an editor leaf. If the active layout's tree
+   * contains an editor leaf, its `pane_state[<id>].active_file` is updated.
+   * Otherwise the root is v-split (existing subtree left, new editor right)
+   * and the new editor leaf's `pane_state` is populated. Passing `null`
+   * is a no-op — use `closeLeaf` to remove an editor.
    */
-  openFile: (path: string | null) => void;
+  openFile: (path: string) => void;
   /**
-   * F-126: reactive getter for the currently-open editor file. Returns the
-   * active layout's `pane_state[EDITOR_LEAF_ID].active_file` or `null`.
-   * Used by SessionWindow to decide whether to mount an EditorPane.
+   * F-150: remove a leaf from the active layout's tree. The leaf's
+   * `pane_state` entry is garbage-collected. If the tree would become
+   * empty, it resets to the default single-chat layout instead.
    */
-  activeEditorFile: () => string | null;
+  closeLeaf: (leafId: string) => void;
   /** Cancel any pending debounced write without persisting. */
   cancelPendingWrite: () => void;
   /** Force the pending debounced write to run immediately. No-op if none pending. */
   flush: () => Promise<void>;
+}
+
+// Module-level monotonic counter for fresh editor-leaf ids. Shared across
+// stores because leaf ids live entirely in the persisted tree — if a newer
+// session happens to reuse `editor-3` after an old one was persisted, the
+// store that loads it still sees a deterministic, collision-free id space
+// going forward. The counter never rolls back on closeLeaf so a rapid open/
+// close sequence can't alias ids.
+let editorIdCounter = 0;
+function defaultNextEditorId(): string {
+  editorIdCounter += 1;
+  return `editor-${editorIdCounter}`;
 }
 
 /**
@@ -124,6 +144,7 @@ export function createLayoutStore(
   const write = options.write ?? writeLayouts;
   const read = options.read ?? readLayouts;
   const scheduler = options.scheduler ?? realScheduler;
+  const nextEditorId = options.nextEditorId ?? defaultNextEditorId;
   const onWriteError =
     options.onWriteError ??
     ((err: unknown) => {
@@ -190,6 +211,13 @@ export function createLayoutStore(
       setState('named', name, reconcile(layout));
       schedule();
     },
+    setLayoutTree(name, tree) {
+      // `reconcile` on the tree node preserves identity for unchanged
+      // subtrees — critical for Solid's downstream `<Show>` memoization of
+      // individual leaf renderers after a drag-to-dock mutation.
+      setState('named', name, 'tree', reconcile(tree));
+      schedule();
+    },
     setPaneState(layoutName, leafId, paneState) {
       setState('named', layoutName, 'pane_state', leafId, paneState);
       schedule();
@@ -199,21 +227,77 @@ export function createLayoutStore(
       schedule();
     },
     openFile(path) {
-      // Write into the active layout's pane_state. `reconcile` on the
-      // leaf-level record avoids stomping sibling fields (scroll_top,
-      // terminal_pid) that may be populated for the same synthetic leaf in
-      // some future landing. `path: null` clears the active file.
       const layoutName = state.active;
-      const current = state.named[layoutName]?.pane_state[EDITOR_LEAF_ID];
-      if (current?.active_file === path) return;
-      const next: PaneState = { ...(current ?? {}), active_file: path };
-      setState('named', layoutName, 'pane_state', EDITOR_LEAF_ID, next);
+      const layout = state.named[layoutName];
+      if (!layout) return;
+      const existing = findFirstLeafByPaneType(layout.tree, 'editor');
+      if (existing !== null) {
+        const current = layout.pane_state[existing.id];
+        if (current?.active_file === path) return;
+        const next: PaneState = { ...(current ?? {}), active_file: path };
+        setState('named', layoutName, 'pane_state', existing.id, next);
+        schedule();
+        return;
+      }
+      // No editor leaf — v-split the root, existing tree on the left, a
+      // fresh editor leaf on the right. `nextEditorId()` never collides with
+      // ids in the current tree because the counter is monotonic and tree
+      // ids are bounded by the active persistence window.
+      //
+      // `cloneTree(layout.tree)` breaks the Solid store proxy: Solid exposes
+      // nested objects as live proxies that delegate back to the root, so
+      // re-inserting `layout.tree` as a child of the new split would create
+      // a self-referential subtree under the proxy — infinite recursion on
+      // any subsequent traversal.
+      const newId = nextEditorId();
+      const newTree: LayoutTree = {
+        kind: 'split',
+        id: `split-${newId}`,
+        direction: 'v',
+        ratio: 0.5,
+        a: cloneTree(layout.tree),
+        b: { kind: 'leaf', id: newId, pane_type: 'editor' },
+      };
+      setState('named', layoutName, 'tree', reconcile(newTree));
+      setState('named', layoutName, 'pane_state', newId, {
+        active_file: path,
+      });
       schedule();
     },
-    activeEditorFile() {
+    closeLeaf(leafId) {
       const layoutName = state.active;
-      const ps = state.named[layoutName]?.pane_state[EDITOR_LEAF_ID];
-      return ps?.active_file ?? null;
+      const layout = state.named[layoutName];
+      if (!layout) return;
+      const next = removeLeaf(layout.tree, leafId);
+      if (next === null || next === layout.tree) {
+        // Sole-leaf removal returns null; reset to the default single-chat
+        // tree so the UI always has something to render. If the leaf wasn't
+        // in the tree at all, `removeLeaf` returns the original reference —
+        // bail out without touching persistence.
+        if (next === null) {
+          const fresh = defaultLayouts().named.default;
+          if (fresh !== undefined) {
+            setState('named', layoutName, 'tree', reconcile(fresh.tree));
+            setState('named', layoutName, 'pane_state', reconcile({}));
+            schedule();
+          }
+        }
+        return;
+      }
+      setState('named', layoutName, 'tree', reconcile(next));
+      // Garbage-collect pane_state for the removed leaf. Leaves that are
+      // still present keep their state by identity.
+      if (layoutName in state.named) {
+        const current = state.named[layoutName]?.pane_state;
+        if (current && leafId in current) {
+          const pruned: { [k: string]: PaneState } = {};
+          for (const [k, v] of Object.entries(current)) {
+            if (k !== leafId) pruned[k] = v;
+          }
+          setState('named', layoutName, 'pane_state', reconcile(pruned));
+        }
+      }
+      schedule();
     },
     cancelPendingWrite() {
       if (pendingHandle !== null) {
@@ -229,5 +313,82 @@ export function createLayoutStore(
         await inflight;
       }
     },
+  };
+}
+
+/**
+ * DFS-traverse a tree, returning the first leaf whose `pane_type` matches.
+ * Left-first traversal gives a predictable reuse rule — the leaf closest to
+ * the top-left of the tree wins, matching the user's mental model of "the
+ * editor I see when I open the session".
+ */
+export function findFirstLeafByPaneType(
+  tree: LayoutTree,
+  paneType: PaneType,
+): (LayoutTree & { kind: 'leaf' }) | null {
+  if (tree.kind === 'leaf') {
+    return tree.pane_type === paneType ? tree : null;
+  }
+  return (
+    findFirstLeafByPaneType(tree.a, paneType) ??
+    findFirstLeafByPaneType(tree.b, paneType)
+  );
+}
+
+/** DFS-collect every leaf id that appears in `tree` (stable iteration order). */
+export function collectLeafIds(tree: LayoutTree): string[] {
+  if (tree.kind === 'leaf') return [tree.id];
+  return [...collectLeafIds(tree.a), ...collectLeafIds(tree.b)];
+}
+
+/**
+ * Remove a leaf from the tree by id. Returns:
+ *   - the unchanged tree reference if the leaf is not present,
+ *   - `null` if the tree itself was the sole leaf being removed,
+ *   - a new tree with the sibling promoted otherwise.
+ * Split nodes along the path are structurally rebuilt; untouched subtrees
+ * are shared by reference so Solid's `reconcile` can preserve identity.
+ */
+export function removeLeaf(tree: LayoutTree, id: string): LayoutTree | null {
+  if (tree.kind === 'leaf') return tree.id === id ? null : tree;
+  if (tree.a.kind === 'leaf' && tree.a.id === id) return tree.b;
+  if (tree.b.kind === 'leaf' && tree.b.id === id) return tree.a;
+  const containsInA = leafExists(tree.a, id);
+  const containsInB = leafExists(tree.b, id);
+  if (containsInA) {
+    const nextA = removeLeaf(tree.a, id);
+    return nextA === null ? tree.b : { ...tree, a: nextA };
+  }
+  if (containsInB) {
+    const nextB = removeLeaf(tree.b, id);
+    return nextB === null ? tree.a : { ...tree, b: nextB };
+  }
+  return tree;
+}
+
+function leafExists(tree: LayoutTree, id: string): boolean {
+  if (tree.kind === 'leaf') return tree.id === id;
+  return leafExists(tree.a, id) || leafExists(tree.b, id);
+}
+
+/**
+ * Structurally clone a layout tree into plain JS objects. Used when reading
+ * a subtree out of the reactive Solid store to splice it back in as a child
+ * of a new parent — the Solid proxy makes nested reads live, so naively
+ * re-inserting a child reference produces a self-referential tree. The
+ * tree is a small, bounded structure (typically a handful of leaves), so
+ * a recursive clone is both obvious and cheap.
+ */
+function cloneTree(tree: LayoutTree): LayoutTree {
+  if (tree.kind === 'leaf') {
+    return { kind: 'leaf', id: tree.id, pane_type: tree.pane_type };
+  }
+  return {
+    kind: 'split',
+    id: tree.id,
+    direction: tree.direction,
+    ratio: tree.ratio,
+    a: cloneTree(tree.a),
+    b: cloneTree(tree.b),
   };
 }

--- a/web/packages/app/src/layout/useDragToDock.test.ts
+++ b/web/packages/app/src/layout/useDragToDock.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createRoot, createSignal } from 'solid-js';
-import type { LayoutNode } from './GridContainer';
+import type { LayoutTree as LayoutNode } from '@forge/ipc';
 import { applyDockDrop, zoneForPoint } from './dockDrop';
 import { useDragToDock } from './useDragToDock';
 
@@ -14,14 +14,14 @@ describe('applyDockDrop — edge zones', () => {
     id: 'root',
     direction: 'v',
     ratio: 0.5,
-    a: { kind: 'leaf', id: 'chat', render: () => null },
+    a: { kind: 'leaf', id: 'chat', pane_type: 'chat' },
     b: {
       kind: 'split',
       id: 'right',
       direction: 'h',
       ratio: 0.5,
-      a: { kind: 'leaf', id: 'editor', render: () => null },
-      b: { kind: 'leaf', id: 'terminal', render: () => null },
+      a: { kind: 'leaf', id: 'editor', pane_type: 'chat' },
+      b: { kind: 'leaf', id: 'terminal', pane_type: 'chat' },
     },
   });
 
@@ -75,14 +75,14 @@ describe('applyDockDrop — center zone', () => {
       id: 'root',
       direction: 'v',
       ratio: 0.5,
-      a: { kind: 'leaf', id: 'a', render: () => null },
+      a: { kind: 'leaf', id: 'a', pane_type: 'chat' },
       b: {
         kind: 'split',
         id: 'inner',
         direction: 'h',
         ratio: 0.5,
-        a: { kind: 'leaf', id: 'b', render: () => null },
-        b: { kind: 'leaf', id: 'c', render: () => null },
+        a: { kind: 'leaf', id: 'b', pane_type: 'chat' },
+        b: { kind: 'leaf', id: 'c', pane_type: 'chat' },
       },
     };
     const next = applyDockDrop(tree, 'a', 'c', 'center');
@@ -99,8 +99,8 @@ describe('applyDockDrop — malformed drops are no-ops', () => {
     id: 'root',
     direction: 'v',
     ratio: 0.5,
-    a: { kind: 'leaf', id: 'a', render: () => null },
-    b: { kind: 'leaf', id: 'b', render: () => null },
+    a: { kind: 'leaf', id: 'a', pane_type: 'chat' },
+    b: { kind: 'leaf', id: 'b', pane_type: 'chat' },
   };
 
   it('returns tree unchanged when sourceId === targetId', () => {
@@ -116,7 +116,7 @@ describe('applyDockDrop — malformed drops are no-ops', () => {
   });
 
   it('refuses to remove the sole leaf of a root-leaf tree', () => {
-    const lonely: LayoutNode = { kind: 'leaf', id: 'only', render: () => null };
+    const lonely: LayoutNode = { kind: 'leaf', id: 'only', pane_type: 'chat' };
     expect(applyDockDrop(lonely, 'only', 'only', 'center')).toBe(lonely);
   });
 });
@@ -261,8 +261,8 @@ describe('useDragToDock — integration', () => {
     id: 'root',
     direction: 'v',
     ratio: 0.5,
-    a: { kind: 'leaf', id: 'a', render: () => null },
-    b: { kind: 'leaf', id: 'b', render: () => null },
+    a: { kind: 'leaf', id: 'a', pane_type: 'chat' },
+    b: { kind: 'leaf', id: 'b', pane_type: 'chat' },
   };
   const geometry: LeafGeometry = {
     a: { left: 0, top: 0, right: 500, bottom: 600, width: 500, height: 600 },

--- a/web/packages/app/src/layout/useDragToDock.ts
+++ b/web/packages/app/src/layout/useDragToDock.ts
@@ -1,6 +1,11 @@
 import { createSignal, onCleanup } from 'solid-js';
-import type { LayoutNode } from './GridContainer';
+import type { LayoutTree } from '@forge/ipc';
 import { applyDockDrop, type DropZone, zoneForPoint } from './dockDrop';
+
+// F-150: the hook now operates on the persisted `LayoutTree` shape so the
+// drop-emitted tree can flow straight into `layoutStore.setLayoutTree`
+// without a closure-stripping pass.
+type LayoutNode = LayoutTree;
 
 /**
  * Active-drag state exposed to consumers so they can render the drag visuals

--- a/web/packages/app/src/panes/EditorPane.tsx
+++ b/web/packages/app/src/panes/EditorPane.tsx
@@ -75,6 +75,12 @@ export interface EditorPaneProps {
    *  iframe. Tests capture these; prod resolves to
    *  `iframe.contentWindow.postMessage`. */
   postToIframe?: (msg: unknown) => void;
+  /** F-150: pointer-down handler wired onto the breadcrumb header so the
+   *  pane participates in the F-118 drag-to-dock gesture. Callers thread
+   *  `dockApi.startDrag(leafId)` through here; the header is the only
+   *  non-content surface on the pane and is the same drag-initiation
+   *  affordance every other grid leaf uses. */
+  onHeaderPointerDown?: (e: PointerEvent) => void;
 }
 
 /** Monaco-style URI. Keeps the round-trip through `readFile` → iframe →
@@ -238,7 +244,11 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
       data-testid="editor-pane"
       onKeyDown={handleKeyDown}
     >
-      <header class="editor-pane__header" role="banner">
+      <header
+        class="editor-pane__header"
+        role="banner"
+        onPointerDown={props.onHeaderPointerDown}
+      >
         <span class="editor-pane__type-label">EDITOR</span>
         <span
           class="editor-pane__breadcrumb"

--- a/web/packages/app/src/routes/Session/SessionWindow.css
+++ b/web/packages/app/src/routes/Session/SessionWindow.css
@@ -14,17 +14,46 @@
   min-height: 0;
 }
 
+/* F-150: the top-level grid host. Occupies the remaining chrome column
+   and delegates pane rendering to GridContainer. The grid's leaves each
+   render with their own `.session-window__pane` chrome. */
+.session-window__grid {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  position: relative;
+}
+
 .session-window__pane {
   display: flex;
   flex-direction: column;
-  flex: 1 1 auto;
-  min-width: 320px;
+  width: 100%;
+  height: 100%;
   background: var(--color-surface-1);
   border: 1px solid var(--color-border-1);
+  min-width: 0;
+  min-height: 0;
+}
+
+.session-window__pane-header {
+  flex: 0 0 auto;
+  cursor: grab;
 }
 
 .session-window__pane-body {
   display: flex;
   flex: 1 1 auto;
   min-height: 0;
+}
+
+.session-window__pane-empty {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-family: var(--font-body);
+  font-size: 12px;
+  opacity: 0.7;
 }

--- a/web/packages/app/src/routes/Session/SessionWindow.test.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.test.tsx
@@ -24,9 +24,12 @@ import {
 import { resetSessionEventStore } from '../../stores/session';
 import { resetMessagesStore } from '../../stores/messages';
 import { setInvokeForTesting } from '../../lib/tauri';
-import type { Layouts, PaneState } from '@forge/ipc';
-import { createStore, produce } from 'solid-js/store';
-import { defaultLayouts, type LayoutStore } from '../../layout/layoutStore';
+import type { LayoutTree, Layouts } from '@forge/ipc';
+import {
+  createLayoutStore,
+  defaultLayouts,
+  type LayoutStore,
+} from '../../layout/layoutStore';
 
 const helloAck = {
   session_id: 'abc123',
@@ -46,59 +49,37 @@ function renderAt(path: string) {
   ));
 }
 
-// F-126: test-only fake layout store that skips the `read_layouts` /
-// `write_layouts` IPC roundtrip. Mirrors the production `LayoutStore`
-// interface closely enough that SessionWindow can drive the Open ->
-// EditorPane flow through it deterministically.
-function makeFakeLayoutStore(): LayoutStore & { __openFileCalls: string[] } {
-  // Use `createStore` so mutations notify Solid reactivity — SessionWindow's
-  // `<Show when={activeEditorFile()}>` only retracks when the underlying
-  // signal is reactive. A plain object would mutate silently and the
-  // EditorPane would never mount.
-  const [state, setState] = createStore<Layouts>(defaultLayouts());
+// F-150: test-only wrapper around the real `createLayoutStore` that skips
+// the `read_layouts` / `write_layouts` IPC roundtrip and exposes an
+// `__openFileCalls` spy. Uses the production implementation so tree-based
+// openFile / closeLeaf / setLayoutTree semantics are tested end-to-end —
+// the previous fake reproduced only the singleton pane_state shape that
+// F-150 removed.
+function makeFakeLayoutStore(
+  seed?: Layouts,
+): LayoutStore & { __openFileCalls: string[] } {
   const calls: string[] = [];
-  return {
-    get layouts() {
-      return state;
+  const initial = seed ?? defaultLayouts();
+  // Synchronous stubs so `load()` completes in-line with `onMount`, keeping
+  // `activeTree()` stable from the first paint. The scheduler is stubbed to
+  // a no-op so no setTimeout handles leak between tests.
+  const store = createLayoutStore('/ws', {
+    read: async () => initial,
+    write: async () => {},
+    scheduler: {
+      setTimeout: () => 0,
+      clearTimeout: () => {},
     },
-    async load() {
-      /* already seeded */
-    },
-    setLayouts() {
-      /* no-op */
-    },
-    setLayout() {
-      /* no-op */
-    },
-    setPaneState(layoutName, leafId, paneState) {
-      setState('named', layoutName, 'pane_state', leafId, paneState);
-    },
-    setActive(name) {
-      setState('active', name);
-    },
-    openFile(path) {
-      calls.push(path ?? '<null>');
-      setState(
-        produce((s) => {
-          const layout = s.named[s.active];
-          if (!layout) return;
-          const current = layout.pane_state.editor ?? ({} as PaneState);
-          layout.pane_state.editor = { ...current, active_file: path };
-        }),
-      );
-    },
-    activeEditorFile() {
-      const layout = state.named[state.active];
-      return layout?.pane_state.editor?.active_file ?? null;
-    },
-    cancelPendingWrite() {
-      /* no-op */
-    },
-    async flush() {
-      /* no-op */
-    },
-    __openFileCalls: calls,
+  });
+  // Seed synchronously so test setup can call `store.openFile(...)` before
+  // mount without awaiting `load()`.
+  store.setLayouts(initial);
+  const origOpen = store.openFile.bind(store);
+  store.openFile = (path: string) => {
+    calls.push(path);
+    origOpen(path);
   };
+  return Object.assign(store, { __openFileCalls: calls });
 }
 
 function renderWithStore(path: string, store: LayoutStore) {
@@ -201,13 +182,16 @@ describe('SessionWindow', () => {
     );
   });
 
-  it('renders exactly one pane slot (no splitter or dock zones)', async () => {
+  it('renders a single-leaf grid when no split is in the active layout (F-150)', async () => {
     const { container, findByTestId } = renderAt('/session/abc123');
     await findByTestId('pane-header-subject');
+    // Default layout is a single chat leaf — GridContainer renders one
+    // `.session-window__pane` and no SplitPane divider. After F-150 the
+    // grid is always present, so assert on the leaf count rather than the
+    // previous "exactly one pane slot" singleton shape.
     const panes = container.querySelectorAll('.session-window__pane');
     expect(panes.length).toBe(1);
-    expect(container.querySelector('.session-window__splitter')).toBeNull();
-    expect(container.querySelector('.session-window__dock-zone')).toBeNull();
+    expect(container.querySelector('[data-testid="split-pane"]')).toBeNull();
   });
 
   it('pane header shows subject, ollama provider label, cost placeholder, close action', async () => {
@@ -377,17 +361,14 @@ describe('SessionWindow', () => {
   });
 
   // -----------------------------------------------------------------------
-  // F-126 mandatory fix: Open action -> layoutStore -> EditorPane end-to-end.
-  // This test is the whole reason PR #291 was closed: the previous Open
-  // handler was a placeholder. Here we assert the full flow:
-  //   1. User opens the Files sidebar.
-  //   2. User double-clicks a file row (or context-menu Open).
-  //   3. SessionWindow.onFileOpen invokes layoutStore.openFile(path).
-  //   4. SessionWindow reactively mounts an EditorPane for that path in the
-  //      main pane body (replacing the ChatPane fallback).
+  // F-150: Files-sidebar Open -> layoutStore -> GridContainer -> EditorPane.
+  // Unlike F-126's singleton-slot flow, opening a file splits the grid so
+  // the existing chat pane remains visible side-by-side with a new editor
+  // leaf. Closing the editor leaf reclaims the grid space and leaves the
+  // chat pane as the sole leaf.
   // -----------------------------------------------------------------------
 
-  it('routes a files-sidebar Open click through the layout store and mounts an EditorPane', async () => {
+  it('splits the grid and mounts an EditorPane when the Files sidebar opens a file', async () => {
     // Arrange the `tree` IPC mock to return a workspace with one file so
     // the sidebar has something to double-click.
     const treeNode = {
@@ -422,7 +403,7 @@ describe('SessionWindow', () => {
       store,
     );
 
-    // Initial state: ChatPane is mounted, no EditorPane.
+    // Initial state: ChatPane is mounted as the sole grid leaf; no editor.
     await findByTestId('chat-pane');
     expect(queryByTestId('editor-pane')).toBeNull();
 
@@ -432,8 +413,8 @@ describe('SessionWindow', () => {
     await findByTestId('files-sidebar');
 
     // Double-click the README row. Sidebar emits onOpen(path);
-    // SessionWindow calls store.openFile(path); reactive Show swaps the
-    // pane body from ChatPane to EditorPane.
+    // SessionWindow calls store.openFile(path); the tree splits so both
+    // the chat leaf and a freshly-minted editor leaf render in parallel.
     const row = await findByText('README.md');
     row.dispatchEvent(
       new MouseEvent('dblclick', { bubbles: true, cancelable: true }),
@@ -442,13 +423,67 @@ describe('SessionWindow', () => {
     const editor = await findByTestId('editor-pane');
     expect(editor).toBeInTheDocument();
     expect(store.__openFileCalls).toContain('/ws/README.md');
-    // ChatPane gone, EditorPane breadcrumb displays the path leaf.
-    expect(queryByTestId('chat-pane')).toBeNull();
+    // F-150: chat pane stays — the split mounts editor beside it.
+    expect(queryByTestId('chat-pane')).not.toBeNull();
     const breadcrumb = await findByTestId('editor-pane-breadcrumb');
     expect(breadcrumb.textContent).toContain('README.md');
+    // Tree is now a v-split with one editor leaf (F-150 DoD: split-when-none).
+    const rootTree = store.layouts.named[store.layouts.active]?.tree;
+    expect(rootTree?.kind).toBe('split');
   });
 
-  it('closing the EditorPane clears the active file and falls back to ChatPane', async () => {
+  it('reuses the existing editor leaf when opening a second file', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'session_hello') return helloAck;
+      if (cmd === 'read_layouts') return defaultLayouts();
+      if (cmd === 'write_layouts') return undefined;
+      if (cmd === 'tree') {
+        return {
+          name: 'ws',
+          path: '/ws',
+          kind: 'Dir',
+          children: [
+            { name: 'a.ts', path: '/ws/a.ts', kind: 'File', children: null },
+            { name: 'b.ts', path: '/ws/b.ts', kind: 'File', children: null },
+          ],
+        };
+      }
+      if (cmd === 'read_file') {
+        return { content: '', bytes: 0, sha256: '' };
+      }
+      return undefined;
+    });
+
+    const store = makeFakeLayoutStore();
+    // First open creates the editor leaf. Count the editor leaves after
+    // the second open to confirm only one exists.
+    store.openFile('/ws/a.ts');
+    const treeAfterFirst = store.layouts.named[store.layouts.active]?.tree;
+    expect(treeAfterFirst?.kind).toBe('split');
+
+    const { findByTestId } = renderWithStore('/session/abc123', store);
+    await findByTestId('editor-pane');
+
+    // Second open should reuse the same leaf, not add another split.
+    store.openFile('/ws/b.ts');
+    const treeAfterSecond = store.layouts.named[store.layouts.active]?.tree;
+    expect(treeAfterSecond?.kind).toBe('split');
+    if (treeAfterSecond?.kind === 'split') {
+      // Still exactly one editor leaf under the root split.
+      const ids = new Set<string>();
+      const walk = (n: LayoutTree): void => {
+        if (n.kind === 'leaf') ids.add(n.id);
+        else {
+          walk(n.a);
+          walk(n.b);
+        }
+      };
+      walk(treeAfterSecond);
+      expect(ids.size).toBe(2); // chat + editor
+    }
+  });
+
+  it('closing the EditorPane reclaims the grid space and leaves the chat pane', async () => {
     invokeMock.mockImplementation(async (cmd: string) => {
       if (cmd === 'session_hello') return helloAck;
       if (cmd === 'read_layouts') return defaultLayouts();
@@ -472,13 +507,176 @@ describe('SessionWindow', () => {
     );
 
     await findByTestId('editor-pane');
-    expect(queryByTestId('chat-pane')).toBeNull();
+    // Both panes render in parallel before the close.
+    await findByTestId('chat-pane');
 
     const close = await findByRole('button', { name: /close editor pane/i });
     close.click();
 
+    // Editor leaf removed; chat leaf promoted to the whole grid.
+    await waitFor(() => expect(queryByTestId('editor-pane')).toBeNull());
     await findByTestId('chat-pane');
-    expect(queryByTestId('editor-pane')).toBeNull();
-    expect(store.activeEditorFile()).toBeNull();
+    const tree = store.layouts.named[store.layouts.active]?.tree;
+    expect(tree?.kind).toBe('leaf');
+  });
+
+  // -----------------------------------------------------------------------
+  // F-150: drag-to-dock regression — dragging an editor pane header must
+  // reposition the leaf in the grid the same way it does for any other
+  // pane type. We drive a real pointer sequence against the editor's
+  // breadcrumb header and assert the tree mutates via layoutStore.
+  // Geometry and hit-testing are stubbed the same way
+  // `useDragToDock.test.ts` stubs them, so the whole pointerdown → pointer-
+  // move → pointerup path participates.
+  // -----------------------------------------------------------------------
+
+  it('drag-to-dock moves an editor leaf like any other grid pane', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'session_hello') return helloAck;
+      if (cmd === 'read_layouts') return defaultLayouts();
+      if (cmd === 'write_layouts') return undefined;
+      if (cmd === 'tree') {
+        return { name: 'ws', path: '/ws', kind: 'Dir', children: [] };
+      }
+      if (cmd === 'read_file') {
+        return { content: '', bytes: 0, sha256: '' };
+      }
+      return undefined;
+    });
+
+    const store = makeFakeLayoutStore();
+    // Seed the tree with chat + editor side-by-side.
+    store.openFile('/ws/seed.ts');
+    const beforeTree = store.layouts.named[store.layouts.active]?.tree;
+    if (beforeTree?.kind !== 'split') throw new Error('expected split');
+    const editorLeaf = beforeTree.b.kind === 'leaf' ? beforeTree.b : null;
+    const chatLeaf = beforeTree.a.kind === 'leaf' ? beforeTree.a : null;
+    if (editorLeaf === null || chatLeaf === null) {
+      throw new Error('expected two sibling leaves');
+    }
+    const editorId = editorLeaf.id;
+    const chatId = chatLeaf.id;
+
+    const { findByTestId } = renderWithStore('/session/abc123', store);
+    await findByTestId('editor-pane');
+
+    // Editor leaf is exposed as a drop target (data-leaf-id marker).
+    const editorMarker = document.querySelector(
+      `[data-leaf-id="${editorId}"]`,
+    ) as HTMLElement | null;
+    expect(editorMarker).not.toBeNull();
+
+    // Stub leaf geometry so `useDragToDock`'s `elementFromPoint` +
+    // `getBoundingClientRect` resolve to the two leaves. Chat on the left
+    // half, editor on the right half — matches the seeded v-split.
+    const geometry: Record<
+      string,
+      { left: number; top: number; right: number; bottom: number; width: number; height: number }
+    > = {
+      [chatId]: { left: 0, top: 0, right: 500, bottom: 600, width: 500, height: 600 },
+      [editorId]: {
+        left: 500,
+        top: 0,
+        right: 1000,
+        bottom: 600,
+        width: 500,
+        height: 600,
+      },
+    };
+    const originalEfp = document.elementFromPoint;
+    const originalRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = function stubbed(
+      this: Element,
+    ): DOMRect {
+      if (this instanceof HTMLElement) {
+        const id = this.getAttribute('data-leaf-id');
+        if (id !== null && geometry[id] !== undefined) {
+          const g = geometry[id];
+          return {
+            ...g,
+            x: g.left,
+            y: g.top,
+            toJSON() {
+              return g;
+            },
+          } as DOMRect;
+        }
+      }
+      return originalRect.call(this);
+    };
+    document.elementFromPoint = function stubbed(
+      x: number,
+      y: number,
+    ): Element | null {
+      for (const [id, g] of Object.entries(geometry)) {
+        if (x >= g.left && x <= g.right && y >= g.top && y <= g.bottom) {
+          const el = document.querySelector(`[data-leaf-id="${id}"]`);
+          if (el !== null) return el;
+        }
+      }
+      return null;
+    };
+
+    try {
+      // EditorPane's own header is where onHeaderPointerDown is wired —
+      // that's the drag source for the editor leaf. Fire pointerdown on
+      // it, then move + up over the chat leaf's left edge to dock the
+      // editor on the far left.
+      const editorHeader = document.querySelector(
+        '.editor-pane__header',
+      ) as HTMLElement | null;
+      expect(editorHeader).not.toBeNull();
+      const pd = new MouseEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 520,
+        clientY: 10,
+        button: 0,
+      });
+      Object.defineProperty(pd, 'pointerId', { value: 1 });
+      editorHeader!.dispatchEvent(pd);
+
+      const firePointer = (
+        kind: 'pointermove' | 'pointerup',
+        x: number,
+        y: number,
+      ) => {
+        const ev = new MouseEvent(kind, {
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+        });
+        Object.defineProperty(ev, 'pointerId', { value: 1 });
+        window.dispatchEvent(ev);
+      };
+      // Dock onto the chat leaf's left edge.
+      firePointer('pointermove', 10, 300);
+      firePointer('pointerup', 10, 300);
+
+      // Tree should have mutated — editor on the left now, chat on the
+      // right — proving the editor leaf is a drag source the same as any
+      // other pane. The exact shape matches `applyDockDrop` semantics.
+      const after = store.layouts.named[store.layouts.active]?.tree;
+      if (after?.kind !== 'split') throw new Error('expected split after drop');
+      // Either (editor, chat) by id or an equivalent structural mutation.
+      const ids: string[] = [];
+      const walk = (n: LayoutTree) => {
+        if (n.kind === 'leaf') ids.push(n.id);
+        else {
+          walk(n.a);
+          walk(n.b);
+        }
+      };
+      walk(after);
+      expect(ids).toContain(editorId);
+      expect(ids).toContain(chatId);
+      // The editor leaf must now sit on the left half of the split.
+      const leftmost = after.a.kind === 'leaf' ? after.a.id : null;
+      expect(leftmost).toBe(editorId);
+    } finally {
+      Element.prototype.getBoundingClientRect = originalRect;
+      document.elementFromPoint = originalEfp;
+    }
   });
 });

--- a/web/packages/app/src/routes/Session/SessionWindow.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.tsx
@@ -1,7 +1,14 @@
-import { type Component, Show, createSignal, onCleanup, onMount } from 'solid-js';
+import {
+  type Component,
+  type JSX,
+  Show,
+  createSignal,
+  onCleanup,
+  onMount,
+} from 'solid-js';
 import { useParams } from '@solidjs/router';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import type { ProviderId, SessionId } from '@forge/ipc';
+import type { LayoutTree, ProviderId, SessionId } from '@forge/ipc';
 import {
   getPersistentApprovals,
   getSettings,
@@ -28,6 +35,8 @@ import {
   createLayoutStore,
   type LayoutStore,
 } from '../../layout/layoutStore';
+import { GridContainer, type LayoutLeaf } from '../../layout/GridContainer';
+import { useDragToDock } from '../../layout/useDragToDock';
 import { ActivityBar, type ActivityId } from '../../shell/ActivityBar';
 import { FilesSidebar } from '../../shell/FilesSidebar';
 import { StatusBar } from '../../shell/StatusBar';
@@ -54,9 +63,11 @@ export function __setInjectedLayoutStoreForTesting(
 
 /**
  * Session window shell — default single-pane layout from
- * docs/ui-specs/layout-panes.md §3.4. Splitters and drag-to-dock are
- * deferred to Phase 2. Subscribes to the session event stream on mount
- * (via the F-020 IPC wrappers) and cleanly detaches on unmount.
+ * docs/ui-specs/layout-panes.md §3.4. F-150 replaces the F-126 "singleton
+ * editor slot" with a real GridContainer: the active layout's tree drives
+ * rendering end-to-end, so multiple editors can coexist, drag-to-dock works
+ * on editor leaves the same as any other pane, and F-119 compactness runs
+ * per-leaf rather than on a single window-scope pane.
  */
 export const SessionWindow: Component = () => {
   const params = useParams<{ id: string }>();
@@ -158,7 +169,7 @@ export const SessionWindow: Component = () => {
     setActiveWorkspaceRoot(null);
   });
 
-  const handleClose = () => {
+  const handleCloseWindow = () => {
     try {
       void getCurrentWindow().close();
     } catch (err) {
@@ -173,15 +184,6 @@ export const SessionWindow: Component = () => {
   const providerId = (): ProviderId => 'ollama' as ProviderId;
   const providerLabel = () => 'ollama \u00b7 pending';
   const costLabel = () => 'in 0 \u00b7 out 0 \u00b7 $0.00';
-
-  // F-119: observe the pane section's width so the header collapses its
-  // chrome below the 320/240 thresholds. The ref is populated synchronously
-  // by Solid when the element mounts, which is the resolution order the
-  // hook expects. In the jsdom test environment ResizeObserver is absent
-  // and the hook degrades to `full` — the existing SessionWindow tests
-  // still pass without a fixture.
-  const [paneEl, setPaneEl] = createSignal<HTMLElement | null>(null);
-  const { compactness } = usePaneWidth(paneEl);
 
   // F-126: activity-bar + files-sidebar chrome. `activeActivity` is `null`
   // when the sidebar is hidden (default) and an activity id when visible.
@@ -218,10 +220,9 @@ export const SessionWindow: Component = () => {
     window.removeEventListener('keydown', onShortcut);
   });
 
-  // F-126 mandatory-fix: route FilesSidebar Open -> layoutStore -> EditorPane.
-  // When `activeEditorFile()` resolves to a non-null path, SessionWindow
-  // mounts an EditorPane pinned to that path in place of the chat pane.
-  // Closing the editor clears the active file and drops back to chat.
+  // F-150: files-sidebar Open routes through layoutStore.openFile(path),
+  // which either updates an existing editor leaf's active_file or splits
+  // the tree to mount a fresh editor leaf.
   const onFileOpen = (path: string): void => {
     const s = store();
     if (s === null) {
@@ -233,14 +234,80 @@ export const SessionWindow: Component = () => {
     s.openFile(path);
   };
 
-  const onEditorClose = (): void => {
+  // F-150: the active layout's tree is what GridContainer renders. When the
+  // store hasn't loaded yet (no-workspace edge case on mount), we fall back
+  // to a synthetic single-chat tree so the first paint isn't empty.
+  const FALLBACK_TREE: LayoutTree = {
+    kind: 'leaf',
+    id: 'root',
+    pane_type: 'chat',
+  };
+  const activeTree = (): LayoutTree => {
     const s = store();
-    if (s) s.openFile(null);
+    if (s === null) return FALLBACK_TREE;
+    const name = s.layouts.active;
+    return s.layouts.named[name]?.tree ?? FALLBACK_TREE;
+  };
+  const paneStateFor = (leafId: string) => {
+    const s = store();
+    if (s === null) return undefined;
+    const name = s.layouts.active;
+    return s.layouts.named[name]?.pane_state[leafId];
   };
 
-  const activeEditorFile = (): string | null => {
+  // Drag-to-dock hook. `getTree` reads the active tree through the store;
+  // `onTreeChange` writes the new tree back via `setLayoutTree` so the
+  // mutation is persisted alongside the next debounced write.
+  const dockApi = useDragToDock({
+    getTree: () => activeTree(),
+    onTreeChange: (next) => {
+      const s = store();
+      if (s === null) return;
+      s.setLayoutTree(s.layouts.active, next);
+    },
+  });
+
+  const onRatioChange = (id: string, ratio: number): void => {
     const s = store();
-    return s ? s.activeEditorFile() : null;
+    if (s === null) return;
+    const current = s.layouts.named[s.layouts.active]?.tree;
+    if (!current) return;
+    const next = updateSplitRatio(current, id, ratio);
+    if (next !== current) s.setLayoutTree(s.layouts.active, next);
+  };
+
+  const onCloseLeaf = (leafId: string): void => {
+    // If the leaf being closed is the last chat leaf in the active tree,
+    // treat CLOSE SESSION as a window-close (preserving the pre-F-150
+    // behavior for the default single-pane session). In any other shape
+    // we remove the leaf from the grid so the surviving panes reclaim
+    // its space.
+    const tree = activeTree();
+    if (tree.kind === 'leaf' && tree.id === leafId && tree.pane_type === 'chat') {
+      handleCloseWindow();
+      return;
+    }
+    const s = store();
+    if (s === null) return;
+    s.closeLeaf(leafId);
+  };
+
+  const renderLeaf = (leaf: LayoutLeaf): JSX.Element => {
+    // Each leaf owns its own compactness observation so a narrow split still
+    // collapses chrome independently of the window width (§3.7).
+    return (
+      <LeafHost
+        leaf={leaf}
+        sessionId={sessionId()}
+        subject={subject()}
+        providerId={providerId()}
+        providerLabel={providerLabel()}
+        costLabel={costLabel()}
+        activeFile={paneStateFor(leaf.id)?.active_file ?? null}
+        onCloseLeaf={() => onCloseLeaf(leaf.id)}
+        onPointerDownHeader={dockApi.startDrag(leaf.id)}
+      />
+    );
   };
 
   return (
@@ -258,32 +325,15 @@ export const SessionWindow: Component = () => {
           />
         </Show>
         <section
-          class="session-window__pane"
-          aria-label="Session pane"
-          ref={setPaneEl}
+          class="session-window__grid"
+          aria-label="Session pane grid"
         >
-          <PaneHeader
-            subject={subject()}
-            providerId={providerId()}
-            providerLabel={providerLabel()}
-            costLabel={costLabel()}
-            compactness={compactness()}
-            onClose={handleClose}
+          <GridContainer
+            tree={activeTree()}
+            renderLeaf={renderLeaf}
+            onRatioChange={onRatioChange}
+            dragState={dockApi.drag()}
           />
-          <div class="session-window__pane-body">
-            <Show
-              when={activeEditorFile()}
-              fallback={<ChatPane />}
-            >
-              {(path) => (
-                <EditorPane
-                  sessionId={sessionId()}
-                  path={path()}
-                  onClose={onEditorClose}
-                />
-              )}
-            </Show>
-          </div>
         </section>
       </div>
       {/* F-138: status bar lives at the bottom of the session chrome.
@@ -293,3 +343,138 @@ export const SessionWindow: Component = () => {
     </main>
   );
 };
+
+/**
+ * Per-leaf renderer. Owns the pane's own `usePaneWidth` observation so the
+ * F-119 compactness thresholds are computed against the leaf's own extent,
+ * not the enclosing window. Dispatches on `pane_type` — chat, editor, and
+ * the remaining variants are stubbed out for now (F-125 / F-140 ship them).
+ */
+interface LeafHostProps {
+  leaf: LayoutLeaf;
+  sessionId: SessionId;
+  subject: string;
+  providerId: ProviderId;
+  providerLabel: string;
+  costLabel: string;
+  activeFile: string | null;
+  onCloseLeaf: () => void;
+  onPointerDownHeader: (e: PointerEvent) => void;
+}
+const LeafHost: Component<LeafHostProps> = (props) => {
+  const [leafEl, setLeafEl] = createSignal<HTMLElement | null>(null);
+  const { compactness } = usePaneWidth(leafEl);
+
+  // Close semantics: chat leaves inherit the prior CLOSE SESSION behavior
+  // (tear down the window). Editor/terminal/etc. leaves call
+  // `layoutStore.closeLeaf(id)` so the grid reclaims the freed space.
+  const closeLabel = (): string =>
+    props.leaf.pane_type === 'chat' ? 'CLOSE SESSION' : 'CLOSE PANE';
+  const closeAriaLabel = (): string =>
+    props.leaf.pane_type === 'chat' ? 'Close session window' : 'Close pane';
+
+  // The editor pane owns its own header (breadcrumb + CLOSE TAB), so we
+  // suppress the outer PaneHeader for editor leaves to avoid a double-header
+  // row. Everything else uses the standard PaneHeader.
+  const showOuterHeader = (): boolean => props.leaf.pane_type !== 'editor';
+
+  return (
+    <div
+      class="session-window__pane"
+      ref={setLeafEl}
+      data-pane-type={props.leaf.pane_type}
+    >
+      <Show when={showOuterHeader()}>
+        <div
+          class="session-window__pane-header"
+          onPointerDown={props.onPointerDownHeader}
+        >
+          <Show
+            when={props.leaf.pane_type === 'chat'}
+            fallback={
+              <PaneHeader
+                subject={props.subject}
+                typeLabel={paneTypeToHeaderLabel(props.leaf.pane_type)}
+                compactness={compactness()}
+                closeLabel={closeLabel()}
+                closeAriaLabel={closeAriaLabel()}
+                onClose={props.onCloseLeaf}
+              />
+            }
+          >
+            <PaneHeader
+              subject={props.subject}
+              providerId={props.providerId}
+              providerLabel={props.providerLabel}
+              costLabel={props.costLabel}
+              typeLabel="CHAT"
+              compactness={compactness()}
+              closeLabel={closeLabel()}
+              closeAriaLabel={closeAriaLabel()}
+              onClose={props.onCloseLeaf}
+            />
+          </Show>
+        </div>
+      </Show>
+      <div class="session-window__pane-body">
+        <Show when={props.leaf.pane_type === 'chat'}>
+          <ChatPane />
+        </Show>
+        <Show when={props.leaf.pane_type === 'editor' && props.activeFile !== null}>
+          <EditorPane
+            sessionId={props.sessionId}
+            path={props.activeFile as string}
+            onClose={props.onCloseLeaf}
+            onHeaderPointerDown={props.onPointerDownHeader}
+          />
+        </Show>
+        <Show when={props.leaf.pane_type === 'editor' && props.activeFile === null}>
+          <div class="session-window__pane-empty" data-testid="editor-pane-empty">
+            No file open.
+          </div>
+        </Show>
+        <Show when={props.leaf.pane_type === 'terminal'}>
+          <div class="session-window__pane-empty" data-testid="terminal-pane-stub">
+            Terminal pane (F-125).
+          </div>
+        </Show>
+        <Show when={props.leaf.pane_type === 'files'}>
+          <div class="session-window__pane-empty" data-testid="files-pane-stub">
+            Files pane.
+          </div>
+        </Show>
+        <Show when={props.leaf.pane_type === 'agentmonitor'}>
+          <div class="session-window__pane-empty" data-testid="agent-monitor-stub">
+            Agent monitor (F-140).
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+function paneTypeToHeaderLabel(
+  paneType: LayoutLeaf['pane_type'],
+): 'CHAT' | 'TERMINAL' | 'EDITOR' {
+  if (paneType === 'terminal') return 'TERMINAL';
+  if (paneType === 'editor') return 'EDITOR';
+  return 'CHAT';
+}
+
+/**
+ * Immutable ratio update: walk `tree`, return a new tree with the matching
+ * split's `ratio` replaced. Returns the original reference if `id` isn't a
+ * split node in the tree so an unknown id is a safe no-op.
+ */
+function updateSplitRatio(
+  tree: LayoutTree,
+  id: string,
+  ratio: number,
+): LayoutTree {
+  if (tree.kind === 'leaf') return tree;
+  if (tree.id === id) return { ...tree, ratio };
+  const nextA = updateSplitRatio(tree.a, id, ratio);
+  const nextB = updateSplitRatio(tree.b, id, ratio);
+  if (nextA === tree.a && nextB === tree.b) return tree;
+  return { ...tree, a: nextA, b: nextB };
+}


### PR DESCRIPTION
Closes forge-ide/forge#295

## Summary

F-126's singleton editor slot (fixed `EDITOR_LEAF_ID = 'editor'` in `pane_state`) is replaced with a real `GridContainer` tree mount. The session window now renders the persisted layout tree end-to-end — multiple editors can coexist, drag-to-dock works on editor leaves like any other pane, and F-119 compactness runs per-leaf rather than on the enclosing window.

- `layoutStore.openFile(path)` reuses the first editor leaf in DFS order (predictable rule per DoD) or v-splits the root right with a fresh `editor-<n>` leaf. `closeLeaf(id)` promotes the sibling, garbage-collects the matching `pane_state` entry, and resets to the default single-chat tree when the last leaf would be removed.
- `GridContainer` / `dockDrop` / `useDragToDock` now operate on the persisted `LayoutTree` shape (`pane_type` on leaves) so tree mutations flow straight back into `setLayoutTree` without adapter boilerplate.
- `SessionWindow` mounts `GridContainer`, wires `useDragToDock` into the layout store, and observes each leaf's width via its own `usePaneWidth` so compactness reflects per-leaf extent.
- `EditorPane` accepts an `onHeaderPointerDown` prop so its breadcrumb header doubles as the drag-to-dock source for editor leaves (editor panes are now sources *and* targets).

## Definition of Done

- [x] Remove `EDITOR_LEAF_ID` singleton slot from `layoutStore.ts` and `SessionWindow.tsx`
- [x] `layoutStore.openFile(path)` reuses the first editor leaf in DFS order; v-splits root right with a fresh `editor-<n>` leaf when none exists
- [x] Predictable rule: "reuse the first editor found; otherwise split right"
- [x] F-118 drag-to-dock moves the EditorPane leaf (EditorPane header now threaded to `startDrag(leafId)`)
- [x] F-119 compactness applies per leaf (each `LeafHost` owns its own `usePaneWidth`)
- [x] Tests cover: open → reuse existing leaf; open → split when no editor; drag editor leaf (regression); close editor reclaims grid space
- [x] `just check-web` + `just test-web` green (665 tests passing)

## Test plan

- [x] `just check-web` passes (typecheck + token drift gate)
- [x] `just test-web` passes (665 tests across 56 files)
- [x] New `layoutStore.test.ts` covers reuse / split / closeLeaf / pane_state GC / setLayoutTree
- [x] New `SessionWindow.test.tsx` flows cover the full grid wiring, close-reclaims, and an end-to-end pointer-driven editor drag that mutates the tree

## Notes for the reviewer

- `applyDockDrop` doesn't prune `pane_state` when a leaf is excised mid-drag. Orphans are benign (the `LayoutTree` schema comment explicitly permits frontend-side GC without schema churn) and the next user-driven close reclaims them via `closeLeaf`. Worth a follow-up if the workspace accumulates many leaves over time.
- `openFile` always reuses the first editor found, so the files-sidebar flow alone can't produce two editors side-by-side — drag-to-dock is the path to that configuration. The DoD asks for the infrastructure to support it, which it does; the UX decision for a "new editor" vs. "reuse editor" command can layer on later.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context per the forge-finish-task handoff protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)