### PR TITLE
[F-156] macOS + Windows resource samplers for AgentMonitor pills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +610,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1484,6 +1522,7 @@ dependencies = [
  "forge-providers",
  "futures",
  "libc",
+ "libproc",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -1492,6 +1531,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2622,7 +2662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2657,6 +2697,27 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libproc"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
 ]
 
 [[package]]
@@ -2783,6 +2844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,6 +2944,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "notify-rust"

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -37,6 +37,24 @@ sha2 = "0.10"
 thiserror = "1"
 tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync", "process", "time", "signal"] }
 
+# F-156: macOS resource sampler. `libproc` wraps the Apple
+# `proc_pidinfo` syscalls used to read task CPU time, resident-size, and
+# open file-descriptor counts. Linux/Windows pull different crates via
+# their own target stanzas below.
+[target.'cfg(target_os = "macos")'.dependencies]
+libproc = "0.14"
+
+# F-156: Windows resource sampler. `windows-sys` is the zero-cost pure-FFI
+# Microsoft-maintained binding crate. Feature set is surgical — one
+# feature per module path — because the generated bindings are gated by
+# these flags and the full crate would balloon compile times.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_ProcessStatus",
+] }
+
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support", "async_tokio"] }
 forge-cli = { path = "../forge-cli" }

--- a/crates/forge-session/src/resource_monitor.rs
+++ b/crates/forge-session/src/resource_monitor.rs
@@ -1,4 +1,4 @@
-//! Per-agent-instance resource sampler (F-152).
+//! Per-agent-instance resource sampler (F-152 Linux, F-156 macOS/Windows).
 //!
 //! Populates the AgentMonitor inspector's cpu / rss / fds pills (F-140).
 //! F-140 shipped the pill chrome with placeholder dashes because there was
@@ -7,10 +7,13 @@
 //! # Architecture
 //!
 //! - [`Sampler`] is the trait every platform probe implements. Tests use
-//!   the [`FakeSampler`] below; Linux is backed by `/proc/<pid>`. macOS and
-//!   Windows ship `None`-returning stubs today — the DoD explicitly names
-//!   those platforms so the `#[cfg]` gating + future probe slots are
-//!   present from day one, even though CI is Linux.
+//!   the [`FakeSampler`] below; Linux is backed by `/proc/<pid>`, macOS
+//!   by `libproc`, Windows by the `GetProcessTimes` /
+//!   `GetProcessMemoryInfo` / `GetProcessHandleCount` trio. Targets
+//!   outside those three fail to compile at the module-level
+//!   `compile_error!` — the F-152 silent `Sample::default()` stub was
+//!   removed in F-156 because all-zero pills masquerading as real
+//!   readings are worse than a build error.
 //!
 //! - [`ResourceMonitor::track`] registers a `(instance_id, pid)` pair and
 //!   spawns a per-instance tokio tick task. On each tick the task asks the
@@ -404,49 +407,391 @@ Threads:   3
     }
 }
 
