### PR TITLE
test(forge-shell): cover stop_bg_agent lifecycle and sandbox-escape rename/delete (F-365)

### DIFF
--- a/crates/forge-shell/tests/ipc_bg_agents.rs
+++ b/crates/forge-shell/tests/ipc_bg_agents.rs
@@ -586,6 +586,155 @@ fn stop_rejects_oversize_instance_id_at_command_layer() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// F-365: explicit DoD coverage for `stop_background_agent`.
+//
+// The sibling tests above (`stop_completes_instance_and_emits_completion_event`
+// + `cross_session_stop_is_rejected_with_label_mismatch`) cover the event
+// fan-out and window-label authz. These two add the remaining gaps the
+// F-365 review called out:
+//
+// 1. `stop_background_agent_transitions_instance_to_terminal_and_stops_sampling`
+//    asserts that a successful stop, driven through the IPC command, (a) flips
+//    the instance to terminal and (b) causes the registry's forwarder to
+//    untrack the instance from the resource monitor. Without this, a regression
+//    that decoupled the forwarder from `monitor.untrack` would leak sampler
+//    tasks and produce misleading `list` rows.
+// 2. `stop_background_agent_from_wrong_session_is_rejected` mirrors the
+//    existing `delete_branch` / promote authz shape — the window label is a
+//    session window, but the payload's `sessionId` targets a different session.
+//    The label check must reject this before the bridge resolves a registry.
+// ---------------------------------------------------------------------------
+
+/// DoD: flip the registry to `Completed` through `stop_background_agent`,
+/// assert the monitor untracks so future samples stop.
+#[tokio::test(flavor = "multi_thread")]
+async fn stop_background_agent_transitions_instance_to_terminal_and_stops_sampling() {
+    use forge_agents::Orchestrator as AgentOrchestrator;
+    use forge_session::{FakeSampler, ResourceMonitor, Sample};
+
+    let app = make_app();
+
+    // Fast-tick monitor with a scripted FakeSampler so we can observe the
+    // `tracked_count` drop without waiting for the 1 s production cadence.
+    let orchestrator = Arc::new(AgentOrchestrator::new());
+    let fake = Arc::new(FakeSampler::new(Sample {
+        cpu_seconds: Some(0.0),
+        rss_bytes: Some(0),
+        fd_count: Some(0),
+    }));
+    let monitor = Arc::new(ResourceMonitor::new(
+        fake as Arc<dyn forge_session::Sampler>,
+        Duration::from_millis(20),
+    ));
+    let registry = Arc::new(BackgroundAgentRegistry::with_monitor(
+        Arc::clone(&orchestrator),
+        Arc::new(vec![def("writer"), def("reviewer")]),
+        Arc::clone(&monitor),
+    ));
+    install_bg_session_for_test(&app.handle().clone(), "sess-term", Arc::clone(&registry));
+    let window = make_window(&app, "session-sess-term");
+
+    let start_res = invoke(
+        &window,
+        "start_background_agent",
+        serde_json::json!({
+            "sessionId": "sess-term",
+            "agentName": "writer",
+            "prompt": "work",
+        }),
+    )
+    .expect("start must succeed");
+    let instance_id = start_res
+        .deserialize::<serde_json::Value>()
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Wait until the monitor has actually begun tracking — `start` registers
+    // on the tracking set synchronously but the monitor hand-off runs on a
+    // spawned task, so we observe it eventually.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while monitor.tracked_count().await == 0 && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert_eq!(
+        monitor.tracked_count().await,
+        1,
+        "monitor must track the instance while it is running"
+    );
+
+    invoke(
+        &window,
+        "stop_background_agent",
+        serde_json::json!({
+            "sessionId": "sess-term",
+            "instanceId": instance_id.clone(),
+        }),
+    )
+    .expect("stop must succeed under matching label");
+
+    // (a) Terminal transition: the registry's forwarder drops the id from
+    // `list` once it observes the orchestrator's terminal event.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let rows: serde_json::Value = invoke(
+            &window,
+            "list_background_agents",
+            serde_json::json!({ "sessionId": "sess-term" }),
+        )
+        .expect("list must succeed")
+        .deserialize()
+        .unwrap();
+        if rows.as_array().unwrap().is_empty() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            panic!("terminal transition did not drop id from list: {rows}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // (b) Sampler is released: `monitor.untrack(id)` ran in the forwarder and
+    // the sampler task is gone. `tracked_count` is the observable proxy for
+    // "sampler not leaking".
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while monitor.tracked_count().await != 0 && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        monitor.tracked_count().await,
+        0,
+        "monitor must untrack the instance on terminal transition — otherwise \
+         the sampler task leaks and `list` rows are misleading"
+    );
+}
+
+/// DoD: `stop_background_agent` from a session-A window with a payload
+/// claiming session-B must be rejected by the window-label gate before any
+/// registry lookup happens.
+#[test]
+fn stop_background_agent_from_wrong_session_is_rejected() {
+    let app = make_app();
+    install_registry(&app, "session-owner");
+    let window = make_window(&app, "session-attacker");
+
+    let err = invoke(
+        &window,
+        "stop_background_agent",
+        serde_json::json!({
+            "sessionId": "session-owner",
+            "instanceId": "deadbeefcafebabe",
+        }),
+    )
+    .expect_err("a session-attacker window must not stop session-owner's agents");
+    assert!(
+        err.contains(LABEL_MISMATCH),
+        "expected label-mismatch error, got: {err}"
+    );
+}
+
 /// Size-cap regression: oversize prompts must be rejected at the command
 /// layer (`require_size`) before the registry's `start` allocates anything.
 #[test]

