### PR TITLE
[F-402] a11y: dialog contract across popovers and StepDrawer

### DIFF
--- a/web/packages/app/src/commands/CommandPalette.test.tsx
+++ b/web/packages/app/src/commands/CommandPalette.test.tsx
@@ -168,6 +168,53 @@ describe('CommandPalette entries + selection (F-157)', () => {
   });
 });
 
+// F-402: dialog contract — aria-modal, focus trap on Tab, focus restore on
+// close.
+describe('CommandPalette — a11y dialog contract (F-402)', () => {
+  it('declares aria-modal="true" when open', async () => {
+    const { findByTestId } = render(() => <CommandPalette />);
+    openWithCtrlK();
+    const root = await findByTestId('command-palette');
+    expect(root.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('Tab at the last focusable cycles to the first (traps focus)', async () => {
+    registerCommand({ id: 'a', title: 'Alpha', run: vi.fn() });
+    const { findByTestId } = render(() => <CommandPalette />);
+    openWithCtrlK();
+    const input = (await findByTestId('command-palette-input')) as HTMLInputElement;
+    // Only the input is focusable inside the dialog (list items are clickable
+    // but not tab-stops). So Tab from the input should wrap back to itself;
+    // we assert focus stays inside the dialog rather than escaping to the
+    // trigger element.
+    input.focus();
+    expect(document.activeElement).toBe(input);
+    const root = await findByTestId('command-palette');
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    input.dispatchEvent(ev);
+    expect(root.contains(document.activeElement)).toBe(true);
+  });
+
+  it('restores focus to the previously-focused element on close', async () => {
+    // Mount a trigger button and focus it; open palette; close; assert the
+    // trigger regains focus.
+    const trigger = document.createElement('button');
+    trigger.textContent = 'open palette';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { findByTestId, queryByTestId } = render(() => <CommandPalette />);
+    openWithCtrlK();
+    const input = (await findByTestId('command-palette-input')) as HTMLInputElement;
+    // Sanity — focus moved into the palette.
+    expect(input).toBe(document.activeElement);
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(queryByTestId('command-palette')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // F-153 bonus — the "Open Agent Monitor" builtin navigates to `/agents`.
 // ---------------------------------------------------------------------------

--- a/web/packages/app/src/commands/CommandPalette.tsx
+++ b/web/packages/app/src/commands/CommandPalette.tsx
@@ -20,6 +20,7 @@ import {
   type Component,
 } from 'solid-js';
 import { filterCommandsByQuery, type Command } from './registry';
+import { useFocusTrap } from '../lib/useFocusTrap';
 import './CommandPalette.css';
 
 interface ShortcutMatch {
@@ -63,8 +64,8 @@ export const CommandPalette: Component = () => {
     setQuery('');
     setActiveIndex(0);
     setOpen(true);
-    // Focus the input on next tick so it's ready for typing.
-    queueMicrotask(() => inputRef?.focus());
+    // Focus of the input is now driven by useFocusTrap on the dialog body's
+    // mount — no queueMicrotask shim needed.
   };
 
   const closePalette = (): void => {
@@ -146,17 +147,24 @@ export const CommandPalette: Component = () => {
     closePalette();
   };
 
-  return (
-    <Show when={open()}>
+  // F-402: the dialog body is a separate component so its mount/unmount
+  // lifecycle drives useFocusTrap — focus trap activates on open, focus
+  // restore runs on close.
+  const Body: Component = () => {
+    let dialogRef: HTMLDivElement | undefined;
+    useFocusTrap(() => dialogRef, { initialFocus: () => inputRef });
+    return (
       <div
         class="command-palette__backdrop"
         data-testid="command-palette-backdrop"
         onClick={onBackdropClick}
       >
         <div
+          ref={dialogRef}
           class="command-palette"
           data-testid="command-palette"
           role="dialog"
+          aria-modal="true"
           aria-label="Command palette"
           onClick={(e) => e.stopPropagation()}
         >
@@ -202,6 +210,12 @@ export const CommandPalette: Component = () => {
           </ul>
         </div>
       </div>
+    );
+  };
+
+  return (
+    <Show when={open()}>
+      <Body />
     </Show>
   );
 };

--- a/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.test.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.test.tsx
@@ -111,3 +111,47 @@ describe('WhitelistedPill — popover behavior', () => {
     expect(queryByTestId('whitelist-popover')).not.toBeInTheDocument();
   });
 });
+
+// F-402: the popover is a contextual menu, not a modal dialog. Verify the
+// role, and verify window-level Esc and outside-click both dismiss.
+describe('WhitelistedPill — a11y (F-402)', () => {
+  it('popover uses role="menu" (not role="dialog")', () => {
+    const { getByTestId } = render(() => (
+      <WhitelistedPill label="this file" level="session" onRevoke={vi.fn()} />
+    ));
+    fireEvent.click(getByTestId('whitelisted-pill'));
+    const popover = getByTestId('whitelist-popover');
+    expect(popover.getAttribute('role')).toBe('menu');
+  });
+
+  it('Escape at the window closes the popover', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <WhitelistedPill label="this file" level="session" onRevoke={vi.fn()} />
+    ));
+    fireEvent.click(getByTestId('whitelisted-pill'));
+    expect(getByTestId('whitelist-popover')).toBeInTheDocument();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(queryByTestId('whitelist-popover')).not.toBeInTheDocument();
+  });
+
+  it('outside-click closes the popover', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <WhitelistedPill label="this file" level="session" onRevoke={vi.fn()} />
+    ));
+    fireEvent.click(getByTestId('whitelisted-pill'));
+    expect(getByTestId('whitelist-popover')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(queryByTestId('whitelist-popover')).not.toBeInTheDocument();
+  });
+
+  it('click inside the popover does NOT close it', () => {
+    const { getByTestId } = render(() => (
+      <WhitelistedPill label="this file" level="session" onRevoke={vi.fn()} />
+    ));
+    fireEvent.click(getByTestId('whitelisted-pill'));
+    const popover = getByTestId('whitelist-popover');
+    fireEvent.mouseDown(popover);
+    // Still visible — the revoke button was not clicked, popover remains.
+    expect(getByTestId('whitelist-popover')).toBeInTheDocument();
+  });
+});

--- a/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.tsx
@@ -1,4 +1,10 @@
-import { type Component, createSignal, Show } from 'solid-js';
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  onCleanup,
+  Show,
+} from 'solid-js';
 import type { ApprovalLevel } from '@forge/ipc';
 import './WhitelistedPill.css';
 
@@ -37,9 +43,39 @@ function revokeLabel(level: ApprovalLevel): string {
 
 export const WhitelistedPill: Component<WhitelistedPillProps> = (props) => {
   const [popoverOpen, setPopoverOpen] = createSignal(false);
+  let wrapperRef: HTMLDivElement | undefined;
+
+  // F-402: the popover is a non-modal menu — attach window-level Esc and
+  // outside-click dismissal while open, detach when closed. Keeps listener
+  // lifetimes tied to visibility, not to component lifetime.
+  createEffect(() => {
+    if (!popoverOpen()) return;
+
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setPopoverOpen(false);
+      }
+    };
+
+    const onOutsideMouseDown = (e: MouseEvent): void => {
+      if (!wrapperRef) return;
+      const target = e.target as Node | null;
+      if (target && wrapperRef.contains(target)) return;
+      setPopoverOpen(false);
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    document.addEventListener('mousedown', onOutsideMouseDown);
+
+    onCleanup(() => {
+      window.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('mousedown', onOutsideMouseDown);
+    });
+  });
 
   return (
-    <div class="whitelisted-pill-wrapper">
+    <div ref={wrapperRef} class="whitelisted-pill-wrapper">
       <button
         type="button"
         class="whitelisted-pill"
@@ -54,11 +90,17 @@ export const WhitelistedPill: Component<WhitelistedPillProps> = (props) => {
       </button>
 
       <Show when={popoverOpen()}>
-        <div class="whitelisted-pill__popover" data-testid="whitelist-popover" role="dialog">
+        <div
+          class="whitelisted-pill__popover"
+          data-testid="whitelist-popover"
+          role="menu"
+          aria-label="Revoke approval"
+        >
           <button
             type="button"
             class="whitelisted-pill__revoke-btn"
             data-testid="revoke-btn"
+            role="menuitem"
             onClick={() => {
               setPopoverOpen(false);
               props.onRevoke();

--- a/web/packages/app/src/components/BranchMetadataPopover.test.tsx
+++ b/web/packages/app/src/components/BranchMetadataPopover.test.tsx
@@ -151,4 +151,54 @@ describe('BranchMetadataPopover', () => {
     fireEvent.keyDown(getByTestId('branch-metadata-popover'), { key: 'Escape' });
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
+
+  // F-402: downgrade from role=dialog to role=menu — this surface is not
+  // modal, it is a non-modal list with its own dismissal affordances.
+  it('uses role="menu" (not role="dialog") — content is not truly modal', () => {
+    const { getByTestId } = render(() => (
+      <BranchMetadataPopover
+        variants={rows}
+        activeVariantId="var-1"
+        onSelect={() => {}}
+        onDelete={() => {}}
+        onExportAll={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    const popover = getByTestId('branch-metadata-popover');
+    expect(popover.getAttribute('role')).toBe('menu');
+  });
+
+  it('outside-click fires onDismiss', () => {
+    const onDismiss = vi.fn();
+    render(() => (
+      <BranchMetadataPopover
+        variants={rows}
+        activeVariantId="var-1"
+        onSelect={() => {}}
+        onDelete={() => {}}
+        onExportAll={() => {}}
+        onDismiss={onDismiss}
+      />
+    ));
+    // Click somewhere that is not inside the popover — the document body.
+    fireEvent.mouseDown(document.body);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('inside-click does NOT fire onDismiss', () => {
+    const onDismiss = vi.fn();
+    const { getByTestId } = render(() => (
+      <BranchMetadataPopover
+        variants={rows}
+        activeVariantId="var-1"
+        onSelect={() => {}}
+        onDelete={() => {}}
+        onExportAll={() => {}}
+        onDismiss={onDismiss}
+      />
+    ));
+    fireEvent.mouseDown(getByTestId('branch-popover-row-1'));
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
 });

--- a/web/packages/app/src/components/BranchMetadataPopover.tsx
+++ b/web/packages/app/src/components/BranchMetadataPopover.tsx
@@ -1,4 +1,4 @@
-import { type Component, For, Show, createMemo } from 'solid-js';
+import { type Component, For, Show, createMemo, onCleanup, onMount } from 'solid-js';
 import './BranchMetadataPopover.css';
 
 /**
@@ -77,12 +77,32 @@ function formatTime(at: string | undefined): string {
 export const BranchMetadataPopover: Component<BranchMetadataPopoverProps> = (props) => {
   const liveCount = createMemo(() => props.variants.length);
 
+  // F-402: this surface is not modal; it is a contextual menu with its own
+  // dismiss affordances (Esc, outside-click). Exposed as role="menu" with
+  // window-level outside-click dismissal.
+  let rootRef: HTMLDivElement | undefined;
+
   const handleKey = (e: KeyboardEvent): void => {
     if (e.key === 'Escape') {
       e.preventDefault();
       props.onDismiss();
     }
   };
+
+  const handleOutsideMouseDown = (e: MouseEvent): void => {
+    if (!rootRef) return;
+    const target = e.target as Node | null;
+    if (target && rootRef.contains(target)) return;
+    props.onDismiss();
+  };
+
+  onMount(() => {
+    document.addEventListener('mousedown', handleOutsideMouseDown);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener('mousedown', handleOutsideMouseDown);
+  });
 
   const canDelete = (row: VariantRow): boolean => {
     // Guard against deleting the root while siblings remain. The sibling
@@ -96,9 +116,10 @@ export const BranchMetadataPopover: Component<BranchMetadataPopoverProps> = (pro
 
   return (
     <div
+      ref={rootRef}
       class="branch-popover"
       data-testid="branch-metadata-popover"
-      role="dialog"
+      role="menu"
       aria-label="Branch variants"
       tabIndex={-1}
       onKeyDown={handleKey}

--- a/web/packages/app/src/lib/useFocusTrap.test.ts
+++ b/web/packages/app/src/lib/useFocusTrap.test.ts
@@ -1,0 +1,135 @@
+// F-402: Reusable focus-trap hook for role="dialog" surfaces.
+//
+// Contract (WAI-ARIA APG dialog pattern):
+//   - On activation, move focus into the container (explicit initialFocus
+//     element, or the first focusable descendant if none given).
+//   - While active, Tab at the last focusable cycles to the first; Shift+Tab
+//     at the first cycles to the last.
+//   - On deactivation, restore focus to the element that had it before
+//     activation, when that element is still connected.
+//
+// These tests drive the hook directly by exercising createRoot scopes so
+// the onMount/onCleanup lifecycle is observable without mounting a real
+// component.
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createRoot } from 'solid-js';
+import { useFocusTrap } from './useFocusTrap';
+
+function makeContainer(buttons: string[]): HTMLDivElement {
+  const div = document.createElement('div');
+  for (const label of buttons) {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.setAttribute('data-label', label);
+    div.appendChild(btn);
+  }
+  document.body.appendChild(div);
+  return div;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('useFocusTrap — initial focus', () => {
+  it('focuses the first focusable descendant by default on mount', async () => {
+    const container = makeContainer(['one', 'two', 'three']);
+    createRoot(() => {
+      useFocusTrap(() => container);
+    });
+    // onMount runs synchronously for Solid under jsdom in tests.
+    expect(document.activeElement).toBe(container.querySelector('[data-label="one"]'));
+  });
+
+  it('focuses the element returned by opts.initialFocus when provided', () => {
+    const container = makeContainer(['one', 'two', 'three']);
+    const target = container.querySelector<HTMLButtonElement>('[data-label="two"]')!;
+    createRoot(() => {
+      useFocusTrap(() => container, { initialFocus: () => target });
+    });
+    expect(document.activeElement).toBe(target);
+  });
+});
+
+describe('useFocusTrap — Tab cycling', () => {
+  it('Tab at the last focusable cycles focus to the first', () => {
+    const container = makeContainer(['one', 'two', 'three']);
+    createRoot(() => {
+      useFocusTrap(() => container);
+    });
+    const last = container.querySelector<HTMLButtonElement>('[data-label="three"]')!;
+    last.focus();
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    last.dispatchEvent(ev);
+    expect(document.activeElement).toBe(container.querySelector('[data-label="one"]'));
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('Shift+Tab at the first focusable cycles focus to the last', () => {
+    const container = makeContainer(['one', 'two', 'three']);
+    createRoot(() => {
+      useFocusTrap(() => container);
+    });
+    const first = container.querySelector<HTMLButtonElement>('[data-label="one"]')!;
+    first.focus();
+    const ev = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    first.dispatchEvent(ev);
+    expect(document.activeElement).toBe(container.querySelector('[data-label="three"]'));
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('Tab in the middle of the sequence does not intercept — browser default', () => {
+    const container = makeContainer(['one', 'two', 'three']);
+    createRoot(() => {
+      useFocusTrap(() => container);
+    });
+    const middle = container.querySelector<HTMLButtonElement>('[data-label="two"]')!;
+    middle.focus();
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    middle.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(false);
+  });
+});
+
+describe('useFocusTrap — focus restore', () => {
+  it('restores focus to the element active before the hook ran, on cleanup', () => {
+    const outside = document.createElement('button');
+    outside.textContent = 'outside';
+    document.body.appendChild(outside);
+    outside.focus();
+    expect(document.activeElement).toBe(outside);
+
+    const container = makeContainer(['one', 'two']);
+    const dispose = createRoot((disposeFn) => {
+      useFocusTrap(() => container);
+      return disposeFn;
+    });
+
+    // Trap moved focus into the container.
+    expect(document.activeElement).toBe(container.querySelector('[data-label="one"]'));
+
+    dispose();
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it('does not throw when the previously-focused element has been removed from the DOM', () => {
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+
+    const container = makeContainer(['only']);
+    const dispose = createRoot((disposeFn) => {
+      useFocusTrap(() => container);
+      return disposeFn;
+    });
+
+    outside.remove();
+    expect(() => dispose()).not.toThrow();
+  });
+});

--- a/web/packages/app/src/lib/useFocusTrap.ts
+++ b/web/packages/app/src/lib/useFocusTrap.ts
@@ -1,0 +1,83 @@
+// F-402: focus-trap hook for role="dialog" surfaces.
+//
+// Implements the WAI-ARIA APG dialog contract for any surface that declares
+// role="dialog" / role="alertdialog":
+//
+//   - Moves focus into the container on activation (explicit target via
+//     opts.initialFocus, else the first focusable descendant).
+//   - Cycles Tab / Shift+Tab at the boundaries so keyboard focus cannot
+//     escape the dialog.
+//   - Restores focus to whatever element was active before activation on
+//     cleanup, when that element is still attached.
+//
+// Callers must invoke this inside a reactive scope (component setup or
+// createRoot) so the onMount/onCleanup lifecycle fires.
+
+import { onCleanup, onMount } from 'solid-js';
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export interface UseFocusTrapOptions {
+  /**
+   * Element to receive focus on activation. When omitted, the first
+   * focusable descendant of the container is used. Returning `undefined`
+   * from this thunk falls back to that default.
+   */
+  initialFocus?: () => HTMLElement | undefined;
+}
+
+export function useFocusTrap(
+  getContainer: () => HTMLElement | undefined,
+  opts: UseFocusTrapOptions = {},
+): void {
+  // Capture the pre-activation active element synchronously during setup
+  // so we can restore focus on cleanup even if onMount steals focus first.
+  const previouslyFocused =
+    typeof document !== 'undefined'
+      ? (document.activeElement as HTMLElement | null)
+      : null;
+
+  const focusables = (): HTMLElement[] => {
+    const root = getContainer();
+    if (!root) return [];
+    return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  };
+
+  const handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key !== 'Tab') return;
+    const list = focusables();
+    const first = list[0];
+    const last = list[list.length - 1];
+    if (!first || !last) return;
+    const active = document.activeElement as HTMLElement | null;
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+
+  onMount(() => {
+    const root = getContainer();
+    if (!root) return;
+    root.addEventListener('keydown', handleKeyDown);
+    const explicit = opts.initialFocus?.();
+    const target = explicit ?? focusables()[0];
+    target?.focus();
+  });
+
+  onCleanup(() => {
+    const root = getContainer();
+    root?.removeEventListener('keydown', handleKeyDown);
+    if (
+      previouslyFocused &&
+      typeof previouslyFocused.focus === 'function' &&
+      previouslyFocused.isConnected
+    ) {
+      previouslyFocused.focus();
+    }
+  });
+}

--- a/web/packages/app/src/routes/AgentMonitor.test.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { cleanup, render, fireEvent, waitFor } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
 
 const { listenMock } = vi.hoisted(() => ({
   listenMock: vi.fn(),
@@ -625,6 +626,49 @@ describe('<StepDrawer>', () => {
     ));
     fireEvent.click(getByLabelText(/Close step detail/i));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  // F-402: dialog contract — focus lands in the drawer on open, Tab wraps
+  // within, focus restores to the previously-focused element on close.
+  it('moves focus into the drawer on open', async () => {
+    const { findByLabelText } = render(() => (
+      <StepDrawer step={step()} onClose={() => {}} />
+    ));
+    const closeBtn = await findByLabelText(/Close step detail/i);
+    expect(document.activeElement).toBe(closeBtn);
+  });
+
+  it('traps Tab inside the drawer — Tab from last focusable cycles to first', async () => {
+    const { findByRole, findByLabelText } = render(() => (
+      <StepDrawer step={step()} onClose={() => {}} />
+    ));
+    const dialog = await findByRole('dialog');
+    const closeBtn = await findByLabelText(/Close step detail/i);
+    // Only the close button is focusable in the drawer, so Tab from it
+    // should cycle back to itself. Assert focus is still inside the drawer.
+    closeBtn.focus();
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    closeBtn.dispatchEvent(ev);
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  it('restores focus to the prior active element when the drawer closes', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'open step';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const [currentStep, setCurrentStep] = createSignal<AgentStep | null>(step());
+    const { queryByRole } = render(() => (
+      <StepDrawer step={currentStep()} onClose={() => setCurrentStep(null)} />
+    ));
+    await waitFor(() => expect(queryByRole('dialog')).not.toBeNull());
+    // Close by flipping the prop to null — simulates the real dismissal path.
+    setCurrentStep(null);
+    await waitFor(() => expect(queryByRole('dialog')).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
   });
 });
 

--- a/web/packages/app/src/routes/AgentMonitor.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.tsx
@@ -25,6 +25,7 @@ import {
 } from 'solid-js';
 import { useParams, useSearchParams } from '@solidjs/router';
 import { invoke } from '../lib/tauri';
+import { useFocusTrap } from '../lib/useFocusTrap';
 import type { BgAgentSummary } from '@forge/ipc';
 import { onSessionEvent, type SessionEventPayload } from '../ipc/session';
 import './AgentMonitor.css';
@@ -624,39 +625,49 @@ export const StepDrawer: Component<{
     }
   });
 
+  // F-402: extract the dialog body so its mount/unmount drives useFocusTrap —
+  // focus lands inside the drawer on open, Tab traps within, focus restores
+  // to the previously-focused element on close.
+  const Body: Component<{ step: AgentStep }> = (p) => {
+    let dialogRef: HTMLDivElement | undefined;
+    useFocusTrap(() => dialogRef);
+    return (
+      <div
+        ref={dialogRef}
+        class="agent-monitor__drawer"
+        role="dialog"
+        aria-label="Step detail"
+        aria-modal="true"
+      >
+        <header class="agent-monitor__drawer-head">
+          <h3>{p.step.title}</h3>
+          <button
+            type="button"
+            class="agent-monitor__drawer-close"
+            aria-label="Close step detail"
+            onClick={props.onClose}
+          >
+            ×
+          </button>
+        </header>
+        <dl class="agent-monitor__def">
+          <dt>kind</dt>
+          <dd>{p.step.kind}</dd>
+          <dt>status</dt>
+          <dd>{p.step.status}</dd>
+          <dt>started</dt>
+          <dd>{p.step.startedAt}</dd>
+        </dl>
+        <Show when={p.step.preview}>
+          <pre class="agent-monitor__drawer-preview">{p.step.preview}</pre>
+        </Show>
+      </div>
+    );
+  };
+
   return (
     <Show when={props.step}>
-      {(step) => (
-        <div
-          class="agent-monitor__drawer"
-          role="dialog"
-          aria-label="Step detail"
-          aria-modal="true"
-        >
-          <header class="agent-monitor__drawer-head">
-            <h3>{step().title}</h3>
-            <button
-              type="button"
-              class="agent-monitor__drawer-close"
-              aria-label="Close step detail"
-              onClick={props.onClose}
-            >
-              ×
-            </button>
-          </header>
-          <dl class="agent-monitor__def">
-            <dt>kind</dt>
-            <dd>{step().kind}</dd>
-            <dt>status</dt>
-            <dd>{step().status}</dd>
-            <dt>started</dt>
-            <dd>{step().startedAt}</dd>
-          </dl>
-          <Show when={step().preview}>
-            <pre class="agent-monitor__drawer-preview">{step().preview}</pre>
-          </Show>
-        </div>
-      )}
+      {(step) => <Body step={step()} />}
     </Show>
   );
 };


### PR DESCRIPTION
Closes forge-ide/forge#403

## Summary
- Extract reusable `useFocusTrap` hook (Solid) in `web/packages/app/src/lib/` — initial focus, Tab/Shift+Tab cycling, focus restore on cleanup. Ported from the focus-management logic already proven in `ApprovalPrompt.tsx`.
- Apply the WAI-ARIA APG dialog contract to the two truly-modal surfaces (`CommandPalette`, `StepDrawer`): keep `role="dialog"`, add `aria-modal="true"`, wrap the dialog body in an inner component so mount/unmount drives the focus-trap lifecycle cleanly.
- Downgrade the two non-modal surfaces (`BranchMetadataPopover`, `WhitelistedPill`) from `role="dialog"` to `role="menu"` and add window-level Esc + outside-click dismissal — they were never modal in practice.

## Test plan
- New `src/lib/useFocusTrap.test.ts` pins the hook contract (initial focus, Tab cycling both directions, focus restore, defensive handling when the prior active element has been removed).
- Per-site regression tests added:
  - `BranchMetadataPopover.test.tsx` — asserts `role="menu"`, outside-click fires `onDismiss`, inside-click does not.
  - `WhitelistedPill.test.tsx` — asserts `role="menu"` on popover, window-level Esc closes, outside-click closes, inside-click does not.
  - `CommandPalette.test.tsx` — asserts `aria-modal="true"`, Tab stays within the dialog, focus restores to the prior trigger on close.
  - `AgentMonitor.test.tsx` `<StepDrawer>` — asserts focus lands inside the drawer on open, Tab stays within, focus restores on close.
- Full web suite (747 tests) passes; `cargo fmt/check/test/clippy` across the workspace clean (no Rust touched, but the gates still run).

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)