-/// Non-Linux placeholder probe. The DoD names macOS (`libproc` /
-/// `sysctl`) and Windows (`GetProcessTimes` / `GetProcessHandleCount` /
-/// `GetProcessMemoryInfo`) as the real implementations; those are
-/// out-of-scope for CI-on-Linux but the stub holds the `#[cfg]` slot so
-/// a follow-up doesn't have to restructure the module.
-#[cfg(not(target_os = "linux"))]
-pub mod unsupported {
+/// macOS `libproc`-backed probe. Reads `proc_taskinfo` for cumulative
+/// user+system CPU nanoseconds and resident memory, and counts open file
+/// descriptors via `listpidinfo::<ListFDs>`.
+///
+/// `proc_taskinfo`'s `pti_total_user` / `pti_total_system` are in
+/// nanoseconds (see `<sys/proc_info.h>` in the macOS SDK). The Linux
+/// probe returns seconds, so we convert. `pti_resident_size` is already
+/// in bytes. `pbi_nfiles` on the BSD-info flavor gives the fd count
+/// without enumerating them — far cheaper than listing — but the listing
+/// path is the one the DoD names and it's the path that matches how the
+/// Linux probe physically counts entries in `/proc/<pid>/fd`, so we use
+/// it for behavioral parity.
+#[cfg(target_os = "macos")]
+pub mod macos {
     use super::{Sample, Sampler};
+    use std::collections::HashMap;
+    use tokio::sync::Mutex;
 
-    pub struct UnsupportedSampler;
+    use libproc::bsd_info::BSDInfo;
+    use libproc::file_info::{ListFDs, ProcFDType};
+    use libproc::proc_pid::{listpidinfo, pidinfo};
+    use libproc::task_info::TaskInfo;
 
-    impl UnsupportedSampler {
+    /// `libproc`-backed sampler. Holds a per-PID CPU-time baseline in
+    /// nanoseconds so the public `Sample::cpu_seconds` can report a
+    /// delta rather than a cumulative total — matching the Linux probe.
+    pub struct LibprocSampler {
+        previous_ns: Mutex<HashMap<u32, u64>>, // pid -> utime+stime ns
+    }
+
+    impl LibprocSampler {
         pub fn new() -> Self {
-            Self
+            Self {
+                previous_ns: Mutex::new(HashMap::new()),
+            }
         }
     }
 
-    impl Default for UnsupportedSampler {
+    impl Default for LibprocSampler {
         fn default() -> Self {
             Self::new()
         }
     }
 
     #[async_trait::async_trait]
-    impl Sampler for UnsupportedSampler {
-        async fn sample(&self, _pid: u32) -> Sample {
-            // Returning an empty sample preserves the Option-per-field
-            // contract without panicking on non-Linux platforms.
-            Sample::default()
+    impl Sampler for LibprocSampler {
+        async fn sample(&self, pid: u32) -> Sample {
+            // `libproc` is synchronous FFI. Calls resolve in microseconds
+            // per the XNU syscall tables, so staying on the tokio worker
+            // is preferable to the allocation cost of `spawn_blocking`.
+            let (cpu_seconds, rss_bytes) = match pidinfo::<TaskInfo>(pid as i32, 0) {
+                Ok(ti) => {
+                    let total_ns = ti.pti_total_user.saturating_add(ti.pti_total_system);
+                    let mut prev = self.previous_ns.lock().await;
+                    let delta_ns = match prev.get(&pid).copied() {
+                        Some(previous) if total_ns >= previous => total_ns - previous,
+                        _ => 0,
+                    };
+                    prev.insert(pid, total_ns);
+                    let seconds = delta_ns as f64 / 1_000_000_000.0;
+                    (Some(seconds), Some(ti.pti_resident_size))
+                }
+                Err(_) => (None, None),
+            };
+            let fd_count = count_fds(pid);
+            Sample {
+                cpu_seconds,
+                rss_bytes,
+                fd_count,
+            }
+        }
+    }
+
+    /// Counts open file descriptors by asking the kernel to enumerate
+    /// them. `listpidinfo::<ListFDs>` takes a max-entries bound; BSDInfo
+    /// carries `pbi_nfiles` which is the kernel's live count. Use that
+    /// as the bound, then count the returned entries — if the kernel
+    /// filled the buffer we still get an accurate count.
+    fn count_fds(pid: u32) -> Option<u64> {
+        let bsd = pidinfo::<BSDInfo>(pid as i32, 0).ok()?;
+        // `pbi_nfiles` is a u32; cast up front so overflow-on-pathological
+        // process is a saturating cast rather than a wrap.
+        let cap = bsd.pbi_nfiles as usize;
+        // A zero cap means the kernel says "no open fds" — return it
+        // straight rather than asking `listpidinfo` for a zero-size Vec.
+        if cap == 0 {
+            return Some(0);
+        }
+        let fds = listpidinfo::<ListFDs>(pid as i32, cap).ok()?;
+        // Filter to the set `pbi_nfiles` really counts: regular
+        // vnode/socket/pipe fds, matching what `/proc/<pid>/fd` on Linux
+        // shows. Kernel-internal entries like fsevents aren't visible on
+        // Linux either.
+        let n = fds
+            .iter()
+            .filter(|fd| {
+                matches!(
+                    fd.proc_fdtype.into(),
+                    ProcFDType::VNode
+                        | ProcFDType::Socket
+                        | ProcFDType::Pipe
+                        | ProcFDType::PSEM
+                        | ProcFDType::PSHM
+                        | ProcFDType::KQueue
+                )
+            })
+            .count() as u64;
+        Some(n)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[tokio::test]
+        async fn libproc_sampler_returns_non_none_rss_and_fds_for_self() {
+            // Mirrors the Linux sibling test
+            // (`proc_sampler_returns_a_non_none_rss_for_self`). The DoD's
+            // per-platform invariant is "monitor emits non-zero samples
+            // for a self-process"; probing the real libproc sampler
+            // against the test's own PID is the strongest live check we
+            // can run inside `cargo test`. `cpu_seconds` is a delta, so
+            // the first call reports 0.0 — hence only RSS and fd_count
+            // carry the "non-None" assertion, matching Linux.
+            //
+            // This test ships live on macOS CI (F-158 added the
+            // macos-latest runner that calls `just test-rust`) so a
+            // regression on the real syscall path fails the PR.
+            let s = LibprocSampler::new();
+            let sample = s.sample(std::process::id()).await;
+            assert!(
+                sample.rss_bytes.is_some(),
+                "libproc must parse live self RSS"
+            );
+            assert!(
+                sample.fd_count.is_some(),
+                "libproc must count live self fds"
+            );
+            let rss = sample.rss_bytes.unwrap();
+            assert!(rss > 0, "test process must report non-zero RSS, got {rss}");
+            let fds = sample.fd_count.unwrap();
+            assert!(
+                fds > 0,
+                "test process must have at least one open fd, got {fds}"
+            );
         }
     }
 }
 
+/// Windows `kernel32` / `psapi`-backed probe. Reads cumulative kernel +
+/// user CPU time via `GetProcessTimes` (returned as 100ns FILETIME
+/// units), working-set bytes via `GetProcessMemoryInfo`, and open kernel
+/// handle count via `GetProcessHandleCount`.
+///
+/// Windows "handles" aren't a perfect analogue of POSIX file descriptors
+/// — they include window handles, event handles, mutex handles, etc. —
+/// but they're the closest off-the-shelf count and the DoD explicitly
+/// names `GetProcessHandleCount` as the probe, so we follow it.
+#[cfg(target_os = "windows")]
+pub mod windows {
+    use super::{Sample, Sampler};
+    use std::collections::HashMap;
+    use tokio::sync::Mutex;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, FILETIME, HANDLE};
+    use windows_sys::Win32::System::ProcessStatus::{
+        GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetProcessHandleCount, GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        PROCESS_VM_READ,
+    };
+
+    /// `windows-sys`-backed sampler. Same delta-from-previous CPU pattern
+    /// as the Linux and macOS probes.
+    pub struct WindowsSampler {
+        /// pid -> cumulative (kernel + user) CPU in 100ns FILETIME units.
+        previous_100ns: Mutex<HashMap<u32, u64>>,
+    }
+
+    impl WindowsSampler {
+        pub fn new() -> Self {
+            Self {
+                previous_100ns: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl Default for WindowsSampler {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    /// Merge two 32-bit halves of a FILETIME into a single u64. Windows
+    /// lays FILETIME out as a struct of `dwLowDateTime` + `dwHighDateTime`
+    /// instead of a u64 for historical 16-bit-alignment reasons.
+    fn filetime_to_u64(ft: FILETIME) -> u64 {
+        ((ft.dwHighDateTime as u64) << 32) | ft.dwLowDateTime as u64
+    }
+
+    /// RAII wrapper around a `HANDLE` so the sampler can't leak handles
+    /// through a `?` / early return. `OpenProcess` returns a handle that
+    /// must be `CloseHandle`'d; forgetting it is the classic long-lived
+    /// Windows service leak.
+    struct OwnedHandle(HANDLE);
+
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                // SAFETY: self.0 came from OpenProcess which returns
+                // either a valid kernel handle or null. The null branch
+                // is skipped above.
+                unsafe {
+                    CloseHandle(self.0);
+                }
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Sampler for WindowsSampler {
+        async fn sample(&self, pid: u32) -> Sample {
+            // Ask for the minimum access rights each probe needs.
+            // PROCESS_QUERY_LIMITED_INFORMATION covers GetProcessTimes and
+            // GetProcessHandleCount; PROCESS_VM_READ is required by the
+            // psapi memory probe. An AV/EDR can still deny this — callers
+            // degrade gracefully (all-None Sample) in that case.
+            //
+            // `HANDLE` is `*mut c_void` and therefore `!Send`. To keep the
+            // `sample()` future `Send` (the `Sampler` trait requires it
+            // through `async_trait`'s `+ Send` bound), we do every syscall
+            // in a tight non-await scope, drop the handle at the end of
+            // it, and only then `.await` the mutex that stores previous
+            // CPU totals. Nothing in the sync block suspends, so there's
+            // no behavioral downside.
+            let (total_100ns_opt, rss_bytes, fd_count) = {
+                let handle = unsafe {
+                    OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ, 0, pid)
+                };
+                if handle.is_null() {
+                    return Sample::default();
+                }
+                let handle = OwnedHandle(handle);
+                (
+                    read_cpu_total_100ns(handle.0),
+                    read_working_set_bytes(handle.0),
+                    read_handle_count(handle.0),
+                )
+            };
+
+            let cpu_seconds = match total_100ns_opt {
+                Some(total_100ns) => {
+                    let mut prev = self.previous_100ns.lock().await;
+                    let delta = match prev.get(&pid).copied() {
+                        Some(previous) if total_100ns >= previous => total_100ns - previous,
+                        _ => 0,
+                    };
+                    prev.insert(pid, total_100ns);
+                    // FILETIME ticks are 100ns. 10_000_000 per second.
+                    Some(delta as f64 / 10_000_000.0)
+                }
+                None => None,
+            };
+
+            Sample {
+                cpu_seconds,
+                rss_bytes,
+                fd_count,
+            }
+        }
+    }
+
+    fn read_cpu_total_100ns(h: HANDLE) -> Option<u64> {
+        let mut creation = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        let mut exit = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        let mut kernel = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        let mut user = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        // SAFETY: `h` is a live process handle from OpenProcess; all four
+        // output pointers target stack-allocated FILETIME locals that
+        // outlive the call.
+        let ok =
+            unsafe { GetProcessTimes(h, &mut creation, &mut exit, &mut kernel, &mut user) != 0 };
+        if !ok {
+            return None;
+        }
+        Some(filetime_to_u64(kernel).saturating_add(filetime_to_u64(user)))
+    }
+
+    fn read_working_set_bytes(h: HANDLE) -> Option<u64> {
+        let mut counters: PROCESS_MEMORY_COUNTERS = unsafe { std::mem::zeroed() };
+        counters.cb = std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+        // SAFETY: `h` is a live process handle. `counters` is a stack
+        // struct sized correctly via the `cb` field set above.
+        let ok = unsafe { GetProcessMemoryInfo(h, &mut counters, counters.cb) != 0 };
+        if !ok {
+            return None;
+        }
+        Some(counters.WorkingSetSize as u64)
+    }
+
+    fn read_handle_count(h: HANDLE) -> Option<u64> {
+        let mut count: u32 = 0;
+        // SAFETY: `h` is a live process handle; `count` is a live stack
+        // local the kernel writes through the out-pointer.
+        let ok = unsafe { GetProcessHandleCount(h, &mut count) != 0 };
+        if !ok {
+            return None;
+        }
+        Some(count as u64)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        // CI gap: there is no Windows GitHub Actions runner wired up to
+        // forge-ide/forge today (F-158 added macOS-latest but Windows is
+        // out of scope for that issue). This test compiles in-tree on
+        // Windows hosts and is the self-process equivalent of the Linux
+        // and macOS siblings; it must be run manually on a Windows dev
+        // box to validate. The `#[cfg(target_os = "windows")]` on the
+        // enclosing module keeps the build green on Linux/macOS CI by
+        // excluding the whole tree from compilation there.
+        #[tokio::test]
+        async fn windows_sampler_returns_non_none_rss_and_fds_for_self() {
+            let s = WindowsSampler::new();
+            let sample = s.sample(std::process::id()).await;
+            assert!(
+                sample.rss_bytes.is_some(),
+                "GetProcessMemoryInfo must succeed for self"
+            );
+            assert!(
+                sample.fd_count.is_some(),
+                "GetProcessHandleCount must succeed for self"
+            );
+            let rss = sample.rss_bytes.unwrap();
+            assert!(rss > 0, "test process must report non-zero RSS, got {rss}");
+            let fds = sample.fd_count.unwrap();
+            assert!(
+                fds > 0,
+                "test process must have at least one handle, got {fds}"
+            );
+        }
+    }
+}
+
+// Any target that isn't one of the three we support fails to compile
+// with a loud error. The F-152 stub's Sample::default() silently produced
+// all-zero pill values on unsupported platforms, which is worse than a
+// hard stop — consumers would think the monitor was working.
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+compile_error!(
+    "forge-session resource monitor is not implemented on this target. \
+     Supported platforms: linux, macos, windows."
+);
+
 /// Return the compile-time "best available" sampler for the current
-/// platform. Linux → `ProcSampler`; everything else → the stub.
+/// platform. One arm per supported OS; unsupported targets fail to
+/// compile at the module-level `compile_error!` above, so this function
+/// is a single `cfg` dispatch with no fallback.
 pub fn default_sampler() -> std::sync::Arc<dyn Sampler> {
     #[cfg(target_os = "linux")]
     {
         std::sync::Arc::new(linux::ProcSampler::new())
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
     {
-        std::sync::Arc::new(unsupported::UnsupportedSampler::new())
+        std::sync::Arc::new(macos::LibprocSampler::new())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::sync::Arc::new(windows::WindowsSampler::new())
     }
 }
 


### PR DESCRIPTION
Closes #319.

Completes F-152's cross-platform coverage. The Linux `/proc`-based
sampler shipped in #318 was paired with a `Sample::default()` stub on
macOS and Windows, which meant non-Linux users saw `0.0% cpu / 0 MB / 0
fds` in the AgentMonitor pills instead of honest data. This PR replaces
both stubs with real probes and removes the silent-zero failure mode.

## What ships

### macOS — `libproc::macos::LibprocSampler`
- `pidinfo::<TaskInfo>(pid, 0)` for `pti_total_user + pti_total_system`
  (nanoseconds) and `pti_resident_size` (bytes).
- `listpidinfo::<ListFDs>(pid, BSDInfo::pbi_nfiles)` for the open-fd
  count, filtered to `VNode`/`Socket`/`Pipe`/`PSEM`/`PSHM`/`KQueue` —
  the fd types `/proc/<pid>/fd` on Linux would also count, for
  behavioral parity.
- Cumulative CPU tracked in `Mutex<HashMap<u32, u64>>` (ns) and
  differenced on each tick, converted to seconds — matches Linux
  probe's contract so `run_ticker`'s rolling-average cpu_pct math is
  platform-independent.

### Windows — `windows::WindowsSampler`
- `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ, …)`
  for the minimum access rights each probe needs.
- `GetProcessTimes` → sum kernel+user FILETIME (100ns ticks) →
  cumulative baseline → delta seconds. Same Mutex<HashMap> pattern as
  macOS.
- `GetProcessMemoryInfo` → `WorkingSetSize` for RSS.
- `GetProcessHandleCount` for the fd-equivalent. (Windows handles are a
  superset of POSIX fds — includes mutex, event, window handles — but
  the DoD explicitly names this API.)
- Custom `OwnedHandle` RAII guard wraps the `HANDLE` so `CloseHandle`
  can't be forgotten. `HANDLE` is `*mut c_void` and therefore `!Send`,
  so all syscalls run in a tight sync block whose scope ends before
  the single `.await`, keeping the `Sampler::sample()` future `Send`
  as required by `async_trait`.

### Unsupported OSes
The F-152 `UnsupportedSampler` stub is deleted. Any target outside
`{linux, macos, windows}` now fails to compile at a module-level
`compile_error!` — loud-failing strictly dominates silently producing
all-zero pill readings. `default_sampler()` is a three-arm `cfg`
dispatch with no fallback.

## Definition of Done — status

- [x] macOS sampler uses `libproc` (crate `libproc = \"0.14\"`)
- [x] Windows sampler uses `GetProcessTimes` + `GetProcessHandleCount` +
      `GetProcessMemoryInfo` (via `windows-sys = \"0.61\"` with features
      `Win32_Foundation`, `Win32_System_Threading`,
      `Win32_System_ProcessStatus`)
- [x] Both samplers behave consistently with the Linux probe — 1s tick
      (default), `cpu_pct` as rolling average over last tick window,
      `rss_bytes` and `fd_count` instantaneous
- [x] Per-platform unit test under `#[cfg(target_os = …)]`: real
      sampler against self-pid, `rss_bytes.is_some() + > 0`,
      `fd_count.is_some() + > 0` — mirrors the existing Linux sibling
      `proc_sampler_returns_a_non_none_rss_for_self`
- [x] `#[cfg]` stubs reduced to a compile_error on unsupported targets
- [x] Linux tests pass locally (`just check-rust`, `just test-rust`)
- [x] macOS tests will exercise live on F-158's macos-latest CI runner
- [ ] Windows tests — no CI runner for forge-ide/forge yet; ships
      code-review-only. Verified via standalone cross-compile (`cargo
      check --target x86_64-pc-windows-gnu`) which caught a real
      `!Send` bug before CI.

## Notes on DoD interpretation

- **"Unit test per platform with a fake probe"** — interpreted as
  "real sampler against self-pid standing in for a real agent",
  mirroring the Linux sibling test which does exactly that. The
  `FakeSampler`-backed tests in the generic `tests` module already
  validate the monitor's plumbing; the per-platform tests exercise the
  actual syscall path. Plain reading of the DoD keeps both kinds.
- **`#[cfg_attr(not(target_os = …), ignore)]`** — does not work here:
  the probe module's body uses `libproc` and `windows-sys` symbols
  that cannot compile off-target. `#[cfg(target_os = …)]` on the whole
  module is the correct adaptation.
- **macOS fd filter** — Linux's `/proc/<pid>/fd` enumeration excludes
  kernel-internal entries like FSEvents and NetPolicy; the filter
  picks the same set for parity. Stdin/stdout/stderr are `Pipe`/
  `VNode` and always counted, so `fds > 0` holds on any live process.

## Local verification
- `just check-rust` — pass
- `just test-rust` — 113 lib tests pass, including the Linux probe's
  live self-pid sampler
- `cargo deny check` — pass
- `cargo check --target x86_64-pc-windows-gnu` on a standalone probe
  clone — pass (caught the `!Send` bug pre-CI)
- `cargo check --target aarch64-apple-darwin` — blocked by `libproc`'s
  bindgen needing the macOS SDK on a Linux host; this is expected and
  deferred to F-158's macOS CI

## Test plan
- [ ] macOS CI (F-158) exercises `libproc_sampler_returns_non_none_rss_and_fds_for_self` live on macos-latest
- [ ] Linux CI runs existing `resource_monitor::tests::*` and
      `resource_monitor::linux::tests::*` unchanged
- [ ] Manual Windows smoke (no CI) once a Windows runner is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)