### PR TITLE
feat(forge-core): macOS XDG_RUNTIME_DIR fallback at ~/Library (F-339)

### DIFF
--- a/crates/forge-cli/src/socket.rs
+++ b/crates/forge-cli/src/socket.rs
@@ -13,36 +13,25 @@ pub fn session_id_is_valid(s: &str) -> bool {
     s.len() == 16 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
 }
 
-/// Error message shared by all path resolvers when `XDG_RUNTIME_DIR` is
-/// unset. Keeping a single message means any caller that surfaces this error
-/// (CLI, shell, daemon startup) advertises the same fix to the operator.
-fn xdg_runtime_dir_missing() -> anyhow::Error {
-    anyhow::anyhow!(
-        "XDG_RUNTIME_DIR is unset: forge refuses to fall back to a \
-         shared /tmp directory because the socket there would be \
-         world-connectable. Set XDG_RUNTIME_DIR to a per-user 0o700 \
-         directory (systemd sets it to /run/user/<uid> automatically). \
-         (F-044 / H8)"
-    )
-}
-
-/// Read `XDG_RUNTIME_DIR` or error. We deliberately do not consult `$UID`
-/// (an unreliable shell-only variable that F-044 removed) nor fall back to
-/// `/tmp/forge-<uid>` — that fallback was the defect H8 closed.
+/// Resolve the per-user runtime directory, delegating to the shared helper
+/// so the CLI, daemon, and Tauri shell agree on the same policy.
+///
+/// We deliberately do not consult `$UID` (an unreliable shell-only variable
+/// that F-044 removed) nor fall back to `/tmp/forge-<uid>` — that fallback
+/// was the defect H8 closed. On macOS (F-339) the shared helper resolves
+/// `$HOME/Library/Application Support/Forge/run` at `0o700`, preserving the
+/// per-user invariant via a platform-native path rather than relaxing it.
 fn xdg_runtime_dir() -> anyhow::Result<PathBuf> {
-    std::env::var("XDG_RUNTIME_DIR")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .ok_or_else(xdg_runtime_dir_missing)
+    forge_core::runtime_dir::runtime_dir()
 }
 
 /// Resolve the Unix socket path for a session, using the same logic as `forged`.
 ///
-/// Returns an error when `XDG_RUNTIME_DIR` is unset. `forged` refuses to
-/// start without it (see `forge_session::socket_path::resolve_socket_path`),
-/// so any CLI resolution without the env var would be pointing at a socket
-/// that can't exist.
+/// Returns an error when no per-user runtime directory can be established
+/// (Linux without `XDG_RUNTIME_DIR`, or macOS with an unreadable `$HOME`).
+/// `forged` refuses to start in the same situations (see
+/// `forge_session::socket_path::resolve_socket_path`), so any CLI resolution
+/// here is pointing at the same socket the daemon would bind.
 pub fn socket_path(session_id: &str) -> anyhow::Result<PathBuf> {
     // Defense-in-depth for F-057 (T12a): the CLI's clap `value_parser`
     // already rejects malformed ids, but any future caller that constructs
@@ -416,11 +405,15 @@ mod tests {
         }
     }
 
-    /// F-044: cover both the success (XDG_RUNTIME_DIR set) and failure
-    /// (unset) branches of every path resolver in a single `#[test]` so
-    /// env-mutation can't race parallel readers in this binary.
+    /// F-044 + F-339: cover the happy path (XDG_RUNTIME_DIR set -> resolves
+    /// under that dir) on every platform, plus the Linux-only failure path
+    /// (XDG unset -> error, no `/tmp` fallback). The macOS F-339 fallback
+    /// has DI-based unit tests in `forge_core::runtime_dir`; we do not
+    /// mutate `$HOME` here to avoid dragging fragile env state into this
+    /// test binary. A single `#[test]` serializes all env mutation so
+    /// parallel tests in this binary can't race it.
     #[test]
