### PR TITLE
chore(skills): fix F-number race in forge-create-task

### DIFF
--- a/.claude/skills/forge-create-task/SKILL.md
+++ b/.claude/skills/forge-create-task/SKILL.md
@@ -7,23 +7,19 @@ description: Use when you need to add a new task to the Forge backlog — create
 
 ## Overview
 
-New tasks are GitHub Issues with a consistent format: `[F-NNN] <title>`, a **Scope** section, and a **Definition of Done** checklist. Use the next available F-number.
+New tasks are GitHub Issues with a consistent format: `[F-NNN] <title>`, a **Scope** section, and a **Definition of Done** checklist. The F-number matches the GitHub-assigned issue number; since GitHub assigns numbers, capture the assigned number from the create-command output and rewrite the title to match.
+
+**Do not** precompute the next F-number with `gh issue list ... | max + 1`. Issues and PRs share GitHub's number sequence, but `gh issue list` only returns issues — so the formula is systematically wrong whenever any PR has been opened since the last issue, and also stale against any activity between lookup and create.
 
 ## Steps
 
-1. **Find the next issue number**
+1. **Choose the right milestone and type label** (see tables below)
+
+2. **Create the issue with an `[F-TBD]` placeholder title**
 
 ```bash
-gh issue list --repo forge-ide/forge --state all --json number --jq '[.[].number] | max + 1'
-```
-
-2. **Choose the right milestone and type label** (see tables below)
-
-3. **Create the issue**
-
-```bash
-gh issue create \
-  --title "[F-NNN] <short imperative title>" \
+URL=$(gh issue create \
+  --title "[F-TBD] <short imperative title>" \
   --milestone "<Phase N: Title>" \
   --label "type: feat" \
   --repo forge-ide/forge \
@@ -38,8 +34,21 @@ gh issue create \
 - [ ] <Another criterion>
 - [ ] Tests pass in CI
 EOF
-)"
+)")
 ```
+
+3. **Extract the assigned number and rewrite the title**
+
+```bash
+NUM=$(basename "$URL")
+gh issue edit "$NUM" --repo forge-ide/forge \
+  --title "[F-$NUM] <short imperative title>"
+echo "Filed F-$NUM: $URL"
+```
+
+### Cross-referencing other issues
+
+If the body needs to reference another issue by F-number, file that issue first so you know its real number. Do not self-reference the issue's own F-number in its body — the body is written before the number is known.
 
 ## Issue Format Rules
 


### PR DESCRIPTION
## Summary

- Removes the `gh issue list ... | [.[].number] | max + 1` precompute step from the `forge-create-task` skill and replaces it with a two-step flow: create the issue with `[F-TBD]`, capture the GitHub-assigned number from the returned URL, then `gh issue edit --title` to stamp `[F-N]`.
- The old formula had a latent bug, not just a race: GitHub's issue and PR numbers share one sequence, but `gh issue list` only returns issues — so the formula undercounts whenever any PR is opened between issues. A concrete case surfaced today when running the skill itself: the lookup returned `322`, but by the time `gh issue create` ran, PRs #322–#325 had claimed those slots and the new issue was assigned #326, producing a title/number mismatch that required a follow-up `gh issue edit` to fix.
- New flow is race-free and number-sequence-correct by construction — the number is read from the thing that assigned it, not guessed in advance.

## Scope limits / follow-up

- Only `forge-create-task` is touched. The same precompute pattern also lives in `forge-milestone-planner`, `forge-milestone-docs-audit`, `forge-milestone-security-audit`, and implicitly in the finding-creation steps of `forge-milestone-backcompat-audit` / `forge-milestone-frontend-review` / `forge-milestone-performance-audit` / `forge-milestone-quality-review` / `forge-milestone-release-readiness`. Those are intentionally out of scope here — they share extra concerns (sibling-issue cross-references, consolidated report issues) that warrant a separate, carefully-scoped sweep.
- Incidental finding (not fixed in this PR): `.claude/worktrees/` exists and is actively used by agents but is not in `.gitignore`. Not touched here because it's tangential and mixing concerns would hurt review. Worth a short separate fix.

## Test plan

- [ ] Re-read the updated `SKILL.md` and confirm the two-step bash is copy-pasteable and uses no `gh` flags that don't exist in the repo's ambient `gh` version
- [ ] Next time `forge-create-task` is invoked, verify the assigned number and the final title match
- [ ] (Optional) Dry-run the new flow by creating a test issue in a scratch repo to confirm `$(basename "$URL")` extracts the issue number correctly from `gh issue create`'s stdout