### PR TITLE
fix(forge-shell): atomic tmp+rename in write_layouts (F-363)

### DIFF
--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -1170,6 +1170,23 @@ fn layouts_file_path(workspace_root: &std::path::Path) -> PathBuf {
     workspace_root.join(".forge").join("layouts.json")
 }
 
+/// Sibling `<path>.tmp` for the atomic tmp+rename write in `write_layouts`.
+/// Mirrors the `tmp_path_for` helpers in `forge_core::approvals` and
+/// `forge_core::settings` — same-directory by construction so the rename is
+/// same-filesystem (POSIX-atomic). F-372 tracks promoting this to a shared
+/// `forge_core::atomic_write`; this keeps the 90-min fix local.
+fn layouts_tmp_path(path: &std::path::Path) -> PathBuf {
+    let mut file_name = path
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    file_name.push(".tmp");
+    match path.parent() {
+        Some(parent) => parent.join(file_name),
+        None => PathBuf::from(file_name),
+    }
+}
+
 /// Load `.forge/layouts.json` under `workspace_root`, degrading to
 /// [`Layouts::default`] on any failure.
 ///
@@ -1210,6 +1227,12 @@ pub async fn read_layouts<R: Runtime>(
 /// label. Write failures (disk full, read-only mount) surface as `Err` — the
 /// frontend debouncer will retry on the next layout change, so a transient
 /// failure does not need a retry loop here.
+///
+/// F-363: mirrors the `approvals::save_to_path` / `settings::save_raw_to_path`
+/// atomic tmp+rename pattern. The rename is atomic on POSIX for same-
+/// filesystem targets (same directory here by construction), so a crash
+/// between the write and the rename leaves either the prior `layouts.json`
+/// or the new one on disk — never a partial JSON payload.
 #[tauri::command]
 pub async fn write_layouts<R: Runtime>(
     workspace_root: String,
@@ -1225,10 +1248,14 @@ pub async fn write_layouts<R: Runtime>(
         .map_err(|e| format!("create .forge dir: {e}"))?;
 
     let path = forge_dir.join("layouts.json");
+    let tmp = layouts_tmp_path(&path);
     let bytes = serde_json::to_vec_pretty(&layouts).map_err(|e| format!("serialize: {e}"))?;
-    tokio::fs::write(&path, &bytes)
+    tokio::fs::write(&tmp, &bytes)
         .await
-        .map_err(|e| format!("write layouts.json: {e}"))
+        .map_err(|e| format!("write layouts.json.tmp: {e}"))?;
+    tokio::fs::rename(&tmp, &path)
+        .await
+        .map_err(|e| format!("rename layouts.json.tmp: {e}"))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/forge-shell/tests/ipc_layouts.rs
+++ b/crates/forge-shell/tests/ipc_layouts.rs
@@ -309,6 +309,84 @@ fn write_layouts_creates_forge_dir_if_missing() {
 }
 
 #[test]
+fn write_layouts_is_atomic_via_tmp_and_rename() {
+    // F-363: `write_layouts` must mirror the `approvals::save_to_path` /
+    // `settings::save_raw_to_path` atomic pattern — write to `<path>.tmp`,
+    // then rename into place. The rename is atomic on POSIX for same-
+    // filesystem targets, so a partially-written `.tmp` never becomes the
+    // visible `layouts.json`.
+    //
+    // We observe the invariant from two angles:
+    //
+    // 1. Pre-plant a stale `layouts.json.tmp` with garbage. A correct
+    //    atomic write `rename`s its freshly-written tmp over that path, so
+    //    no `.tmp` residue remains. A direct `tokio::fs::write` on the
+    //    canonical path leaves the stale tmp untouched.
+    // 2. After the write returns, `layouts.json` must contain the new
+    //    payload regardless of the prior `.tmp` state — the stale tmp must
+    //    not leak into the visible file.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_string_lossy().to_string();
+
+    let forge_dir = dir.path().join(".forge");
+    std::fs::create_dir_all(&forge_dir).unwrap();
+    let tmp_path = forge_dir.join("layouts.json.tmp");
+    std::fs::write(&tmp_path, b"{ partial-crash-residue").expect("seed stale layouts.json.tmp");
+
+    let app = make_app();
+    let window = make_session_window(&app, "atomic");
+
+    let _ = invoke_ok(&window, "write_layouts", sample_layouts_payload(&root));
+
+    let final_path = forge_dir.join("layouts.json");
+    assert!(final_path.exists(), "final layouts.json must exist");
+    assert!(
+        !tmp_path.exists(),
+        "layouts.json.tmp must be consumed by rename, not left behind"
+    );
+
+    // And the final file is the new payload, not the stale-tmp garbage.
+    let bytes = std::fs::read(&final_path).expect("read final layouts.json");
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&bytes).expect("final layouts.json is valid JSON");
+    assert_eq!(parsed["active"], "default");
+    assert_eq!(parsed["named"]["default"]["tree"]["kind"], "split");
+}
+
+#[test]
+fn write_layouts_crash_mid_write_leaves_last_valid_on_disk() {
+    // F-363 DoD: simulate a crash mid-write by leaving a partial tmp on
+    // disk without completing the rename. The next `read_layouts` must
+    // return the last-valid payload — never a partial JSON — because the
+    // canonical `layouts.json` is only ever touched by the atomic rename.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_string_lossy().to_string();
+
+    let app = make_app();
+    let window = make_session_window(&app, "crash-mid-write");
+
+    // First, a successful write establishes the last-valid canonical file.
+    let _ = invoke_ok(&window, "write_layouts", sample_layouts_payload(&root));
+
+    // Simulate a crash after a second save wrote its tmp but before it
+    // renamed: plant a corrupt `.tmp` alongside the valid canonical file.
+    let forge_dir = dir.path().join(".forge");
+    let tmp_path = forge_dir.join("layouts.json.tmp");
+    std::fs::write(&tmp_path, b"{ mid-write-crash").expect("seed crash tmp");
+
+    // Read must return the last-valid payload — not `Layouts::default()`,
+    // not the partial JSON from the tmp.
+    let out = invoke_ok(
+        &window,
+        "read_layouts",
+        serde_json::json!({ "workspaceRoot": root }),
+    );
+    assert_eq!(out["active"], "default");
+    assert_eq!(out["named"]["default"]["tree"]["kind"], "split");
+    assert_eq!(out["named"]["default"]["tree"]["a"]["pane_type"], "chat");
+}
+
+#[test]
 fn write_layouts_rejects_oversize_workspace_root() {
     // `workspace_root` reuses the same 4 KiB PATH_MAX envelope as the F-036
     // approval commands. A 5 KiB value must be rejected before the filesystem


### PR DESCRIPTION
Closes forge-ide/forge#364

## Summary
- `write_layouts` now writes to `<path>.tmp` then `rename`s into place, mirroring `approvals::save_to_path` / `settings::save_raw_to_path`. A crash between the two syscalls leaves either the prior `layouts.json` or the new one — never a partial serde_json payload.
- Regression tests cover (1) the atomic invariant (stale `.tmp` is consumed by the rename, final file is the new payload) and (2) a mid-write crash simulation (valid canonical file + stray `.tmp` → next `read_layouts` returns the last-valid layout, never a partial JSON).
- F-372 tracks promoting this to a shared `forge_core::atomic_write`; this PR is the acute durability fix.

## Test plan
- `cargo test --workspace` passes
- `cargo test -p forge-shell --features webview-test` passes (includes the new `write_layouts_is_atomic_via_tmp_and_rename` and `write_layouts_crash_mid_write_leaves_last_valid_on_disk` cases)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)