### PR TITLE
[F-152] Backend resource monitor for AgentMonitor pills (cpu/rss/fds)

### DIFF
--- a/crates/forge-core/src/event.rs
+++ b/crates/forge-core/src/event.rs
@@ -225,4 +225,26 @@ pub enum Event {
         ok: bool,
         bytes_out: u64,
     },
+    /// F-152: per-agent-instance resource sample.
+    ///
+    /// Emitted on a steady tick (default 1 Hz, configurable) by
+    /// `forge_session::resource_monitor::ResourceMonitor` while the instance
+    /// is tracked. Populates the AgentMonitor inspector's cpu / rss / fds
+    /// pills (F-140). Emission stops on `untrack(id)` so a terminated
+    /// instance clears its pills back to `—`.
+    ///
+    /// `cpu_pct` is a rolling average over the last tick window (0..=100);
+    /// `rss_bytes` is resident set size in bytes; `fd_count` is the live
+    /// file-descriptor count sampled from the platform probe. All three are
+    /// `Option<_>` on the wire because per-platform probes may legitimately
+    /// fail for a given field (e.g. fd count via `libproc` on macOS is
+    /// best-effort) — the UI renders `None` as the `—` placeholder the
+    /// pre-F-152 stub already rendered.
+    ResourceSample {
+        instance_id: AgentInstanceId,
+        cpu_pct: Option<f64>,
+        rss_bytes: Option<u64>,
+        fd_count: Option<u64>,
+        sampled_at: DateTime<Utc>,
+    },
 }

--- a/crates/forge-core/tests/event_wire_shape.rs
+++ b/crates/forge-core/tests/event_wire_shape.rs
@@ -19,7 +19,7 @@
 //! fields; `serde_json::from_value` is the only stable constructor.
 
 use chrono::{DateTime, Utc};
-use forge_core::{ApprovalPreview, Event, MessageId, ToolCallId};
+use forge_core::{AgentInstanceId, ApprovalPreview, Event, MessageId, ToolCallId};
 use serde_json::{json, Value};
 
 fn fixed_time() -> DateTime<Utc> {
@@ -286,6 +286,59 @@ fn tool_call_completed_wire_shape() {
             "result": { "ok": true, "bytes": 42 },
             "duration_ms": 12,
             "at": "2026-04-18T10:00:00Z",
+        }),
+    );
+}
+
+fn instance_id(s: &str) -> AgentInstanceId {
+    serde_json::from_value(Value::String(s.to_string())).unwrap()
+}
+
+#[test]
+fn resource_sample_wire_shape_all_fields_present() {
+    // F-152: AgentMonitor pills fold on this event. Pinning the wire shape
+    // here keeps the TS side (`applyEventToState` in
+    // `web/packages/app/src/routes/AgentMonitor.tsx`) honest across refactors.
+    assert_wire_eq(
+        Event::ResourceSample {
+            instance_id: instance_id("inst-1"),
+            cpu_pct: Some(12.5),
+            rss_bytes: Some(64 * 1024 * 1024),
+            fd_count: Some(18),
+            sampled_at: fixed_time(),
+        },
+        json!({
+            "type": "resource_sample",
+            "instance_id": "inst-1",
+            "cpu_pct": 12.5,
+            "rss_bytes": 64 * 1024 * 1024,
+            "fd_count": 18,
+            "sampled_at": "2026-04-18T10:00:00Z",
+        }),
+    );
+}
+
+#[test]
+fn resource_sample_wire_shape_missing_fields_are_null() {
+    // A best-effort platform probe can leave any subset of fields unpopulated
+    // (notably `fd_count` on macOS via libproc). The wire shape must preserve
+    // `null` for those — the UI renders `null` as the `—` placeholder and must
+    // not see a field disappear from the JSON object between emissions.
+    assert_wire_eq(
+        Event::ResourceSample {
+            instance_id: instance_id("inst-partial"),
+            cpu_pct: Some(5.0),
+            rss_bytes: None,
+            fd_count: None,
+            sampled_at: fixed_time(),
+        },
+        json!({
+            "type": "resource_sample",
+            "instance_id": "inst-partial",
+            "cpu_pct": 5.0,
+            "rss_bytes": null,
+            "fd_count": null,
+            "sampled_at": "2026-04-18T10:00:00Z",
         }),
     );
 }

--- a/crates/forge-session/src/bg_agents.rs
+++ b/crates/forge-session/src/bg_agents.rs
@@ -34,6 +34,8 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, Mutex};
 
+use crate::resource_monitor::{default_sampler, ResourceMonitor, DEFAULT_TICK};
+
 /// Channel capacity for the background-agent event bus. Matches
 /// `forge-session`'s `Session::event_tx` capacity (1024). A dropped
 /// subscriber is a non-fatal warmup state — the event is still registered
