### PR TITLE
fix(forge-session): guard bg_agents monitor spawn on tokio runtime availability

### DIFF
--- a/crates/forge-session/src/bg_agents.rs
+++ b/crates/forge-session/src/bg_agents.rs
@@ -133,19 +133,30 @@ impl BackgroundAgentRegistry {
         // registry's own events bus. Subscribers then see lifecycle
         // events and resource samples on a single channel — the shell's
         // existing `session:event` forwarder needs no extra plumbing.
+        //
+        // Production `with_monitor` is called from Tauri's setup hook, which
+        // runs inside the Tauri-managed tokio runtime, so `Handle::current`
+        // is always available. The `try_current` guard makes the function
+        // safe to call from sync test harnesses (webview-test suite
+        // constructs `BridgeState` outside any runtime); when no runtime is
+        // available the monitor-forwarding task is simply skipped — tests
+        // that assert bg_agents lifecycle don't depend on resource samples
+        // flowing through this channel.
         let mut monitor_rx = monitor.events();
         let events_tx = events.clone();
-        tokio::spawn(async move {
-            loop {
-                match monitor_rx.recv().await {
-                    Ok(ev) => {
-                        let _ = events_tx.send(ev);
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                loop {
+                    match monitor_rx.recv().await {
+                        Ok(ev) => {
+                            let _ = events_tx.send(ev);
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Closed) => break,
                     }
-                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                    Err(broadcast::error::RecvError::Closed) => break,
                 }
-            }
-        });
+            });
+        }
 
         Self {
             orchestrator,


### PR DESCRIPTION
## Summary

Main CI's `Rust webview integration tests` step has been red since F-152 merged. 10 `ipc_bg_agents` tests panic with:

> there is no reactor running, must be called from the context of a Tokio 1.x runtime

Root cause: F-152's `BgAgentSession::with_monitor` calls `tokio::spawn` unconditionally to forward `ResourceSample` events onto the bg_agents bus. Production callers run inside Tauri's tokio runtime and the spawn works; the `webview-test` harness constructs `BridgeState` in sync setup code, with no runtime on the calling thread — panic.

Fix: guard the spawn with `tokio::runtime::Handle::try_current()`. Production behavior is unchanged (`Handle::current` always available inside Tauri's runtime); the test harness path now skips the forwarder task safely.

## Changes

- `crates/forge-session/src/bg_agents.rs` — wrap the monitor-forwarding spawn in `Handle::try_current()`; only spawn when a runtime is available.

## Verification

- Local build blocked by `/tmp` disk quota, so relying on CI to confirm the fix. The wrap is mechanical and the semantics are:
  - Production (tokio runtime present): `handle.spawn(fut)` — same as before
  - Test harness (no runtime): spawn skipped, forwarder task absent
- Safety: `ipc_bg_agents` tests assert lifecycle + authz; none depend on resource-sample flow through the bg_agents bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)