### PR TITLE
docs(agents): correct web/ repo-layout paths (F-429)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,10 +35,10 @@ crates/
   forge-cli         forge binary, thin clap wrapper
   forge-shell       Tauri binary, bridges Tauri commands ↔ UDS
 web/
-  apps/shell          SolidJS shell app
-  apps/monaco-host    Monaco in isolated iframe
-  packages/ipc        generated TS types + typed IPC client
-  packages/state      Solid signals as module-level stores
+  packages/app          SolidJS shell app
+  packages/monaco-host  Monaco in isolated iframe
+  packages/ipc          generated TS types + typed IPC client
+  packages/design       design tokens
 docs/               architecture, build, design, product, ui-specs
 ```
 


### PR DESCRIPTION
Closes forge-ide/forge#430

## Summary
- AGENTS.md `web/` block matches actual structure (`packages/{app,monaco-host,ipc,design}`)
- Tests pass in CI

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- Manually verified every listed path exists under `web/packages/`

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code