### PR TITLE
fix(forge-session): cfg-gate pid_file starttime read for macOS (F-338)

### DIFF
--- a/crates/forge-cli/src/socket.rs
+++ b/crates/forge-cli/src/socket.rs
@@ -111,19 +111,24 @@ pub fn pid_file_contents(pid: Option<u32>) -> anyhow::Result<String> {
 
 /// Format a session pid-file record as `"<pid>\n<start_time>\n"`.
 ///
-/// Two-line format pairs the pid with the daemon's start-time (from
-/// `/proc/<pid>/stat` field 22) so `session_kill` can detect kernel PID
-/// reuse before signaling: if the recorded start-time differs from the
-/// current `/proc/<pid>/stat` reading, the pid has been recycled and we
-/// refuse to signal.
+/// Two-line format pairs the pid with the daemon's platform-dependent
+/// start-time (see `forge_session::starttime::read_self_starttime`) so
+/// `session_kill` can detect kernel PID reuse before signaling: if the
+/// recorded start-time differs from the value the live process reports
+/// now, the pid has been recycled and we refuse to signal. The `u64`'s
+/// physical meaning is platform-specific (Linux: clock ticks since
+/// boot; macOS: microseconds since epoch; Windows: 100ns FILETIME
+/// creation time) and is only ever compared against a freshly-probed
+/// value on the same host.
 pub fn format_pid_file_record(pid: libc::pid_t, start_time: u64) -> String {
     format!("{pid}\n{start_time}\n")
 }
 
 /// Parse a two-line pid-file record written by `format_pid_file_record`.
 ///
-/// Returns `(pid, start_time)`. Refuses single-line files (legacy one-line
-/// format) so `session_kill` cannot silently skip the identity check.
+/// Returns `(pid, platform_start_time)`. Refuses single-line files
+/// (legacy one-line format) so `session_kill` cannot silently skip the
+/// identity check.
 pub fn parse_pid_file_record(raw: &str) -> anyhow::Result<(libc::pid_t, u64)> {
     let mut lines = raw.lines();
     let pid_line = lines

--- a/crates/forge-session/README.md
+++ b/crates/forge-session/README.md
@@ -16,11 +16,17 @@ The session daemon — `forged` — and its supporting library. A long-running p
 - `tools/` — built-in tool implementations (fs, shell, etc.) wired through `forge-fs` for write paths.
 - `archive::archive_or_purge` — end-of-life handling: rename into `.forge/sessions/archived/<id>/` or remove the session directory.
 - `socket_path` — resolves the session UDS path with the `XDG_RUNTIME_DIR` / `FORGE_SOCKET_PATH` policy.
-- `pid_file` — daemon liveness file with stale-pid detection.
+- `pid_file` — daemon liveness file with stale-pid detection. Cross-platform: the start-time token uses `/proc/self/stat` on Linux, `libproc`'s `BSDInfo` on macOS, and `GetProcessTimes` on Windows (see `starttime`).
+- `starttime` — platform-gated `read_self_starttime()` that produces the opaque `u64` token the pid-file embeds so `forge session kill` can detect pid reuse before signalling.
 - `sandbox` — `pre_exec` hooks that cap NPROC/NOFILE/FSIZE for spawned children.
 - `byte_budget` — per-session aggregate byte budget used to bound output growth.
 - `provider_spec` — parses the `provider:model` selector strings the CLI accepts.
 - `error::SessionError` — the session-local error type.
+
+## Platform notes
+
+- **macOS `forged`** runs the full persistent-mode lifecycle (F-338), including the pid-file write-and-remove cycle. The `session_kill` path, however, is still Linux-only: race-free signal delivery requires `pidfd_open` / `pidfd_send_signal`, which has no direct macOS equivalent (`kqueue EVFILT_PROC` is the planned follow-up). On macOS, terminate a persistent daemon manually via Activity Monitor, `kill`, or equivalent. `forge session kill` returns a typed error rather than falling back to `libc::kill`, which would reintroduce the pid-reuse race that F-049 closed.
+- **Windows** is not a supported host for `forged` today; the UDS handshake and signal plumbing are Unix-only. Windows-specific starttime code exists so the `forge-session` library compiles on Windows for future cross-compilation work.
 
 ## Further reading
 

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -10,6 +10,7 @@ pub mod sandbox;
 pub mod server;
 pub mod session;
 pub mod socket_path;
+pub mod starttime;
 pub mod tools;
 
 pub use bg_agents::{BackgroundAgentRegistry, BgAgentError, BgAgentState, BgAgentSummary};

--- a/crates/forge-session/src/pid_file.rs
+++ b/crates/forge-session/src/pid_file.rs
@@ -1,18 +1,20 @@
-//! `forged`'s pid-file lifecycle (F-049).
+//! `forged`'s pid-file lifecycle (F-049, cross-platform via F-338).
 //!
 //! Persistent-mode `forged` owns the pid file pointed at by
 //! `$FORGE_PID_FILE`. It writes `"<pid>\n<start_time>\n"` atomically via
 //! `O_EXCL` (so a leftover file from a crashed prior run cannot be
 //! silently clobbered), and removes the file on clean shutdown.
 //!
-//! The start-time field is `/proc/self/stat` field 22, which `forge-cli`'s
-//! `session_kill` uses to detect kernel PID reuse before signalling.
+//! The start-time field is an opaque, platform-dependent `u64` produced
+//! by [`crate::starttime::read_self_starttime`]; `forge-cli`'s
+//! `session_kill` uses it to detect kernel PID reuse before signalling.
 //! See `forge_cli::socket::{parse_pid_file_record, kill_session_from_pid_file}`.
 //!
 //! Ephemeral `forged` does not write a pid file — it's spawned by
 //! `forge run agent` whose wait is synchronous, so there is no external
 //! caller that would need to locate its pid.
 
+use crate::starttime::read_self_starttime;
 use anyhow::{Context, Result};
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -32,8 +34,8 @@ impl OwnedPidFile {
     pub fn create(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
         let pid = std::process::id() as libc::pid_t;
-        let start_time =
-            read_self_starttime().context("failed to read /proc/self/stat for pid-file record")?;
+        let start_time = read_self_starttime()
+            .context("failed to read process start-time for pid-file record")?;
         let contents = format!("{pid}\n{start_time}\n");
 
         if let Some(parent) = path.parent() {
@@ -73,35 +75,14 @@ impl Drop for OwnedPidFile {
     }
 }
 
-/// Read `/proc/self/stat` and return field 22 (start-time in clock ticks
-/// since boot). Separate from `forge_cli::socket::read_process_starttime`
-/// because that helper targets an arbitrary pid; `forged` can take the
-/// fast path of `/proc/self/stat` and avoid re-parsing its own pid.
-fn read_self_starttime() -> Result<u64> {
-    let contents = std::fs::read_to_string("/proc/self/stat").context("read /proc/self/stat")?;
-    parse_proc_stat_starttime(&contents)
-}
-
-/// Extract field 22 (`starttime`) from a `/proc/<pid>/stat` line.
-///
-/// Mirrors `forge_cli::socket::parse_proc_stat_starttime`. Duplicated
-/// here to avoid a forge-cli -> forge-session dep in production code;
-/// the two implementations are tested against each other in the
-/// `pid_file_lifecycle` integration test.
-fn parse_proc_stat_starttime(line: &str) -> Result<u64> {
-    let close = line
-        .rfind(')')
-        .ok_or_else(|| anyhow::anyhow!("malformed /proc/self/stat: no closing paren"))?;
-    let tail = &line[close + 1..];
-    let st = tail
-        .split_ascii_whitespace()
-        .nth(19)
-        .ok_or_else(|| anyhow::anyhow!("malformed /proc/self/stat: not enough fields"))?;
-    st.parse::<u64>()
-        .map_err(|_| anyhow::anyhow!("invalid starttime field: {st:?}"))
-}
-
-#[cfg(all(test, target_os = "linux"))]
+// Unit tests exercise the pid-file lifecycle (create / O_EXCL refusal /
+// drop-removes-file). They are platform-agnostic now that the start-time
+// probe lives behind `crate::starttime::read_self_starttime` (F-338), so
+// the unit-gate introduced by #333 (`target_os = "linux"`-only) has been
+// lifted. The parser-level tests that used to live here moved into
+// `crate::starttime::linux::tests` because only the Linux probe parses
+// text — macOS/Windows go through FFI.
+#[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
@@ -144,18 +125,37 @@ mod tests {
         assert!(!p.exists(), "pid file must be removed on drop");
     }
 
+    /// F-338: macOS-specific end-to-end coverage of the pid-file
+    /// lifecycle on the cross-platform starttime path. The generic
+    /// lifecycle tests above already run on macOS now (the unit gate
+    /// from #333 is lifted), but this test pins the macOS-specific DoD
+    /// item: "returns a usable record on macOS". Asserts the recorded
+    /// start-time is a plausible microseconds-since-epoch value from
+    /// libproc (non-zero, > 10^15 so it can't collide with a Linux
+    /// clock-ticks value that's always < 10^12 even after a century
+    /// uptime). Keeps the invariant readable for future maintainers.
+    #[cfg(target_os = "macos")]
     #[test]
-    fn parses_self_stat_field_22() {
-        let line = "1 (init) S 0 1 1 0 -1 4194560 0 0 0 0 0 0 0 0 20 0 1 0 7 0 0 0 0 0 0 0";
-        let st = parse_proc_stat_starttime(line).expect("parses");
-        assert_eq!(st, 7);
-    }
-
-    #[test]
-    fn parses_comm_with_spaces() {
-        let line =
-            "1234 (weird (comm) name) S 1 0 0 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 98765 0 0 0 0 0";
-        let st = parse_proc_stat_starttime(line).expect("parses comm with parens");
-        assert_eq!(st, 98765);
+    fn create_records_macos_style_starttime() {
+        let td = TempDir::new().unwrap();
+        let p = td.path().join("session.pid");
+        let _owned = OwnedPidFile::create(&p).expect("create");
+        let raw = std::fs::read_to_string(&p).expect("read");
+        let mut lines = raw.lines();
+        let _pid = lines.next().expect("pid");
+        let st: u64 = lines
+            .next()
+            .expect("starttime")
+            .parse()
+            .expect("starttime int");
+        // libproc returns microseconds-since-epoch. At 2026-04-21 the
+        // value is ~1.77e15 (any live process). 10^15 is the smallest
+        // value that cleanly falls outside the Linux /proc/self/stat
+        // clock-ticks range (< 10^12 for any realistic uptime × HZ),
+        // so this threshold documents the platform-shape difference.
+        assert!(
+            st > 1_000_000_000_000_000,
+            "macOS start-time is microseconds since epoch; got implausibly small value {st}"
+        );
     }
 }

--- a/crates/forge-session/src/starttime.rs
+++ b/crates/forge-session/src/starttime.rs
@@ -1,0 +1,221 @@
+//! Cross-platform process start-time probe (F-338).
+//!
+//! [`read_self_starttime`] returns an opaque `u64` that uniquely identifies
+//! the current process across its lifetime on a single host. Consumers use
+//! it as a second factor alongside the pid to detect kernel pid reuse
+//! between the moment the pid is recorded and the moment something tries
+//! to act on it (see `pid_file::OwnedPidFile` and
+//! `forge_cli::socket::parse_pid_file_record`).
+//!
+//! The value's physical meaning is deliberately platform-dependent:
+//!
+//! - **Linux**: field 22 of `/proc/self/stat` — monotonic clock ticks
+//!   since boot. Historically the only shape this value had, hence the
+//!   "/proc/self/stat field 22" phrasing still in older comments.
+//! - **macOS**: `libproc::BSDInfo::pbi_start_tvsec * 10^6 +
+//!   pbi_start_tvusec` — start time in microseconds since the Unix
+//!   epoch. Pulled via `proc_pidinfo`, which F-156's resource sampler
+//!   already depends on.
+//! - **Windows**: the creation-time `FILETIME` returned by
+//!   `GetProcessTimes`, merged into a `u64` of 100ns units since 1601.
+//!
+//! **The value is not comparable across platforms.** Every consumer must
+//! treat the `u64` as an opaque identity token and only compare values
+//! produced on the same host. Nothing in the tree does arithmetic on it.
+//!
+//! Non-self lookups (arbitrary pid) intentionally stay Linux-only — see
+//! `forge_cli::socket::read_process_starttime`. The pid-reuse kill path
+//! layers on `pidfd_open`, which has no macOS/Windows analogue; falling
+//! back to `libc::kill` there would re-open the race F-049 closed.
+
+use anyhow::Result;
+
+/// Return a `u64` that uniquely identifies this process across its
+/// lifetime on the current host. The shape is platform-dependent; see
+/// the module docs.
+pub fn read_self_starttime() -> Result<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::read_self_starttime()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::read_self_starttime()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows::read_self_starttime()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        compile_error!(
+            "forge-session starttime probe is not implemented on this target. \
+             Supported: linux, macos, windows."
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use anyhow::{Context, Result};
+
+    pub(super) fn read_self_starttime() -> Result<u64> {
+        let contents =
+            std::fs::read_to_string("/proc/self/stat").context("read /proc/self/stat")?;
+        parse_proc_stat_starttime(&contents)
+    }
+
+    /// Extract field 22 (`starttime`) from a `/proc/<pid>/stat` line.
+    ///
+    /// Field 2 (`comm`) is parenthesised and may contain arbitrary
+    /// characters, including spaces and `(`/`)`. We locate the comm
+    /// terminator by finding the **last** `)` in the line, then count
+    /// space-separated fields from there: field 3 is at index 0 after
+    /// the split, so `starttime` (field 22) lands at index 19.
+    pub(super) fn parse_proc_stat_starttime(line: &str) -> Result<u64> {
+        let close = line
+            .rfind(')')
+            .ok_or_else(|| anyhow::anyhow!("malformed /proc/self/stat: no closing paren"))?;
+        let tail = &line[close + 1..];
+        let st = tail
+            .split_ascii_whitespace()
+            .nth(19)
+            .ok_or_else(|| anyhow::anyhow!("malformed /proc/self/stat: not enough fields"))?;
+        st.parse::<u64>()
+            .map_err(|_| anyhow::anyhow!("invalid starttime field: {st:?}"))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn parses_self_stat_field_22() {
+            let line = "1 (init) S 0 1 1 0 -1 4194560 0 0 0 0 0 0 0 0 20 0 1 0 7 0 0 0 0 0 0 0";
+            let st = parse_proc_stat_starttime(line).expect("parses");
+            assert_eq!(st, 7);
+        }
+
+        #[test]
+        fn parses_comm_with_spaces() {
+            let line =
+                "1234 (weird (comm) name) S 1 0 0 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 98765 0 0 0 0 0";
+            let st = parse_proc_stat_starttime(line).expect("parses comm with parens");
+            assert_eq!(st, 98765);
+        }
+
+        #[test]
+        fn rejects_missing_close_paren() {
+            let line = "1234 (forged S 1";
+            assert!(parse_proc_stat_starttime(line).is_err());
+        }
+
+        #[test]
+        fn rejects_truncated_after_paren() {
+            let line = "1234 (forged) S 1 1234 1234";
+            assert!(parse_proc_stat_starttime(line).is_err());
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use anyhow::{Context, Result};
+    use libproc::bsd_info::BSDInfo;
+    use libproc::proc_pid::pidinfo;
+
+    pub(super) fn read_self_starttime() -> Result<u64> {
+        let pid = std::process::id() as i32;
+        let bsd = pidinfo::<BSDInfo>(pid, 0)
+            .map_err(|e| anyhow::anyhow!("proc_pidinfo(BSDInfo, pid={pid}): {e}"))
+            .context("read self BSDInfo via libproc")?;
+        // Compose microseconds-since-epoch into a single opaque u64.
+        // `pbi_start_tvsec` and `pbi_start_tvusec` are both `u64` in
+        // libproc 0.14's bindings — no i64 conversion needed. A process
+        // whose start would overflow `u64::MAX / 1_000_000` seconds is
+        // ~580k years in the future; saturating for that case keeps the
+        // function total without changing observable behaviour.
+        Ok(bsd
+            .pbi_start_tvsec
+            .saturating_mul(1_000_000)
+            .saturating_add(bsd.pbi_start_tvusec))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn read_self_starttime_is_non_zero_and_stable() {
+            // A live process must have a non-zero start time (since the
+            // Unix epoch), and reading twice within the same millisecond
+            // must return the identical value — start-time is monotonic
+            // per process.
+            let a = read_self_starttime().expect("libproc must resolve self");
+            let b = read_self_starttime().expect("second read must succeed");
+            assert_eq!(a, b, "self start-time must be stable across reads");
+            assert!(a > 0, "self start-time must be non-zero, got {a}");
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use anyhow::Result;
+    use windows_sys::Win32::Foundation::FILETIME;
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, GetProcessTimes};
+
+    pub(super) fn read_self_starttime() -> Result<u64> {
+        let mut creation = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        let mut exit = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        let mut kernel = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        let mut user = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        // SAFETY: `GetCurrentProcess` returns a pseudo-handle that is
+        // valid for the life of the process and must NOT be closed. All
+        // four FILETIME out-pointers target stack locals that outlive
+        // the call.
+        let ok = unsafe {
+            GetProcessTimes(
+                GetCurrentProcess(),
+                &mut creation,
+                &mut exit,
+                &mut kernel,
+                &mut user,
+            ) != 0
+        };
+        if !ok {
+            let err = std::io::Error::last_os_error();
+            anyhow::bail!("GetProcessTimes(self) failed: {err}");
+        }
+        Ok(((creation.dwHighDateTime as u64) << 32) | creation.dwLowDateTime as u64)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        // CI gap: no Windows runner in forge-ide/forge today (F-158
+        // added macOS-latest only). This test compiles and runs on
+        // Windows dev hosts; the macOS/Linux CI excludes this module at
+        // the `cfg(target_os)` boundary so the suite stays green there.
+        #[test]
+        fn read_self_starttime_is_non_zero_and_stable() {
+            let a = read_self_starttime().expect("GetProcessTimes(self) must succeed");
+            let b = read_self_starttime().expect("second read must succeed");
+            assert_eq!(a, b, "self start-time must be stable across reads");
+            assert!(a > 0, "self start-time must be non-zero, got {a}");
+        }
+    }
+}

--- a/crates/forge-session/tests/pid_file_lifecycle.rs
+++ b/crates/forge-session/tests/pid_file_lifecycle.rs
@@ -1,22 +1,28 @@
-//! Integration test: `forged` owns its pid file lifecycle (F-049).
+//! Integration test: `forged` owns its pid file lifecycle (F-049, F-338).
 //!
 //! Persistent-mode `forged` must:
 //!   - write its pid file atomically via `O_EXCL` (refuse to overwrite an
 //!     existing file),
 //!   - write the two-line `<pid>\n<start_time>\n` format so `session_kill`
-//!     can detect PID reuse,
+//!     can detect pid reuse,
 //!   - remove the pid file on clean SIGTERM exit.
 //!
 //! These tests spawn `forged` with an explicit `FORGE_PID_FILE` pointing
 //! into a `TempDir` so they don't collide with live sessions on the host.
 //!
-//! Linux-only: the start-time parser reads `/proc/<pid>/stat`, which is
-//! Linux-specific. macOS / Windows `forged` uses a different liveness
-//! check (not yet implemented); this module compiles out on those targets.
+//! Cross-platform: the F-338 rework replaced the Linux-only
+//! `/proc/self/stat` probe with `crate::starttime::read_self_starttime`,
+//! so the full lifecycle runs on macOS too. The Linux-only assertion
+//! that used to compare the recorded value to `/proc/<pid>/stat` field
+//! 22 stays gated — macOS can't round-trip through `/proc`. macOS
+//! asserts the same invariant via the pid-file shape + starttime range.
+//! Windows isn't exercised (no CI runner yet, and the pid-file test
+//! spawner drives a persistent daemon whose full UDS handshake is
+//! Unix-only anyway).
 
-#![cfg(target_os = "linux")]
+#![cfg(any(target_os = "linux", target_os = "macos"))]
 
-use forge_cli::socket::{parse_pid_file_record, parse_proc_stat_starttime};
+use forge_cli::socket::parse_pid_file_record;
 use forge_ipc::{ClientInfo, Hello, IpcMessage, Subscribe, PROTO_VERSION};
 use std::process::Stdio;
 use std::time::Duration;
@@ -96,10 +102,28 @@ async fn forged_writes_two_line_pid_file_with_self_starttime() {
     let forged_pid = child.id().expect("child pid") as libc::pid_t;
     assert_eq!(recorded_pid, forged_pid);
 
-    // Recorded start-time matches /proc/<pid>/stat field 22.
-    let stat = std::fs::read_to_string(format!("/proc/{forged_pid}/stat")).expect("proc stat");
-    let current_st = parse_proc_stat_starttime(&stat).expect("parse starttime");
-    assert_eq!(recorded_st, current_st);
+    // F-338: the Linux probe exposes `parse_proc_stat_starttime` so
+    // the recorded value can be round-tripped against a fresh read of
+    // `/proc/<forged_pid>/stat`. macOS has no equivalent text-parsing
+    // entry point (libproc is FFI), so on that platform we only assert
+    // the value is non-zero and shaped like microseconds-since-epoch
+    // (what the macOS branch of `read_self_starttime` produces). Both
+    // branches enforce the same end-to-end invariant: the pid file
+    // contains a value that uniquely identifies the live `forged`.
+    #[cfg(target_os = "linux")]
+    {
+        use forge_cli::socket::parse_proc_stat_starttime;
+        let stat = std::fs::read_to_string(format!("/proc/{forged_pid}/stat")).expect("proc stat");
+        let current_st = parse_proc_stat_starttime(&stat).expect("parse starttime");
+        assert_eq!(recorded_st, current_st);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        assert!(
+            recorded_st > 1_000_000_000_000_000,
+            "macOS starttime is microseconds-since-epoch; got implausibly small value {recorded_st}"
+        );
+    }
 
     // Clean up: SIGTERM forged so the test doesn't leak it.
     // SAFETY: pid is the live child we spawned.


### PR DESCRIPTION
## Summary

Closes #338.

`OwnedPidFile::create()` unconditionally read `/proc/self/stat`, which broke `forged` on macOS when `FORGE_PID_FILE` was set. #333 gated only the unit tests; this PR fixes the production call site.

- New `forge-session::starttime` module: cross-platform `read_self_starttime()` with Linux (`/proc/self/stat` field 22), macOS (`libproc::BSDInfo` via `proc_pidinfo`), and Windows (`GetProcessTimes(GetCurrentProcess())`) branches. `pid_file::OwnedPidFile::create` delegates to it.
- Unit-gate from #333 lifted — the lifecycle tests (`create_writes_two_line_record`, `create_refuses_when_file_exists`, `drop_removes_file`) no longer assume `/proc` and run on every platform. Parser-level tests moved into `starttime::linux::tests` where they belong.
- New macOS-specific lifecycle test asserts the recorded start-time is shaped like microseconds-since-epoch (DoD: "usable record on macOS").
- `tests/pid_file_lifecycle.rs` broadens from `cfg(target_os = "linux")` to `any(linux, macos)`; the "recorded matches live probe" check splits per-platform (Linux round-trips through `/proc`, macOS pins the value range).
- `session_kill`'s arbitrary-pid + pidfd path stays Linux-only (no race-free macOS analogue). Documented as a platform note in `crates/forge-session/README.md` per DoD option 2. Comment renames in `forge-cli::socket` reflect the `u64` as a platform-opaque start-time token.

## DoD — per-item evidence

- [x] `read_self_starttime()` cfg-gated / cross-platform replacement — `crates/forge-session/src/starttime.rs` module with three `#[cfg(target_os = …)]` branches.
- [x] `OwnedPidFile::create` Linux regression test — `pid_file::tests::create_writes_two_line_record` passes on Linux (unit-gate lifted, test now runs on every platform).
- [x] macOS pid-file lifecycle test — `pid_file::tests::create_records_macos_style_starttime` (gated `#[cfg(target_os = "macos")]`).
- [x] `forge_cli::socket::read_process_starttime` treatment — kept Linux-only because its only callers are `verify_kill_target` / `kill_session_from_pid_file`, both already `cfg(target_os = "linux")`. macOS limitation documented in the daemon README.
- [x] #333 unit-gate reconsidered — lifted back to plain `#[cfg(test)]`. Parser-specific tests that can't run on macOS were moved into `starttime::linux::tests` (correctly gated).
- [x] Tests pass in CI on Linux (local `just check-rust` + `just test-rust` green). macOS CI runs the same recipes on push and will exercise the new macOS lifecycle test.

## Test plan

- [x] `just check-rust` — green locally (fmt, cargo check, clippy, rustdoc -D warnings)
- [x] `just test-rust` — green locally on Linux; all pid_file / starttime tests pass
- [ ] macOS CI — watch the `Check (macOS)` job; the new `create_records_macos_style_starttime` test is the strongest smoke check for the libproc path
- [ ] Windows — no CI runner; Windows branch compiles but isn't exercised (`windows` tests documented as a CI gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)