--- a/crates/forge-shell/tests/ipc_fs.rs
+++ b/crates/forge-shell/tests/ipc_fs.rs
@@ -688,3 +688,92 @@ async fn delete_path_returns_not_connected_when_cache_is_empty() {
     );
     assert!(file.exists(), "file must remain on not-connected");
 }
+
+// ---------------------------------------------------------------------------
+// F-365: sandbox-escape coverage on the shell side.
+//
+// The existing tests above cover out-of-workspace *destinations* for rename
+// and out-of-workspace *paths* for delete. The F-365 review flagged that the
+// `from` side of `rename_path` was not exercised, and that neither command
+// had an assertion aligned with the concrete attack shape called out in the
+// issue:
+//
+//     rename_path(session_id, "/etc/passwd", "/tmp/x")
+//
+// i.e. both endpoints are absolute paths outside the primed workspace_root.
+// These tests pin that exact shape so a regression that loosens the
+// `forge-fs` allowlist check cannot land silently.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rename_path_rejects_absolute_paths_outside_primed_workspace() {
+    // Cache is primed with an empty workspace; the webview supplies absolute
+    // paths pointing completely outside it. Both endpoints must be path-denied
+    // via the `forge-fs` allowlist, and neither path may be created, moved,
+    // or otherwise touched on disk.
+    let workspace = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let canonical_outside = fs::canonicalize(outside.path()).unwrap();
+    let from = canonical_outside.join("source.txt");
+    let to = canonical_outside.join("destination.txt");
+    fs::write(&from, "source").unwrap();
+
+    let (app, _conn) = make_app_with_workspace(workspace.path(), TEST_SESSION).await;
+    let window = make_session_window(&app, TEST_SESSION);
+
+    let err = invoke_err(
+        &window,
+        "rename_path",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "from": from,
+            "to": to,
+        }),
+    );
+    assert!(
+        err.contains("not allowed") || err.contains("PathDenied"),
+        "rename_path with an out-of-workspace `from` must be denied by forge-fs, got: {err}"
+    );
+    assert!(
+        from.exists(),
+        "source outside workspace must remain untouched"
+    );
+    assert!(
+        !to.exists(),
+        "destination outside workspace must not be created"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_path_rejects_absolute_path_outside_primed_workspace() {
+    // Mirrors the `rename_path` absolute-path escape: a delete targeting an
+    // absolute path fully outside the session's workspace must be rejected,
+    // and the target must remain on disk.
+    let workspace = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let canonical_outside = fs::canonicalize(outside.path()).unwrap();
+    let victim = canonical_outside.join("keep.txt");
+    fs::write(&victim, "do not delete").unwrap();
+
+    let (app, _conn) = make_app_with_workspace(workspace.path(), TEST_SESSION).await;
+    let window = make_session_window(&app, TEST_SESSION);
+
+    let err = invoke_err(
+        &window,
+        "delete_path",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "path": victim,
+        }),
+    );
+    assert!(
+        err.contains("not allowed") || err.contains("PathDenied"),
+        "delete_path with an out-of-workspace absolute path must be denied by forge-fs, got: {err}"
+    );
+    assert!(victim.exists(), "victim outside workspace must remain");
+    assert_eq!(
+        fs::read_to_string(&victim).unwrap(),
+        "do not delete",
+        "victim contents must be unchanged"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the three coverage gaps the F-365 quality review called out on Phase 2's late-landing Tauri commands (`stop_background_agent`, `rename_path`, `delete_path`). Without these tests, a regression that decouples the bg-agent registry forwarder from `ResourceMonitor::untrack`, relaxes the stop window-label authz, or loosens the `forge-fs` allowlist could land silently.

## Changes

- `crates/forge-shell/tests/ipc_bg_agents.rs`
  - `stop_background_agent_transitions_instance_to_terminal_and_stops_sampling` — drives the IPC command end-to-end with a fast-tick `FakeSampler`-backed `ResourceMonitor`, injected via the `webview-test` seam. Pins the observable contract: post-stop the instance drops from `list_background_agents` AND `monitor.tracked_count()` returns to `0`.
  - `stop_background_agent_from_wrong_session_is_rejected` — session-A window + session-B payload → label-mismatch rejection before any registry resolution happens.
- `crates/forge-shell/tests/ipc_fs.rs`
  - `rename_path_rejects_absolute_paths_outside_primed_workspace` — absolute `from` + `to` fully outside the cached workspace_root → `forge-fs` allowlist denial; source untouched, destination not created.
  - `delete_path_rejects_absolute_path_outside_primed_workspace` — absolute path outside the cached workspace_root → denial; victim file remains on disk with unchanged contents.

No production code changes — the underlying behavior is already correct (shown by the tests passing without any source edits). This PR pins that behavior.

## Issue

Addresses forge-ide/forge#365.

## Definition of Done

- [x] Three named tests exist under `crates/forge-shell/tests/`
- [x] Tests pass in CI

## Test plan

- [x] `cargo test -p forge-shell --features webview-test --test ipc_bg_agents` — 14/14 pass (includes the two new bg-agent tests)
- [x] `cargo test -p forge-shell --features webview-test --test ipc_fs` — 21/21 pass (includes the two new sandbox-escape tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` — no regressions