### PR TITLE
[F-410] docs(ui-specs): mark session-roster.md deferred post-Phase-2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ Navigation hub for all Forge documentation. One topic per file; use the table be
 | [agent-monitor.md](ui-specs/agent-monitor.md) | Three-column: agent list, trace timeline, inspector panel |
 | [approval-prompt.md](ui-specs/approval-prompt.md) | Inline four-scope whitelisting, keyboard shortcuts, preview by tool type |
 | [streaming-states.md](ui-specs/streaming-states.md) | Streaming cursor, pulse ring, transitions, and complete motion reference |
-| [session-roster.md](ui-specs/session-roster.md) | Scope-aware asset display and the repeatable asset card |
+| [session-roster.md](ui-specs/session-roster.md) | *(deferred post-Phase-2)* Scope-aware asset display and the repeatable asset card — no component exists yet |
 | [branching.md](ui-specs/branching.md) | Message tree data model, variant rendering, conversation flow |
 
 ## build/

--- a/docs/ui-specs/dashboard.md
+++ b/docs/ui-specs/dashboard.md
@@ -67,7 +67,7 @@ The Dashboard itself has no global loading or error state — it always renders 
 
 ### D.6 Cross-spec references
 
-- `session-roster.md` — the in-session roster of loaded assets. Different surface (Session window sidebar) but related vocabulary; the Dashboard's session cards link a user *into* a session whose roster lives there.
+- `session-roster.md` *(deferred post-Phase-2)* — forward-looking spec for an in-session roster of loaded assets. No component or hosting sidebar exists in Phase 2; the Dashboard's session cards still open sessions, but those sessions do not render a roster today.
 - `ai-patterns.md` — provider accent colors used by the provider indicator and any future provider chips on session cards.
 - `provider-selector.md` — composer-time provider switching (Phase 2+). The Dashboard's provider panel is read-only status, not a switcher.
 - `layout-panes.md` — pane model used by the Session window. The Dashboard does not use the pane model.

--- a/docs/ui-specs/session-roster.md
+++ b/docs/ui-specs/session-roster.md
@@ -1,5 +1,7 @@
 # Session Roster & Asset Card
 
+> **Status: DEFERRED post-Phase-2.** No component exists; no sidebar hosts this in the current session shell. The Phase 2 session shell is ActivityBar + FilesSidebar (file tree only) — there is no sidebar surface for a roster. Parked until Phase 3+ when asset loading becomes user-visible. Retained as forward-looking reference; do not cite as a paired spec.
+
 > Extracted from SPECS.md §12-13 — scope-aware asset display and the repeatable asset card for skills, MCP servers, and agents
 
 ---


### PR DESCRIPTION
Closes forge-ide/forge#411

## Summary
- Add top-of-file `DEFERRED post-Phase-2` banner to `docs/ui-specs/session-roster.md` stating no component exists and no sidebar hosts it in the current session shell; retained as forward-looking reference.
- Stamp cross-references to session-roster as deferred in `docs/README.md` (spec index) and `docs/ui-specs/dashboard.md` §D.6 (cross-spec references).
- No code changes; spec `§13 Asset Card` content is preserved for Phase 3/4 resurrection.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code