### PR TITLE
[F-395] Wire chat PaneHeader to live provider/cost telemetry

### DIFF
--- a/web/packages/app/src/routes/Session/SessionWindow.test.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.test.tsx
@@ -23,6 +23,12 @@ import {
 } from './SessionWindow';
 import { resetSessionEventStore } from '../../stores/session';
 import { resetMessagesStore } from '../../stores/messages';
+import {
+  recordProviderModel,
+  recordUsageTick,
+  resetSessionTelemetryStore,
+} from '../../stores/sessionTelemetry';
+import type { ProviderId } from '@forge/ipc';
 import { setInvokeForTesting } from '../../lib/tauri';
 import type { LayoutTree, Layouts } from '@forge/ipc';
 import {
@@ -101,6 +107,7 @@ describe('SessionWindow', () => {
     closeMock.mockReset();
     resetSessionEventStore();
     resetMessagesStore();
+    resetSessionTelemetryStore();
     invokeMock.mockImplementation(async (cmd: string) => {
       if (cmd === 'session_hello') return helloAck;
       // F-126: layoutStore.load() calls read_layouts on mount when no store
@@ -194,16 +201,128 @@ describe('SessionWindow', () => {
     expect(container.querySelector('[data-testid="split-pane"]')).toBeNull();
   });
 
-  it('pane header shows subject, ollama provider label, cost placeholder, close action', async () => {
+  // F-395: PaneHeader reflects live provider/model + session cost telemetry.
+  // Before any AssistantMessage or UsageTick arrives, the pill falls back to
+  // the sanctioned provider-id-only label (no "pending") and the cost meter
+  // renders an em-dash placeholder (not $0.00). Once the telemetry store
+  // records real values, both update reactively.
+
+  it('pane header: before any telemetry, cost renders em-dash placeholder and pill has no "pending"', async () => {
     const { findByTestId, findByRole } = renderAt('/session/abc123');
     const subject = await findByTestId('pane-header-subject');
-    expect(subject.textContent).toContain('abc123');
+    // Subject no longer starts with the placeholder "Session " prefix —
+    // F-395 removes the legacy `Session <id>` hardcoded label.
+    expect(subject.textContent).not.toMatch(/^Session /);
     const provider = await findByTestId('pane-header-provider');
-    expect(provider.textContent?.toLowerCase()).toContain('ollama');
+    // "pending" is not in the sanctioned state vocabulary — must not appear.
+    expect(provider.textContent?.toLowerCase()).not.toContain('pending');
     const cost = await findByTestId('pane-header-cost');
-    expect(cost.textContent).toMatch(/in\s+0.*out\s+0.*\$0/i);
+    // Documented placeholder — literal em-dash, not the fabricated $0.00.
+    expect(cost.textContent).toContain('—');
+    expect(cost.textContent).not.toContain('$0.00');
     const close = await findByRole('button', { name: /close/i });
     expect(close).toBeInTheDocument();
+  });
+
+  it('pane header reflects the telemetry store provider/model after recordProviderModel', async () => {
+    const { findByTestId } = renderAt('/session/abc123');
+    await findByTestId('pane-header-subject');
+    recordProviderModel(
+      'abc123' as never,
+      'anthropic' as ProviderId,
+      'claude-opus-4-7',
+    );
+    const provider = await findByTestId('pane-header-provider');
+    await waitFor(() =>
+      expect(provider.textContent?.toLowerCase()).toContain('anthropic'),
+    );
+    const subject = await findByTestId('pane-header-subject');
+    await waitFor(() =>
+      expect(subject.textContent).toContain('claude-opus-4-7'),
+    );
+  });
+
+  it('pane header reflects provider + cost driven end-to-end by mocked Rust-shaped IPC events (F-395 regression)', async () => {
+    const handlers: Array<(ev: { payload: unknown }) => void> = [];
+    listenMock.mockImplementation(
+      async (_name: string, handler: (ev: { payload: unknown }) => void) => {
+        handlers.push(handler);
+        return unlistenMock;
+      },
+    );
+
+    const { findByTestId } = renderAt('/session/abc123');
+    await findByTestId('pane-header-subject');
+    // Both adapter + bg-agents listeners must attach before we dispatch.
+    await waitFor(() => expect(handlers.length).toBeGreaterThanOrEqual(2));
+
+    // 1. assistant_message carries provider + model on the wire. Adapter
+    //    routes it into the sessionTelemetry store, which the PaneHeader
+    //    reads via getSessionTelemetry(sessionId).
+    for (const h of handlers) {
+      h({
+        payload: {
+          session_id: 'abc123',
+          seq: 1,
+          event: {
+            type: 'assistant_message',
+            id: 'a-1',
+            at: '2026-04-21T10:00:00Z',
+            provider: 'anthropic',
+            model: 'claude-opus-4-7',
+            text: 'hello',
+            stream_finalised: true,
+            branch_parent: null,
+            branch_variant_index: 0,
+          },
+        },
+      });
+    }
+    const provider = await findByTestId('pane-header-provider');
+    await waitFor(() =>
+      expect(provider.textContent?.toLowerCase()).toContain('anthropic'),
+    );
+
+    // 2. usage_tick on the wire must land in the cost meter. Until F-395 the
+    //    adapter dropped it (returned null) — this is the regression.
+    const cost = await findByTestId('pane-header-cost');
+    expect(cost.textContent).toContain('—');
+    for (const h of handlers) {
+      h({
+        payload: {
+          session_id: 'abc123',
+          seq: 2,
+          event: {
+            type: 'usage_tick',
+            provider: 'anthropic',
+            model: 'claude-opus-4-7',
+            tokens_in: 500,
+            tokens_out: 1500,
+            cost_usd: 0.02,
+            scope: 'SessionWide',
+          },
+        },
+      });
+    }
+    await waitFor(() => {
+      expect(cost.textContent).toMatch(/in\s+500/);
+      // 1500 abbreviates to `1.5k` per spec §PH.4.
+      expect(cost.textContent).toMatch(/out\s+1\.5k/);
+      expect(cost.textContent).toContain('$0.02');
+    });
+  });
+
+  it('pane header cost meter switches from placeholder to live values on UsageTick', async () => {
+    const { findByTestId } = renderAt('/session/abc123');
+    const cost = await findByTestId('pane-header-cost');
+    expect(cost.textContent).toContain('—');
+    recordUsageTick('abc123' as never, 1234, 5678, 0.042);
+    await waitFor(() => {
+      // Spec §PH.4: tokens abbreviated above 1000 — `1.2k`, `5.7k`.
+      expect(cost.textContent).toMatch(/in\s+1\.2k/);
+      expect(cost.textContent).toMatch(/out\s+5\.7k/);
+      expect(cost.textContent).toContain('$0.04');
+    });
   });
 
   it('close button invokes the current window close()', async () => {

--- a/web/packages/app/src/routes/Session/SessionWindow.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.tsx
@@ -24,7 +24,17 @@ import {
   setSessions,
 } from '../../stores/session';
 import { pushEvent } from '../../stores/messages';
+import {
+  getSessionTelemetry,
+  routeTelemetryEvent,
+} from '../../stores/sessionTelemetry';
 import { fromRustEvent } from '../../ipc/events';
+import {
+  formatChatSubject,
+  formatCostLabel,
+  formatProviderLabel,
+  resolveProviderId,
+} from './costLabel';
 import { seedPersistentApprovals } from '../../stores/approvals';
 import { seedSettings } from '../../stores/settings';
 import { PaneHeader } from './PaneHeader';
@@ -144,6 +154,12 @@ export const SessionWindow: Component = () => {
         // store's discriminated union. Non-renderable variants return null.
         const storeEvent = fromRustEvent(payload.event);
         if (storeEvent) pushEvent(payload.session_id, storeEvent);
+        // F-395: side-channel — the PaneHeader's provider pill + cost meter
+        // read from the per-session telemetry store, which is fed by the
+        // same wire events (assistant_message for provider/model, usage_tick
+        // for tokens + cost). Kept off the messages-store path so a chat
+        // log shape change can't ripple into the header.
+        routeTelemetryEvent(payload.session_id, payload.event);
       });
       if (mounted) {
         unlisten = listener;
@@ -177,13 +193,22 @@ export const SessionWindow: Component = () => {
     }
   };
 
-  const subject = () => `Session ${sessionId()}`;
-  // Phase 1 ships only the Ollama provider; once the active session carries
-  // its provider id over IPC (Phase 2), wire it through here so the pill
-  // accent follows the live provider per ai-patterns.md §7 (F-091).
-  const providerId = (): ProviderId => 'ollama' as ProviderId;
-  const providerLabel = () => 'ollama \u00b7 pending';
-  const costLabel = () => 'in 0 \u00b7 out 0 \u00b7 $0.00';
+  // F-395: PaneHeader fields derive from the per-session telemetry store,
+  // which is fed by wire events (`assistant_message` → provider/model,
+  // `usage_tick` → tokens + cost). Reading through `getSessionTelemetry`
+  // inside these accessor functions opts into Solid's fine-grained store
+  // reactivity so the header updates the moment a tick lands. Before the
+  // first assistant turn, the provider pill falls back to the `ollama`
+  // Phase-1 default per `pane-header.md §PH.3` — never the unsanctioned
+  // `pending` state suffix (`voice-terminology.md §8`). Before the first
+  // usage_tick, the cost meter renders a documented em-dash placeholder
+  // rather than the fabricated `$0.00` that triggered the F-395 report.
+  const telemetry = () => getSessionTelemetry(sessionId());
+  const subject = () => formatChatSubject(sessionId(), telemetry());
+  const providerId = (): ProviderId =>
+    resolveProviderId(telemetry()) as ProviderId;
+  const providerLabel = () => formatProviderLabel(telemetry());
+  const costLabel = () => formatCostLabel(telemetry());
 
   // F-126: activity-bar + files-sidebar chrome. `activeActivity` is `null`
   // when the sidebar is hidden (default) and an activity id when visible.

--- a/web/packages/app/src/routes/Session/costLabel.test.ts
+++ b/web/packages/app/src/routes/Session/costLabel.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionTelemetry } from '../../stores/sessionTelemetry';
+import {
+  formatChatSubject,
+  formatCostLabel,
+  formatProviderLabel,
+  resolveProviderId,
+} from './costLabel';
+
+function telem(partial: Partial<SessionTelemetry> = {}): SessionTelemetry {
+  return {
+    provider: null,
+    model: null,
+    tokensIn: null,
+    tokensOut: null,
+    costUsd: null,
+    ...partial,
+  };
+}
+
+describe('formatCostLabel (F-395 / pane-header.md §PH.4)', () => {
+  it('renders the em-dash placeholder when no UsageTick has landed', () => {
+    expect(formatCostLabel(telem())).toBe('—');
+  });
+
+  it('renders in/out/cost once telemetry is populated', () => {
+    const s = formatCostLabel(
+      telem({ tokensIn: 500, tokensOut: 1500, costUsd: 0.04 }),
+    );
+    expect(s).toMatch(/in\s+500/);
+    expect(s).toMatch(/out\s+1\.5k/);
+    expect(s).toContain('$0.04');
+  });
+
+  it('abbreviates tokens above 1000', () => {
+    expect(formatCostLabel(telem({ tokensIn: 999, tokensOut: 1, costUsd: 0 }))).toMatch(
+      /in\s+999/,
+    );
+    expect(
+      formatCostLabel(telem({ tokensIn: 1500, tokensOut: 1, costUsd: 0 })),
+    ).toMatch(/in\s+1\.5k/);
+    expect(
+      formatCostLabel(telem({ tokensIn: 15_000, tokensOut: 1, costUsd: 0 })),
+    ).toMatch(/in\s+15k/);
+    expect(
+      formatCostLabel(telem({ tokensIn: 1_200_000, tokensOut: 1, costUsd: 0 })),
+    ).toMatch(/in\s+1\.2M/);
+  });
+
+  it('never strips the leading zero on dollars (spec §PH.4)', () => {
+    expect(
+      formatCostLabel(telem({ tokensIn: 1, tokensOut: 1, costUsd: 0.04 })),
+    ).toContain('$0.04');
+    // Never renders the offending "$.04" form.
+    expect(
+      formatCostLabel(telem({ tokensIn: 1, tokensOut: 1, costUsd: 0.04 })),
+    ).not.toContain('$.04');
+  });
+
+  it('renders the live totals even when cost is exactly zero (local provider)', () => {
+    const s = formatCostLabel(
+      telem({ tokensIn: 100, tokensOut: 200, costUsd: 0 }),
+    );
+    // Zero cost is a legitimate Ollama state — the meter must still render
+    // the real token counts, not the placeholder.
+    expect(s).not.toBe('—');
+    expect(s).toContain('$0.00');
+  });
+});
+
+describe('formatProviderLabel (F-395)', () => {
+  it('falls back to `ollama` before the first assistant turn', () => {
+    expect(formatProviderLabel(telem())).toBe('ollama');
+  });
+
+  it('uses the observed provider id once recorded', () => {
+    expect(formatProviderLabel(telem({ provider: 'anthropic' }))).toBe(
+      'anthropic',
+    );
+  });
+
+  it('never renders the unsanctioned `pending` state suffix', () => {
+    expect(formatProviderLabel(telem())).not.toContain('pending');
+    expect(formatProviderLabel(telem({ provider: 'ollama' }))).not.toContain(
+      'pending',
+    );
+  });
+});
+
+describe('formatChatSubject (F-395)', () => {
+  it('drops the legacy `Session <id>` prefix entirely', () => {
+    const s = formatChatSubject('abc123-uuid-very-long', telem());
+    expect(s).not.toMatch(/^Session /);
+  });
+
+  it('uses a short session id as the fallback head', () => {
+    expect(formatChatSubject('abcdefghijkl', telem())).toBe('abcdefgh');
+  });
+
+  it('appends the live model when known', () => {
+    expect(
+      formatChatSubject(
+        'abcdefghijkl',
+        telem({ provider: 'anthropic', model: 'claude-opus-4-7' }),
+      ),
+    ).toBe('abcdefgh · claude-opus-4-7');
+  });
+});
+
+describe('resolveProviderId (F-395)', () => {
+  it('falls back to `ollama` when no provider observed', () => {
+    expect(resolveProviderId(telem())).toBe('ollama');
+  });
+  it('returns the observed provider id', () => {
+    expect(resolveProviderId(telem({ provider: 'anthropic' }))).toBe(
+      'anthropic',
+    );
+  });
+});

--- a/web/packages/app/src/routes/Session/costLabel.ts
+++ b/web/packages/app/src/routes/Session/costLabel.ts
@@ -1,0 +1,80 @@
+import type { SessionTelemetry } from '../../stores/sessionTelemetry';
+
+/**
+ * F-395 / `pane-header.md §PH.4`: format the chat PaneHeader's cost meter.
+ *
+ * When the session has not yet observed a `UsageTick` (all telemetry fields
+ * null), returns the sanctioned em-dash placeholder — never a fabricated
+ * `$0.00`. Per the spec the tokens render abbreviated above 1000 (`1.2k`,
+ * `34k`); the dollar value uses two decimals.
+ *
+ * Kept as a pure helper so unit tests can pin the format without a full
+ * `render()` roundtrip, and so the SessionWindow call-site is a one-liner.
+ */
+export function formatCostLabel(t: SessionTelemetry): string {
+  if (t.tokensIn === null || t.tokensOut === null || t.costUsd === null) {
+    return '—';
+  }
+  return `in ${formatTokens(t.tokensIn)} · out ${formatTokens(
+    t.tokensOut,
+  )} · ${formatUsd(t.costUsd)}`;
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  // Abbreviate: 1.2k up to 9.9k, then 10k, 100k, 1.2M, ...
+  if (n < 10_000) return `${(n / 1000).toFixed(1)}k`;
+  if (n < 1_000_000) return `${Math.round(n / 1000)}k`;
+  if (n < 10_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  return `${Math.round(n / 1_000_000)}M`;
+}
+
+function formatUsd(n: number): string {
+  // Spec §PH.4: "$0.04, not $.04" — two decimals, always leading zero.
+  return `$${n.toFixed(2)}`;
+}
+
+/**
+ * F-395: formats the PaneHeader subject for a chat pane. The spec prescribes
+ * `<provider dot> <agent name> · <model>`; Phase-2 IPC doesn't yet carry an
+ * agent name, so we fall back to a short session id until an extended
+ * `HelloAck` ships (tracked separately). The bare legacy `Session <id>`
+ * placeholder is removed outright — the issue explicitly calls it stale.
+ */
+export function formatChatSubject(
+  sessionId: string,
+  t: SessionTelemetry,
+): string {
+  const head = shortSessionId(sessionId);
+  if (t.model !== null) {
+    return `${head} · ${t.model}`;
+  }
+  return head;
+}
+
+function shortSessionId(id: string): string {
+  if (id.length <= 8) return id;
+  return id.slice(0, 8);
+}
+
+/**
+ * F-395: formats the PaneHeader provider pill label. Before the first
+ * `AssistantMessage` arrives, falls back to the Phase-1 sanctioned default
+ * (`ollama`) per `pane-header.md §PH.3` — never a `· pending` state suffix,
+ * which is not in `voice-terminology.md §8`'s state vocabulary. Once a
+ * provider/model pair is observed on the wire, the label promotes to the
+ * live pair.
+ */
+export function formatProviderLabel(t: SessionTelemetry): string {
+  if (t.provider === null) return 'ollama';
+  return t.provider;
+}
+
+/**
+ * F-395: resolves the provider-id for accent-color lookup. Mirrors
+ * `formatProviderLabel`'s fallback so the pill background and text stay in
+ * lockstep before the first assistant turn lands.
+ */
+export function resolveProviderId(t: SessionTelemetry): string {
+  return t.provider ?? 'ollama';
+}

--- a/web/packages/app/src/stores/sessionTelemetry.test.ts
+++ b/web/packages/app/src/stores/sessionTelemetry.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { ProviderId, SessionId } from '@forge/ipc';
+import {
+  getSessionTelemetry,
+  recordProviderModel,
+  recordUsageTick,
+  resetSessionTelemetryStore,
+  routeTelemetryEvent,
+} from './sessionTelemetry';
+
+const SID = 'session-telemetry-test' as SessionId;
+
+describe('sessionTelemetry store (F-395)', () => {
+  beforeEach(() => {
+    resetSessionTelemetryStore();
+  });
+
+  it('defaults to null provider/model/tokens/cost for a fresh session', () => {
+    const t = getSessionTelemetry(SID);
+    expect(t.provider).toBeNull();
+    expect(t.model).toBeNull();
+    expect(t.tokensIn).toBeNull();
+    expect(t.tokensOut).toBeNull();
+    expect(t.costUsd).toBeNull();
+  });
+
+  it('recordProviderModel sets provider and model', () => {
+    recordProviderModel(SID, 'anthropic' as ProviderId, 'claude-opus-4-7');
+    const t = getSessionTelemetry(SID);
+    expect(t.provider).toBe('anthropic');
+    expect(t.model).toBe('claude-opus-4-7');
+  });
+
+  it('recordProviderModel overwrites prior values (most-recent wins)', () => {
+    recordProviderModel(SID, 'anthropic' as ProviderId, 'claude-opus-4-7');
+    recordProviderModel(SID, 'openai' as ProviderId, 'gpt-5');
+    const t = getSessionTelemetry(SID);
+    expect(t.provider).toBe('openai');
+    expect(t.model).toBe('gpt-5');
+  });
+
+  it('recordUsageTick sets tokens_in / tokens_out / cost_usd', () => {
+    recordUsageTick(SID, 1234, 5678, 0.042);
+    const t = getSessionTelemetry(SID);
+    expect(t.tokensIn).toBe(1234);
+    expect(t.tokensOut).toBe(5678);
+    expect(t.costUsd).toBeCloseTo(0.042);
+  });
+
+  it('provider and usage are tracked independently', () => {
+    recordProviderModel(SID, 'ollama' as ProviderId, 'qwen2.5-coder');
+    recordUsageTick(SID, 100, 200, 0);
+    const t = getSessionTelemetry(SID);
+    expect(t.provider).toBe('ollama');
+    expect(t.model).toBe('qwen2.5-coder');
+    expect(t.tokensIn).toBe(100);
+    expect(t.tokensOut).toBe(200);
+    expect(t.costUsd).toBe(0);
+  });
+
+  describe('routeTelemetryEvent (wire-shape router)', () => {
+    it('routes assistant_message with provider + model into the store', () => {
+      routeTelemetryEvent(SID, {
+        type: 'assistant_message',
+        id: 'a-1',
+        at: '2026-04-21T10:00:00Z',
+        provider: 'anthropic',
+        model: 'claude-opus-4-7',
+        text: 'hi',
+        stream_finalised: true,
+        branch_parent: null,
+        branch_variant_index: 0,
+      });
+      const t = getSessionTelemetry(SID);
+      expect(t.provider).toBe('anthropic');
+      expect(t.model).toBe('claude-opus-4-7');
+    });
+
+    it('ignores an assistant_message that omits provider/model (keeps last-observed pair)', () => {
+      recordProviderModel(SID, 'ollama' as ProviderId, 'qwen');
+      routeTelemetryEvent(SID, {
+        type: 'assistant_message',
+        id: 'a-2',
+        text: 'hi',
+        stream_finalised: true,
+        branch_parent: null,
+        branch_variant_index: 0,
+      });
+      const t = getSessionTelemetry(SID);
+      // Still the prior pair — we don't clear on a metadata-less event.
+      expect(t.provider).toBe('ollama');
+      expect(t.model).toBe('qwen');
+    });
+
+    it('routes usage_tick with tokens + cost into the store', () => {
+      routeTelemetryEvent(SID, {
+        type: 'usage_tick',
+        provider: 'anthropic',
+        model: 'claude-opus-4-7',
+        tokens_in: 1234,
+        tokens_out: 5678,
+        cost_usd: 0.042,
+        scope: 'SessionWide',
+      });
+      const t = getSessionTelemetry(SID);
+      expect(t.tokensIn).toBe(1234);
+      expect(t.tokensOut).toBe(5678);
+      expect(t.costUsd).toBeCloseTo(0.042);
+    });
+
+    it('is a no-op for unrelated wire events', () => {
+      routeTelemetryEvent(SID, {
+        type: 'user_message',
+        id: 'u-1',
+        at: '2026-04-21T10:00:00Z',
+        text: 'hi',
+        context: [],
+        branch_parent: null,
+      });
+      const t = getSessionTelemetry(SID);
+      expect(t.provider).toBeNull();
+      expect(t.tokensIn).toBeNull();
+    });
+
+    it('is a no-op for non-object inputs', () => {
+      routeTelemetryEvent(SID, null);
+      routeTelemetryEvent(SID, undefined);
+      routeTelemetryEvent(SID, 'string');
+      routeTelemetryEvent(SID, 42);
+      const t = getSessionTelemetry(SID);
+      expect(t.provider).toBeNull();
+      expect(t.tokensIn).toBeNull();
+    });
+  });
+
+  it('resetSessionTelemetryStore clears every session', () => {
+    recordProviderModel(SID, 'anthropic' as ProviderId, 'claude-opus-4-7');
+    recordUsageTick(SID, 1, 2, 3);
+    resetSessionTelemetryStore();
+    const t = getSessionTelemetry(SID);
+    expect(t.provider).toBeNull();
+    expect(t.tokensIn).toBeNull();
+  });
+});

--- a/web/packages/app/src/stores/sessionTelemetry.ts
+++ b/web/packages/app/src/stores/sessionTelemetry.ts
@@ -1,0 +1,158 @@
+import { createStore, reconcile } from 'solid-js/store';
+import type { ProviderId, SessionId } from '@forge/ipc';
+
+/**
+ * F-395: per-session provider/model + running usage telemetry.
+ *
+ * Fed by the IPC adapter as wire events arrive:
+ * - `AssistantMessage` → provider + model (the wire event is where each turn's
+ *   provider/model is authoritative; the session's "active" provider is the
+ *   most recently observed one).
+ * - `UsageTick` → tokens_in / tokens_out / cost_usd (running session totals).
+ *
+ * Components (`PaneHeader`) read the signals through `getSessionTelemetry`.
+ * `null` fields mean "not observed yet" — callers render a sanctioned
+ * placeholder (`—` for cost; provider id alone for the pill) rather than a
+ * fabricated zero. This is the documented placeholder requirement in the
+ * F-395 DoD — never render `$0.00` before a real tick has arrived.
+ */
+export interface SessionTelemetry {
+  /** Latest observed provider id. `null` before any `AssistantMessage`. */
+  provider: ProviderId | null;
+  /** Latest observed model id. `null` before any `AssistantMessage`. */
+  model: string | null;
+  /** Running session-wide tokens_in. `null` before any `UsageTick`. */
+  tokensIn: number | null;
+  /** Running session-wide tokens_out. `null` before any `UsageTick`. */
+  tokensOut: number | null;
+  /** Running session-wide cost in USD. `null` before any `UsageTick`. */
+  costUsd: number | null;
+}
+
+const EMPTY: SessionTelemetry = {
+  provider: null,
+  model: null,
+  tokensIn: null,
+  tokensOut: null,
+  costUsd: null,
+};
+
+const [telemetryStore, setTelemetryStore] = createStore<
+  Record<SessionId, SessionTelemetry>
+>({});
+
+function ensure(sessionId: SessionId): void {
+  if (!telemetryStore[sessionId]) {
+    setTelemetryStore(sessionId, { ...EMPTY });
+  }
+}
+
+/**
+ * Reactive accessor — Solid stores proxy through property access, so calling
+ * this inside a `createMemo` / JSX expression tracks the per-field updates.
+ * Returns the zero-state record for unknown sessions so callers never crash
+ * on first paint before any event has landed.
+ */
+export function getSessionTelemetry(sessionId: SessionId): SessionTelemetry {
+  ensure(sessionId);
+  return telemetryStore[sessionId]!;
+}
+
+/**
+ * Record the provider + model from an `AssistantMessage` event. Idempotent:
+ * re-recording the same pair is a no-op on the signal graph so subscribers
+ * don't re-render when the model hasn't changed. We deliberately **do not**
+ * clear the pair on an unrelated `AssistantMessage` that omits provider/model
+ * (older fixtures, pre-F-145 events) — once observed, the live pill should
+ * keep showing the most recent identity rather than flicker back to `null`.
+ */
+export function recordProviderModel(
+  sessionId: SessionId,
+  provider: ProviderId,
+  model: string,
+): void {
+  ensure(sessionId);
+  const current = telemetryStore[sessionId]!;
+  if (current.provider !== provider) {
+    setTelemetryStore(sessionId, 'provider', provider);
+  }
+  if (current.model !== model) {
+    setTelemetryStore(sessionId, 'model', model);
+  }
+}
+
+/**
+ * Record a `UsageTick` event. The Rust wire shape carries running totals
+ * per-scope (`SessionWide`, `PerAgent`) — we track session-wide totals here.
+ * Per-agent totals are out of scope for the chat PaneHeader.
+ */
+export function recordUsageTick(
+  sessionId: SessionId,
+  tokensIn: number,
+  tokensOut: number,
+  costUsd: number,
+): void {
+  ensure(sessionId);
+  setTelemetryStore(sessionId, {
+    tokensIn,
+    tokensOut,
+    costUsd,
+  });
+}
+
+/**
+ * Wire-event → telemetry-store router.
+ *
+ * SessionWindow's adapter listener calls this alongside `pushEvent` so both
+ * the messages-store chat log and the PaneHeader's provider/cost pills see
+ * every relevant wire event. Unknown / non-telemetry events are no-ops.
+ *
+ * Handled events:
+ * - `assistant_message` — extracts `provider` + `model` (both required on the
+ *   Rust wire shape since F-145; earlier replays may omit them, in which case
+ *   we keep the last-observed pair rather than clear it).
+ * - `usage_tick` — extracts `tokens_in`, `tokens_out`, `cost_usd`.
+ *
+ * Kept separate from `fromRustEvent` (which returns a `SessionEvent` for the
+ * chat message store) so the telemetry path stays a pure side-channel — no
+ * risk of a chat-store shape change rippling into the header, and vice versa.
+ */
+export function routeTelemetryEvent(
+  sessionId: SessionId,
+  rustEvent: unknown,
+): void {
+  if (typeof rustEvent !== 'object' || rustEvent === null) return;
+  const ev = rustEvent as Record<string, unknown>;
+  const type = ev['type'];
+
+  if (type === 'assistant_message') {
+    const provider = ev['provider'];
+    const model = ev['model'];
+    if (typeof provider === 'string' && typeof model === 'string') {
+      recordProviderModel(sessionId, provider as ProviderId, model);
+    }
+    return;
+  }
+
+  if (type === 'usage_tick') {
+    const tokensIn = ev['tokens_in'];
+    const tokensOut = ev['tokens_out'];
+    const costUsd = ev['cost_usd'];
+    if (
+      typeof tokensIn === 'number' &&
+      Number.isFinite(tokensIn) &&
+      typeof tokensOut === 'number' &&
+      Number.isFinite(tokensOut) &&
+      typeof costUsd === 'number' &&
+      Number.isFinite(costUsd)
+    ) {
+      recordUsageTick(sessionId, tokensIn, tokensOut, costUsd);
+    }
+    return;
+  }
+}
+
+/** Test helper — clears all telemetry between tests. */
+export function resetSessionTelemetryStore(): void {
+  setTelemetryStore(reconcile({}));
+}


### PR DESCRIPTION
Closes forge-ide/forge#396

## Summary
- PaneHeader for chat pane now shows live provider + model from IPC (wire events: `AssistantMessage` → provider/model, `UsageTick` → tokens/cost).
- Subject drops the legacy `Session <id>` prefix — uses short session id as head, appends `· <model>` once observed.
- Cost meter renders the real session totals or the sanctioned em-dash placeholder (`—`) — never a fabricated `$0.00`.
- `pending` vocabulary removed from the provider pill; pill falls back to Phase-1 sanctioned default (`ollama`) until first turn.
- New per-session `sessionTelemetry` side-channel store keeps chat-messages shape untouched.
- Pure formatter helpers (`formatCostLabel`, `formatProviderLabel`, `formatChatSubject`, `resolveProviderId`) unit-tested without a render roundtrip.
- End-to-end regression test: mocks the Rust IPC `listen` channel, dispatches `assistant_message` + `usage_tick` payloads, and asserts the PaneHeader reflects the mocked labels (per DoD item §5).

## Test plan
- `cargo fmt --check`, `cargo check --workspace`, `cargo clippy --all-targets --workspace -- -D warnings`, `cargo test --workspace --all-targets` all pass locally.
- `pnpm -r test` (751 tests) passes; `pnpm -r typecheck` clean; `pnpm check-tokens` clean.
- New unit tests: `stores/sessionTelemetry.test.ts`, `routes/Session/costLabel.test.ts`.
- Extended `routes/Session/SessionWindow.test.tsx` with the DoD regression test.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the `forge-finish-task` handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)