### PR TITLE
[F-426] persistence.md missing approvals.toml and settings.toml schemas

### DIFF
--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -15,6 +15,8 @@ Forge has no embedded database. All persistent state is on disk as plain files.
   config.toml              # user-global settings (TOML)
   workspaces.toml          # known-workspaces registry
   credentials.toml         # {provider_id → keychain_ref}
+  approvals.toml           # persistent approval whitelist (user tier) — §7.7
+  settings.toml            # user preferences (notifications, windows) — §7.8
   memory/
     <agent-name>.md        # opt-in cross-session memory
 
@@ -32,13 +34,15 @@ Forge has no embedded database. All persistent state is on disk as plain files.
   .skills/<name>/SKILL.md  # workspace skills
   .forge/                  # internal, self-gitignored
     .gitignore             # contents: *
+    approvals.toml         # persistent approval whitelist (workspace tier) — §7.7
+    settings.toml          # workspace setting overrides — §7.8
     sessions/
       <id>/
         meta.toml
         events.jsonl
         snapshots/
       archived/<id>/       # same layout as above, moved on archive
-    layouts.json
+    layouts.json           # window/pane layout (see `session-layout.md`)
     languages.toml         # user-added LSP servers
     cache/                 # fetch results, etc.
 ```
@@ -111,3 +115,57 @@ When an `ephemeral` session ends:
 3. Spawns `forged` with `--reactivate <id>` flag
 4. Session replays event log to restore in-memory state
 5. Ready for new activity; state becomes `active` again
+
+### 7.7 `approvals.toml` schema (F-036)
+
+Persistent approval whitelist. Two tiers — user (`~/.config/forge/approvals.toml`) and workspace (`<workspace>/.forge/approvals.toml`). Both optional; a missing file is treated as empty (first-run is the common case, not an error). Source of truth: `crates/forge-core/src/approvals.rs`.
+
+```toml
+[[entries]]
+scope_key = "file:fs.write:/src/foo.ts"  # deterministic key derived from tool + target
+tool_name = "fs.write"                    # the tool the key was derived from
+label     = "this file"                   # short UI label (e.g. "this file", "this tool", "pattern /src/*")
+
+[[entries]]
+scope_key = "tool:shell.exec"
+tool_name = "shell.exec"
+label     = "this tool"
+```
+
+**Validation.** Strict: `#[serde(deny_unknown_fields)]` on every record. Unknown or misspelled keys are rejected at load — the approval trust boundary does not accept forward-compat garbage.
+
+**Atomic writes.** Saves go to `<path>.tmp` then `rename` into place. Rename is atomic on POSIX for same-filesystem targets, so a partial `.tmp` never becomes the visible config.
+
+**Merge precedence.** On `scope_key` collision between user and workspace entries, **workspace wins**. The shell surfaces both tiers to the frontend so UI can show provenance, but a single winning entry per key seeds the in-memory auto-approve whitelist. Unlike settings, this is a coarse whole-entry override — there are no sub-fields to deep-merge.
+
+### 7.8 `settings.toml` schema (F-151)
+
+Structured user preferences. Two tiers — user (`~/.config/forge/settings.toml`) and workspace (`<workspace>/.forge/settings.toml`). Both optional; a missing file yields defaults. Source of truth: `crates/forge-core/src/settings.rs`.
+
+```toml
+[notifications]
+bg_agents = "toast"     # one of: "toast" | "os" | "both" | "silent" (default "toast")
+
+[windows]
+session_mode = "single" # one of: "single" | "split" (default "single")
+```
+
+**Forward-compat.** The top-level struct does **not** carry `deny_unknown_fields`. A newer release may add sections; older builds reading a newer file ignore unknown keys rather than refuse to load. This is the intentional inverse of `approvals.toml`.
+
+**`#[serde(default)]` everywhere.** Every field and nested struct is defaulted, so a file containing only `[notifications]` still loads — the missing `[windows]` section falls back to defaults.
+
+**Atomic writes.** Same `<path>.tmp` + rename pattern as approvals.
+
+**Deep merge: workspace overrides user at field granularity.** Workspace does **not** wholesale replace user. The merge runs on the raw `toml::Value` tree parsed from each file (empty tree when absent) and overlays workspace keys onto user keys at every depth before deserializing into `AppSettings`. Concretely:
+
+- `user.windows.session_mode = "split"`
+- `workspace.notifications.bg_agents = "os"` (workspace file contains **only** `[notifications]`)
+- → merged: `notifications.bg_agents = "os"`, `windows.session_mode = "split"`
+
+The reason this runs on raw TOML and not on `AppSettings` structs: `#[serde(default)]` erases the distinction between "workspace explicitly set `windows.session_mode = single`" and "workspace did not mention windows at all" — both deserialize identically. A struct-level merge would clobber a user's non-default value with the workspace's implicit default.
+
+**`set_setting` write path.** Writes mutate the **raw TOML tree** (`apply_setting_update`) then atomic-save the resulting text — never a re-serialized `AppSettings`. Re-serializing would promote every in-memory default into the persisted file and silently destroy the absent-means-pick-up-default semantic the merge layer depends on. Validation happens by deserializing the updated tree into `AppSettings` before write: type mismatches (e.g. `bg_agents = 42`) are rejected at the IPC boundary; unknown keys pass through untouched for forward-compat.
+
+**Array merge.** Arrays overwrite wholesale rather than concatenate. The current schema has no additive lists; if one is added later, this section must be revisited.
+
+> The third user-visible persistence file, `<workspace>/.forge/layouts.json` (F-150), is documented separately in [`session-layout.md`](./session-layout.md).


### PR DESCRIPTION
Closes forge-ide/forge#427

## Summary
- Adds `approvals.toml` + `settings.toml` to §7.1 filesystem tree at both tiers (user `~/.config/forge/` and workspace `<root>/.forge/`).
- New §7.7 "Approvals schema" (F-036): `entries = [{scope_key, tool_name, label}]`, strict `deny_unknown_fields`, atomic write (`.tmp` + rename), coarse workspace-wins-on-`scope_key` merge.
- New §7.8 "Settings schema" (F-151): `[notifications].bg_agents`, `[windows].session_mode`, forward-compat (no `deny_unknown_fields`, `#[serde(default)]` everywhere), raw-TOML deep merge with workspace-overrides-user at field granularity, rationale for why `set_setting` mutates the raw tree instead of the struct.
- Cross-reference to `session-layout.md` for `layouts.json` (tracked separately in F-433).

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- Grep confirms §7.7 and §7.8 exist and the tree lists both files at both tiers

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)