### PR TITLE
[F-403] ContextPicker combobox: aria-activedescendant + stable option ids

### DIFF
--- a/web/packages/app/src/components/ContextPicker.test.tsx
+++ b/web/packages/app/src/components/ContextPicker.test.tsx
@@ -337,6 +337,184 @@ describe('ContextPicker chip insertion flow (F-141)', () => {
   });
 });
 
+describe('ContextPicker combobox aria-activedescendant (F-403)', () => {
+  // WAI-ARIA combobox pattern: focus stays in the composer textarea, so the
+  // combobox root must carry `aria-activedescendant` pointing at the id of the
+  // currently-active option. Assistive tech reads the announcement from that
+  // referenced element. Option rows need stable ids for that reference to
+  // resolve.
+  const anchor = { top: 100, bottom: 160, left: 0, right: 360 };
+
+  it('assigns stable ids to each option row', () => {
+    const items: PickerResult[] = [
+      { category: 'file', label: 'a.ts', value: 'a.ts' },
+      { category: 'file', label: 'b.ts', value: 'b.ts' },
+      { category: 'file', label: 'c.ts', value: 'c.ts' },
+    ];
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: items }}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    expect(getByTestId('context-picker-result-0').id).toBe(
+      'context-picker-result-0',
+    );
+    expect(getByTestId('context-picker-result-1').id).toBe(
+      'context-picker-result-1',
+    );
+    expect(getByTestId('context-picker-result-2').id).toBe(
+      'context-picker-result-2',
+    );
+  });
+
+  it('points aria-activedescendant at the active option on initial render', () => {
+    const items: PickerResult[] = [
+      { category: 'file', label: 'a.ts', value: 'a.ts' },
+      { category: 'file', label: 'b.ts', value: 'b.ts' },
+    ];
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: items }}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const root = getByTestId('context-picker');
+    expect(root.getAttribute('aria-activedescendant')).toBe(
+      'context-picker-result-0',
+    );
+  });
+
+  it('updates aria-activedescendant when ArrowDown moves the active row', () => {
+    const items: PickerResult[] = [
+      { category: 'file', label: 'a.ts', value: 'a.ts' },
+      { category: 'file', label: 'b.ts', value: 'b.ts' },
+      { category: 'file', label: 'c.ts', value: 'c.ts' },
+    ];
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: items }}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const root = getByTestId('context-picker');
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(root.getAttribute('aria-activedescendant')).toBe(
+      'context-picker-result-1',
+    );
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(root.getAttribute('aria-activedescendant')).toBe(
+      'context-picker-result-2',
+    );
+  });
+
+  it('updates aria-activedescendant when ArrowUp moves the active row', () => {
+    const items: PickerResult[] = [
+      { category: 'file', label: 'a.ts', value: 'a.ts' },
+      { category: 'file', label: 'b.ts', value: 'b.ts' },
+      { category: 'file', label: 'c.ts', value: 'c.ts' },
+    ];
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: items }}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const root = getByTestId('context-picker');
+    // From active=0, ArrowUp wraps to the last option.
+    fireEvent.keyDown(window, { key: 'ArrowUp' });
+    expect(root.getAttribute('aria-activedescendant')).toBe(
+      'context-picker-result-2',
+    );
+  });
+
+  it('resets aria-activedescendant to the new category’s first option after Tab', () => {
+    const fileItems: PickerResult[] = [
+      { category: 'file', label: 'a.ts', value: 'a.ts' },
+      { category: 'file', label: 'b.ts', value: 'b.ts' },
+    ];
+    const dirItems: PickerResult[] = [
+      { category: 'directory', label: 'src/', value: 'src/' },
+      { category: 'directory', label: 'tests/', value: 'tests/' },
+    ];
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: fileItems, directory: dirItems }}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const root = getByTestId('context-picker');
+    fireEvent.keyDown(window, { key: 'ArrowDown' }); // file[1]
+    expect(root.getAttribute('aria-activedescendant')).toBe(
+      'context-picker-result-1',
+    );
+    fireEvent.keyDown(window, { key: 'Tab' }); // switch to directory, cursor → 0
+    expect(root.getAttribute('aria-activedescendant')).toBe(
+      'context-picker-result-0',
+    );
+  });
+
+  it('omits aria-activedescendant when the active category has no items', () => {
+    // With no items, there is no option id to reference — the attribute must
+    // not point at a non-existent node.
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const root = getByTestId('context-picker');
+    expect(root.hasAttribute('aria-activedescendant')).toBe(false);
+  });
+
+  it('keyboard navigation does not move DOM focus onto the options', () => {
+    // Focus must remain wherever it was (the composer textarea in practice);
+    // the WAI-ARIA combobox pattern relies on aria-activedescendant instead of
+    // focus movement. The options themselves must never become activeElement.
+    const items: PickerResult[] = [
+      { category: 'file', label: 'a.ts', value: 'a.ts' },
+      { category: 'file', label: 'b.ts', value: 'b.ts' },
+    ];
+    const { getByTestId } = render(() => (
+      <ContextPicker
+        query=""
+        anchorRect={anchor}
+        items={{ file: items }}
+        onPick={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const optionBefore = document.activeElement;
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    // No option row should have grabbed focus.
+    expect(document.activeElement).toBe(optionBefore);
+    expect(getByTestId('context-picker-result-0')).not.toBe(
+      document.activeElement,
+    );
+    expect(getByTestId('context-picker-result-1')).not.toBe(
+      document.activeElement,
+    );
+  });
+});
+
 describe('ContextPicker placement data attribute', () => {
   it('flags placement=above when the anchor sits near the viewport bottom', () => {
     // jsdom's default innerHeight is 768. Put the anchor bottom at 700 →

--- a/web/packages/app/src/components/ContextPicker.tsx
+++ b/web/packages/app/src/components/ContextPicker.tsx
@@ -158,6 +158,13 @@ export interface ContextPickerProps {
 const POPUP_MAX_HEIGHT = 360;
 const POPUP_MIN_WIDTH = 360;
 
+// Stable id prefix for option rows. The combobox root's
+// `aria-activedescendant` points at `<prefix>-<index>` so assistive tech can
+// announce the active option while DOM focus stays in the composer textarea
+// (WAI-ARIA combobox pattern). See F-403.
+const RESULT_ID_PREFIX = 'context-picker-result';
+const resultId = (index: number): string => `${RESULT_ID_PREFIX}-${index}`;
+
 export const ContextPicker: Component<ContextPickerProps> = (props) => {
   const [activeCategoryIndex, setActiveCategoryIndex] = createSignal(0);
   const [activeItemIndex, setActiveItemIndex] = createSignal(0);
@@ -256,6 +263,15 @@ export const ContextPicker: Component<ContextPickerProps> = (props) => {
     }
   });
 
+  // Resolve the active option's DOM id for `aria-activedescendant`. Returns
+  // `undefined` when the active category has no items — SR should not be
+  // pointed at a non-existent node, and Solid drops `undefined` attributes.
+  const activeDescendantId = (): string | undefined => {
+    const items = activeItems();
+    if (items.length === 0) return undefined;
+    return resultId(activeItemIndex());
+  };
+
   return (
     <div
       class="context-picker"
@@ -268,6 +284,7 @@ export const ContextPicker: Component<ContextPickerProps> = (props) => {
       role="combobox"
       aria-expanded="true"
       aria-haspopup="listbox"
+      aria-activedescendant={activeDescendantId()}
       ref={rootRef}
       style={{
         'min-width': `${POPUP_MIN_WIDTH}px`,
@@ -337,6 +354,7 @@ export const ContextPicker: Component<ContextPickerProps> = (props) => {
           <For each={activeItems()}>
             {(item, i) => (
               <div
+                id={resultId(i())}
                 class="context-picker__result"
                 classList={{
                   'context-picker__result--active':


### PR DESCRIPTION
Closes forge-ide/forge#404

## Summary
- Option rows carry stable ids (`context-picker-result-<i>`)
- Combobox root sets `aria-activedescendant` to the active row's id, updating on ArrowUp/ArrowDown and on Tab-reset after category switch
- `aria-activedescendant` is omitted when the active category has no items (no node to reference)
- DOM focus stays in the composer textarea — navigation is announced via `aria-activedescendant`, per the WAI-ARIA combobox pattern

## Test plan
- New suite `ContextPicker combobox aria-activedescendant (F-403)` covers: stable ids, initial active descendant, ArrowDown/ArrowUp tracking, Tab category-switch reset, empty-category omission, and focus-stability during navigation
- `pnpm --filter app test` — 734 pass
- `just check-web` (typecheck + token-drift) — clean
- `cargo fmt --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` — clean

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)