### PR TITLE
fix(forge-session): gate shell.exec timeout consts to Linux (F-158 macOS CI)

### DIFF
--- a/crates/forge-session/src/tools/shell_exec.rs
+++ b/crates/forge-session/src/tools/shell_exec.rs
@@ -27,9 +27,17 @@ use std::time::Duration;
 /// Upper bound for `shell.exec` `timeout_ms`. A provider-supplied value larger
 /// than this is silently clamped. Prevents a runaway tool call from holding
 /// the future open indefinitely (F-066 / CWE-400).
+///
+/// Gated to Linux because the entire `shell.exec` implementation is Linux-only
+/// (drives the `SandboxedCommand` L1 sandbox). On non-Linux the constant
+/// would be dead code — gate it so macOS/Windows compile cleanly.
+#[cfg(target_os = "linux")]
 pub(crate) const MAX_TIMEOUT_MS: u64 = 10 * 60 * 1000;
 
 /// Default `timeout_ms` when the caller does not supply one.
+///
+/// Linux-gated for the same reason as [`MAX_TIMEOUT_MS`].
+#[cfg(target_os = "linux")]
 pub(crate) const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
 pub struct ShellExecTool;


### PR DESCRIPTION
## Summary

Second macOS CI finding after #325. \`check-rust\` surfaced two dead-code errors:

\`\`\`
error: constant \`MAX_TIMEOUT_MS\` is never used
error: constant \`DEFAULT_TIMEOUT_MS\` is never used
\`\`\`

Both are at the top of \`crates/forge-session/src/tools/shell_exec.rs\`. The entire shell.exec implementation is already \`#[cfg(target_os = \"linux\")]\`, but the two module-level timeout constants weren't gated. On macOS the tool body compiles out, nothing uses the constants → dead code.

## Changes

- \`crates/forge-session/src/tools/shell_exec.rs\` — \`#[cfg(target_os = \"linux\")]\` on \`MAX_TIMEOUT_MS\` and \`DEFAULT_TIMEOUT_MS\` + rationale docstring.

## Verification

- Linux behavior unchanged (constants still present when \`target_os = \"linux\"\`, tool body + tests reference them exactly as before).
- macOS should now compile past this error; if more platform issues surface, they're in-scope per the maintainer's earlier directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)