### PR TITLE
ci(macos): restore just recipes after F-158 fallout sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,14 +171,8 @@ jobs:
       - name: Rust checks (fmt, cargo check, clippy, rustdoc)
         run: just check-rust
 
-      # Temporary override for the F-158 fallout sweep: `--no-fail-fast`
-      # so a single macOS CI run surfaces every cross-platform regression
-      # at once (instead of stopping at the first failing test binary,
-      # which forced a per-binary PR cascade during F-158). Matches the
-      # flags the Linux `just test-rust` recipe would use otherwise;
-      # remove and restore `just test-rust` once macOS is stably green.
       - name: Rust tests
-        run: cargo test --all --no-fail-fast
+        run: just test-rust
 
       # F-154: McpManager + stdio transport + real subprocess composition
       # test. Same serial-single-binary constraint applies on macOS:
@@ -187,7 +181,7 @@ jobs:
         run: just test-rust-serial
 
       - name: Rust tests — forge-term ghostty-vt feature
-        run: cargo test -p forge-term --features ghostty-vt --all-targets --no-fail-fast
+        run: cargo test -p forge-term --features ghostty-vt --all-targets
 
       - name: Rust clippy — forge-term ghostty-vt feature
         run: cargo clippy -p forge-term --features ghostty-vt --all-targets -- -D warnings
@@ -200,12 +194,8 @@ jobs:
       # Tauri webview integration tests on macOS use the native
       # WebKit.framework that `wry` bundles — no system-dep install
       # needed (unlike Linux, which needs libwebkit2gtk).
-      #
-      # Temporary F-158 override: inlined with `--no-fail-fast` for the
-      # same reason as the earlier `Rust tests` step — restore
-      # `just test-rust-webview` once macOS is stably green.
       - name: Rust webview integration tests
-        run: cargo test -p forge-shell --features webview-test --no-fail-fast
+        run: just test-rust-webview
 
       # Web lane runs here too so any macOS-specific node/pnpm
       # regression (native binding resolution, path casing) surfaces on


### PR DESCRIPTION
## Summary

Reverts the temporary \`--no-fail-fast\` override added in #336. The F-158 macOS CI fallout sweep (#332-#335 + #330) has landed and main is stably green on macOS, so single-binary fail-fast is informative again — we're no longer discovering new regressions each round.

Restores \`just test-rust\` and \`just test-rust-webview\` so the macOS job matches the Linux job's invocation surface.

## Test plan

- [x] YAML lint clean.
- [ ] CI passes green on macOS and Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)