### PR TITLE
[F-427] StatusBar.css canonical tokens, drop --fg-* namespace

### DIFF
--- a/web/packages/app/src/shell/StatusBar.css
+++ b/web/packages/app/src/shell/StatusBar.css
@@ -4,19 +4,25 @@
  * Thin strip, neutral chrome; the `BgAgentsBadge` is the only interactive
  * element today — room reserved for workspace/provider/cost pills in
  * follow-ups.
+ *
+ * All colors, spacing, radii, and typography resolve to canonical tokens
+ * declared in `web/packages/design/src/tokens.css` and mirrored in
+ * `docs/design/token-reference.md`. Do not introduce new namespaces or
+ * raw-hex fallbacks — see `docs/design/color-system.md` for the rules and
+ * `StatusBar.css.test.ts` for the regression guard (F-427).
  */
 
 .status-bar {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: var(--fg-space-2, 8px);
+  gap: var(--sp-2);
   padding: 2px 8px;
   min-height: 22px;
   font-size: 12px;
-  background: var(--fg-surface-1, #1e1e1e);
-  border-top: 1px solid var(--fg-border-subtle, rgba(255, 255, 255, 0.06));
-  color: var(--fg-fg-muted, #cfcfcf);
+  background: var(--color-surface-1);
+  border-top: 1px solid var(--color-border-1);
+  color: var(--color-text-secondary);
   position: relative;
   flex-shrink: 0;
 }
@@ -29,19 +35,19 @@
   padding: 0 8px;
   height: 18px;
   border-radius: 10px;
-  background: var(--fg-accent-bg, rgba(255, 140, 0, 0.18));
-  color: var(--fg-accent-fg, #ff9a33);
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
   font-weight: 600;
   cursor: pointer;
   transition: background 120ms ease;
 }
 
 .status-bar__bg-badge:hover {
-  background: var(--fg-accent-bg-strong, rgba(255, 140, 0, 0.32));
+  background: var(--color-warning-border);
 }
 
 .status-bar__bg-badge:focus-visible {
-  outline: 2px solid var(--fg-focus, #4a9eff);
+  outline: 2px solid var(--color-info);
   outline-offset: 2px;
 }
 
@@ -60,8 +66,8 @@
   bottom: calc(100% + 4px);
   min-width: 280px;
   padding: 4px;
-  background: var(--fg-surface-2, #262626);
-  border: 1px solid var(--fg-border, rgba(255, 255, 255, 0.12));
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-2);
   border-radius: 6px;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
   z-index: 40;
@@ -77,21 +83,21 @@
 }
 
 .status-bar__bg-row:hover {
-  background: var(--fg-surface-3, rgba(255, 255, 255, 0.04));
+  background: var(--color-surface-3);
 }
 
 .status-bar__bg-row-name {
   flex: 1;
-  color: var(--fg-fg, #eaeaea);
+  color: var(--color-text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .status-bar__bg-row-id {
-  font-family: var(--fg-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--fg-fg-muted, #9a9a9a);
+  color: var(--color-text-secondary);
 }
 
 .status-bar__bg-row-action {
@@ -103,20 +109,20 @@
   border-radius: 4px;
   cursor: pointer;
   font-size: 11px;
-  background: var(--fg-button-bg, rgba(255, 255, 255, 0.06));
-  color: var(--fg-fg, #eaeaea);
+  background: var(--color-surface-3);
+  color: var(--color-text-primary);
   transition: background 120ms ease;
 }
 
 .status-bar__bg-row-action:hover {
-  background: var(--fg-button-bg-strong, rgba(255, 255, 255, 0.12));
+  background: var(--color-border-2);
 }
 
 .status-bar__bg-row-action:focus-visible {
-  outline: 2px solid var(--fg-focus, #4a9eff);
+  outline: 2px solid var(--color-info);
   outline-offset: 2px;
 }
 
 .status-bar__bg-row-action--stop {
-  color: var(--fg-danger-fg, #ff6b6b);
+  color: var(--color-error);
 }

--- a/web/packages/app/src/shell/StatusBar.css.test.ts
+++ b/web/packages/app/src/shell/StatusBar.css.test.ts
@@ -1,0 +1,63 @@
+// F-427 drift guard for StatusBar.css.
+//
+// The file previously referenced a `--fg-*` token namespace that was never
+// declared in `web/packages/design/src/tokens.css` or
+// `docs/design/token-reference.md`, with raw-hex fallbacks bypassing the
+// token enforcement invariant documented in `docs/design/color-system.md`.
+// These tests fail fast if either regression returns — any custom property
+// used in the file must belong to the canonical `--color-*` / `--sp-*` /
+// `--r-*` / `--font-*` / `--ease` namespace, and no raw color fallbacks
+// may be supplied to `var(...)`.
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const cssPath = resolve(__dirname, 'StatusBar.css');
+const source = readFileSync(cssPath, 'utf-8');
+
+const CANONICAL_PREFIXES = ['--color-', '--sp-', '--r-', '--font-', '--ease'];
+
+interface VarCall {
+  name: string;
+  fallback: string | null;
+  raw: string;
+}
+
+/**
+ * Extract every `var(--name[, fallback])` call from the CSS source.
+ * Handles nested `var(..., var(...))` by walking parentheses.
+ */
+function collectVarCalls(src: string): VarCall[] {
+  const calls: VarCall[] = [];
+  const re = /var\(\s*(--[a-zA-Z0-9_-]+)\s*(,([^)]|\([^)]*\))*)?\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) {
+    const name = m[1] ?? '';
+    const fallback = m[2] ? m[2].replace(/^,\s*/, '').trim() : null;
+    calls.push({ name, fallback, raw: m[0] });
+  }
+  return calls;
+}
+
+describe('StatusBar.css token hygiene (F-427)', () => {
+  const calls = collectVarCalls(source);
+
+  it('references at least one custom property (sanity check)', () => {
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it('uses only canonical design tokens — no --fg-* or other ad-hoc namespaces', () => {
+    const offenders = calls
+      .filter(({ name }) => !CANONICAL_PREFIXES.some((p) => name.startsWith(p)))
+      .map(({ raw }) => raw);
+    expect(offenders).toEqual([]);
+  });
+
+  it('does not supply raw-hex or rgb/rgba fallbacks to var()', () => {
+    const rawValue = /^(#[0-9a-fA-F]{3,8}|rgba?\()/;
+    const offenders = calls
+      .filter(({ fallback }) => fallback !== null && rawValue.test(fallback!))
+      .map(({ raw }) => raw);
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes forge-ide/forge#428

## Summary
- Replace 19 `--fg-*` references in `web/packages/app/src/shell/StatusBar.css` with canonical `--color-*` / `--sp-*` / `--font-*` tokens (declared in `web/packages/design/src/tokens.css` and mirrored in `docs/design/token-reference.md`).
- Drop every raw-hex / rgba fallback from `var(...)` calls — they bypassed the token-enforcement invariant documented in `docs/design/color-system.md`.
- Add `web/packages/app/src/shell/StatusBar.css.test.ts` as a co-located drift guard: fails if any non-canonical custom property or raw-color fallback is reintroduced in this file.

Token mapping (semantic, not mechanical):
- surface/border/text → `--color-surface-1..3`, `--color-border-1..2`, `--color-text-primary/secondary`
- running-agent pill accent (amber) → `--color-warning-bg` / `--color-warning` / `--color-warning-border`
- focus ring (blue) → `--color-info` (the canonical Steel accent)
- stop-action text → `--color-error`
- row action bg → `--color-surface-3` (normal) / `--color-border-2` (hover), one step elevated from the popover surface
- mono id → `--font-mono`; spacing → `--sp-2`

## Test plan
- `node scripts/check-tokens.mjs` — passes (57 tokens match reference)
- `pnpm --filter app test` — 707/707 passing (includes 3 new hygiene tests + 19 existing StatusBar behavior tests)
- `pnpm --filter app typecheck` — clean
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` — all green (change is CSS/TS only; Rust gates run for parity with the skill)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Follow-up (noted in DoD, not done here): extend `scripts/check-tokens.mjs` to grep *consumer* files for unknown `var(--...)` references. That's a broader CI-gate enhancement covering all component CSS, not just this file — best as its own task.

Generated with [Claude Code](https://claude.com/claude-code)