### PR TITLE
[F-391] Composer Stop button unwired and Send button missing

### DIFF
--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -289,6 +289,23 @@ pub async fn session_send_message<R: Runtime>(
         .map_err(|e| e.to_string())
 }
 
+/// F-391: cancel the in-flight turn for this session.
+///
+/// Fired by the Composer's Stop button and Esc handler. The authz check is
+/// the primary contract today: only the session's own window may cancel it.
+/// A server-side transport for the actual cancel is a separate follow-up
+/// (no `IpcMessage::CancelTurn` exists yet); the frontend optimistically
+/// clears its streaming lock so the composer becomes interactive regardless.
+#[tauri::command]
+pub async fn session_cancel<R: Runtime>(
+    session_id: String,
+    webview: Webview<R>,
+    _state: State<'_, BridgeState>,
+) -> Result<(), String> {
+    require_window_label(&webview, &format!("session-{session_id}"))?;
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn session_approve_tool<R: Runtime>(
     session_id: String,
@@ -389,6 +406,8 @@ pub fn build_invoke_handler<R: Runtime>() -> Box<dyn Fn(tauri::ipc::Invoke<R>) -
         session_hello,
         session_subscribe,
         session_send_message,
+        // F-391: Composer Stop / Esc cancel target.
+        session_cancel,
         session_approve_tool,
         session_reject_tool,
         rerun_message,

--- a/crates/forge-shell/tests/ipc_commands.rs
+++ b/crates/forge-shell/tests/ipc_commands.rs
@@ -468,3 +468,47 @@ fn session_approve_tool_accepts_valid_scope_variants() {
         );
     }
 }
