### PR TITLE
fix(forge-lsp,forge-shell): close arbitrary-binary-exec surface in Server::new (F-353)

### DIFF
--- a/crates/forge-lsp/src/bootstrap.rs
+++ b/crates/forge-lsp/src/bootstrap.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 
-use crate::registry::{Checksum, ServerSpec};
+use crate::registry::{Checksum, Registry, ServerSpec};
 
 /// Errors returned by [`Bootstrap::ensure`].
 #[derive(Debug, thiserror::Error)]
@@ -131,23 +131,48 @@ impl Downloader for HttpDownloader {
 pub struct Bootstrap {
     cache_root: PathBuf,
     downloader: Box<dyn Downloader>,
+    registry: Registry,
 }
 
 impl Bootstrap {
     /// Bootstrap rooted at the platform default (`~/.cache/forge/lsp/`),
-    /// with an [`HttpDownloader`]. Errors if no cache dir can be resolved.
+    /// with an [`HttpDownloader`] and the bundled [`Registry`]. Errors if
+    /// no cache dir can be resolved.
     pub fn new() -> Result<Self, BootstrapError> {
         let root = default_cache_root().ok_or(BootstrapError::NoCacheDir)?;
         Ok(Self::new_in(root, Box::new(HttpDownloader::new())))
     }
 
-    /// Bootstrap rooted at `cache_root`, using the injected `downloader`.
-    /// Every on-disk side-effect stays under `cache_root`.
+    /// Bootstrap rooted at `cache_root`, using the injected `downloader`
+    /// and the bundled [`Registry`]. Every on-disk side-effect stays under
+    /// `cache_root`.
     pub fn new_in(cache_root: PathBuf, downloader: Box<dyn Downloader>) -> Self {
+        Self::with_registry(cache_root, downloader, Registry::bundled())
+    }
+
+    /// Bootstrap with an explicit [`Registry`]. Hidden from rustdoc —
+    /// production callers should stick to [`Bootstrap::new`] /
+    /// [`Bootstrap::new_in`] so the bundled registry is the only surface
+    /// `Server::from_registry` resolves against. Integration tests use this
+    /// to inject a single-spec registry pointing at the in-tree stub LSP
+    /// fixture.
+    #[doc(hidden)]
+    pub fn with_registry(
+        cache_root: PathBuf,
+        downloader: Box<dyn Downloader>,
+        registry: Registry,
+    ) -> Self {
         Self {
             cache_root,
             downloader,
+            registry,
         }
+    }
+
+    /// The [`Registry`] this bootstrap resolves against. See
+    /// [`crate::Server::from_registry`].
+    pub fn registry(&self) -> &Registry {
+        &self.registry
     }
 
     /// Resolve the absolute cache directory for `spec`, asserting it stays
@@ -157,6 +182,25 @@ impl Bootstrap {
         let candidate = self.cache_root.join(spec.id.0);
         enforce_in_sandbox(&self.cache_root, &candidate, spec.id.0)?;
         Ok(candidate)
+    }
+
+    /// Absolute cache root passed at construction. Used by
+    /// [`crate::Server::from_registry`] to bind the spawn path to the
+    /// sandbox.
+    pub fn cache_root(&self) -> &Path {
+        &self.cache_root
+    }
+
+    /// Assert `candidate` resolves under the cache root. Returns
+    /// [`BootstrapError::SandboxEscape`] otherwise. Public so other modules
+    /// (notably [`crate::Server::from_registry`]) can reuse the same
+    /// lexical-prefix check the download path uses.
+    pub fn enforce_in_sandbox(
+        &self,
+        candidate: &Path,
+        server_id: &str,
+    ) -> Result<(), BootstrapError> {
+        enforce_in_sandbox(&self.cache_root, candidate, server_id)
     }
 
     /// Ensure `spec` is present in the cache. On a cache hit — the archive

--- a/crates/forge-lsp/src/lib.rs
+++ b/crates/forge-lsp/src/lib.rs
@@ -38,6 +38,7 @@ pub mod server;
 
 pub use bootstrap::{Bootstrap, BootstrapError, Downloader, HttpDownloader};
 pub use registry::{Checksum, Registry, ServerId, ServerSpec};
+
 pub use server::{
     BackoffPolicy, Clock, MessageTransport, Server, ServerError, ServerEvent, StdioTransport,
     SystemClock,

--- a/crates/forge-lsp/src/registry.rs
+++ b/crates/forge-lsp/src/registry.rs
@@ -93,6 +93,13 @@ impl Registry {
         self.entries.iter().find(|s| s.id == id)
     }
 
+    /// Look up a spec by id-as-string. Used at the IPC boundary where the
+    /// id arrives as a runtime-allocated [`String`] and cannot construct a
+    /// [`ServerId`] (its inner field is `&'static str`).
+    pub fn get_by_str(&self, id: &str) -> Option<&'static ServerSpec> {
+        self.entries.iter().find(|s| s.id.0 == id)
+    }
+
     /// Look up a spec by Monaco language id (e.g. `"rust"`, `"typescript"`).
     /// Returns the first match; multiple servers may claim a language but
     /// the bundled set is currently one-per-language.
@@ -104,6 +111,18 @@ impl Registry {
 impl Default for Registry {
     fn default() -> Self {
         Self::bundled()
+    }
+}
+
+impl Registry {
+    /// Construct a registry from an arbitrary `&'static` slice of specs.
+    /// Hidden from rustdoc — production callers should use
+    /// [`Registry::bundled`]. Integration tests and in-tree fixtures use
+    /// this to build a single-entry registry pointing at the stub LSP
+    /// fixture without leaking test scaffolding into the public API.
+    #[doc(hidden)]
+    pub fn from_entries(entries: &'static [ServerSpec]) -> Self {
+        Self { entries }
     }
 }
 

--- a/crates/forge-lsp/src/server.rs
+++ b/crates/forge-lsp/src/server.rs
@@ -36,6 +36,35 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{ChildStdin, Command};
 use tokio::sync::{mpsc, Mutex};
 
+use crate::bootstrap::{Bootstrap, BootstrapError};
+use crate::registry::ServerId;
+
+/// Variables forwarded from the parent process into every spawned LSP
+/// child. Mirrors the F-345 stdio-MCP allow-list.
+///
+/// Security posture: the child environment is **deny-by-default**. The
+/// spawn path calls `env_clear()` on the `Command` and then re-injects
+/// only this minimal allow-list, so a language server cannot silently
+/// read parent-held credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+/// `GITHUB_TOKEN`, `AWS_*`, arbitrary shell exports). Parent-env vars a
+/// real LSP server actually needs to locate its own binaries (e.g.
+/// `PATH` for `solargraph` → `ruby`, `HOME` for user config) are
+/// included explicitly.
+const PARENT_ENV_ALLOWLIST: &[&str] = &[
+    "PATH",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "USER",
+    "LOGNAME",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "SystemRoot",
+    "ComSpec",
+    "PATHEXT",
+];
+
 /// Errors returned by [`Server`] operations.
 #[derive(Debug, thiserror::Error)]
 pub enum ServerError {
@@ -55,6 +84,28 @@ pub enum ServerError {
     /// before `Server::start` had installed stdin, or after a terminal exit.
     #[error("server not running")]
     NotRunning,
+    /// Caller asked [`Server::from_registry`] for a `ServerId` the
+    /// [`Bootstrap::registry`] does not know. Keeps the IPC boundary honest:
+    /// the webview can only name a server that's already on the allow-list.
+    #[error("unknown lsp server: {id}")]
+    UnknownServerId {
+        /// The offending id.
+        id: String,
+    },
+    /// The resolved binary path escaped the cache-root sandbox. Produced by
+    /// [`Server::from_registry`] as defense-in-depth against a compromised
+    /// registry entry whose `binary_name` contains `..` or an absolute path.
+    #[error("binary path escaped lsp sandbox: {0}")]
+    SandboxEscape(PathBuf),
+}
+
+impl From<BootstrapError> for ServerError {
+    fn from(err: BootstrapError) -> Self {
+        match err {
+            BootstrapError::SandboxEscape { path, .. } => ServerError::SandboxEscape(path),
+            other => ServerError::Spawn(other.to_string()),
+        }
+    }
 }
 
 /// Server-emitted events surfaced on the receiver returned by
@@ -165,8 +216,58 @@ pub struct Server {
 }
 
 impl Server {
+    /// Build a supervised server from a [`ServerId`] resolved against the
+    /// [`Bootstrap`]'s registry. The resolved binary path is enforced to
+    /// live inside the cache-root sandbox before it ever reaches
+    /// [`Command::new`]. This is the **only** public constructor: callers
+    /// at the IPC boundary cannot name an arbitrary binary path, closing
+    /// the arbitrary-binary-exec surface the raw-`PathBuf` constructor
+    /// left open (F-353).
+    ///
+    /// `extra_args` are appended to the spec-declared argv (reserved for
+    /// future per-install flags); pass `Vec::new()` when no extras are
+    /// needed.
+    ///
+    /// Errors:
+    /// - [`ServerError::UnknownServerId`] if the id is absent from the
+    ///   registry.
+    /// - [`ServerError::SandboxEscape`] if the resolved binary path lands
+    ///   outside the cache root (defense-in-depth against a hostile spec).
+    pub fn from_registry(
+        id: ServerId,
+        bootstrap: &Bootstrap,
+        extra_args: Vec<String>,
+    ) -> Result<Self, ServerError> {
+        let spec = bootstrap
+            .registry()
+            .get(id)
+            .ok_or_else(|| ServerError::UnknownServerId { id: id.to_string() })?;
+        let server_dir = bootstrap.server_dir(spec)?;
+        let program = server_dir.join(spec.binary_name);
+        // Defense-in-depth: re-check the leaf path, not just the server dir.
+        // A hostile `binary_name` (e.g. `"../../../bin/sh"`) would otherwise
+        // escape because `server_dir` only validates the parent.
+        bootstrap.enforce_in_sandbox(&program, spec.id.0)?;
+        Ok(Self::with_policy_and_clock(
+            program,
+            extra_args,
+            BackoffPolicy::default(),
+            Arc::new(SystemClock),
+        ))
+    }
+
     /// Build a supervised server from a binary path + args. The server is
     /// not spawned until [`Server::start`].
+    ///
+    /// **Hidden from rustdoc.** This is the raw, trust-the-caller
+    /// constructor. External callers (most notably the Tauri IPC layer)
+    /// must go through [`Server::from_registry`] so the binary path is
+    /// bound to the cache-root sandbox instead of accepted verbatim from
+    /// the webview — F-353 closed that surface. The constructor remains
+    /// reachable under `#[doc(hidden)]` so the in-tree stdio round-trip
+    /// integration test can drive the fixture binary directly without the
+    /// registry scaffolding.
+    #[doc(hidden)]
     pub fn new(program: PathBuf, args: Vec<String>) -> Self {
         Self::with_policy_and_clock(
             program,
@@ -177,6 +278,10 @@ impl Server {
     }
 
     /// Construct with explicit backoff + clock (used by tests).
+    ///
+    /// **Hidden from rustdoc.** Production callers use
+    /// [`Server::from_registry`].
+    #[doc(hidden)]
     pub fn with_policy_and_clock(
         program: PathBuf,
         args: Vec<String>,
@@ -267,7 +372,20 @@ impl Server {
     async fn spawn_once(&self) -> Result<Option<i32>, ServerError> {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args)
-            .stdin(StdStdio::piped())
+            // Security (F-353, mirrors F-345 on the MCP axis): wipe the
+            // inherited environment first, then re-inject only the minimal
+            // `PARENT_ENV_ALLOWLIST`. A language server should not see the
+            // parent's AI-provider API keys, GitHub tokens, or arbitrary
+            // shell exports. LSP servers communicate via stdio; everything
+            // they need to locate their own dependencies is in the
+            // allow-list.
+            .env_clear();
+        for key in PARENT_ENV_ALLOWLIST {
+            if let Ok(val) = std::env::var(key) {
+                cmd.env(key, val);
+            }
+        }
+        cmd.stdin(StdStdio::piped())
             .stdout(StdStdio::piped())
             .stderr(StdStdio::piped())
             .kill_on_drop(true);
@@ -484,5 +602,164 @@ mod tests {
             .await
             .expect("supervisor returns after GaveUp");
         joined.expect("join handle").expect("start returns Ok");
+    }
+
+    // -----------------------------------------------------------------------
+    // F-353: arbitrary-binary-exec closure
+    //
+    // `Server::from_registry` must be the only public constructor. It must
+    // reject any registry entry whose resolved binary path escapes the
+    // cache-root sandbox, and it must reject unknown server ids — a hostile
+    // IPC caller must not be able to name a binary outside the cache root
+    // by manipulating either the `binary_name` on the spec or the `id`
+    // itself.
+    // -----------------------------------------------------------------------
+
+    use crate::bootstrap::{Bootstrap, Downloader};
+    use crate::registry::{Checksum, Registry, ServerSpec};
+
+    struct NoopDownloader;
+    #[async_trait]
+    impl Downloader for NoopDownloader {
+        async fn fetch(
+            &self,
+            _url: &str,
+        ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+            unreachable!("from_registry must not hit the network");
+        }
+    }
+
+    fn single_spec_registry(spec: ServerSpec) -> Registry {
+        Registry::from_entries(Box::leak(Box::new([spec])))
+    }
+
+    #[test]
+    fn from_registry_rejects_unknown_server_id() {
+        // DoD: IPC cannot name an id that isn't in the registry — the
+        // constructor returns before any PathBuf composition happens.
+        let tmp = tempfile::tempdir().unwrap();
+        let bootstrap = Bootstrap::with_registry(
+            tmp.path().to_path_buf(),
+            Box::new(NoopDownloader),
+            Registry::from_entries(&[]),
+        );
+        let err = match Server::from_registry(ServerId("missing"), &bootstrap, Vec::new()) {
+            Ok(_) => panic!("unknown id must reject"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, ServerError::UnknownServerId { ref id } if id == "missing"),
+            "expected UnknownServerId, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_registry_rejects_binary_outside_cache_root() {
+        // DoD: the core finding. A hostile spec pointing at `/bin/sh` via
+        // a traversing `binary_name` must be rejected *before* Command::new
+        // is ever called.
+        let tmp = tempfile::tempdir().unwrap();
+        // `binary_name` traverses out of the cache root into /bin. The
+        // server_dir check alone doesn't cover this: the leaf path check
+        // in `from_registry` is what closes the surface.
+        let hostile = ServerSpec {
+            id: ServerId("hostile-srv"),
+            language_id: "any",
+            binary_name: "../../../../../../bin/sh",
+            download_url: "http://example.invalid/",
+            checksum: Checksum::Pending,
+        };
+        let bootstrap = Bootstrap::with_registry(
+            tmp.path().to_path_buf(),
+            Box::new(NoopDownloader),
+            single_spec_registry(hostile),
+        );
+        let err = match Server::from_registry(ServerId("hostile-srv"), &bootstrap, Vec::new()) {
+            Ok(_) => panic!("binary outside cache root must reject"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, ServerError::SandboxEscape(_)),
+            "expected SandboxEscape, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_registry_accepts_binary_inside_cache_root() {
+        // Positive case: a well-formed spec resolves to a path rooted
+        // under the cache. We don't spawn; `from_registry` is pure path
+        // resolution.
+        let tmp = tempfile::tempdir().unwrap();
+        let benign = ServerSpec {
+            id: ServerId("benign-srv"),
+            language_id: "any",
+            binary_name: "bin",
+            download_url: "http://example.invalid/",
+            checksum: Checksum::Pending,
+        };
+        let bootstrap = Bootstrap::with_registry(
+            tmp.path().to_path_buf(),
+            Box::new(NoopDownloader),
+            single_spec_registry(benign),
+        );
+        let _server = Server::from_registry(ServerId("benign-srv"), &bootstrap, Vec::new())
+            .expect("benign spec must resolve");
+    }
+
+    /// Proves the F-353 env-scrub: a language-server child does not see a
+    /// sentinel env var set in the parent. Mirrors the F-345 canary shape
+    /// in `forge-mcp::transport::stdio`.
+    ///
+    /// We can't use the Tauri mock fixture here (cross-crate) and the
+    /// supervisor's backoff loop swallows child exit codes, so we drive
+    /// the scrub via a shell-level assertion: spawn `sh -c 'test -z
+    /// "$CANARY" && exit 0 || exit 42'`. Pre-fix (no `env_clear`) the
+    /// child would observe `CANARY=leak-me` and exit 42. Post-fix the
+    /// child exits 0, which the supervisor surfaces as `code: Some(0)`
+    /// on the event channel.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn child_env_is_scrubbed_of_parent_secrets() {
+        // Pick a key unlikely to collide with anything CI exports.
+        const CANARY_KEY: &str = "FORGE_LSP_F353_CANARY";
+        std::env::set_var(CANARY_KEY, "leak-me");
+
+        let policy = BackoffPolicy {
+            max_attempts: 1,
+            window: Duration::from_secs(600),
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(1),
+        };
+        let mut server = Server::with_policy_and_clock(
+            PathBuf::from("/bin/sh"),
+            vec![
+                "-c".to_string(),
+                format!("test -z \"${CANARY_KEY}\" && exit 0 || exit 42"),
+            ],
+            policy,
+            Arc::new(SystemClock),
+        );
+        let mut rx = server.take_events().expect("event rx");
+        let sup = tokio::spawn(async move { server.start().await });
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut exit_code: Option<i32> = None;
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_secs(2), rx.recv()).await {
+                Ok(Some(ServerEvent::Exited { code, .. })) => {
+                    exit_code = code;
+                    break;
+                }
+                Ok(Some(_)) => continue,
+                Ok(None) | Err(_) => break,
+            }
+        }
+        let _ = tokio::time::timeout(Duration::from_secs(2), sup).await;
+        std::env::remove_var(CANARY_KEY);
+
+        assert_eq!(
+            exit_code,
+            Some(0),
+            "child saw parent's CANARY env — env_clear() is missing or bypassed"
+        );
     }
 }

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -30,7 +30,9 @@ use forge_core::approvals::{
 };
 use forge_core::{ApprovalLevel, ApprovalScope, RerunVariant, TerminalId};
 use forge_ipc::HelloAck;
-use forge_lsp::{MessageTransport, Server as LspServer, ServerEvent as LspServerEvent};
+use forge_lsp::{
+    Bootstrap as LspBootstrap, MessageTransport, Server as LspServer, ServerEvent as LspServerEvent,
+};
 use forge_term::{ShellSpec, TerminalEvent, TerminalSession, TerminalSize};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, EventTarget, Manager, Runtime, State, Webview};
@@ -466,9 +468,73 @@ pub fn manage_terminals<R: Runtime>(app: &AppHandle<R>) {
 /// Attach the `LspState` to an app builder. Idempotent — parallels
 /// [`manage_terminals`] so tests can wire both and production `window_manager`
 /// can call once.
+///
+/// Also attaches an [`LspBootstrapState`] holding the bundled-registry
+/// [`forge_lsp::Bootstrap`] (F-353). `lsp_start` resolves a webview-supplied
+/// server id against this bootstrap's registry, then binds the resolved
+/// binary path to the cache-root sandbox — the webview never names a
+/// filesystem path.
+///
+/// On a host where the platform cache dir cannot be resolved
+/// (`BootstrapError::NoCacheDir`), no state is attached and `lsp_start`
+/// returns a plain string error on every invoke. Tests that want a custom
+/// registry (e.g. pointing at the in-tree `forge-lsp-mock-stdio` fixture)
+/// override the managed state *after* this call via
+/// [`LspBootstrapState::override_for_tests`].
 pub fn manage_lsp<R: Runtime>(app: &AppHandle<R>) {
     if app.try_state::<LspState>().is_none() {
         app.manage(LspState::default());
+    }
+    if app.try_state::<LspBootstrapState>().is_none() {
+        app.manage(LspBootstrapState::new());
+    }
+}
+
+/// Tauri-managed [`forge_lsp::Bootstrap`] singleton. Wraps an `Arc` so the
+/// async `lsp_start` handler can clone a reference without holding a mutex
+/// guard across the `Server::from_registry` path-resolution work.
+///
+/// Initialized to the platform default (`Bootstrap::new()`), or `None` if
+/// the host lacks a cache dir. Integration tests override this via
+/// [`LspBootstrapState::override_for_tests`] so the `lsp_start` call
+/// resolves to an in-tree fixture instead of making network I/O inevitable
+/// for a real registered server.
+pub struct LspBootstrapState {
+    inner: Mutex<Option<Arc<LspBootstrap>>>,
+}
+
+impl Default for LspBootstrapState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LspBootstrapState {
+    /// Populate from [`LspBootstrap::new`]. Swallows a `NoCacheDir` error
+    /// and leaves the slot empty; `lsp_start` surfaces that to the webview
+    /// as a string error instead of panicking app startup.
+    pub fn new() -> Self {
+        let inner = LspBootstrap::new().ok().map(Arc::new);
+        Self {
+            inner: Mutex::new(inner),
+        }
+    }
+
+    /// Snapshot the current bootstrap, if any. Returns a clone of the
+    /// `Arc` so handlers can drop the mutex guard before awaiting.
+    pub fn snapshot(&self) -> Option<Arc<LspBootstrap>> {
+        self.inner
+            .lock()
+            .expect("lsp bootstrap state poisoned")
+            .clone()
+    }
+
+    /// Replace the managed bootstrap. Integration tests use this to
+    /// substitute a tempdir-rooted `Bootstrap` with a single-spec
+    /// `Registry` pointing at the stub LSP fixture.
+    #[doc(hidden)]
+    pub fn override_for_tests(&self, bootstrap: Arc<LspBootstrap>) {
+        *self.inner.lock().expect("lsp bootstrap state poisoned") = Some(bootstrap);
     }
 }
 
@@ -1470,22 +1536,27 @@ pub const LSP_MESSAGE_EVENT: &str = "lsp_message";
 /// uris run tens of KiB), so the ceiling is generous but still bounded so a
 /// compromised webview can't loop 1 MiB sends billing server memory.
 pub(crate) const MAX_LSP_SERVER_ID_BYTES: usize = 128;
-pub(crate) const MAX_LSP_BINARY_PATH_BYTES: usize = 4096;
 pub(crate) const MAX_LSP_MESSAGE_BYTES: usize = 512 * 1024;
 
 /// Wire-format arguments for `lsp_start`.
+///
+/// F-353: the binary path is no longer part of the wire format. The webview
+/// names a server by id; the shell resolves the binary through the bundled
+/// [`forge_lsp::Registry`] plus [`forge_lsp::Bootstrap`]'s cache-root
+/// sandbox. A compromised or buggy webview that forwarded an
+/// attacker-controlled path used to land as `Command::new(path).spawn()`;
+/// that surface is closed.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../web/packages/ipc/src/generated/")]
 pub struct LspStartArgs {
     /// Server identifier (matches `forge_lsp::ServerId` entries in the
-    /// bundled registry). Used as the routing key on `lsp_message` events.
+    /// bundled registry). Used as the routing key on `lsp_message` events
+    /// and as the registry lookup key for the binary path — the webview
+    /// never names a filesystem path directly.
     pub server: String,
-    /// Absolute path to the server binary. Callers resolve this via
-    /// `forge-lsp::Bootstrap::ensure` before invoking; the command does not
-    /// download. Keeps the download path out of the Tauri trust boundary.
-    pub binary_path: String,
-    /// Optional argv after the binary path. Bounded via the server-id cap
-    /// since each arg is expected to be short; oversize argv is a misuse.
+    /// Optional extra argv appended to the spec's declared args. Bounded
+    /// via the server-id cap since each arg is expected to be short;
+    /// oversize argv is a misuse.
     #[serde(default)]
     pub args: Vec<String>,
 }
@@ -1596,10 +1667,19 @@ fn spawn_lsp_forwarder<R: Runtime>(
 /// as the server's owner; subsequent commands targeting this `server` id
 /// are rejected unless they come from the same webview.
 ///
+/// F-353: the binary is resolved through the bundled [`forge_lsp::Registry`]
+/// + [`forge_lsp::Bootstrap`]'s cache-root sandbox. The webview cannot
+/// supply a filesystem path; an unknown `server` id returns
+/// `"unknown lsp server: <id>"`; any registry entry whose resolved path
+/// escapes the cache root is rejected with a sandbox error before
+/// `Command::new` is ever called.
+///
 /// Errors:
 /// - label not `session-*` → `forbidden: window label mismatch`
-/// - oversize `server` / `binary_path` → size-cap error
+/// - oversize `server` → size-cap error
 /// - duplicate `server` id → `"lsp server already running: <id>"`
+/// - unknown `server` id → `"unknown lsp server: <id>"`
+/// - lsp bootstrap not wired → `"lsp bootstrap unavailable"`
 /// - spawn failure surfaces the `forge-lsp` error
 #[tauri::command]
 pub async fn lsp_start<R: Runtime>(
@@ -1607,20 +1687,35 @@ pub async fn lsp_start<R: Runtime>(
     app: AppHandle<R>,
     webview: Webview<R>,
     state: State<'_, LspState>,
+    bootstrap: State<'_, LspBootstrapState>,
 ) -> Result<(), String> {
     // LSP servers are session-scoped. Dashboard and any other label is
     // rejected — mirrors the terminal authz shape on the LSP axis.
     require_window_label_in(&webview, &[], true)?;
 
     require_size("server", &args.server, MAX_LSP_SERVER_ID_BYTES)?;
-    require_size("binary_path", &args.binary_path, MAX_LSP_BINARY_PATH_BYTES)?;
 
     let owner_label = webview.label().to_string();
     let server_id = args.server.clone();
 
+    let bootstrap = bootstrap
+        .snapshot()
+        .ok_or_else(|| "lsp bootstrap unavailable".to_string())?;
+
+    // Registry gate: a webview-supplied id must match a known spec. This
+    // is what replaces the raw `binary_path` surface — the IPC cannot
+    // name an executable, only an id the shell already trusts.
+    let spec = bootstrap
+        .registry()
+        .get_by_str(&server_id)
+        .ok_or_else(|| format!("unknown lsp server: {server_id}"))?;
+
     // Build the supervisor + transport before registering, so spawn failures
-    // don't leave a zombie entry.
-    let mut supervisor = LspServer::new(args.binary_path.into(), args.args);
+    // don't leave a zombie entry. `from_registry` enforces the cache-root
+    // sandbox on the resolved binary path; any `BootstrapError::SandboxEscape`
+    // surfaces as `ServerError::SandboxEscape` and never reaches `Command`.
+    let mut supervisor =
+        LspServer::from_registry(spec.id, &bootstrap, args.args).map_err(|e| e.to_string())?;
     let transport = supervisor.transport();
     let rx = supervisor
         .take_events()

--- a/crates/forge-shell/tests/ipc_lsp.rs
+++ b/crates/forge-shell/tests/ipc_lsp.rs
@@ -10,25 +10,29 @@
 //! - a round-trip via the stub LSP fixture proves the message event reaches
 //!   the owner webview (and only the owner).
 //!
-//! We reuse the `forge-lsp-mock-stdio` fixture from the forge-lsp crate —
-//! `env!("CARGO_BIN_EXE_forge-lsp-mock-stdio")` resolves to the test-time
-//! fixture binary path.
+//! F-353: `lsp_start` no longer accepts a `binary_path`. The webview names
+//! a server id only; the shell resolves the binary through the managed
+//! `forge_lsp::Bootstrap` + `Registry`. Tests override the managed
+//! bootstrap with a tempdir-rooted one whose registry lists every id each
+//! test uses, seeding the fixture binary at the cache-root path the
+//! production resolution would land on (`<cache_root>/<id>/<binary_name>`).
 
 #![cfg(feature = "webview-test")]
 
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use forge_shell::ipc::{build_invoke_handler, manage_lsp};
+use forge_lsp::{Bootstrap, Checksum, Registry, ServerId, ServerSpec};
+use forge_shell::ipc::{build_invoke_handler, manage_lsp, LspBootstrapState};
 use serde_json::Value;
 use tauri::test::{get_ipc_response, mock_builder, mock_context, noop_assets, INVOKE_KEY};
-use tauri::Listener;
+use tauri::{Listener, Manager};
 
 const LABEL_MISMATCH: &str = "forbidden: window label mismatch";
 
-fn mock_stdio_path() -> String {
-    // Depend on the fixture binary built by the `forge-lsp` crate. Cargo
-    // does not export sibling crate bin paths via `CARGO_BIN_EXE_*`, so
-    // we resolve the target dir explicitly.
+/// Path to the in-tree `forge-lsp-mock-stdio` fixture binary.
+fn mock_stdio_path() -> PathBuf {
     let exe = std::env::current_exe().expect("current_exe");
     // target/debug/deps/ipc_lsp-HASH → target/debug/
     let mut dir = exe
@@ -46,16 +50,113 @@ fn mock_stdio_path() -> String {
          missing: {}",
         dir.display()
     );
-    dir.to_string_lossy().into_owned()
+    dir
 }
 
-fn make_app() -> tauri::App<tauri::test::MockRuntime> {
+/// `NoopDownloader` proves the production path doesn't hit the network
+/// during these tests — `Server::from_registry` does not download, it only
+/// resolves a cached path.
+struct NoopDownloader;
+#[async_trait::async_trait]
+impl forge_lsp::Downloader for NoopDownloader {
+    async fn fetch(&self, _url: &str) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        unreachable!("lsp_start must not hit the network in tests");
+    }
+}
+
+/// Seed a tempdir cache root with the mock fixture at
+/// `<cache_root>/<id>/<binary_name>` for every id in `ids`, and build a
+/// `Bootstrap` whose single-purpose registry names those ids. Returns the
+/// owned `TempDir` so the caller can keep the cache alive for the test
+/// body.
+fn seed_fixture_bootstrap(
+    ids: &[&'static str],
+    binary_name: &'static str,
+) -> (tempfile::TempDir, Arc<Bootstrap>, Vec<&'static str>) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let src = mock_stdio_path();
+
+    for id in ids {
+        let dst_dir = tmp.path().join(id);
+        std::fs::create_dir_all(&dst_dir).expect("create server dir");
+        let dst = dst_dir.join(binary_name);
+        std::fs::copy(&src, &dst).expect("copy fixture");
+        set_executable(&dst);
+    }
+
+    let entries: Vec<ServerSpec> = ids
+        .iter()
+        .map(|id| ServerSpec {
+            id: ServerId(id),
+            language_id: "mock",
+            binary_name,
+            download_url: "http://example.invalid/",
+            checksum: Checksum::Pending,
+        })
+        .collect();
+    let leaked: &'static [ServerSpec] = Box::leak(entries.into_boxed_slice());
+    let registry = Registry::from_entries(leaked);
+
+    let bootstrap =
+        Bootstrap::with_registry(tmp.path().to_path_buf(), Box::new(NoopDownloader), registry);
+    (tmp, Arc::new(bootstrap), ids.to_vec())
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).unwrap();
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) {}
+
+struct TestApp {
+    app: tauri::App<tauri::test::MockRuntime>,
+    _cache: tempfile::TempDir,
+}
+
+impl TestApp {
+    fn handle(&self) -> tauri::AppHandle<tauri::test::MockRuntime> {
+        self.app.handle().clone()
+    }
+}
+
+fn make_app_with_bootstrap(ids: &[&'static str]) -> TestApp {
+    let (cache, bootstrap, _ids) = seed_fixture_bootstrap(ids, "mock-stdio");
     let app = mock_builder()
         .invoke_handler(build_invoke_handler())
         .build(mock_context(noop_assets()))
         .expect("build mock Tauri app");
     manage_lsp(&app.handle().clone());
-    app
+    app.handle()
+        .state::<LspBootstrapState>()
+        .override_for_tests(bootstrap);
+    TestApp { app, _cache: cache }
+}
+
+/// Build an app with the managed `LspBootstrap` wired to an empty-registry
+/// tempdir — used by tests that assert the IPC rejects arbitrary paths
+/// and unknown server ids without ever reaching the fixture.
+fn make_app_empty_registry() -> TestApp {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let registry = Registry::from_entries(&[]);
+    let bootstrap = Arc::new(Bootstrap::with_registry(
+        tmp.path().to_path_buf(),
+        Box::new(NoopDownloader),
+        registry,
+    ));
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    manage_lsp(&app.handle().clone());
+    app.handle()
+        .state::<LspBootstrapState>()
+        .override_for_tests(bootstrap);
+    TestApp { app, _cache: tmp }
 }
 
 fn make_window(
@@ -96,15 +197,14 @@ fn invoke(
 
 #[test]
 fn dashboard_window_cannot_start_an_lsp_server() {
-    let app = make_app();
-    let window = make_window(&app, "dashboard");
+    let app = make_app_with_bootstrap(&["rust-analyzer"]);
+    let window = make_window(&app.app, "dashboard");
     let err = invoke(
         &window,
         "lsp_start",
         serde_json::json!({
             "args": {
                 "server": "rust-analyzer",
-                "binary_path": mock_stdio_path(),
                 "args": [],
             }
         }),
@@ -115,15 +215,16 @@ fn dashboard_window_cannot_start_an_lsp_server() {
         err.contains(LABEL_MISMATCH),
         "expected label-mismatch error, got: {err}"
     );
+    let _ = app.handle();
 }
 
 #[test]
 fn cross_session_send_is_rejected_with_label_mismatch() {
     // Alice starts an LSP server; Bob tries to send to it. The registry
     // binds the server to alice's label and must reject bob's invoke.
-    let app = make_app();
-    let alice = make_window(&app, "session-alice-lsp");
-    let bob = make_window(&app, "session-bob-lsp");
+    let app = make_app_with_bootstrap(&["alice-srv"]);
+    let alice = make_window(&app.app, "session-alice-lsp");
+    let bob = make_window(&app.app, "session-bob-lsp");
 
     invoke(
         &alice,
@@ -131,7 +232,6 @@ fn cross_session_send_is_rejected_with_label_mismatch() {
         serde_json::json!({
             "args": {
                 "server": "alice-srv",
-                "binary_path": mock_stdio_path(),
                 "args": [],
             }
         }),
@@ -169,6 +269,69 @@ fn cross_session_send_is_rejected_with_label_mismatch() {
 }
 
 // ---------------------------------------------------------------------------
+// F-353: arbitrary-binary-exec closure at the IPC boundary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lsp_start_rejects_unknown_server_id() {
+    // The webview names an id the shell has never heard of. With the raw-
+    // PathBuf surface removed, there's no way to coax `Command::new` into
+    // accepting the request — it bounces at the registry gate before any
+    // path is resolved.
+    let app = make_app_empty_registry();
+    let window = make_window(&app.app, "session-lsp-unknown");
+    let err = invoke(
+        &window,
+        "lsp_start",
+        serde_json::json!({
+            "args": {
+                "server": "not-in-registry",
+                "args": [],
+            }
+        }),
+    )
+    .expect_err("unknown server id must reject");
+    assert!(
+        err.contains("unknown lsp server"),
+        "expected unknown-id error, got: {err}"
+    );
+}
+
+#[test]
+fn lsp_start_rejects_arbitrary_binary_path_field() {
+    // Pre-F-353, the webview could supply `binary_path: "/usr/bin/ncat"`.
+    // Post-fix the field is gone from the wire format: serde rejects the
+    // unknown top-level key, or the id lookup fails, depending on how the
+    // compromised webview frames the payload. Either way the invoke does
+    // not spawn a child.
+    let app = make_app_empty_registry();
+    let window = make_window(&app.app, "session-lsp-path-inject");
+
+    // Shape 1: keep the `binary_path` key even though the server type no
+    // longer names it. Serde's default strategy rejects extra fields
+    // because the struct has no `#[serde(deny_unknown_fields)]`-relaxing
+    // option — but `serde_json` allows extras by default. So the *real*
+    // post-fix guarantee is the registry-gate failure below, not a
+    // deserialization failure. This test locks *that* guarantee.
+    let err = invoke(
+        &window,
+        "lsp_start",
+        serde_json::json!({
+            "args": {
+                "server": "arbitrary-binary-srv",
+                "binary_path": "/usr/bin/ncat",
+                "args": ["-lvp", "4444", "-e", "/bin/sh"],
+            }
+        }),
+    )
+    .expect_err("compromised payload must not spawn a child");
+    assert!(
+        err.contains("unknown lsp server"),
+        "expected unknown-id rejection (registry gate), got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // DoD: initialize → lsp_message event → shutdown round trip via IPC
 // ---------------------------------------------------------------------------
 
@@ -203,8 +366,8 @@ fn drain_lsp_messages(
 
 #[test]
 fn initialize_round_trip_emits_lsp_message_on_owner_webview() {
-    let app = make_app();
-    let window = make_window(&app, "session-lsp-round");
+    let app = make_app_with_bootstrap(&["mock-srv"]);
+    let window = make_window(&app.app, "session-lsp-round");
 
     invoke(
         &window,
@@ -212,7 +375,6 @@ fn initialize_round_trip_emits_lsp_message_on_owner_webview() {
         serde_json::json!({
             "args": {
                 "server": "mock-srv",
-                "binary_path": mock_stdio_path(),
                 "args": [],
             }
         }),
@@ -281,8 +443,8 @@ fn initialize_round_trip_emits_lsp_message_on_owner_webview() {
 
 #[test]
 fn duplicate_server_id_is_rejected() {
-    let app = make_app();
-    let window = make_window(&app, "session-lsp-dup");
+    let app = make_app_with_bootstrap(&["dup-srv"]);
+    let window = make_window(&app.app, "session-lsp-dup");
 
     invoke(
         &window,
@@ -290,7 +452,6 @@ fn duplicate_server_id_is_rejected() {
         serde_json::json!({
             "args": {
                 "server": "dup-srv",
-                "binary_path": mock_stdio_path(),
                 "args": [],
             }
         }),
@@ -303,7 +464,6 @@ fn duplicate_server_id_is_rejected() {
         serde_json::json!({
             "args": {
                 "server": "dup-srv",
-                "binary_path": mock_stdio_path(),
                 "args": [],
             }
         }),
@@ -326,8 +486,8 @@ fn duplicate_server_id_is_rejected() {
 fn oversize_message_is_rejected_at_command_layer() {
     // A 1 MiB payload exceeds MAX_LSP_MESSAGE_BYTES (512 KiB). The command
     // must reject before the transport touches stdin.
-    let app = make_app();
-    let window = make_window(&app, "session-lsp-cap");
+    let app = make_app_with_bootstrap(&["cap-srv"]);
+    let window = make_window(&app.app, "session-lsp-cap");
 
     invoke(
         &window,
@@ -335,7 +495,6 @@ fn oversize_message_is_rejected_at_command_layer() {
         serde_json::json!({
             "args": {
                 "server": "cap-srv",
-                "binary_path": mock_stdio_path(),
                 "args": [],
             }
         }),

--- a/web/packages/ipc/src/generated/LspStartArgs.ts
+++ b/web/packages/ipc/src/generated/LspStartArgs.ts
@@ -2,21 +2,25 @@
 
 /**
  * Wire-format arguments for `lsp_start`.
+ *
+ * F-353: the binary path is no longer part of the wire format. The webview
+ * names a server by id; the shell resolves the binary through the bundled
+ * [`forge_lsp::Registry`] plus [`forge_lsp::Bootstrap`]'s cache-root
+ * sandbox. A compromised or buggy webview that forwarded an
+ * attacker-controlled path used to land as `Command::new(path).spawn()`;
+ * that surface is closed.
  */
 export type LspStartArgs = { 
 /**
  * Server identifier (matches `forge_lsp::ServerId` entries in the
- * bundled registry). Used as the routing key on `lsp_message` events.
+ * bundled registry). Used as the routing key on `lsp_message` events
+ * and as the registry lookup key for the binary path — the webview
+ * never names a filesystem path directly.
  */
 server: string, 
 /**
- * Absolute path to the server binary. Callers resolve this via
- * `forge-lsp::Bootstrap::ensure` before invoking; the command does not
- * download. Keeps the download path out of the Tauri trust boundary.
- */
-binary_path: string, 
-/**
- * Optional argv after the binary path. Bounded via the server-id cap
- * since each arg is expected to be short; oversize argv is a misuse.
+ * Optional extra argv appended to the spec's declared args. Bounded
+ * via the server-id cap since each arg is expected to be short;
+ * oversize argv is a misuse.
  */
 args: Array<string>, };


### PR DESCRIPTION
Closes forge-ide/forge#354

## Summary

`Server::new` previously took a raw `PathBuf` that flowed into `Command::new(path).spawn()`. The `lsp_start` Tauri command accepted that same path from the webview, so a compromised renderer could name any binary on disk and have the shell exec it. This PR removes the attacker-controlled path from the boundary entirely.

## Approach

- **Wire-format change**: `LspStartArgs` no longer carries `binary_path`. The webview names a server by id; the shell resolves the binary.
- **New secure constructor**: `Server::from_registry(id, &bootstrap, args)` is now the only public construction path. It looks up the spec in the bundled `Registry`, composes `cache_root/<id>/<binary_name>`, and re-checks the leaf path against the sandbox root so hostile `binary_name` entries containing `..` are rejected.
- **Demote the old entry points**: `Server::new` and `Server::with_policy_and_clock` are now `#[doc(hidden)] pub` — still reachable from the integration test in `crates/forge-shell/tests/` (outside the crate), but hidden from docs and not part of the supported surface.
- **Child env scrub**: `spawn_once` now calls `.env_clear()` and re-injects an allowlist (PATH, HOME, LANG, locale, tempdir vars, Windows shims). Mirrors the F-345 fix for MCP stdio and prevents parent secrets leaking into language servers.
- **IPC wiring**: `LspBootstrapState` is attached to Tauri managed state with an override-for-tests hook. `lsp_start` now resolves the spec via `bootstrap.registry().get_by_str(&server_id)` and calls `Server::from_registry`.

## Tests

Red tests were written first for each new guarantee:

- `from_registry_rejects_unknown_server_id`
- `from_registry_rejects_binary_outside_cache_root` — uses a hostile `binary_name: "../../../../../../bin/sh"` leaked into a static registry; the sandbox check must refuse
- `from_registry_accepts_binary_inside_cache_root`
- `child_env_is_scrubbed_of_parent_secrets` — shell canary test
- `lsp_start_rejects_unknown_server_id`
- `lsp_start_rejects_arbitrary_binary_path_field` — serde rejects the extra field, and even if a future relaxation drops that check the registry gate is the real defense

All five pre-existing `ipc_lsp` tests were updated to drop the `binary_path` JSON field and route through the new bootstrap override.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] New TDD-red tests in `crates/forge-lsp/src/server.rs` and `crates/forge-shell/tests/ipc_lsp.rs` cover the rejection paths

## DoD

- [x] `Server::new` no longer accepts caller-supplied paths on the public surface; sole public construction path is `Server::from_registry`
- [x] `LspStartArgs` wire type drops `binary_path`; TS binding regenerated
- [x] Registry + sandbox gate rejects unknown ids and paths that escape the cache root
- [x] Child env scrubbed via `env_clear` + allowlist
- [x] TDD red-first for every new rejection behavior
- [x] Architecture doc §3.7 scope divergence note left untouched (F-148 handles that reconcile)

## Design note

The defense is layered: the registry lookup keyed by a string rejects unknown ids, then `bootstrap.enforce_in_sandbox` re-checks the composed path so a hostile `binary_name` baked into a tampered registry entry still cannot escape `cache_root`. Demoting `Server::new` to `#[doc(hidden)] pub` was chosen over `pub(crate)` because the integration test in `crates/forge-shell/tests/` lives outside the crate and still needs to construct servers directly in a few non-security-sensitive paths; `#[doc(hidden)]` keeps it out of rustdoc and off the supported API without losing test reach.