### PR TITLE
[F-412] frontend: ActivityBar swaps opacity for iron-600 disabled token

### DIFF
--- a/web/packages/app/src/shell/ActivityBar.css
+++ b/web/packages/app/src/shell/ActivityBar.css
@@ -35,9 +35,12 @@
   outline-offset: -2px;
 }
 
+/* F-412: disabled state uses the semantic iron-600 text token per
+ * `docs/design/component-principles.md §Buttons`. Opacity is banned — it
+ * makes disabled controls look interactive and muddies the surface. */
 .activity-bar__item:disabled {
   cursor: default;
-  opacity: 0.4;
+  color: var(--color-text-disabled);
 }
 
 .activity-bar__item--active {

--- a/web/packages/app/src/shell/ActivityBar.css.test.ts
+++ b/web/packages/app/src/shell/ActivityBar.css.test.ts
@@ -1,0 +1,45 @@
+// F-412: ActivityBar disabled-state CSS contract.
+//
+// `docs/design/component-principles.md §Buttons` bans opacity as a disabled
+// affordance: "Disabled buttons use iron-600 background and text. Never
+// reduce opacity on a button to show disabled state — opacity makes elements
+// appear interactive." Mirror the `ChatPane.css` composer-disabled precedent
+// by asserting against the CSS source directly — jsdom does not resolve
+// external stylesheets at render time, so the file itself is the contract.
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const cssSource = readFileSync(resolve(__dirname, 'ActivityBar.css'), 'utf-8');
+
+// Match `.activity-bar__item:disabled { ... }` and capture the rule body.
+const ruleMatch = cssSource.match(
+  /\.activity-bar__item:disabled\s*\{([^}]*)\}/,
+);
+
+describe('ActivityBar disabled state CSS (F-412)', () => {
+  it('declares a `:disabled` rule for the activity-bar item', () => {
+    expect(ruleMatch).not.toBeNull();
+  });
+
+  it('does not reduce opacity to signal disabled (component-principles.md)', () => {
+    const body = ruleMatch?.[1] ?? '';
+    expect(body).not.toMatch(/\bopacity\s*:/);
+  });
+
+  it('uses --color-text-disabled (iron-600) for the disabled text color', () => {
+    const body = ruleMatch?.[1] ?? '';
+    expect(body).toMatch(/color\s*:\s*var\(--color-text-disabled\)/);
+  });
+
+  it('keeps `cursor: default` to signal the non-interactive state', () => {
+    const body = ruleMatch?.[1] ?? '';
+    expect(body).toMatch(/cursor\s*:\s*default/);
+  });
+});
+
+describe('ActivityBar.css global opacity hygiene (F-412)', () => {
+  it('declares no opacity rule anywhere in the file', () => {
+    expect(cssSource).not.toMatch(/\bopacity\s*:/);
+  });
+});


### PR DESCRIPTION
Closes forge-ide/forge#413

## Summary
- Replace `opacity: 0.4` in `ActivityBar.css:38-41` with `color: var(--color-text-disabled)` (the semantic iron-600 token).
- Add `ActivityBar.css.test.ts` — CSS-source contract test mirroring the `ChatPane.css` composer-disabled precedent. Fails if opacity reappears in the file or if the semantic disabled token is dropped.
- Keep `cursor: default`. No behavioral change to the component.

## Design rationale
`docs/design/component-principles.md §Buttons` explicitly bans opacity as a disabled affordance: "Never reduce opacity on a button to show disabled state — opacity makes elements appear interactive." `--color-text-disabled` resolves to `#252f3e` (iron-600), exactly the color the design system prescribes for disabled text. This is the same pattern already adopted by the composer textarea in `ChatPane.css`.

## Test plan
- `pnpm -r test` — 732/732 pass (60 files)
- `just check-web` — typecheck clean, token drift check clean
- RED-first TDD: `ActivityBar.css.test.ts` failed 3/5 before the fix, passes 5/5 after

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)