+
+// F-391: `session_cancel` is the Tauri command wired to the Composer's Stop
+// button and Esc handler. The daemon-side cancel transport is a separate
+// follow-up — this task establishes the command surface and its window-
+// ownership check so the frontend has a stable target to invoke.
+
+#[test]
+fn session_cancel_is_registered_and_succeeds_for_the_owning_window() {
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    let window = make_session_window(&app, "cancel-ok");
+
+    let res = tauri::test::get_ipc_response(
+        &window,
+        tauri::webview::InvokeRequest {
+            cmd: "session_cancel".into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(serde_json::json!({ "sessionId": "cancel-ok" })),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+    res.expect("session_cancel must succeed for the matching window label");
+}
+
+#[test]
+fn session_cancel_rejects_cross_window_callers() {
+    let app = make_app();
+    app.manage(BridgeState::new(SessionConnections::new()));
+    // Window labelled for *another* session — the authz check must block it.
+    let window = make_session_window(&app, "owned-by-a");
+
+    let err = invoke_err(
+        &window,
+        "session_cancel",
+        serde_json::json!({ "sessionId": "victim-b" }),
+    );
+    assert!(
+        err.contains("window label mismatch"),
+        "cross-window session_cancel must be rejected, got: {err}"
+    );
+}

--- a/web/packages/app/src/routes/Session/ChatPane.css
+++ b/web/packages/app/src/routes/Session/ChatPane.css
@@ -339,9 +339,38 @@
   color: var(--color-ember-400);
 }
 
-.composer__send-hint {
-  font-family: var(--font-mono);
-  font-size: 10px;
+/* F-391: ember-filled primary used by Stop (streaming) and Send (idle).
+   Shares sizing with `.composer__btn` so width stays stable across the
+   stream→idle flip. */
+.composer__btn--primary {
+  background: var(--color-ember-400);
+  border: 1px solid var(--color-ember-400);
+  color: var(--color-text-primary);
   letter-spacing: 0.08em;
-  color: var(--color-text-tertiary);
+}
+
+.composer__btn--primary:hover {
+  background: var(--color-ember-300);
+  border-color: var(--color-ember-300);
+}
+
+.composer__btn--primary:active {
+  background: var(--color-ember-500);
+  border-color: var(--color-ember-500);
+  transform: translateY(1px);
+}
+
+/* `component-principles.md` — Buttons: disabled uses iron-600 surface with
+   disabled text; never drop opacity. Applies to the composer's Send while
+   streaming. */
+.composer__btn--primary:disabled {
+  background: var(--color-iron-600);
+  border-color: var(--color-iron-600);
+  color: var(--color-text-disabled);
+  cursor: not-allowed;
+}
+
+.composer__btn-kbd {
+  margin-left: var(--sp-1);
+  opacity: 0.7;
 }

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -1403,3 +1403,209 @@ describe('ChatPane — branch variants (F-145)', () => {
     expect(queryByText('variant one')).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// F-391: Composer Stop + Send buttons
+// ---------------------------------------------------------------------------
+//
+// chat-pane.md §4.1 bottom bar: `[Stop] [Send ⌘↵]`
+// - Stop is visible only while streaming, flips to primary/ember.
+// - Esc while streaming cancels (same as Stop click).
+// - Send is a real primary/ember button, UPPERCASE label, disabled while
+//   streaming, wired to the same handler as bare-Enter.
+describe('Composer Stop button (F-391)', () => {
+  it('Stop button is not rendered when not streaming', () => {
+    setAwaitingResponse(SID, false);
+    const { queryByTestId } = render(() => <ChatPane />);
+    expect(queryByTestId('composer-stop-btn')).not.toBeInTheDocument();
+  });
+
+  it('Stop button is rendered while streaming', () => {
+    setAwaitingResponse(SID, true);
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('composer-stop-btn')).toBeInTheDocument();
+  });
+
+  it('Stop button uses primary (ember) class while streaming', () => {
+    setAwaitingResponse(SID, true);
+    const { getByTestId } = render(() => <ChatPane />);
+    const stop = getByTestId('composer-stop-btn');
+    expect(stop.className).toContain('composer__btn--primary');
+  });
+
+  it('clicking Stop invokes session_cancel with the active sessionId', () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+    setAwaitingResponse(SID, true);
+    const { getByTestId } = render(() => <ChatPane />);
+
+    fireEvent.click(getByTestId('composer-stop-btn'));
+
+    const cancelCalls = invokeMock.mock.calls.filter(
+      (c) => c[0] === 'session_cancel',
+    );
+    expect(cancelCalls).toHaveLength(1);
+    expect(cancelCalls[0]?.[1]).toEqual({ sessionId: SID });
+  });
+
+  it('clicking Stop locally re-enables the composer (clears awaiting + streaming)', () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+    // Simulate a mid-stream state: awaitingResponse has flipped false but
+    // a streamingMessageId is still set.
+    pushEvent(SID, { kind: 'AssistantDelta', delta: 'partial', message_id: 'streaming-1' });
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+    expect(textarea).toBeDisabled();
+
+    fireEvent.click(getByTestId('composer-stop-btn'));
+
+    expect(textarea).not.toBeDisabled();
+  });
+
+  it('Esc on textarea while streaming fires session_cancel', () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+    setAwaitingResponse(SID, true);
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+
+    const cancelCalls = invokeMock.mock.calls.filter(
+      (c) => c[0] === 'session_cancel',
+    );
+    expect(cancelCalls).toHaveLength(1);
+    expect(cancelCalls[0]?.[1]).toEqual({ sessionId: SID });
+  });
+
+  it('Esc on textarea when not streaming does not fire session_cancel', () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+    setAwaitingResponse(SID, false);
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+
+    const cancelCalls = invokeMock.mock.calls.filter(
+      (c) => c[0] === 'session_cancel',
+    );
+    expect(cancelCalls).toHaveLength(0);
+  });
+
+  it('surfaces an error turn when session_cancel rejects', async () => {
+    invokeMock.mockReset();
+    invokeMock.mockRejectedValueOnce(new Error('cancel boom'));
+    setAwaitingResponse(SID, true);
+    const { getByTestId, findByText } = render(() => <ChatPane />);
+
+    fireEvent.click(getByTestId('composer-stop-btn'));
+
+    await flushMicrotasks();
+    expect(await findByText(/cancel boom/)).toBeInTheDocument();
+  });
+});
+
+describe('Composer Send button (F-391)', () => {
+  it('renders a Send button at all times', () => {
+    setAwaitingResponse(SID, false);
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('composer-send-btn')).toBeInTheDocument();
+  });
+
+  it('Send button label is UPPERCASE SEND', () => {
+    setAwaitingResponse(SID, false);
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('composer-send-btn').textContent).toContain('SEND');
+  });
+
+  it('Send button uses primary (ember) class', () => {
+    setAwaitingResponse(SID, false);
+    const { getByTestId } = render(() => <ChatPane />);
+    const send = getByTestId('composer-send-btn');
+    expect(send.className).toContain('composer__btn--primary');
+  });
+
+  it('Send button is disabled while streaming', () => {
+    setAwaitingResponse(SID, true);
+    const { getByTestId } = render(() => <ChatPane />);
+    const send = getByTestId('composer-send-btn') as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
+  });
+
+  it('Send button is enabled when idle', () => {
+    setAwaitingResponse(SID, false);
+    const { getByTestId } = render(() => <ChatPane />);
+    const send = getByTestId('composer-send-btn') as HTMLButtonElement;
+    expect(send.disabled).toBe(false);
+  });
+
+  it('clicking Send invokes session_send_message with the trimmed text', () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.input(textarea, { target: { value: 'click send' } });
+    fireEvent.click(getByTestId('composer-send-btn'));
+
+    expect(invokeMock).toHaveBeenCalledWith('session_send_message', {
+      sessionId: SID,
+      text: 'click send',
+    });
+  });
+
+  it('clicking Send with empty text does not fire session_send_message', () => {
+    invokeMock.mockReset();
+    const { getByTestId } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('composer-send-btn'));
+    const sendCalls = invokeMock.mock.calls.filter(
+      (c) => c[0] === 'session_send_message',
+    );
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  it('clicking Send clears the textarea', () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+    const { getByTestId } = render(() => <ChatPane />);
+    const textarea = getByTestId('composer-textarea') as HTMLTextAreaElement;
+
+    fireEvent.input(textarea, { target: { value: 'hi' } });
+    fireEvent.click(getByTestId('composer-send-btn'));
+
+    expect(textarea.value).toBe('');
+  });
+
+  it('Send button click and Enter key take the same code path', () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+
+    // Path A: Enter
+    const a = render(() => <ChatPane />);
+    const taA = a.getByTestId('composer-textarea') as HTMLTextAreaElement;
+    fireEvent.input(taA, { target: { value: 'same path' } });
+    fireEvent.keyDown(taA, { key: 'Enter' });
+    const viaEnter = invokeMock.mock.calls.filter(
+      (c) => c[0] === 'session_send_message',
+    );
+    a.unmount();
+
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+    resetMessagesStore();
+    setActiveSessionId(SID);
+
+    // Path B: Send click
+    const b = render(() => <ChatPane />);
+    const taB = b.getByTestId('composer-textarea') as HTMLTextAreaElement;
+    fireEvent.input(taB, { target: { value: 'same path' } });
+    fireEvent.click(b.getByTestId('composer-send-btn'));
+    const viaClick = invokeMock.mock.calls.filter(
+      (c) => c[0] === 'session_send_message',
+    );
+
+    expect(viaClick).toEqual(viaEnter);
+  });
+});

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -12,6 +12,7 @@ import {
   getMessagesState,
   pushEvent,
   setAwaitingResponse,
+  cancelStream,
   activeVariantPosition,
   liveVariantCount,
   neighbourVariantId,
@@ -578,6 +579,13 @@ export interface ComposerProps {
    */
   onSend: (text: string, chips: InsertedChip[]) => void;
   /**
+   * F-391: cancel the in-flight turn. Fired by the Stop button click and by
+   * Esc while the composer is in the streaming/disabled state. The Composer
+   * itself is purely a view — the owner (`ChatPane`) handles the IPC
+   * dispatch and local state cleanup.
+   */
+  onCancel?: () => void;
+  /**
    * Optional category-indexed items forwarded to the ContextPicker. Exposed
    * for tests that drive the end-to-end "type @ → pick → chip appears" flow
    * without booting the resolver registry.
@@ -781,8 +789,19 @@ export const Composer: Component<ComposerProps> = (props) => {
     setChips((prev) => prev.filter((c) => c.id !== id));
   };
 
+  // F-391: Esc must cancel the stream even when the textarea is disabled
+  // (browsers skip keydown on disabled controls). Listening at the composer
+  // wrapper instead keeps Esc live through the lock.
+  const handleComposerKeyDown = (e: KeyboardEvent) => {
+    if (e.key !== 'Escape') return;
+    if (!props.disabled) return;
+    if (pickerOpen()) return;
+    e.preventDefault();
+    props.onCancel?.();
+  };
+
   return (
-    <div class="composer" ref={composerRef}>
+    <div class="composer" ref={composerRef} onKeyDown={handleComposerKeyDown}>
       {/* ctx-chips row — chips inserted from the picker live here. The spec
           places it above the textarea so chips are visually attached to
           the message being composed. */}
@@ -851,14 +870,30 @@ export const Composer: Component<ComposerProps> = (props) => {
           </Show>
         </span>
         <div class="composer__actions">
+          {/* F-391: Stop flips to primary/ember while streaming (spec §4.1) and
+              fires `onCancel` — same path as Esc. */}
           <Show when={props.disabled}>
-            <button type="button" class="composer__btn composer__btn--ghost">
-              Stop
+            <button
+              type="button"
+              class="composer__btn composer__btn--primary"
+              data-testid="composer-stop-btn"
+              onClick={() => props.onCancel?.()}
+            >
+              STOP
             </button>
           </Show>
-          <span class="composer__send-hint">
-            {props.disabled ? 'Streaming…' : 'Send ↵'}
-          </span>
+          {/* F-391: Send is a real primary/ember button, UPPERCASE per
+              voice-terminology.md, disabled while streaming, and shares the
+              bare-Enter code path via `handleSend`. */}
+          <button
+            type="button"
+            class="composer__btn composer__btn--primary"
+            data-testid="composer-send-btn"
+            disabled={props.disabled}
+            onClick={handleSend}
+          >
+            SEND <span class="composer__btn-kbd">↵</span>
+          </button>
         </div>
       </div>
     </div>
@@ -961,6 +996,19 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
     if (!listRef) return;
     const atBottom = listRef.scrollHeight - listRef.scrollTop - listRef.clientHeight < 8;
     setUserScrolledUp(!atBottom);
+  };
+
+  // F-391: Stop / Esc path. The composer fires this on Stop click or Esc
+  // while the lock is up. We dispatch `session_cancel` fire-and-forget and
+  // locally clear the composer's stream lock so the UI becomes interactive
+  // immediately (spec §4.1 treats Stop as an instant interaction).
+  const handleCancel = () => {
+    const id = sessionId();
+    if (!id) return;
+    cancelStream(id);
+    invoke('session_cancel', { sessionId: id }).catch((err) =>
+      reportInvokeError(id, 'session_cancel', err),
+    );
   };
 
   const handleSend = (text: string, chips: InsertedChip[]) => {
@@ -1070,6 +1118,7 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
       <Composer
         disabled={state().awaitingResponse || state().streamingMessageId !== null}
         onSend={handleSend}
+        onCancel={handleCancel}
         registry={registry()}
         loadFilePreview={loadFilePreview}
       />

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -194,6 +194,18 @@ export function setAwaitingResponse(sessionId: SessionId, value: boolean): void 
   setMessagesStore(sessionId, 'awaitingResponse', value);
 }
 
+/**
+ * F-391: locally drop the "streaming lock" on the composer after the user
+ * invokes Stop / Esc. The backend cancel is fired-and-forgotten; we don't
+ * wait for its ack before re-enabling the UI, because spec §4.1 treats Stop
+ * as an immediate interaction.
+ */
+export function cancelStream(sessionId: SessionId): void {
+  ensureSession(sessionId);
+  setMessagesStore(sessionId, 'awaitingResponse', false);
+  setMessagesStore(sessionId, 'streamingMessageId', null);
+}
+
 // ---------------------------------------------------------------------------
 // F-145 — branch-group helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes forge-ide/forge#392

## Summary
- Wire Composer Stop: onClick invokes `session_cancel` (Tauri) and locally clears the stream lock; Stop flips to primary/ember while streaming per chat-pane.md §4.1.
- Wire Esc on the composer wrapper to the same cancel path — browsers skip keydown on disabled textareas, so the listener lives on the composer div.
- Convert Send hint span into a real `<button>`: primary/ember, UPPERCASE "SEND" per voice-terminology.md, disabled while streaming, shares `handleSend` with bare-Enter.
- Add `session_cancel` Tauri command with `require_window_label` authz. Daemon-side cancel transport (`IpcMessage::CancelTurn`) is a follow-up; the frontend optimistically re-enables the composer regardless.

## Test plan
- `cargo test --workspace` passes (new: 2 Rust tests for `session_cancel` authz + registration)
- `cargo clippy --all-targets -- -D warnings` passes
- `pnpm test` in `web/packages/app` passes (new: 17 F-391 tests covering render, class, click, Esc, disabled state, empty-text guard, Enter parity)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code