### PR TITLE
fix(forge-session): demote SandboxedCommand rustdoc link for macOS (F-158)

### DIFF
--- a/crates/forge-session/src/sandbox.rs
+++ b/crates/forge-session/src/sandbox.rs
@@ -24,8 +24,9 @@ use std::sync::{Arc, Mutex};
 /// of sibling sandboxes and the daemon's own uid.
 ///
 /// Defaults are conservative values intended for short-lived tool invocations;
-/// callers should override via [`SandboxedCommand::with_config`] for workloads
-/// that need more:
+/// callers should override via `SandboxedCommand::with_config` for workloads
+/// that need more (`SandboxedCommand` is Linux-only, defined in the module's
+/// `imp` submodule):
 ///
 /// - `cpu_seconds`: 30 s of CPU time (SIGXCPU on overflow).
 /// - `address_space_bytes`: 512 MiB of virtual memory.


### PR DESCRIPTION
## Summary

Third macOS CI finding. F-158 main CI run now surfaces:

\`\`\`
error: unresolved link to \`SandboxedCommand::with_config\`
  --> crates/forge-session/src/sandbox.rs:27
\`\`\`

\`SandboxConfig\` is cross-platform but \`SandboxedCommand\` lives in the module's Linux-gated \`imp\` submodule. On macOS the link target doesn't exist and rustdoc's \`-D rustdoc::broken_intra_doc_links\` fails.

Same fix pattern as #276 (F-143's private intra-doc link): demote the intra-doc-link brackets to plain backticks.

## Changes

- \`crates/forge-session/src/sandbox.rs\` — line 27 \`[\`SandboxedCommand::with_config\`]\` → \`\`SandboxedCommand::with_config\`\` + clarifying note that the type is Linux-only.

## Test plan

- macOS rustdoc step should now compile cleanly — if more issues surface, they're in-scope per the macOS-bugs-in-Phase-2 directive.
- Linux rustdoc unchanged (backticks render the same as resolved intra-doc links in the intent of prose reading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)