-    fn path_resolvers_require_xdg_runtime_dir() {
+    fn path_resolvers_use_xdg_runtime_dir_when_set() {
         let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
         let prev_uid = std::env::var("UID").ok();
 
@@ -446,23 +439,30 @@ mod tests {
         let dir = sessions_socket_dir().expect("should resolve");
         assert_eq!(dir.to_string_lossy(), "/run/user/4242/forge/sessions");
 
-        // --- Failure path: XDG_RUNTIME_DIR unset, no /tmp fallback ---
-        unsafe {
-            std::env::remove_var("XDG_RUNTIME_DIR");
-            std::env::remove_var("UID");
+        // --- Linux failure path: XDG_RUNTIME_DIR unset, no /tmp fallback ---
+        // On macOS the F-339 fallback kicks in and resolves a per-user
+        // 0o700 directory under `$HOME/Library/...`, so the CLI must NOT
+        // error in that case. The shared `forge_core::runtime_dir` module
+        // covers the macOS branch with dedicated DI-based tests.
+        #[cfg(target_os = "linux")]
+        {
+            unsafe {
+                std::env::remove_var("XDG_RUNTIME_DIR");
+                std::env::remove_var("UID");
+            }
+            let err = socket_path("deadbeefcafebabe").expect_err("no xdg -> err");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("XDG_RUNTIME_DIR"),
+                "error must name XDG_RUNTIME_DIR, got: {msg}"
+            );
+            assert!(
+                !msg.contains("/tmp/forge-"),
+                "error must not advertise /tmp fallback, got: {msg}"
+            );
+            assert!(sessions_socket_dir().is_err());
+            assert!(pid_path("abc123def4560000").is_err());
         }
-        let err = socket_path("deadbeefcafebabe").expect_err("no xdg -> err");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("XDG_RUNTIME_DIR"),
-            "error must name XDG_RUNTIME_DIR, got: {msg}"
-        );
-        assert!(
-            !msg.contains("/tmp/forge-"),
-            "error must not advertise /tmp fallback, got: {msg}"
-        );
-        assert!(sessions_socket_dir().is_err());
-        assert!(pid_path("abc123def4560000").is_err());
 
         // Restore
         unsafe {

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -5,6 +5,7 @@ mod event_log;
 pub mod ids;
 pub mod mcp_state;
 pub mod meta;
+pub mod runtime_dir;
 pub mod settings;
 mod tool;
 mod transcript;

--- a/crates/forge-core/src/runtime_dir.rs
+++ b/crates/forge-core/src/runtime_dir.rs
@@ -1,0 +1,337 @@
+//! Per-user runtime directory resolution for the `forged` daemon, CLI, and
+//! Tauri shell.
+//!
+//! # F-044 (H8) invariant, preserved
+//!
+//! Prior to F-044 the various resolvers fell back to `/tmp/forge-{uid}` when
+//! `XDG_RUNTIME_DIR` was unset. The socket under `/tmp` is world-connectable,
+//! so any local user could drive another user's session. F-044 closed that
+//! fallback — the resolvers now refuse to return a path when the runtime dir
+//! cannot be established as a per-user, mode-`0o700` directory.
+//!
+//! # F-339 (macOS fallback)
+//!
+//! Apple's launchd does not export `XDG_RUNTIME_DIR`, so a fresh `cargo run
+//! -p forge-shell` on macOS errored out at startup. Rather than relax the
+//! F-044 invariant, this module resolves a natively-appropriate per-user
+//! directory on macOS: `$HOME/Library/Application Support/Forge/run`. The
+//! directory is created with mode `0o700` when missing; an existing
+//! directory whose mode is not `0o700` is rejected (to catch either a
+//! downgraded-perm state or a shared-dir misconfiguration).
+//!
+//! Linux behavior is unchanged: `XDG_RUNTIME_DIR` must be set (systemd
+//! provides `/run/user/<uid>` automatically), and no `/tmp` fallback is
+//! ever attempted. Windows is not supported yet; see the TODO in
+//! [`runtime_dir_with`].
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+
+/// Resolve the per-user runtime directory used by `forged` and its clients.
+///
+/// Reads `XDG_RUNTIME_DIR` from the environment and `$HOME` via
+/// [`dirs::home_dir`]; delegates the actual policy to [`runtime_dir_with`]
+/// so tests can exercise every branch without mutating process-global env.
+pub fn runtime_dir() -> Result<PathBuf> {
+    let xdg = std::env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let home = dirs::home_dir();
+    runtime_dir_with(xdg.as_deref(), home.as_deref())
+}
+
+/// DI variant of [`runtime_dir`] — takes the env/home values explicitly so
+/// tests can drive the macOS and Linux branches with tempdirs instead of
+/// unsafe env mutation.
+///
+/// Policy:
+///   - If `XDG_RUNTIME_DIR` is set (non-empty), use it. This preserves the
+///     Linux priority ordering on every platform, so operators can still
+///     override the macOS fallback by exporting `XDG_RUNTIME_DIR` explicitly.
+///   - Else, on macOS, return `$HOME/Library/Application Support/Forge/run`,
+///     creating it with mode `0o700` if missing; reject a pre-existing
+///     directory whose mode is not `0o700`.
+///   - Else, on Linux, error with a message naming `XDG_RUNTIME_DIR`.
+///   - Else, on Windows, error (tracked as a follow-up; Windows daemon/CLI
+///     is out of scope for F-339).
+pub fn runtime_dir_with(xdg: Option<&str>, home: Option<&std::path::Path>) -> Result<PathBuf> {
+    if let Some(xdg) = xdg.filter(|s| !s.is_empty()) {
+        return Ok(PathBuf::from(xdg));
+    }
+    platform_fallback(home)
+}
+
+#[cfg(target_os = "macos")]
+fn platform_fallback(home: Option<&std::path::Path>) -> Result<PathBuf> {
+    let home = home.ok_or_else(|| {
+        anyhow!(
+            "XDG_RUNTIME_DIR is unset and $HOME is unavailable; \
+             forge cannot resolve a per-user runtime directory. \
+             Set XDG_RUNTIME_DIR to a 0o700 directory or ensure \
+             $HOME is set. (F-044 / F-339)"
+        )
+    })?;
+    let dir = home.join("Library/Application Support/Forge/run");
+    ensure_macos_runtime_dir(&dir)?;
+    Ok(dir)
+}
+
+#[cfg(target_os = "linux")]
+fn platform_fallback(_home: Option<&std::path::Path>) -> Result<PathBuf> {
+    // F-044 / H8: Linux must never fall back to a shared directory. The
+    // socket there would be world-connectable; any local user could drive
+    // another user's session. systemd provides a per-user 0o700 tmpfs at
+    // `/run/user/<uid>` — any non-systemd deployment must set the env var
+    // explicitly before starting forge.
+    Err(anyhow!(
+        "XDG_RUNTIME_DIR is unset: forge refuses to fall back to a \
+         shared /tmp directory because the socket there would be \
+         world-connectable. Set XDG_RUNTIME_DIR to a per-user 0o700 \
+         directory (systemd sets it to /run/user/<uid> automatically). \
+         (F-044 / H8)"
+    ))
+}
+
+// TODO(F-339 follow-up): Windows daemon/CLI/shell is out of scope for
+// this task. When Windows support lands, pick a per-user directory
+// under `%LOCALAPPDATA%` (or equivalent) and enforce the same
+// single-user ACL invariant as macOS/Linux.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn platform_fallback(_home: Option<&std::path::Path>) -> Result<PathBuf> {
+    Err(anyhow!(
+        "XDG_RUNTIME_DIR is unset and no platform-native fallback is \
+         implemented for this target; set XDG_RUNTIME_DIR explicitly. \
+         (F-044 / F-339)"
+    ))
+}
+
+/// macOS runtime-dir creation + permission enforcement.
+///
+/// The whole F-044 rationale is that the socket's parent must be per-user
+/// (`0o700`). We enforce that on both sides of the creation:
+///   - If the directory is missing, create it (and its parents) with mode
+///     `0o700` via [`std::os::unix::fs::DirBuilderExt::mode`]. This applies
+///     the mode to any intermediate component we create, which is the
+///     conservative choice (`~/Library` and `~/Library/Application Support`
+///     already exist on every macOS install; the only component this
+///     typically creates is the final `Forge/run` leaf).
+///   - If the directory exists, read its mode. Refuse if `mode & 0o777`
+///     isn't exactly `0o700`. We deliberately do not auto-chmod — a
+///     pre-existing relaxed directory may be adversarial (another user's
+///     directory we inherited through a user-switch), and silently
+///     downgrading its perms would hide the problem.
+#[cfg(target_os = "macos")]
+fn ensure_macos_runtime_dir(dir: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+    match std::fs::metadata(dir) {
+        Ok(meta) => {
+            if !meta.is_dir() {
+                return Err(anyhow!(
+                    "{} exists but is not a directory; refusing to use as a \
+                     per-user runtime dir. (F-044 / F-339)",
+                    dir.display()
+                ));
+            }
+            let mode = meta.permissions().mode() & 0o777;
+            if mode != 0o700 {
+                return Err(anyhow!(
+                    "{} exists with mode 0o{:o}; expected 0o700 \
+                     (F-044 per-user runtime invariant). Remove or chmod \
+                     the directory and retry. (F-339)",
+                    dir.display(),
+                    mode
+                ));
+            }
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(dir)
+                .map_err(|e| {
+                    anyhow!(
+                        "failed to create per-user runtime dir {} \
+                         with mode 0o700: {e} (F-339)",
+                        dir.display()
+                    )
+                })?;
+            Ok(())
+        }
+        Err(e) => Err(anyhow!(
+            "failed to stat runtime dir {}: {e} (F-339)",
+            dir.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xdg_set_wins_on_all_platforms() {
+        // Priority: XDG_RUNTIME_DIR always beats the platform fallback,
+        // so Linux operators' existing muscle memory (and ops playbooks)
+        // keep working on macOS too.
+        let got = runtime_dir_with(
+            Some("/run/user/4242"),
+            Some(std::path::Path::new("/home/x")),
+        )
+        .expect("xdg set -> Ok");
+        assert_eq!(got, PathBuf::from("/run/user/4242"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn empty_xdg_is_treated_as_unset_on_linux() {
+        // Empty XDG_RUNTIME_DIR must fall through to the same branch as
+        // unset — matches the filter in `runtime_dir()`. Linux: error.
+        let home = std::path::Path::new("/home/x");
+        let result = runtime_dir_with(Some(""), Some(home));
+        assert!(result.is_err(), "empty xdg on Linux -> err");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn empty_xdg_is_treated_as_unset_on_macos() {
+        // Empty XDG_RUNTIME_DIR must fall through to the same branch as
+        // unset — matches the filter in `runtime_dir()`. macOS with a
+        // tempdir HOME: drives the fallback successfully.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let got = runtime_dir_with(Some(""), Some(tmp.path())).expect("empty xdg -> fallback");
+        assert!(got.ends_with("Library/Application Support/Forge/run"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_errors_when_xdg_unset_regardless_of_home() {
+        // F-044 regression guard: Linux must never resolve without
+        // XDG_RUNTIME_DIR. The macOS fallback is cfg-gated out.
+        let err = runtime_dir_with(None, Some(std::path::Path::new("/home/x")))
+            .expect_err("linux + no xdg -> err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("XDG_RUNTIME_DIR"),
+            "error must name XDG_RUNTIME_DIR so operators see the fix, got: {msg}"
+        );
+        assert!(
+            !msg.contains("/tmp/forge-"),
+            "error must not advertise an actual /tmp/forge- resolved path, \
+             got: {msg}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_creates_runtime_dir_with_mode_700_when_missing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Simulate $HOME under tempdir so we can inspect what the helper
+        // creates without touching the real user profile.
+        let got = runtime_dir_with(None, Some(tmp.path())).expect("macos fallback -> Ok");
+        let expected = tmp.path().join("Library/Application Support/Forge/run");
+        assert_eq!(got, expected);
+        assert!(expected.is_dir(), "helper must create the dir");
+        let mode = std::fs::metadata(&expected)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "leaf dir must be 0o700 per F-044 invariant, got 0o{mode:o}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_accepts_preexisting_0700_dir() {
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let expected = tmp.path().join("Library/Application Support/Forge/run");
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&expected)
+            .expect("pre-create 0o700");
+
+        let got = runtime_dir_with(None, Some(tmp.path())).expect("preexisting 0o700 -> Ok");
+        assert_eq!(got, expected);
+        let mode = std::fs::metadata(&expected)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_rejects_preexisting_dir_with_loose_perms() {
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let expected = tmp.path().join("Library/Application Support/Forge/run");
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o755)
+            .create(&expected)
+            .expect("pre-create 0o755");
+
+        let err = runtime_dir_with(None, Some(tmp.path())).expect_err("loose perms -> err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("0o755"),
+            "error must name the observed mode, got: {msg}"
+        );
+        assert!(
+            msg.contains("0o700"),
+            "error must name the required mode, got: {msg}"
+        );
+        // The helper must not auto-chmod — the existing relaxed state
+        // could be adversarial and silently repairing it would hide the
+        // problem.
+        let mode = std::fs::metadata(&expected)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o755, "helper must not silently chmod");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_honors_xdg_when_set() {
+        // When XDG_RUNTIME_DIR IS set on macOS, we MUST use it verbatim —
+        // not the Library fallback — so the priority ordering matches
+        // Linux. An operator who exports XDG_RUNTIME_DIR on macOS (e.g.
+        // for testing / custom sandboxes) deserves the same contract.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let got = runtime_dir_with(Some("/run/user/4242"), Some(tmp.path()))
+            .expect("xdg set on macos -> Ok");
+        assert_eq!(got, PathBuf::from("/run/user/4242"));
+        // And the fallback dir must NOT have been created as a side effect.
+        assert!(
+            !tmp.path().join("Library").exists(),
+            "XDG-set path must not create the macOS fallback tree"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_errors_when_home_missing() {
+        // $HOME unavailable is a hard error on macOS when XDG is also unset
+        // — we cannot invent a per-user directory out of thin air.
+        let err = runtime_dir_with(None, None).expect_err("no xdg + no home -> err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("HOME") || msg.contains("home"),
+            "error must mention $HOME, got: {msg}"
+        );
+    }
+}

--- a/crates/forge-session/README.md
+++ b/crates/forge-session/README.md
@@ -1,6 +1,6 @@
 # forge-session
 
-The session daemon — `forged` — and its supporting library. A long-running per-session process that owns the append-only event log, hosts the agent orchestrator and tool dispatcher, accepts client connections over a Unix domain socket under `$XDG_RUNTIME_DIR/forge/sessions/<id>.sock`, and on shutdown either archives or purges the session directory based on the `SessionPersistence` mode. The library half (`forge_session`) exposes the building blocks used by integration tests and the `forge` CLI; the binary half (`forged`) wires them together.
+The session daemon — `forged` — and its supporting library. A long-running per-session process that owns the append-only event log, hosts the agent orchestrator and tool dispatcher, accepts client connections over a Unix domain socket under the per-user runtime directory (`$XDG_RUNTIME_DIR/forge/sessions/<id>.sock` on Linux; `$HOME/Library/Application Support/Forge/run/forge/sessions/<id>.sock` on macOS when `XDG_RUNTIME_DIR` is unset — see `forge_core::runtime_dir`), and on shutdown either archives or purges the session directory based on the `SessionPersistence` mode. The library half (`forge_session`) exposes the building blocks used by integration tests and the `forge` CLI; the binary half (`forged`) wires them together.
 
 ## Role in the workspace
 
@@ -15,7 +15,7 @@ The session daemon — `forged` — and its supporting library. A long-running p
 - `orchestrator` — drives provider chat turns and dispatches tool calls.
 - `tools/` — built-in tool implementations (fs, shell, etc.) wired through `forge-fs` for write paths.
 - `archive::archive_or_purge` — end-of-life handling: rename into `.forge/sessions/archived/<id>/` or remove the session directory.
-- `socket_path` — resolves the session UDS path with the `XDG_RUNTIME_DIR` / `FORGE_SOCKET_PATH` policy.
+- `socket_path` — resolves the session UDS path via `forge_core::runtime_dir` (`XDG_RUNTIME_DIR` on Linux, or the macOS per-user `~/Library/Application Support/Forge/run` fallback at mode `0o700`) or the `FORGE_SOCKET_PATH` override.
 - `pid_file` — daemon liveness file with stale-pid detection.
 - `sandbox` — `pre_exec` hooks that cap NPROC/NOFILE/FSIZE for spawned children.
 - `byte_budget` — per-session aggregate byte budget used to bound output growth.

--- a/crates/forge-session/src/socket_path.rs
+++ b/crates/forge-session/src/socket_path.rs
@@ -11,39 +11,40 @@
 //! world-accessible `/tmp/forge-0/forge/sessions/` directory.
 //!
 //! The remediation (option 4 of the H8 finding) is to refuse to resolve a
-//! path at all when `XDG_RUNTIME_DIR` is unset. `forged` will fail to start
-//! with a clear error naming the missing env var. On Linux with systemd
-//! `XDG_RUNTIME_DIR` is always set to a per-user `0o700` tmpfs mount, so the
-//! only production path is through `$XDG_RUNTIME_DIR/forge/sessions/<id>.sock`;
-//! anything else is a misconfiguration that we surface loudly rather than
-//! mask with a shared-tmp fallback.
+//! path at all when a per-user runtime directory cannot be established.
+//! `forged` will fail to start with a clear error naming the fix. On Linux
+//! with systemd `XDG_RUNTIME_DIR` is always set to a per-user `0o700` tmpfs
+//! mount; anything else is a misconfiguration that we surface loudly rather
+//! than mask with a shared-tmp fallback.
+//!
+//! # F-339: macOS fallback
+//!
+//! launchd does not export `XDG_RUNTIME_DIR`, so out-of-the-box `cargo run
+//! -p forge-shell` on macOS used to error out at startup. The shared helper
+//! in [`forge_core::runtime_dir`] now resolves
+//! `$HOME/Library/Application Support/Forge/run` on macOS when
+//! `XDG_RUNTIME_DIR` is unset — creating it with mode `0o700` and rejecting
+//! any pre-existing directory with looser perms. The F-044 invariant
+//! (per-user `0o700`) is preserved, just via a natively-appropriate path.
 //!
 //! See `server.rs` for the post-bind `chmod` defense-in-depth that runs
 //! irrespective of this resolver's input.
 
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
-/// Resolve the UDS socket path for a session under `$XDG_RUNTIME_DIR`.
+/// Resolve the UDS socket path for a session under the per-user runtime dir.
 ///
-/// Returns `Err` when `XDG_RUNTIME_DIR` is unset or empty. The error message
-/// names the missing env var so operators reading `forged`'s stderr know the
-/// fix. No `/tmp` fallback is attempted.
+/// Delegates the runtime-dir policy to [`forge_core::runtime_dir::runtime_dir`]
+/// so `forged`, the CLI, and the Tauri shell all agree on the same rules:
+///   - honor `XDG_RUNTIME_DIR` when set (Linux priority preserved);
+///   - on macOS, fall back to `$HOME/Library/Application Support/Forge/run`
+///     with `0o700` enforcement (F-339);
+///   - on Linux with `XDG_RUNTIME_DIR` unset, error rather than fall back
+///     to a shared `/tmp` directory (F-044 / H8).
 pub fn resolve_socket_path(session_id: &str) -> Result<PathBuf> {
-    let base = std::env::var("XDG_RUNTIME_DIR")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            anyhow!(
-                "forged refuses to start: XDG_RUNTIME_DIR is unset. \
-                 This env var must point to a per-user 0o700 directory \
-                 (systemd sets it to /run/user/<uid> automatically). \
-                 Set it explicitly or use FORGE_SOCKET_PATH to override \
-                 the socket location. (F-044 / H8)"
-            )
-        })?;
-    Ok(PathBuf::from(base)
+    Ok(forge_core::runtime_dir::runtime_dir()?
         .join("forge/sessions")
         .join(format!("{session_id}.sock")))
 }

--- a/crates/forge-session/tests/socket_path_fallback.rs
+++ b/crates/forge-session/tests/socket_path_fallback.rs
@@ -1,4 +1,7 @@
-//! F-044 (H8) regression: `resolve_socket_path` rejects the `/tmp` fallback.
+//! F-044 (H8) + F-339 regression: `resolve_socket_path` refuses the
+//! world-connectable `/tmp` fallback, but does fall back to a per-user
+//! `0o700` directory under `~/Library/...` on macOS when
+//! `XDG_RUNTIME_DIR` is unset.
 //!
 //! Before F-044, `resolve_socket_path` fell back to `/tmp/forge-{uid}` when
 //! `XDG_RUNTIME_DIR` was unset, and read the UID from `std::env::var("UID")`
@@ -6,14 +9,23 @@
 //! fallback of `"0"`. The result: multiple local users all binding under
 //! `/tmp/forge-0/forge/sessions/`, world-connectable.
 //!
-//! Remediation (option 4 from H8): require `XDG_RUNTIME_DIR` and refuse to
-//! start otherwise. Tests cover:
-//!   - success when XDG_RUNTIME_DIR is set
-//!   - error when XDG_RUNTIME_DIR is unset (no silent /tmp fallback)
+//! F-044 remediation (option 4 from H8): require a per-user runtime dir and
+//! refuse to start otherwise.
+//!
+//! F-339 refinement: on macOS (where launchd does not export
+//! `XDG_RUNTIME_DIR`), fall back to `$HOME/Library/Application Support/
+//! Forge/run` at `0o700` — the F-044 invariant is preserved, just via a
+//! platform-native path.
+//!
+//! Tests cover:
+//!   - success when XDG_RUNTIME_DIR is set (all platforms)
+//!   - Linux-only error when XDG_RUNTIME_DIR is unset (no silent /tmp fallback)
 //!   - the error message names `XDG_RUNTIME_DIR` so operators see the fix
 //!
 //! Both cases run in a single `#[test]` so env mutation can't race another
-//! parallel reader in this same test binary.
+//! parallel reader in this same test binary. The macOS fallback branch has
+//! dedicated DI-based tests in `forge_core::runtime_dir` — we do not
+//! mutate `$HOME` here to avoid dragging fragile env state into this file.
 
 use forge_session::socket_path::resolve_socket_path;
 
@@ -34,23 +46,30 @@ fn resolve_socket_path_requires_xdg_runtime_dir() {
         "/run/user/1234/forge/sessions/abc123.sock"
     );
 
-    // --- Case 2: XDG_RUNTIME_DIR unset (and UID unset too) -> Err ---
-    // Clear UID so no caller can smuggle a uid through the old fallback.
-    unsafe {
-        std::env::remove_var("XDG_RUNTIME_DIR");
-        std::env::remove_var("UID");
+    // --- Case 2 (Linux-only): XDG_RUNTIME_DIR unset -> Err ---
+    // On macOS the F-339 fallback path kicks in and uses $HOME/Library/...
+    // at 0o700; the dedicated unit tests in `forge_core::runtime_dir`
+    // cover that branch with tempdir-injected HOME so this binary does
+    // not need to mutate $HOME at all.
+    #[cfg(target_os = "linux")]
+    {
+        // Clear UID too so no caller can smuggle a uid through the old fallback.
+        unsafe {
+            std::env::remove_var("XDG_RUNTIME_DIR");
+            std::env::remove_var("UID");
+        }
+        let err = resolve_socket_path("abc123").expect_err("must refuse without XDG_RUNTIME_DIR");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("XDG_RUNTIME_DIR"),
+            "error must name XDG_RUNTIME_DIR so operators see the fix, got: {msg}"
+        );
+        // Defense-in-depth: never silently resolve to /tmp/forge-<uid>.
+        assert!(
+            !msg.contains("/tmp/forge-"),
+            "error must not advertise an actual /tmp/forge- path, got: {msg}"
+        );
     }
-    let err = resolve_socket_path("abc123").expect_err("must refuse without XDG_RUNTIME_DIR");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("XDG_RUNTIME_DIR"),
-        "error must name XDG_RUNTIME_DIR so operators see the fix, got: {msg}"
-    );
-    // Defense-in-depth: never silently resolve to /tmp.
-    assert!(
-        !msg.contains("/tmp"),
-        "error must not advertise a /tmp fallback, got: {msg}"
-    );
 
     // Restore
     unsafe {

--- a/crates/forge-shell/src/bridge.rs
+++ b/crates/forge-shell/src/bridge.rs
@@ -162,26 +162,18 @@ impl SessionConnections {
 /// rules as `forge-session::socket_path::resolve_socket_path`. Exposed so
 /// the Tauri command layer and tests agree on the convention.
 ///
-/// Returns `Err` when `XDG_RUNTIME_DIR` is unset. F-044 (H8) closed the
-/// pre-existing `/tmp/forge-<uid>` fallback; `forged` itself refuses to
-/// start without `XDG_RUNTIME_DIR`, so a shell that silently resolved to
-/// `/tmp/...` would only ever hit `ENOENT`. Surfacing the missing env var
-/// here gives the operator a clearer error than "no such file".
+/// Returns `Err` when no per-user runtime directory can be established:
+///   - Linux without `XDG_RUNTIME_DIR`: errors (F-044 / H8 — no `/tmp`
+///     fallback, socket there would be world-connectable).
+///   - macOS without `XDG_RUNTIME_DIR`: falls back to
+///     `$HOME/Library/Application Support/Forge/run` at `0o700` (F-339).
+///     The per-user `0o700` invariant is preserved, just via a natively-
+///     appropriate path rather than relaxed into a shared directory.
+///
+/// Delegates the runtime-dir policy to [`forge_core::runtime_dir::runtime_dir`]
+/// so every callsite (daemon, CLI, shell) agrees on the same rules.
 pub fn default_socket_path(session_id: &str) -> Result<PathBuf> {
-    let base = std::env::var("XDG_RUNTIME_DIR")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .ok_or_else(|| {
-            anyhow!(
-                "XDG_RUNTIME_DIR is unset: forge-shell refuses to fall \
-                 back to /tmp because the socket there would be \
-                 world-connectable. Set XDG_RUNTIME_DIR to a per-user \
-                 0o700 directory (systemd sets /run/user/<uid> \
-                 automatically). (F-044 / H8)"
-            )
-        })?;
-    Ok(base
+    Ok(forge_core::runtime_dir::runtime_dir()?
         .join("forge/sessions")
         .join(format!("{session_id}.sock")))
 }


### PR DESCRIPTION
## Summary

Adds `forge_core::runtime_dir` — a shared per-user runtime-directory resolver used by `forged`, the CLI, and the Tauri shell. On macOS (where launchd does not export `XDG_RUNTIME_DIR`) it falls back to `\$HOME/Library/Application Support/Forge/run`, created at mode `0o700` and refused if it already exists with looser perms. Linux behavior is unchanged — `XDG_RUNTIME_DIR` still required, no `/tmp` fallback — so the F-044/H8 per-user invariant is preserved, just via a natively-appropriate path on macOS.

Closes #339.

## Design

- **Centralized** the policy in `forge-core` (the only crate all three call sites already depend on); pulling the helper into `forge-session` would have forced `forge-cli` to take on `forge-session`'s heavy dep tree (tokio multi-thread, forge-agents, forge-mcp, …). `forge-core` already has `dirs` as a dep, so no new deps in the workspace.
- **DI-friendly API.** `runtime_dir()` is the thin production wrapper; `runtime_dir_with(xdg, home)` takes the env/home values explicitly so the macOS branch (mkdir 0o700, permission enforcement, pre-existing-dir check) is testable with tempdir-injected HOME — no fragile `unsafe { set_var }` env mutation.
- **Platform split via `cfg`.** `platform_fallback` has a separate body per target OS; Linux still refuses, macOS falls back to `~/Library/Application Support/Forge/run` at `0o700`, Windows emits a hard error with a TODO pointing to the future `%LOCALAPPDATA%` implementation.
- **0o700 enforcement, no auto-chmod.** If the directory already exists with the wrong mode we error out instead of silently downgrading — per the F-044 rationale, a relaxed state could be adversarial (e.g. a dir inherited from another user), so papering over it would hide the problem.

## DoD mapping

- [x] macOS fallback when `XDG_RUNTIME_DIR` unset → `$HOME/Library/Application Support/Forge/run`, mkdir 0o700 — `macos_creates_runtime_dir_with_mode_700_when_missing`
- [x] macOS honors `XDG_RUNTIME_DIR` when set (priority preserved) — `macos_honors_xdg_when_set`
- [x] 0o700 enforced on pre-existing directory — `macos_rejects_preexisting_dir_with_loose_perms` (and asserts no auto-chmod)
- [x] Linux behavior unchanged — `linux_errors_when_xdg_unset_regardless_of_home` + integration test `resolve_socket_path_requires_xdg_runtime_dir`
- [x] Windows — `TODO` + cfg-gated error in `platform_fallback`
- [x] Comments updated in `forge_cli::socket` and `forge_shell::bridge` to reflect the macOS fallback
- [x] README updated (`crates/forge-session/README.md`) so docs don't contradict the new fallback
- [x] `just check-rust` clean (fmt, check, clippy `-D warnings`, rustdoc `-D warnings`)
- [x] `just test-rust` passes all relevant suites (1 unrelated `forge-mcp` HTTP SSE flake observed on first run, passed on rerun — existing issue, not introduced here)
- [x] macOS CI will cover the macOS-only `#[cfg(target_os = "macos")]` tests (cannot run locally on Linux host)

## Test plan

- [ ] CI green on both Linux and macOS runners (macOS especially — all `macos_*` unit tests in `forge_core::runtime_dir` gate F-339 coverage)
- [ ] Manual smoke: on macOS, `cargo run -p forge-shell` should no longer require `export XDG_RUNTIME_DIR=...` before starting

🤖 Generated with [Claude Code](https://claude.com/claude-code)