### PR TITLE
docs(forge-session): clarify sandbox module's cross-platform surface (F-340)

### DIFF
--- a/crates/forge-session/src/sandbox.rs
+++ b/crates/forge-session/src/sandbox.rs
@@ -10,7 +10,19 @@
 //!   for the full scope story; the rlimit [`SandboxConfig::rlimit_nproc_backstop`]
 //!   remains as a uid-wide defense-in-depth backstop.
 //!
-//! Linux-only. macOS and Windows support is deferred beyond Phase 1.
+//! # Platform surface
+//!
+//! The **enforcement** primitives — `SandboxedCommand`, `SandboxedChild`,
+//! the cgroup v2 writes and `setrlimit` calls — live in the `imp`
+//! submodule and are `#[cfg(target_os = "linux")]`. macOS and Windows
+//! support for real sandboxing is deferred beyond Phase 1.
+//!
+//! The **bookkeeping** types — [`SandboxConfig`], [`ChildRegistry`],
+//! [`BASE_ENV_WHITELIST`] — compile on every platform so non-Linux
+//! callers (tools, server, orchestrator) can still plumb configuration
+//! through without platform branching. On non-Linux
+//! [`ChildRegistry::kill_all`] is a no-op that simply clears the
+//! registry; real process-group kill is a Linux-only concept.
 
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
## Summary

F-340 (#340) as originally filed asked to add \`#[cfg(target_os = \"linux\")]\` to \`pub mod sandbox;\` in \`lib.rs\`. Closer inspection shows the module is already correctly gated at the **item** level — \`SandboxConfig\`, \`ChildRegistry\`, and \`BASE_ENV_WHITELIST\` are cross-platform by design, with \`ChildRegistry::kill_all\` being a no-op on non-Linux. Only the \`imp\` submodule (which exports \`SandboxedCommand\` / \`SandboxedChild\`) is cfg-gated to Linux, and the re-export at line 685 already carries the gate.

Gating the module itself would break the non-Linux compile of \`forge-session::tools\`, \`forge-session::orchestrator\`, and \`forge-session::server\`, all of which use \`ChildRegistry\` directly.

The real bug was the **module-level doc comment** claiming \"Linux-only\". Replaced with an accurate \"Platform surface\" section that describes what's cross-platform and what's Linux-only.

Closes #340.

## Test plan

- [x] \`cargo check -p forge-session\` passes.
- [ ] CI Linux + macOS green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)