### PR TITLE
docs(session-layout): document PaneType enum contract (F-424)

### DIFF
--- a/docs/architecture/session-layout.md
+++ b/docs/architecture/session-layout.md
@@ -10,21 +10,23 @@ Sessions use standard editor layout semantics. There is no fixed layout; users c
 
 ### 4.1 Pane types
 
-| Pane type | Purpose |
-|---|---|
-| **Chat** | Agent conversation. Streaming, tool calls inline, sub-agent banners, `@`-context. |
-| **Terminal** | Shell emulation via Ghostty's VT library. Shared or agent-controlled. |
-| **Editor** | Buffer on disk or in memory. Monaco in a webview (see §7). |
+Source of truth: `PaneType` in `crates/forge-shell/src/ipc.rs`. Five variants, persisted on every leaf in `.forge/layouts.json` and carried on the IPC contract. An unknown variant fails deserialization loudly, so a new pane type must land as an enum variant before it can ship.
 
-Files is **not** a pane type. The file tree lives in the sidebar slot (part of the shell), toggleable from the activity bar with `Cmd/Ctrl+Shift+E` to reveal. It never takes a main-pane slot.
+| Pane type | Variant (`pane_type`) | Purpose |
+|---|---|---|
+| **Chat** | `chat` | Agent conversation. Streaming, tool calls inline, sub-agent banners, `@`-context. |
+| **Terminal** | `terminal` | Shell emulation via Ghostty's VT library. Shared or agent-controlled. |
+| **Editor** | `editor` | Buffer on disk or in memory. Monaco in a webview (see §7). |
+| **Files** | `files` | File tree surfaced as a main-area pane. Distinct from the activity-bar sidebar file tree — the sidebar remains the primary entry point (toggle: `Cmd/Ctrl+Shift+E`); this variant exists for users who want the tree docked inside the pane grid. |
+| **Agent monitor** | `agentmonitor` | Three-column agent monitor view (F-140): agent list, trace timeline, inspector. Dockable so multi-agent workflows don't compete with the chat pane for space. |
 
 ### 4.2 Layout rules
 - Standard splits: single, horizontal, vertical, grid
 - No hard cap on pane count — users split as needed
-- Any pane can hold chat, terminal, or editor; pane type is not fixed at creation
+- Any pane can hold any of the five `PaneType` variants; pane type is not fixed at creation
 - Panes can be resized; minimum width 320px (below that, pane header collapses to icons)
 - Drag any pane to any edge of another pane to re-dock (including effectively sidebar-sized positions)
-- Layouts persist per-workspace in `.forge/layouts.json`
+- Layouts persist per-workspace in `.forge/layouts.json`; see §4.1 for the enum that gates what a leaf may hold
 
 ### 4.3 Default layout
 A new session opens with **a single chat pane** filling the main area. When the user opens a file (from the files sidebar, `@`-ref click, or a tool call that reads/edits one), an editor pane opens via a sensible split — first file splits right; subsequent files become tabs in that editor pane.

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -16,7 +16,7 @@ The original PDF described Forge in IDE terms (activity bar, file explorer, git)
 
 - The **session** is the unit of work, not the workspace.
 - The **dashboard** is the home screen, not the editor.
-- The **editor** is one of three peer pane types (chat, terminal, editor) that live inside a session, not the main event.
+- The **editor** is one of several peer pane types that live inside a session — chat, terminal, editor, files, and agent monitor — not the main event. See `architecture/session-layout.md §4.1` for the full list.
 
 This matters because it determines everything downstream: window hierarchy, the CLI surface, sandboxing boundaries, config file locations, and what we even call the top-level concept.
 

--- a/docs/ui-specs/layout-panes.md
+++ b/docs/ui-specs/layout-panes.md
@@ -21,9 +21,9 @@
 Gridlines are 1px in `--color-border-1`. Dragging resizes in 4px snaps; Alt+drag is unsnapped. Double-clicking a gridline resets to balanced split.
 
 ### 3.2 Pane types
-Three types: `chat`, `terminal`, `editor`. Each pane header shows its type.
+Five types: `chat`, `terminal`, `editor`, `files`, `agentmonitor`. Each pane header shows its type. The authoritative list is the `PaneType` enum in `crates/forge-shell/src/ipc.rs`; see `docs/architecture/session-layout.md §4.1` for the full variant table.
 
-**Files is not a pane type.** The file tree lives in the sidebar (part of the activity-bar-driven shell). `Cmd/Ctrl+Shift+E` toggles the files sidebar.
+The activity-bar sidebar file tree is independent of the `files` pane variant — the sidebar is part of the shell chrome (`Cmd/Ctrl+Shift+E` toggles it), while the `files` pane is a main-area dockable variant for users who want the tree inside the pane grid.
 
 ### 3.3 Pane header (28px)
 - Left: type label in `--label` style (mono xs, uppercase, tracked) — e.g. `CHAT`, `TERMINAL`


### PR DESCRIPTION
Closes forge-ide/forge#425

## Summary
- `docs/architecture/session-layout.md §4.1` now lists all five `PaneType` variants (`chat`, `terminal`, `editor`, `files`, `agentmonitor`) with the Rust source-of-truth path and the wire-string in a new `Variant` column; deletes the "Files is not a pane type" paragraph.
- `§4.2` no longer contradicts `§4.1` — drops the "chat, terminal, or editor" phrasing and points back at the enum as the gate for what a leaf may hold.
- `docs/ui-specs/layout-panes.md §3.2` mirrors the same correction and distinguishes the `files` pane variant from the activity-bar sidebar file tree.
- `docs/product/vision.md §1` updated from "three peer pane types" to the full five, with a cross-ref to `session-layout.md §4.1` so the list stays in one place.

## Why update docs instead of removing enum variants
Both `PaneType::Files` and `PaneType::AgentMonitor` are shipped: they are persisted on every leaf in `.forge/layouts.json`, round-tripped through the IPC contract, rendered in `web/packages/app/src/routes/Session/SessionWindow.tsx`, and backed by generated TS bindings at `web/packages/ipc/src/generated/PaneType.ts`. Removing them would be a breaking change to the persisted layout schema and is out of scope for a `docs: high` / `type: bug` correction. The bug is drift in the specs, not a mistaken enum.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)