@@ -84,11 +86,18 @@ pub enum BgAgentError {
 /// defs the `start` call resolves `agent_name` against, and a local
 /// broadcast channel the caller subscribes to for the two
 /// `BackgroundAgent*` session events.
+///
+/// F-152: the registry also owns a [`ResourceMonitor`] that ticks per-
+/// instance resource samples while the instance is tracked. The monitor's
+/// broadcast stream is forwarded onto the same `events` channel so the
+/// shell's `session:event` forwarder delivers `Event::ResourceSample`
+/// to the webview alongside every other `forge_core::Event` variant.
 pub struct BackgroundAgentRegistry {
     orchestrator: Arc<Orchestrator>,
     agent_defs: Arc<Vec<AgentDef>>,
     tracked: Arc<Mutex<HashSet<AgentInstanceId>>>,
     events: broadcast::Sender<Event>,
+    monitor: Arc<ResourceMonitor>,
 }
 
 impl BackgroundAgentRegistry {
@@ -96,13 +105,54 @@ impl BackgroundAgentRegistry {
     /// The returned instance starts empty — call [`Self::start`] to spawn a
     /// background agent and [`Self::events`] to subscribe to lifecycle
     /// events.
+    ///
+    /// The resource monitor uses the platform default sampler (`/proc` on
+    /// Linux, no-op stub elsewhere) and the [`DEFAULT_TICK`] cadence. A
+    /// forwarder task pipes every `Event::ResourceSample` the monitor
+    /// emits onto the registry's own `events` bus so subscribers see one
+    /// unified stream.
     pub fn new(orchestrator: Arc<Orchestrator>, agent_defs: Arc<Vec<AgentDef>>) -> Self {
+        Self::with_monitor(
+            orchestrator,
+            agent_defs,
+            Arc::new(ResourceMonitor::new(default_sampler(), DEFAULT_TICK)),
+        )
+    }
+
+    /// Construct with an externally-provided [`ResourceMonitor`]. Used by
+    /// integration tests that need a deterministic sampler or tick
+    /// cadence; production callers go through [`Self::new`].
+    pub fn with_monitor(
+        orchestrator: Arc<Orchestrator>,
+        agent_defs: Arc<Vec<AgentDef>>,
+        monitor: Arc<ResourceMonitor>,
+    ) -> Self {
         let (events, _rx) = broadcast::channel(EVENT_BUS_CAPACITY);
+
+        // Forward every ResourceSample the monitor emits onto the
+        // registry's own events bus. Subscribers then see lifecycle
+        // events and resource samples on a single channel — the shell's
+        // existing `session:event` forwarder needs no extra plumbing.
+        let mut monitor_rx = monitor.events();
+        let events_tx = events.clone();
+        tokio::spawn(async move {
+            loop {
+                match monitor_rx.recv().await {
+                    Ok(ev) => {
+                        let _ = events_tx.send(ev);
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+
         Self {
             orchestrator,
             agent_defs,
             tracked: Arc::new(Mutex::new(HashSet::new())),
             events,
+            monitor,
         }
     }
 
@@ -162,6 +212,14 @@ impl BackgroundAgentRegistry {
 
         self.tracked.lock().await.insert(id.clone());
 
+        // F-152: start per-instance resource sampling. No per-agent
+        // sidecar process exists yet, so we sample the daemon's own PID
+        // — this gives the AgentMonitor inspector a *live* pill stream
+        // today and lets a future step executor swap in the real PID by
+        // calling `monitor().track(id, child_pid)` at spawn time without
+        // reshaping the event wiring.
+        self.monitor.track(id.clone(), std::process::id()).await;
+
         // `broadcast::Sender::send` errors only when no subscribers are
         // attached — a valid warmup state for an embedded registry whose
         // events only matter once a webview has subscribed.
@@ -177,6 +235,7 @@ impl BackgroundAgentRegistry {
         let target_id = id.clone();
         let events = self.events.clone();
         let tracked = Arc::clone(&self.tracked);
+        let monitor = Arc::clone(&self.monitor);
         tokio::spawn(async move {
             while let Some(next) = stream.next().await {
                 let event = match next {
@@ -198,6 +257,11 @@ impl BackgroundAgentRegistry {
                 }
                 if is_terminal {
                     tracked.lock().await.remove(&target_id);
+                    // F-152: stop sampling for the terminated instance so
+                    // the UI pills clear back to `—` (no further
+                    // `ResourceSample` events reach the webview for this
+                    // id).
+                    monitor.untrack(&target_id).await;
                     let _ = events.send(Event::BackgroundAgentCompleted {
                         id: target_id.clone(),
                         at: Utc::now(),
@@ -252,6 +316,15 @@ impl BackgroundAgentRegistry {
     pub fn orchestrator(&self) -> &Arc<Orchestrator> {
         &self.orchestrator
     }
+
+    /// F-152: accessor for the resource monitor. A future step executor
+    /// that forks a provider sidecar per instance can call
+    /// `registry.monitor().track(id, child_pid)` to swap the degenerate
+    /// daemon-PID sampling set up in `start()` for real per-child
+    /// sampling.
+    pub fn monitor(&self) -> &Arc<ResourceMonitor> {
+        &self.monitor
+    }
 }
 
 #[cfg(test)]
@@ -273,6 +346,24 @@ mod tests {
         let orch = Arc::new(Orchestrator::new());
         let defs = Arc::new(vec![def("writer"), def("reviewer")]);
         BackgroundAgentRegistry::new(orch, defs)
+    }
+
+    /// Construct a registry with a fast-tick resource monitor so the
+    /// end-to-end integration test below doesn't wait a full second.
+    async fn fresh_with_fast_monitor() -> BackgroundAgentRegistry {
+        use crate::resource_monitor::{FakeSampler, ResourceMonitor, Sample};
+        let orch = Arc::new(Orchestrator::new());
+        let defs = Arc::new(vec![def("writer"), def("reviewer")]);
+        let fake = Arc::new(FakeSampler::new(Sample {
+            cpu_seconds: Some(0.001),
+            rss_bytes: Some(4096),
+            fd_count: Some(3),
+        }));
+        let monitor = Arc::new(ResourceMonitor::new(
+            fake as Arc<dyn crate::resource_monitor::Sampler>,
+            std::time::Duration::from_millis(20),
+        ));
+        BackgroundAgentRegistry::with_monitor(orch, defs, monitor)
     }
 
     #[tokio::test]
@@ -421,5 +512,74 @@ mod tests {
         assert!(
             matches!(completed, Event::BackgroundAgentCompleted { id: ev_id, .. } if ev_id == id),
         );
+    }
+
+    // F-152: end-to-end wiring — spawning a background agent must produce
+    // `Event::ResourceSample` on the registry's event bus. This pins the
+    // integration that connects the sampler to the webview-facing stream.
+
+    #[tokio::test]
+    async fn start_drives_resource_samples_onto_the_registry_event_bus() {
+        let reg = fresh_with_fast_monitor().await;
+        let mut rx = reg.events();
+        let id = reg.start("writer", Arc::from("p")).await.unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut saw_sample = false;
+        while std::time::Instant::now() < deadline {
+            let next = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
+            match next {
+                Ok(Ok(Event::ResourceSample { instance_id, .. })) if instance_id == id => {
+                    saw_sample = true;
+                    break;
+                }
+                Ok(Ok(_other)) => continue,
+                Ok(Err(_)) => break,
+                Err(_elapsed) => continue,
+            }
+        }
+        assert!(
+            saw_sample,
+            "registry event bus must surface ResourceSample after start"
+        );
+    }
+
+    #[tokio::test]
+    async fn termination_stops_sample_emission_for_that_id() {
+        // After the orchestrator drives an instance to terminal, the
+        // `untrack(id)` side-effect in the forwarder must stop any further
+        // `ResourceSample` events for that id. Any sample observed after a
+        // wait window past completion fails the invariant.
+        let reg = fresh_with_fast_monitor().await;
+        let mut rx = reg.events();
+        let id = reg.start("writer", Arc::from("p")).await.unwrap();
+
+        // Wait for at least one resource sample so we know the sampler is live.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await {
+                Ok(Ok(Event::ResourceSample { instance_id, .. })) if instance_id == id => break,
+                _ => continue,
+            }
+        }
+
+        reg.orchestrator().stop(&id).await.unwrap();
+        // Let the forwarder's `monitor.untrack(id)` land before draining.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Drain anything already queued.
+        while rx.try_recv().is_ok() {}
+        // Now sample for 200ms more — no ResourceSample for `id` should
+        // arrive. Samples for other ids are fine (there are none in this
+        // test, but the assertion tolerates them anyway).
+        let post_deadline = std::time::Instant::now() + std::time::Duration::from_millis(200);
+        while std::time::Instant::now() < post_deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await {
+                Ok(Ok(Event::ResourceSample { instance_id, .. })) if instance_id == id => {
+                    panic!("untrack failed: ResourceSample arrived after termination");
+                }
+                _ => continue,
+            }
+        }
     }
 }

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod orchestrator;
 pub mod pid_file;
 pub mod provider_spec;
+pub mod resource_monitor;
 pub mod sandbox;
 pub mod server;
 pub mod session;
@@ -14,3 +15,6 @@ pub mod tools;
 pub use bg_agents::{BackgroundAgentRegistry, BgAgentError, BgAgentState, BgAgentSummary};
 pub use error::SessionError;
 pub use orchestrator::Orchestrator;
+pub use resource_monitor::{
+    default_sampler, FakeSampler, ResourceMonitor, Sample, Sampler, DEFAULT_TICK,
+};

--- a/crates/forge-session/src/resource_monitor.rs
+++ b/crates/forge-session/src/resource_monitor.rs
@@ -1,0 +1,764 @@
+//! Per-agent-instance resource sampler (F-152).
+//!
+//! Populates the AgentMonitor inspector's cpu / rss / fds pills (F-140).
+//! F-140 shipped the pill chrome with placeholder dashes because there was
+//! no backend monitor yet; this module is that backend.
+//!
+//! # Architecture
+//!
+//! - [`Sampler`] is the trait every platform probe implements. Tests use
+//!   the [`FakeSampler`] below; Linux is backed by `/proc/<pid>`. macOS and
+//!   Windows ship `None`-returning stubs today — the DoD explicitly names
+//!   those platforms so the `#[cfg]` gating + future probe slots are
+//!   present from day one, even though CI is Linux.
+//!
+//! - [`ResourceMonitor::track`] registers a `(instance_id, pid)` pair and
+//!   spawns a per-instance tokio tick task. On each tick the task asks the
+//!   sampler for a fresh [`Sample`], folds it into a small rolling-average
+//!   CPU history, and emits an [`Event::ResourceSample`] on the monitor's
+//!   broadcast channel.
+//!
+//! - [`ResourceMonitor::untrack`] aborts the matching task; the event
+//!   stream naturally stops for that id so the UI pills clear back to `—`.
+//!   Dropping the monitor aborts every tracked task.
+//!
+//! # Why the instance-id is the caller's input
+//!
+//! `forge_agents::AgentInstance` does not carry a PID today — instances
+//! are logical entities in the orchestrator registry. Rather than adding
+//! `pid: Option<u32>` to the registry (which would couple logical
+//! lifecycle to OS-level identity), this module takes both pieces
+//! externally. The spawn site that has the PID (e.g. a future step
+//! executor that forks a provider sidecar) calls `track`; the
+//! orchestrator's terminal event handler calls `untrack`.
+//!
+//! The DoD's "no sampler thread leaks on instance drop" invariant is
+//! expressed at the `ResourceMonitor::drop` boundary — dropping the
+//! monitor aborts every task, so scoping the monitor to the session
+//! lifetime is sufficient to guarantee no leaks when the session ends.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use forge_core::{AgentInstanceId, Event};
+use tokio::sync::{broadcast, Mutex};
+use tokio::task::JoinHandle;
+
+/// Default tick cadence. 1 Hz — the low end of the DoD's 1–5 Hz range.
+/// Low enough to keep `/proc` read amplification negligible on a big
+/// session, fast enough that a human sees the pill value change.
+pub const DEFAULT_TICK: Duration = Duration::from_secs(1);
+
+/// Capacity of the monitor's broadcast bus. Matches
+/// `forge_session::bg_agents::EVENT_BUS_CAPACITY` so a slow subscriber
+/// on the merged `session:event` stream doesn't drop resource samples
+/// before every other variant.
+const EVENT_BUS_CAPACITY: usize = 1024;
+
+/// Number of most-recent CPU samples to average when emitting the pill
+/// value. Small — the pill is a "what is this agent doing right now?"
+/// glance, not a long-horizon chart. A larger window would smooth
+/// meaningful spikes away.
+const CPU_WINDOW: usize = 5;
+
+/// Raw platform sample returned by a [`Sampler`].
+///
+/// Each field is independently `Option` because best-effort platform
+/// probes can fail on a single dimension while the rest succeed. The
+/// wire contract (`Event::ResourceSample`) preserves the `None`s
+/// verbatim so the UI never sees a value ghost between emissions.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Sample {
+    /// CPU-time the process has used since the previous sample, in
+    /// **seconds of on-cpu time**. A delta, not a total — the monitor
+    /// divides by the tick window to compute `cpu_pct`. `None` when the
+    /// probe cannot read a fresh cumulative total.
+    pub cpu_seconds: Option<f64>,
+    /// Resident set size in bytes. `None` when unreadable.
+    pub rss_bytes: Option<u64>,
+    /// Live file-descriptor count. `None` when unreadable.
+    pub fd_count: Option<u64>,
+}
+
+/// Platform-agnostic resource probe.
+///
+/// Implementations hold per-instance state across calls (the delta path
+/// for CPU needs the previous cumulative total). The trait is `async`
+/// so a real Linux probe can `tokio::fs::read` `/proc/<pid>/stat` without
+/// blocking the sampler task.
+#[async_trait::async_trait]
+pub trait Sampler: Send + Sync + 'static {
+    /// Return a fresh [`Sample`] for the given PID. Called on every tick
+    /// while the instance is tracked. Implementations must return a
+    /// default `Sample` (all `None`) rather than error — a transient
+    /// probe failure surfaces as `—` in the UI, not as a hard stop.
+    async fn sample(&self, pid: u32) -> Sample;
+}
+
+/// Owns a broadcast channel and a set of per-instance tick tasks.
+pub struct ResourceMonitor {
+    events: broadcast::Sender<Event>,
+    sampler: Arc<dyn Sampler>,
+    tick: Duration,
+    tasks: Arc<Mutex<HashMap<AgentInstanceId, JoinHandle<()>>>>,
+}
+
+impl ResourceMonitor {
+    /// Construct a monitor bound to `sampler` that ticks every `tick`.
+    pub fn new(sampler: Arc<dyn Sampler>, tick: Duration) -> Self {
+        let (events, _rx) = broadcast::channel(EVENT_BUS_CAPACITY);
+        Self {
+            events,
+            sampler,
+            tick,
+            tasks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Convenience constructor with the default 1 Hz tick.
+    pub fn with_default_tick(sampler: Arc<dyn Sampler>) -> Self {
+        Self::new(sampler, DEFAULT_TICK)
+    }
+
+    /// Subscribe to the resource-sample event stream. Each subscriber
+    /// gets its own receiver; late subscribers miss earlier events
+    /// (bounded broadcast).
+    pub fn events(&self) -> broadcast::Receiver<Event> {
+        self.events.subscribe()
+    }
+
+    /// Start sampling the process at `pid` for the agent instance
+    /// identified by `id`. Idempotent on `id` — a repeated `track` with
+    /// the same id replaces the previous task (used when a restarted
+    /// instance reuses its id).
+    pub async fn track(&self, id: AgentInstanceId, pid: u32) {
+        let mut tasks = self.tasks.lock().await;
+        if let Some(prev) = tasks.remove(&id) {
+            prev.abort();
+        }
+        let sampler = Arc::clone(&self.sampler);
+        let tick = self.tick;
+        let events = self.events.clone();
+        let task_id = id.clone();
+        let handle = tokio::spawn(async move {
+            run_ticker(task_id, pid, sampler, tick, events).await;
+        });
+        tasks.insert(id, handle);
+    }
+
+    /// Stop sampling `id`. Idempotent — unknown ids are a no-op.
+    pub async fn untrack(&self, id: &AgentInstanceId) {
+        let mut tasks = self.tasks.lock().await;
+        if let Some(handle) = tasks.remove(id) {
+            handle.abort();
+        }
+    }
+
+    /// Number of currently-tracked instances. Exposed for tests that
+    /// want to pin the no-leak invariant without reaching into the
+    /// `tasks` map.
+    pub async fn tracked_count(&self) -> usize {
+        self.tasks.lock().await.len()
+    }
+}
+
+impl Drop for ResourceMonitor {
+    /// Aborts every outstanding tick task. This is the mechanical
+    /// implementation of the DoD's "no sampler thread leaks on instance
+    /// drop" invariant — callers scope the monitor to the session and
+    /// every task dies with the session.
+    fn drop(&mut self) {
+        // `try_lock` so a panicking subscriber somewhere down the stack
+        // that still holds the mutex doesn't turn drop-time abort into a
+        // deadlock. On contention we fall back to draining what we can
+        // see — the tokio runtime cancels the rest when the session's
+        // runtime shuts down.
+        if let Ok(mut tasks) = self.tasks.try_lock() {
+            for (_id, handle) in tasks.drain() {
+                handle.abort();
+            }
+        }
+    }
+}
+
+async fn run_ticker(
+    id: AgentInstanceId,
+    pid: u32,
+    sampler: Arc<dyn Sampler>,
+    tick: Duration,
+    events: broadcast::Sender<Event>,
+) {
+    let mut interval = tokio::time::interval(tick);
+    // Skip the zero-duration first tick that `interval` fires
+    // immediately on creation — the first sample has no delta to
+    // difference against, so emitting a pill value with `cpu_pct: None`
+    // at t=0 would flicker the UI. Waiting one tick guarantees the
+    // first emission carries a meaningful `cpu_pct`.
+    interval.tick().await;
+    let mut history: VecDeque<f64> = VecDeque::with_capacity(CPU_WINDOW);
+    let tick_secs = tick.as_secs_f64().max(f64::EPSILON);
+    loop {
+        interval.tick().await;
+        let sample = sampler.sample(pid).await;
+        if let Some(cpu_seconds) = sample.cpu_seconds {
+            let pct = (cpu_seconds / tick_secs) * 100.0;
+            if history.len() == CPU_WINDOW {
+                history.pop_front();
+            }
+            history.push_back(pct);
+        }
+        let cpu_pct = if history.is_empty() {
+            None
+        } else {
+            Some(history.iter().sum::<f64>() / history.len() as f64)
+        };
+        let _ = events.send(Event::ResourceSample {
+            instance_id: id.clone(),
+            cpu_pct,
+            rss_bytes: sample.rss_bytes,
+            fd_count: sample.fd_count,
+            sampled_at: Utc::now(),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Platform probes
+// ---------------------------------------------------------------------------
+
+/// Linux `/proc/<pid>` probe. Parses `stat` for cumulative CPU ticks,
+/// `status` for RSS (kB), and counts entries in `fd/`.
+///
+/// Per-instance delta state is kept in an async mutex keyed by PID so
+/// repeated `track`s for the same PID share a CPU baseline.
+#[cfg(target_os = "linux")]
+pub mod linux {
+    use super::{Sample, Sampler};
+    use std::collections::HashMap;
+    use tokio::sync::Mutex;
+
+    /// Clock ticks per second read from `sysconf(_SC_CLK_TCK)` once at
+    /// probe construction. 100 on every Linux distro I've seen, but
+    /// reading it keeps the code portable across architectures that
+    /// might pick 1000.
+    fn clock_ticks_per_sec() -> u64 {
+        // SAFETY: sysconf(3) is a thread-safe pure function taking no
+        // Rust references. `_SC_CLK_TCK` is always defined on Linux.
+        let raw = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+        if raw <= 0 {
+            100
+        } else {
+            raw as u64
+        }
+    }
+
+    /// `/proc/<pid>`-backed sampler.
+    pub struct ProcSampler {
+        clk_tck: u64,
+        previous: Mutex<HashMap<u32, u64>>, // pid -> utime+stime ticks
+    }
+
+    impl ProcSampler {
+        pub fn new() -> Self {
+            Self {
+                clk_tck: clock_ticks_per_sec(),
+                previous: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl Default for ProcSampler {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Sampler for ProcSampler {
+        async fn sample(&self, pid: u32) -> Sample {
+            let cpu_seconds = cpu_delta_seconds(self, pid).await;
+            let rss_bytes = read_rss_bytes(pid).await;
+            let fd_count = count_fds(pid).await;
+            Sample {
+                cpu_seconds,
+                rss_bytes,
+                fd_count,
+            }
+        }
+    }
+
+    async fn cpu_delta_seconds(s: &ProcSampler, pid: u32) -> Option<f64> {
+        let text = tokio::fs::read_to_string(format!("/proc/{pid}/stat"))
+            .await
+            .ok()?;
+        let total_ticks = parse_stat_utime_stime(&text)?;
+        let mut prev = s.previous.lock().await;
+        let delta_ticks = match prev.get(&pid).copied() {
+            Some(previous) if total_ticks >= previous => total_ticks - previous,
+            _ => 0,
+        };
+        prev.insert(pid, total_ticks);
+        if s.clk_tck == 0 {
+            return None;
+        }
+        Some(delta_ticks as f64 / s.clk_tck as f64)
+    }
+
+    /// Parse columns 14 (`utime`) and 15 (`stime`) out of a
+    /// `/proc/<pid>/stat` line. The comm field may contain spaces and
+    /// parentheses, so we split on the last `)` to get the post-comm
+    /// tail and index from there.
+    pub(crate) fn parse_stat_utime_stime(text: &str) -> Option<u64> {
+        let tail_start = text.rfind(')')?;
+        let tail = &text[tail_start + 1..];
+        let fields: Vec<&str> = tail.split_whitespace().collect();
+        // After `)` the first field is `state` (index 0 = column 3);
+        // utime is column 14 = fields index 11; stime column 15 = 12.
+        let utime: u64 = fields.get(11)?.parse().ok()?;
+        let stime: u64 = fields.get(12)?.parse().ok()?;
+        Some(utime + stime)
+    }
+
+    async fn read_rss_bytes(pid: u32) -> Option<u64> {
+        let text = tokio::fs::read_to_string(format!("/proc/{pid}/status"))
+            .await
+            .ok()?;
+        parse_status_rss_bytes(&text)
+    }
+
+    /// Parse `VmRSS:\s+N kB` out of `/proc/<pid>/status`. Returns bytes.
+    pub(crate) fn parse_status_rss_bytes(text: &str) -> Option<u64> {
+        for line in text.lines() {
+            if let Some(rest) = line.strip_prefix("VmRSS:") {
+                let rest = rest.trim();
+                let kb_str = rest.split_whitespace().next()?;
+                let kb: u64 = kb_str.parse().ok()?;
+                return Some(kb * 1024);
+            }
+        }
+        None
+    }
+
+    async fn count_fds(pid: u32) -> Option<u64> {
+        let mut dir = tokio::fs::read_dir(format!("/proc/{pid}/fd")).await.ok()?;
+        let mut n: u64 = 0;
+        while let Ok(Some(_)) = dir.next_entry().await {
+            n += 1;
+        }
+        Some(n)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn parse_status_rss_extracts_kilobytes_and_converts_to_bytes() {
+            // Fixture mirrors a real `/proc/<pid>/status` fragment.
+            let text = "\
+Name:   forged
+VmPeak:   123456 kB
+VmSize:   123456 kB
+VmRSS:      4096 kB
+Threads:   3
+";
+            assert_eq!(parse_status_rss_bytes(text), Some(4096 * 1024));
+        }
+
+        #[test]
+        fn parse_status_rss_returns_none_when_missing() {
+            assert_eq!(parse_status_rss_bytes("Name: forged\n"), None);
+        }
+
+        #[test]
+        fn parse_stat_finds_utime_stime_with_spaces_in_comm() {
+            // Real fixture shape — comm (`my proc (dev)`) contains spaces
+            // and an inner parenthesis. Matches the parser's "last `)` wins"
+            // rule that defends against this case.
+            let text = "12345 (my proc (dev)) S 1 12345 12345 0 -1 4194304 0 0 0 0 \
+                        42 17 0 0 20 0 1 0 100 0 0 rest ignored";
+            // 42 + 17 = 59
+            assert_eq!(parse_stat_utime_stime(text), Some(59));
+        }
+
+        #[tokio::test]
+        async fn proc_sampler_returns_a_non_none_rss_for_self() {
+            // The test's own PID is guaranteed to have a live /proc
+            // entry, so RSS must parse to Some(_). CPU is a delta, so
+            // the first call is expected to report 0.0s (no baseline).
+            // This is the live end-to-end hook — if /proc isn't mounted
+            // the test harness itself would have failed earlier.
+            let s = ProcSampler::new();
+            let sample = s.sample(std::process::id()).await;
+            assert!(
+                sample.rss_bytes.is_some(),
+                "live /proc/self/status must parse"
+            );
+            assert!(
+                sample.fd_count.is_some(),
+                "live /proc/self/fd must be readable"
+            );
+        }
+    }
+}
+
+/// Non-Linux placeholder probe. The DoD names macOS (`libproc` /
+/// `sysctl`) and Windows (`GetProcessTimes` / `GetProcessHandleCount` /
+/// `GetProcessMemoryInfo`) as the real implementations; those are
+/// out-of-scope for CI-on-Linux but the stub holds the `#[cfg]` slot so
+/// a follow-up doesn't have to restructure the module.
+#[cfg(not(target_os = "linux"))]
+pub mod unsupported {
+    use super::{Sample, Sampler};
+
+    pub struct UnsupportedSampler;
+
+    impl UnsupportedSampler {
+        pub fn new() -> Self {
+            Self
+        }
+    }
+
+    impl Default for UnsupportedSampler {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Sampler for UnsupportedSampler {
+        async fn sample(&self, _pid: u32) -> Sample {
+            // Returning an empty sample preserves the Option-per-field
+            // contract without panicking on non-Linux platforms.
+            Sample::default()
+        }
+    }
+}
+
+/// Return the compile-time "best available" sampler for the current
+/// platform. Linux → `ProcSampler`; everything else → the stub.
+pub fn default_sampler() -> std::sync::Arc<dyn Sampler> {
+    #[cfg(target_os = "linux")]
+    {
+        std::sync::Arc::new(linux::ProcSampler::new())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        std::sync::Arc::new(unsupported::UnsupportedSampler::new())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test harness — the fake sampler is part of the public API so integration
+// tests in other crates can use it too.
+// ---------------------------------------------------------------------------
+
+/// Test sampler that returns a scripted sequence of samples and counts
+/// how many times it was called. Public so integration tests outside
+/// this crate can drive the monitor deterministically.
+pub struct FakeSampler {
+    calls: std::sync::Mutex<u64>,
+    queue: std::sync::Mutex<std::collections::VecDeque<Sample>>,
+    fallback: Sample,
+}
+
+impl FakeSampler {
+    /// New sampler that returns `fallback` once the scripted queue is
+    /// drained. Useful for tests that want "N scripted samples, then
+    /// steady state".
+    pub fn new(fallback: Sample) -> Self {
+        Self {
+            calls: std::sync::Mutex::new(0),
+            queue: std::sync::Mutex::new(std::collections::VecDeque::new()),
+            fallback,
+        }
+    }
+
+    /// Enqueue a specific sample to be returned on the next `sample()`.
+    pub fn enqueue(&self, s: Sample) {
+        self.queue.lock().unwrap().push_back(s);
+    }
+
+    /// How many times `sample()` has been invoked. Lets a test probe
+    /// "did the tick task keep running past drop?" by reading this
+    /// number before and after `advance` / drop.
+    pub fn calls(&self) -> u64 {
+        *self.calls.lock().unwrap()
+    }
+}
+
+#[async_trait::async_trait]
+impl Sampler for FakeSampler {
+    async fn sample(&self, _pid: u32) -> Sample {
+        *self.calls.lock().unwrap() += 1;
+        self.queue
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(self.fallback)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inst() -> AgentInstanceId {
+        AgentInstanceId::new()
+    }
+
+    fn sample(cpu: f64, rss: u64, fds: u64) -> Sample {
+        Sample {
+            cpu_seconds: Some(cpu),
+            rss_bytes: Some(rss),
+            fd_count: Some(fds),
+        }
+    }
+
+    // Tests use a small real-time tick (20ms) so they complete quickly and
+    // don't depend on paused-time cooperating with multi-task broadcast
+    // channels. `cpu_seconds` fields are scaled proportionally so the
+    // computed `cpu_pct` equals the pre-scale value. That is: with a 20ms
+    // tick, `cpu_seconds: 0.002` yields 10% — the same intent as 0.1 with
+    // a 1s tick, but without waiting a real second.
+    const TEST_TICK: Duration = Duration::from_millis(20);
+    /// Scale factor `tick / 1s`: multiply a "what cpu_pct do I want"
+    /// fraction by this to get the `cpu_seconds` delta that produces it.
+    const TICK_SCALE: f64 = 0.020;
+    const RECV_TIMEOUT: Duration = Duration::from_secs(2);
+
+    async fn recv_one(rx: &mut broadcast::Receiver<Event>) -> Event {
+        tokio::time::timeout(RECV_TIMEOUT, rx.recv())
+            .await
+            .expect("receiver should see a sample within RECV_TIMEOUT")
+            .expect("broadcast must not lag or close")
+    }
+
+    #[tokio::test]
+    async fn track_emits_a_resource_sample_after_one_tick() {
+        // RED test for the core DoD item: "spawn a mock instance, advance
+        // time, assert pill values update".
+        let fake = Arc::new(FakeSampler::new(sample(0.1 * TICK_SCALE, 4096, 7)));
+        let mon = ResourceMonitor::new(Arc::clone(&fake) as Arc<dyn Sampler>, TEST_TICK);
+        let mut rx = mon.events();
+        let id = inst();
+        mon.track(id.clone(), 12345).await;
+
+        let ev = recv_one(&mut rx).await;
+        match ev {
+            Event::ResourceSample {
+                instance_id,
+                cpu_pct,
+                rss_bytes,
+                fd_count,
+                ..
+            } => {
+                assert_eq!(instance_id, id);
+                assert_eq!(rss_bytes, Some(4096));
+                assert_eq!(fd_count, Some(7));
+                // 0.1 * TICK_SCALE seconds on-cpu in a TEST_TICK window →
+                // 10% rolling avg (single sample in history).
+                let pct = cpu_pct.expect("cpu_pct populated when cpu_seconds is Some");
+                assert!((pct - 10.0).abs() < 0.5, "expected ~10% cpu_pct, got {pct}");
+            }
+            other => panic!("expected ResourceSample, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn track_respects_custom_tick() {
+        // 10ms tick — first emission must arrive well before the 2s
+        // receive timeout.
+        let fake = Arc::new(FakeSampler::new(sample(0.0, 1, 1)));
+        let mon = ResourceMonitor::new(
+            Arc::clone(&fake) as Arc<dyn Sampler>,
+            Duration::from_millis(10),
+        );
+        let mut rx = mon.events();
+        let id = inst();
+        mon.track(id, 12345).await;
+
+        let _ = recv_one(&mut rx).await;
+        assert!(fake.calls() >= 1, "fake sampler must have been called");
+    }
+
+    #[tokio::test]
+    async fn untrack_stops_future_samples_for_that_id() {
+        let fake = Arc::new(FakeSampler::new(sample(0.1 * TICK_SCALE, 1, 1)));
+        let mon = ResourceMonitor::new(Arc::clone(&fake) as Arc<dyn Sampler>, TEST_TICK);
+        let mut rx = mon.events();
+        let id_a = inst();
+        let id_b = inst();
+        mon.track(id_a.clone(), 1).await;
+        mon.track(id_b.clone(), 2).await;
+
+        // Observe at least one sample from each tracked instance before
+        // untracking A.
+        let mut seen_a = false;
+        let mut seen_b = false;
+        for _ in 0..32 {
+            let ev = recv_one(&mut rx).await;
+            if let Event::ResourceSample { instance_id, .. } = ev {
+                if instance_id == id_a {
+                    seen_a = true;
+                } else if instance_id == id_b {
+                    seen_b = true;
+                }
+            }
+            if seen_a && seen_b {
+                break;
+            }
+        }
+        assert!(seen_a && seen_b, "both tracked instances must emit");
+
+        mon.untrack(&id_a).await;
+        // Drain any samples already queued before `untrack` landed.
+        while rx.try_recv().is_ok() {}
+        // New ticks arriving after untrack must only produce B samples.
+        let mut saw_b_after = false;
+        for _ in 0..32 {
+            let ev = recv_one(&mut rx).await;
+            if let Event::ResourceSample { instance_id, .. } = ev {
+                assert_ne!(
+                    instance_id, id_a,
+                    "untracked id must not emit further samples"
+                );
+                if instance_id == id_b {
+                    saw_b_after = true;
+                    break;
+                }
+            }
+        }
+        assert!(saw_b_after, "still-tracked id must continue emitting");
+        assert_eq!(
+            mon.tracked_count().await,
+            1,
+            "tasks map drops the untracked id"
+        );
+    }
+
+    #[tokio::test]
+    async fn dropping_monitor_aborts_outstanding_tasks() {
+        // The DoD's second test invariant: "no sampler thread leaks on
+        // instance drop". Probe via the fake sampler's call counter — if
+        // the task survived drop, the counter would keep ticking.
+        let fake = Arc::new(FakeSampler::new(sample(0.0, 1, 1)));
+        let calls_at_drop = {
+            let mon = ResourceMonitor::new(Arc::clone(&fake) as Arc<dyn Sampler>, TEST_TICK);
+            mon.track(inst(), 1).await;
+            mon.track(inst(), 2).await;
+            // Wait for at least one sample from each task so we know the
+            // ticker loops are actually running.
+            let mut rx = mon.events();
+            let mut seen = 0;
+            while seen < 2 {
+                if recv_one(&mut rx).await.is_resource_sample() {
+                    seen += 1;
+                }
+            }
+            fake.calls()
+            // `mon` drops here; `Drop` aborts every task.
+        };
+
+        // Give any stray task several full tick windows to run — if drop
+        // didn't actually abort them, the counter would increase.
+        tokio::time::sleep(TEST_TICK * 10).await;
+        let calls_after_drop = fake.calls();
+
+        assert_eq!(
+            calls_after_drop, calls_at_drop,
+            "tick task must not survive ResourceMonitor::drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn track_replaces_previous_task_for_same_id() {
+        // Idempotency invariant: `track(id, pid_a)` followed by
+        // `track(id, pid_b)` leaves exactly one task for `id`.
+        let fake = Arc::new(FakeSampler::new(sample(0.0, 1, 1)));
+        let mon = ResourceMonitor::new(Arc::clone(&fake) as Arc<dyn Sampler>, TEST_TICK);
+        let id = inst();
+        mon.track(id.clone(), 1).await;
+        mon.track(id.clone(), 2).await;
+        assert_eq!(
+            mon.tracked_count().await,
+            1,
+            "re-tracking the same id must replace, not duplicate"
+        );
+    }
+
+    #[tokio::test]
+    async fn cpu_pct_is_rolling_average_over_recent_samples() {
+        // Two scripted samples so the first two emissions exercise the
+        // rolling-average fold, then fall through to the fallback.
+        let fake = Arc::new(FakeSampler::new(sample(0.0, 1, 1)));
+        fake.enqueue(sample(0.1 * TICK_SCALE, 1, 1)); // 10% first tick
+        fake.enqueue(sample(0.3 * TICK_SCALE, 1, 1)); // 30% second tick
+        let mon = ResourceMonitor::new(Arc::clone(&fake) as Arc<dyn Sampler>, TEST_TICK);
+        let mut rx = mon.events();
+        let id = inst();
+        mon.track(id, 1).await;
+
+        let first = recv_one(&mut rx).await;
+        let Event::ResourceSample { cpu_pct: pct1, .. } = first else {
+            panic!("wrong variant")
+        };
+        let pct1 = pct1.unwrap();
+        assert!(
+            (pct1 - 10.0).abs() < 0.5,
+            "first tick → 10% only, got {pct1}"
+        );
+
+        let second = recv_one(&mut rx).await;
+        let Event::ResourceSample { cpu_pct: pct2, .. } = second else {
+            panic!("wrong variant")
+        };
+        let pct2 = pct2.unwrap();
+        assert!(
+            (pct2 - 20.0).abs() < 0.5,
+            "second tick is avg(10, 30) = 20%, got {pct2}"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_cpu_seconds_produces_none_cpu_pct_on_first_sample() {
+        // When the platform probe can't read CPU (all None), the rolling
+        // history stays empty and the emitted `cpu_pct` is None. RSS/fds
+        // are preserved verbatim.
+        let fake = Arc::new(FakeSampler::new(Sample {
+            cpu_seconds: None,
+            rss_bytes: Some(4096),
+            fd_count: Some(3),
+        }));
+        let mon = ResourceMonitor::new(Arc::clone(&fake) as Arc<dyn Sampler>, TEST_TICK);
+        let mut rx = mon.events();
+        mon.track(inst(), 1).await;
+
+        let ev = recv_one(&mut rx).await;
+        match ev {
+            Event::ResourceSample {
+                cpu_pct,
+                rss_bytes,
+                fd_count,
+                ..
+            } => {
+                assert_eq!(cpu_pct, None);
+                assert_eq!(rss_bytes, Some(4096));
+                assert_eq!(fd_count, Some(3));
+            }
+            other => panic!("expected ResourceSample, got {other:?}"),
+        }
+    }
+
+    // Small helper keeps the drop test readable.
+    trait IsResourceSample {
+        fn is_resource_sample(&self) -> bool;
+    }
+    impl IsResourceSample for Event {
+        fn is_resource_sample(&self) -> bool {
+            matches!(self, Event::ResourceSample { .. })
+        }
+    }
+}

--- a/web/packages/app/src/routes/AgentMonitor.test.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.test.tsx
@@ -17,6 +17,7 @@ import {
   AgentTrace,
   applyEventToState,
   filterAgents,
+  inspectorStub,
   sortAgents,
   StepDrawer,
   stopAgentInstance,
@@ -101,7 +102,7 @@ describe('AgentMonitor: filter + sort helpers', () => {
 // ---------------------------------------------------------------------------
 
 describe('applyEventToState', () => {
-  const empty: LiveAgentState = { subAgents: [], stepsByAgent: {} };
+  const empty: LiveAgentState = { subAgents: [], stepsByAgent: {}, resourcesByAgent: {} };
 
   it('upserts a session row the first time StepStarted arrives with an instance id', () => {
     const after = applyEventToState(empty, {
@@ -238,6 +239,169 @@ describe('applyEventToState', () => {
     // Stable reference proves we did not allocate a new state tree for a
     // redundant completion event.
     expect(second).toBe(first);
+  });
+
+  // F-152: resource_sample fold — populates the pills, clears on termination.
+
+  it('upserts a resource snapshot on resource_sample', () => {
+    const after = applyEventToState(empty, {
+      event: {
+        type: 'resource_sample',
+        instance_id: 'inst-1',
+        cpu_pct: 12.5,
+        rss_bytes: 4 * 1024 * 1024,
+        fd_count: 18,
+        sampled_at: '2026-04-20T12:00:00Z',
+      },
+    });
+    expect(after.resourcesByAgent['inst-1']).toEqual({
+      cpu: 12.5,
+      rss: 4 * 1024 * 1024,
+      fds: 18,
+    });
+  });
+
+  it('preserves missing fields as undefined on resource_sample', () => {
+    // Partial platform probes send `null` for fields they could not read;
+    // those survive as undefined in the snapshot so the Inspector renders
+    // the `—` placeholder without falsely reading the pill value as zero.
+    const after = applyEventToState(empty, {
+      event: {
+        type: 'resource_sample',
+        instance_id: 'inst-2',
+        cpu_pct: 5.0,
+        rss_bytes: null,
+        fd_count: null,
+        sampled_at: '2026-04-20T12:00:00Z',
+      },
+    });
+    const snapshot = after.resourcesByAgent['inst-2'];
+    expect(snapshot).toBeDefined();
+    expect(snapshot?.cpu).toBe(5.0);
+    expect(snapshot?.rss).toBeUndefined();
+    expect(snapshot?.fds).toBeUndefined();
+  });
+
+  it('overwrites an earlier resource snapshot for the same instance', () => {
+    const first = applyEventToState(empty, {
+      event: {
+        type: 'resource_sample',
+        instance_id: 'inst-3',
+        cpu_pct: 1.0,
+        rss_bytes: 1000,
+        fd_count: 1,
+        sampled_at: '2026-04-20T12:00:00Z',
+      },
+    });
+    const second = applyEventToState(first, {
+      event: {
+        type: 'resource_sample',
+        instance_id: 'inst-3',
+        cpu_pct: 9.0,
+        rss_bytes: 9000,
+        fd_count: 9,
+        sampled_at: '2026-04-20T12:00:01Z',
+      },
+    });
+    expect(second.resourcesByAgent['inst-3']).toEqual({
+      cpu: 9.0,
+      rss: 9000,
+      fds: 9,
+    });
+  });
+
+  it('keeps snapshots for other instances when a new one arrives', () => {
+    const a = applyEventToState(empty, {
+      event: {
+        type: 'resource_sample',
+        instance_id: 'a',
+        cpu_pct: 1,
+        rss_bytes: 1,
+        fd_count: 1,
+        sampled_at: '2026-04-20T12:00:00Z',
+      },
+    });
+    const b = applyEventToState(a, {
+      event: {
+        type: 'resource_sample',
+        instance_id: 'b',
+        cpu_pct: 2,
+        rss_bytes: 2,
+        fd_count: 2,
+        sampled_at: '2026-04-20T12:00:01Z',
+      },
+    });
+    expect(Object.keys(b.resourcesByAgent)).toEqual(['a', 'b']);
+  });
+
+  it('drops the resource snapshot on background_agent_completed', () => {
+    // DoD: "pills clear back to '—' when the instance terminates". The
+    // Inspector reads from `resourcesByAgent`, so clearing the entry is
+    // the mechanism.
+    const populated = applyEventToState(empty, {
+      event: {
+        type: 'resource_sample',
+        instance_id: 'term',
+        cpu_pct: 7,
+        rss_bytes: 77,
+        fd_count: 777,
+        sampled_at: '2026-04-20T12:00:00Z',
+      },
+    });
+    expect(populated.resourcesByAgent['term']).toBeDefined();
+    const spawned = applyEventToState(populated, {
+      event: { type: 'sub_agent_spawned', parent: 'p', child: 'term' },
+    });
+    const completed = applyEventToState(spawned, {
+      event: { type: 'background_agent_completed', id: 'term' },
+    });
+    expect(completed.resourcesByAgent['term']).toBeUndefined();
+  });
+
+  it('is a no-op on malformed resource_sample (missing instance_id)', () => {
+    const after = applyEventToState(empty, {
+      event: {
+        type: 'resource_sample',
+        cpu_pct: 1,
+        rss_bytes: 1,
+        fd_count: 1,
+        sampled_at: '2026-04-20T12:00:00Z',
+      },
+    });
+    expect(after).toBe(empty);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inspectorStub resource mapping (F-152)
+// ---------------------------------------------------------------------------
+
+describe('inspectorStub', () => {
+  it('returns em-dash placeholders when no resources are supplied', () => {
+    const data = inspectorStub(row());
+    expect(data.resources).toEqual({});
+  });
+
+  it('converts rss_bytes to MB for the pill label', () => {
+    // The pill template renders `${rss}MB` — the backend emits bytes, so
+    // the adapter must convert. 10 MiB should render as 10.
+    const data = inspectorStub(row(), {
+      cpu: 12.5,
+      rss: 10 * 1024 * 1024,
+      fds: 17,
+    });
+    expect(data.resources.cpu).toBe(12.5);
+    expect(data.resources.rss).toBe(10);
+    expect(data.resources.fds).toBe(17);
+  });
+
+  it('omits a field when the snapshot value is undefined', () => {
+    // A partial platform probe yields e.g. `{cpu: 5}` with rss/fds absent.
+    // The pill for the missing fields must render `—`, not `0MB` / `0`.
+    const data = inspectorStub(row(), { cpu: 5 });
+    expect(data.resources.cpu).toBe(5);
+    expect(data.resources.rss).toBeUndefined();
+    expect(data.resources.fds).toBeUndefined();
   });
 });
 

--- a/web/packages/app/src/routes/AgentMonitor.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.tsx
@@ -89,6 +89,17 @@ export interface AgentInspectorData {
   };
 }
 
+/** Per-instance resource-sample snapshot folded from F-152
+ * `Event::ResourceSample`. Stored in the live state map so the Inspector's
+ * cpu / rss / fds pills read the most recent value. `null` fields in the
+ * wire payload survive as `undefined` here so the pill renders the `—`
+ * placeholder the design calls out. */
+export interface ResourceSnapshot {
+  cpu?: number;
+  rss?: number;
+  fds?: number;
+}
+
 // ---------------------------------------------------------------------------
 // Filter + sort
 // ---------------------------------------------------------------------------
@@ -144,6 +155,10 @@ interface InternalAgentState {
 export interface LiveAgentState {
   subAgents: AgentRow[];
   stepsByAgent: Record<string, AgentStep[]>;
+  /** F-152: most recent resource sample per instance id. Undefined keys
+   * render as `—` pills in the Inspector. A completion event clears the
+   * entry so the pills reset automatically. */
+  resourcesByAgent: Record<string, ResourceSnapshot>;
 }
 
 /**
@@ -225,6 +240,7 @@ export function applyEventToState(
     };
     const existing = prev.stepsByAgent[agentId] ?? [];
     return {
+      ...prev,
       subAgents,
       stepsByAgent: { ...prev.stepsByAgent, [agentId]: [...existing, newStep] },
     };
@@ -270,8 +286,42 @@ export function applyEventToState(
       changed = true;
       return { ...r, state: 'done' as AgentRowState, progress: 1 };
     });
-    if (!changed) return prev;
-    return { ...prev, subAgents: nextSubAgents };
+    // F-152: clearing the resources map entry on terminal transition is
+    // the mechanism behind "pills clear back to '—' when the instance
+    // terminates" — the inspector reads from this map and an absent key
+    // resolves to undefined → dash.
+    const hadResources = id in prev.resourcesByAgent;
+    if (!changed && !hadResources) return prev;
+    let nextResources = prev.resourcesByAgent;
+    if (hadResources) {
+      const { [id]: _cleared, ...rest } = prev.resourcesByAgent;
+      nextResources = rest;
+    }
+    return {
+      ...prev,
+      subAgents: changed ? nextSubAgents : prev.subAgents,
+      resourcesByAgent: nextResources,
+    };
+  }
+
+  if (type === 'resource_sample') {
+    // F-152: fold the sampler's per-instance emission into the live
+    // resources map. Missing fields (Option<None> on the Rust side) arrive
+    // as `null` on the wire; they're preserved as `undefined` here so the
+    // pill renders the `—` placeholder without falsely reading as zero.
+    const instanceId = ev['instance_id'];
+    if (typeof instanceId !== 'string') return prev;
+    const snapshot: ResourceSnapshot = {};
+    const cpu = ev['cpu_pct'];
+    if (typeof cpu === 'number') snapshot.cpu = cpu;
+    const rss = ev['rss_bytes'];
+    if (typeof rss === 'number') snapshot.rss = rss;
+    const fds = ev['fd_count'];
+    if (typeof fds === 'number') snapshot.fds = fds;
+    return {
+      ...prev,
+      resourcesByAgent: { ...prev.resourcesByAgent, [instanceId]: snapshot },
+    };
   }
 
   return prev;
@@ -661,13 +711,35 @@ export async function stopAgentInstance(
   }
 }
 
-/** Inspector stub — real data lands when the backend exposes def metadata. */
-function inspectorStub(row: AgentRow): AgentInspectorData {
+/** Inspector stub — real data lands when the backend exposes def metadata.
+ *
+ * F-152: the `resources` field accepts the live snapshot from
+ * `resourcesByAgent` so the pills show real sampler output instead of
+ * placeholder dashes. Passing `undefined` preserves pre-F-152 behavior
+ * (pills show `—`), which is exactly what happens when an instance is
+ * untracked or terminated.
+ *
+ * The snapshot carries `rss` in bytes (Rust wire shape `rss_bytes`); the
+ * pill renders the label "MB", so we divide by 1024*1024 here to keep the
+ * display units honest. `cpu` is already a percent (0..=100); `fds` is a
+ * raw count.
+ */
+export function inspectorStub(
+  row: AgentRow,
+  resources?: ResourceSnapshot,
+): AgentInspectorData {
   const data: AgentInspectorData = {
     allowedTools: [],
     allowedPaths: [],
     resources: {},
   };
+  if (resources) {
+    if (resources.cpu !== undefined) data.resources.cpu = resources.cpu;
+    if (resources.rss !== undefined) {
+      data.resources.rss = Math.round(resources.rss / (1024 * 1024));
+    }
+    if (resources.fds !== undefined) data.resources.fds = resources.fds;
+  }
   if (row.model) data.model = row.model;
   return data;
 }
@@ -695,6 +767,11 @@ export const AgentMonitor: Component = () => {
   // hardcoded placeholder competing with the live id.
   const [subAgents, setSubAgents] = createSignal<AgentRow[]>([]);
   const [stepsByAgent, setStepsByAgent] = createSignal<Record<string, AgentStep[]>>({});
+  // F-152: per-instance cpu / rss / fds folded from `resource_sample`
+  // events. A completion event clears the entry so the pills reset.
+  const [resourcesByAgent, setResourcesByAgent] = createSignal<
+    Record<string, ResourceSnapshot>
+  >({});
 
   const rows = createMemo<AgentRow[]>(() => [
     ...bgAgents().map(toBgRow),
@@ -717,11 +794,15 @@ export const AgentMonitor: Component = () => {
     const snapshot: LiveAgentState = {
       subAgents: subAgents(),
       stepsByAgent: stepsByAgent(),
+      resourcesByAgent: resourcesByAgent(),
     };
     const next = applyEventToState(snapshot, payload);
     if (next === snapshot) return;
     if (next.subAgents !== snapshot.subAgents) setSubAgents(next.subAgents);
     if (next.stepsByAgent !== snapshot.stepsByAgent) setStepsByAgent(next.stepsByAgent);
+    if (next.resourcesByAgent !== snapshot.resourcesByAgent) {
+      setResourcesByAgent(next.resourcesByAgent);
+    }
   }
 
   // Auto-select the session root so the trace column isn't empty on mount.
@@ -754,7 +835,9 @@ export const AgentMonitor: Component = () => {
   });
   const inspector = createMemo<AgentInspectorData | null>(() => {
     const row = selected();
-    return row ? inspectorStub(row) : null;
+    if (!row) return null;
+    const resources = resourcesByAgent()[row.id];
+    return inspectorStub(row, resources);
   });
 
   const onStop = async (id: string) => {


### PR DESCRIPTION
Closes forge-ide/forge#302

## Summary

Lands the backend that populates F-140's AgentMonitor inspector pills
(cpu / rss / fds). Before this change the pills rendered placeholder
dashes because no backend monitor existed; now a per-instance tokio
sampler feeds live values via a new `Event::ResourceSample` variant.

- New `forge_session::resource_monitor` module with:
  - `Sampler` trait + Linux `/proc/<pid>` probe (utime/stime for cpu,
    VmRSS for rss, /proc/<pid>/fd entry count for fds).
  - `ResourceMonitor` that ticks per-instance, emits `Event::ResourceSample`
    on a broadcast channel, and aborts all tasks on drop (DoD no-leak
    invariant).
  - Default 1 Hz tick, configurable per `ResourceMonitor::new(tick)`.
- `forge_core::Event::ResourceSample { instance_id, cpu_pct, rss_bytes,
  fd_count, sampled_at }` with golden wire-shape tests (including
  partial-probe `null` field preservation).
- `BackgroundAgentRegistry` now owns a `ResourceMonitor`. `start()`
  calls `track(id, daemon_pid)`; the orchestrator-terminal forwarder
  calls `untrack(id)`. Samples ride the registry's existing broadcast
  channel so the shell's `session:event` forwarder delivers them to
  the webview without any new plumbing.
- `AgentMonitor.tsx` folds `resource_sample` into `resourcesByAgent`,
  clears on `background_agent_completed`, and the Inspector pills
  read live values (with bytes→MB conversion). 8 new vitest cases
  pin the fold behavior end-to-end.
- macOS / Windows `Sampler` impls stubbed (`#[cfg]`-gated return of
  `Sample::default()`); the DoD's `libproc` / `sysctl` /
  `GetProcess*` real probes are follow-up work since CI is Linux.

Today the registry samples the daemon's own PID because per-instance
forking hasn't landed yet. A future step executor can swap in real
per-child PIDs via `registry.monitor().track(id, child_pid)` without
reshaping this wiring.

## Test plan

- `just check-rust` passes (cargo fmt, check, clippy -D warnings, doc)
- `just test-rust` passes — 113 forge-session lib tests including 7
  new `resource_monitor` tests and 2 bg_agents wire-integration tests
- `just check-web` passes (tsc + check-tokens)
- `just test-web` passes — 682 tests across 56 files, 43 in
  `AgentMonitor.test.tsx` (8 new)

## Verification status

PR is open; DoD and code-review gates are pending in the parent context
(per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)