### PR TITLE
fix(forge-session): gate pid_file_lifecycle test to Linux (F-158 macOS CI)

### DIFF
--- a/crates/forge-session/tests/pid_file_lifecycle.rs
+++ b/crates/forge-session/tests/pid_file_lifecycle.rs
@@ -9,6 +9,12 @@
 //!
 //! These tests spawn `forged` with an explicit `FORGE_PID_FILE` pointing
 //! into a `TempDir` so they don't collide with live sessions on the host.
+//!
+//! Linux-only: the start-time parser reads `/proc/<pid>/stat`, which is
+//! Linux-specific. macOS / Windows `forged` uses a different liveness
+//! check (not yet implemented); this module compiles out on those targets.
+
+#![cfg(target_os = "linux")]
 
 use forge_cli::socket::{parse_pid_file_record, parse_proc_stat_starttime};
 use forge_ipc::{ClientInfo, Hello, IpcMessage, Subscribe, PROTO_VERSION};


### PR DESCRIPTION
## Summary

F-158's new macOS CI job failed on its first run with:

\`\`\`
error[E0432]: unresolved import \`forge_cli::socket::parse_proc_stat_starttime\`
\`\`\`

The imported function is \`#[cfg(target_os = \"linux\")]\` (it reads \`/proc/<pid>/stat\`) but the importer — the \`pid_file_lifecycle\` integration test — wasn't gated. macOS CI never exercised this before F-158.

## Changes

- \`crates/forge-session/tests/pid_file_lifecycle.rs\` — add \`#![cfg(target_os = \"linux\")]\` at module level + rationale comment

The whole module tests Linux-specific liveness semantics; macOS/Windows \`forged\` will need a different verifier (e.g. \`sysctl\` \`kinfo_proc\` on macOS) that's not yet implemented.

## Test plan

- Compile passes on macOS after this fix (the failing step was compile, not a runtime test)
- Linux test suite unchanged (the \`#![cfg]\` is satisfied on Linux)
- CI on this PR will confirm — **the macOS job's compile step should advance past this error**, likely surfacing further macOS-specific issues that we'll address in follow-up fixes per the maintainer's "macOS bugs in scope" directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)