### PR TITLE
[F-425] docs(isolation-model): add cgroup v2 pids.max to §8.2

### DIFF
--- a/docs/architecture/isolation-model.md
+++ b/docs/architecture/isolation-model.md
@@ -85,6 +85,7 @@ Implementation:
 - Path access enforced by `forge-fs`: every `fs.*` tool validates the path against the agent's `allowed_paths` glob
 - **Network is open at Level 1.** No per-agent firewall. MCP servers and the built-in `fetch` tool do their own allow-listing. Users who need network restriction use Level 2.
 - CPU/RAM: soft limits via `setrlimit` (Linux/macOS)
+- **Per-sandbox process ceiling via cgroup v2 `pids.max` (F-149).** Each sandbox gets its own leaf under the daemon's cgroup parent so a misbehaving tool cannot starve sibling sandboxes or the daemon itself. Linux-only; requires the host to delegate the `pids` controller to the daemon's slice (default on systemd user sessions). On non-delegated hosts (cgroup v1, containers without delegation, non-Linux) setup is skipped silently and `RLIMIT_NPROC` becomes the only ceiling. `RLIMIT_NPROC` is retained as a uid-wide backstop regardless. See [`docs/dev/sandbox-limits.md`](../dev/sandbox-limits.md) for the full operator-facing reference.
 - Kill on session end: process group guarantees cleanup
 
 ### 8.3 Level 2 — Container


### PR DESCRIPTION
Closes forge-ide/forge#426

## Summary
- §8.2 documents cgroup v2 `pids.max` as the authoritative per-sandbox process ceiling (F-149)
- Documents Linux-only + cgroup-v2-delegation scope and the `RLIMIT_NPROC` uid-wide fallback on non-delegated hosts
- Cross-references `docs/dev/sandbox-limits.md` for the full operator-facing reference

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (one pre-existing flake in `forge-mcp::http_roundtrip::post_roundtrip_and_sse_notification` passes on retry; unrelated to this docs-only change)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)