### PR TITLE
ci(github-actions): add macOS CI job mirroring Linux check (F-158)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,92 @@ jobs:
       - name: Check TS bindings are up to date
         run: just ts-check
 
+  # F-158: parallel macOS CI job mirroring the Linux `check` above.
+  # Closes the dual-platform gap F-146 (zig install) and F-156 (macOS
+  # resource sampler) assumed. `macos-latest` is Apple Silicon (arm64)
+  # as of 2026; `wry` bundles WebKit.framework, so no apt-style system
+  # deps are needed — the Linux-only "Install Tauri system
+  # dependencies" step has no counterpart here. `cargo deny` and
+  # `ts-check` also run Linux-side only; both are platform-independent
+  # and running them twice adds cost without signal.
+  check-macos:
+    name: Check (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      # F-146: libghostty-vt-sys vendor-fetches the Ghostty C sources and
+      # compiles them via zig at build time. Same zig version as Linux so
+      # both platforms exercise the identical VT state authority.
+      - name: Install zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable pnpm via corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.0 --activate
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Install web workspace deps
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web app (Tauri frontendDist)
+        working-directory: web
+        run: pnpm --filter app build
+
+      - name: Rust checks (fmt, cargo check, clippy, rustdoc)
+        run: just check-rust
+
+      - name: Rust tests
+        run: just test-rust
+
+      # F-154: McpManager + stdio transport + real subprocess composition
+      # test. Same serial-single-binary constraint applies on macOS:
+      # tokio's SIGCHLD reaper is a process-wide primitive on every Unix.
+      - name: Rust tests -- McpManager subprocess (serial)
+        run: just test-rust-serial
+
+      - name: Rust tests — forge-term ghostty-vt feature
+        run: cargo test -p forge-term --features ghostty-vt --all-targets
+
+      - name: Rust clippy — forge-term ghostty-vt feature
+        run: cargo clippy -p forge-term --features ghostty-vt --all-targets -- -D warnings
+
+      # F-155: same reason as Linux — the running-session webview test
+      # silently skips without this fixture binary on PATH.
+      - name: Build forge-mcp-mock-stdio for running-session test
+        run: cargo build -p forge-mcp --bin forge-mcp-mock-stdio
+
+      # Tauri webview integration tests on macOS use the native
+      # WebKit.framework that `wry` bundles — no system-dep install
+      # needed (unlike Linux, which needs libwebkit2gtk).
+      - name: Rust webview integration tests
+        run: just test-rust-webview
+
+      # Web lane runs here too so any macOS-specific node/pnpm
+      # regression (native binding resolution, path casing) surfaces on
+      # this PR rather than in a downstream report.
+      - name: Web checks (typecheck + token drift)
+        run: just check-web
+
+      - name: Web tests
+        run: just test-web
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes forge-ide/forge#321

## Summary
- Adds `check-macos` job on `macos-latest` (Apple Silicon) mirroring the Linux `check` job step-for-step, minus Linux-only pieces.
- Closes the dual-platform gap F-146 (zig install) and F-156 (macOS resource sampler) assumed but shipped Linux-only.
- Two-jobs approach over `strategy.matrix.os`: platforms diverge on enough steps (system deps, `cargo deny`, `ts-check`) that a matrix would turn into `if: runner.os == ...` conditionals. Distinct jobs read cleaner.

## What macOS runs
- `rustup` + rustfmt + clippy
- `mlugg/setup-zig@v2` at zig 0.15.2 (matches Linux)
- node 20 + pnpm 9.12.0 via corepack, pnpm install, web `frontendDist` build
- `just check-rust` (fmt --check, cargo check, clippy -D warnings, rustdoc -D warnings)
- `just test-rust`
- `just test-rust-serial` (F-154 McpManager subprocess; same tokio SIGCHLD reaper constraint applies on every Unix)
- `forge-term --features ghostty-vt` test + clippy (F-146)
- `forge-mcp-mock-stdio` fixture build (F-155)
- `just test-rust-webview` — macOS `wry` bundles WebKit.framework so no apt-style system deps needed
- `just check-web` + `just test-web`

## What macOS skips (documented inline in ci.yml)
- `Install Tauri system dependencies` (libwebkit2gtk et al.) — Linux-only
- `cargo deny` — platform-independent; running twice adds cost without signal
- `just ts-check` — same

## Test plan
- Local: `just check-rust && just test-rust && just check-web && just test-web` all green on this branch.
- Workflow YAML: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` passes.
- Real acceptance signal is the CI run on this PR itself — watch for the new `Check (macOS)` job to complete.

## Deviations / notes for reviewers
- **TDD gate doesn't map cleanly to CI YAML.** Local RED was the YAML parse + careful review; real RED/GREEN is the PR's own CI run. Flagging this up-front rather than pretending a unit test drove it.
- **Expected first-run friction.** macOS runners often surface platform-specific surprises (slower build, native-dep edge cases, path casing). If the first run fails on the macOS side, the plan is a follow-up commit on this same branch — either a fix or a scope-down to the DoD's "smoke subset" escape hatch with the rationale inline.
- **F-156 not yet landed.** The DoD mentions exercising F-156's `#[cfg_attr(not(target_os = "..."), ignore)]` annotations on macOS. F-156 (#319) is still open — when it lands, the macOS job added here will exercise those tests automatically with no further changes needed.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)