### PR TITLE
docs(build): sync approach.md §2 web-tree with real 4-package shape (F-430)

### DIFF
--- a/docs/build/approach.md
+++ b/docs/build/approach.md
@@ -58,14 +58,11 @@ forge/
 ├── web/                    # webview frontend (pnpm workspace)
 │   ├── package.json
 │   ├── pnpm-workspace.yaml
-│   ├── apps/
-│   │   ├── shell/          # Tauri webview app (Solid SPA)
-│   │   └── monaco-host/    # isolated iframe hosting Monaco
 │   └── packages/
+│       ├── app/            # SolidJS shell app (Tauri webview)
+│       ├── monaco-host/    # isolated iframe hosting Monaco
 │       ├── design/         # CSS tokens from DESIGN.md
-│       ├── ui/             # Solid components (per SPECS.md)
-│       ├── ipc/            # generated TS types from forge-ipc
-│       └── state/          # Solid signal-based stores
+│       └── ipc/            # generated TS types + typed IPC client
 │
 ├── docs/
 │   └── architecture/       # ADRs
@@ -85,4 +82,4 @@ forge/
 - Cargo workspace gives us one build graph, one lockfile, easy cross-crate refactoring.
 - `forge-shell` (GUI) and `forge-cli` (CLI) are thin binaries on top of `forge-core` — no duplication, no "GUI-only logic."
 - The webview sits in `web/` so frontend engineers don't need a Rust toolchain to iterate on UI (though the full dev loop does).
-- Monaco lives in an **iframe** (`monaco-host`) rather than directly in the shell app — this keeps Monaco's window globals, web workers, and language-service assumptions from leaking into our Solid tree.
+- Monaco lives in an **iframe** (`packages/monaco-host`) rather than directly in `packages/app` — this keeps Monaco's window globals, web workers, and language-service assumptions from leaking into our Solid tree.


### PR DESCRIPTION
Closes forge-ide/forge#431

## Summary
- Replace stale `web/apps/{shell,monaco-host}` + `packages/{ui,state}` layout in `docs/build/approach.md §2` with the real 4-package shape: `packages/{app, monaco-host, design, ipc}`.
- Rewrite the "Why this shape" Monaco bullet to reference `packages/monaco-host` and `packages/app` instead of the nonexistent `apps/` placement.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- Manual grep confirms stale strings (`apps/`, `packages/ui`, `packages/state`) gone and correct strings (`packages/app`, `packages/monaco-host`, `packages/design`, `packages/ipc`) present in §2.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)