### PR TITLE
fix(forge-mcp): use /bin/sh -c exit 0 in stdio tests (macOS CI)

### DIFF
--- a/crates/forge-mcp/src/transport/stdio.rs
+++ b/crates/forge-mcp/src/transport/stdio.rs
@@ -302,11 +302,13 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn surfaces_exit_event_when_child_exits_immediately() {
-        // `/bin/true` spawns, writes nothing, exits 0. We expect exactly
-        // one Exit event and then a closed channel.
-        let mut t = Stdio::connect(&stdio_spec("/bin/true", &[]))
+        // `sh -c 'exit 0'` spawns, writes nothing, exits 0. We expect
+        // exactly one Exit event and then a closed channel.
+        // (Using `/bin/sh` rather than `/bin/true` because GitHub's
+        // macos-latest runner image ships without `/bin/true`.)
+        let mut t = Stdio::connect(&stdio_spec("/bin/sh", &["-c", "exit 0"]))
             .await
-            .expect("spawn /bin/true");
+            .expect("spawn sh exit 0");
         let ev = tokio::time::timeout(std::time::Duration::from_secs(5), t.recv())
             .await
             .expect("recv did not yield Exit in time")
@@ -352,11 +354,13 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn send_errors_when_child_stdin_is_closed() {
-        // `/bin/true` exits before we can send; stdin pipe is broken.
-        // Give the child a moment to actually reap.
-        let t = Stdio::connect(&stdio_spec("/bin/true", &[]))
+        // Short-lived shell exits before we can send; stdin pipe is
+        // broken. Give the child a moment to actually reap.
+        // (Using `/bin/sh` rather than `/bin/true` because GitHub's
+        // macos-latest runner image ships without `/bin/true`.)
+        let t = Stdio::connect(&stdio_spec("/bin/sh", &["-c", "exit 0"]))
             .await
-            .expect("spawn /bin/true");
+            .expect("spawn sh exit 0");
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         let err = t.send(serde_json::json!({"jsonrpc":"2.0","id":1})).await;
         // Either the write fails outright, or it succeeds into a closed


### PR DESCRIPTION
## Summary

macOS CI fallout sweep: two forge-mcp stdio transport tests spawn \`/bin/true\` directly, but GitHub's \`macos-latest\` runner image doesn't ship it (\`os error 2: No such file or directory\`). Both tests fail on every macOS run.

Affected:
- \`surfaces_exit_event_when_child_exits_immediately\`
- \`send_errors_when_child_stdin_is_closed\`

## Fix

Swap to \`/bin/sh -c \"exit 0\"\`. The neighbouring \`drops_malformed_lines_without_closing_stream\` test already uses \`/bin/sh\` and passes on both runners. Test intent unchanged: spawn a short-lived child that exits 0 so we observe a single \`Exit\` event and \`send\` hits EPIPE on a closed stdin.

Other \`\"/bin/true\"\` occurrences in the tree are config-only (\`manager.rs\`, \`ipc_mcp.rs\`, \`http.rs\`) — those tests never actually spawn, so no further changes needed.

## Test plan

- [x] \`cargo test -p forge-mcp --lib transport::stdio\` — all 5 tests pass on Linux.
- [ ] macOS CI should pass these tests after landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)