### PR TITLE
[F-408] docs(ui-specs): align sub-agent-banner §6 with Phase-2 shipped UI

### DIFF
--- a/docs/ui-specs/sub-agent-banner.md
+++ b/docs/ui-specs/sub-agent-banner.md
@@ -10,19 +10,23 @@
 
 **Size.** Full width, content-driven.
 
-**Visual anatomy.**
+**Phase 2 scope.** The banner ships with glyph, agent name, delegated-at timestamp, state chip, and chevron. Model and tool-count chips, plus the state-chip details popover, are **deferred to Phase 3** (tracked in F-448) — they require wire fields the orchestrator does not forward today (`SubAgentBannerTurn` carries no `model` or `tool_count`) and a popover surface that Phase 2 does not host.
+
+**Visual anatomy (Phase 2 — shipped).**
 ```
 ┌───────────────────────────────────────────────────┐
-│[↳] ↳ spawned · test-writer   [sonnet-4.5] [4 tools] [running]
+│[↳] ↳ spawned · test-writer   delegated at 14:37   [running]  [>]
 ├───────────────────────────────────────────────────┤
 │  sub-agent body: message thread, indented,       │
 │  with its own tool calls nested inside           │
 └───────────────────────────────────────────────────┘
 ```
 - Container: `--color-surface-1` bg, 1px `--color-border-1`, **2px left border `--color-ember-400`**, radius `--r-sm`
-- Header: `↳ spawned · <n>` in Fira Code 11px, text-primary
-- Right chips: model, tool count, state (`running` / `done` / `queued` / `error` / `killed`)
+- Header (left → right): `↳ spawned · <n>` in Fira Code 11px text-primary, then `delegated at HH:MM` in text-tertiary 10px, then the state chip pushed right, then the chevron
+- State chip values: `running` / `done` / `queued` / `error` / `killed`
 - State chip uses semantic color: running=warn, done=ok, queued=text-secondary, error=err, killed=text-tertiary
+
+**Visual anatomy (Phase 3 — deferred).** Once the orchestrator forwards `model` and `tool_count` on `SubAgentBannerTurn`, the header adds `[model]` and `[N tools]` chips between the timestamp and the state chip, and the state chip becomes an interactive `<button>` that opens the status-details popover (see Interaction). Header shape becomes `[↳] ↳ spawned · <n>  delegated at HH:MM  [sonnet-4.5] [4 tools] [running]  [>]`.
 
 **Collapsed state.**
 - Just the header row. Chevron on far right opens.
@@ -34,8 +38,8 @@
 
 **Interaction.**
 - Click header: toggle collapse
-- Click `<n>`: focus the agent in the Agent Monitor (§9)
-- Click state chip: show sub-agent status details popover
+- Double-click header: focus the agent in the Agent Monitor (§9) *(Phase 2)*
+- Click state chip: show sub-agent status details popover *(Phase 3 — deferred; state chip is a passive label in Phase 2)*
 
 **Doesn't do.**
 - Does not let the user inject messages directly into a sub-agent's thread from here. To steer a sub-agent, use Agent Monitor's "interrupt + refine".

--- a/web/packages/app/src/components/SubAgentBanner.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.tsx
@@ -4,11 +4,16 @@ import './SubAgentBanner.css';
 
 // ---------------------------------------------------------------------------
 // SubAgentBanner — inline representation of a spawned sub-agent in the
-// parent's ChatPane (F-136). Matches `docs/ui-specs/sub-agent-banner.md` §6:
-// 2px ember left-border accent, header row (`↳ spawned · <name>`), model +
-// step-count + state chips, click header to toggle collapse. Double-click
-// navigates to the Agent Monitor (F-140) with the child instance pre-selected
-// — the route 404s until F-140 lands.
+// parent's ChatPane (F-136). Matches `docs/ui-specs/sub-agent-banner.md` §6
+// Phase-2 anatomy: 2px ember left-border accent, header row
+// (`↳ spawned · <name>  delegated at HH:MM  [state]  [chevron]`), click
+// header to toggle collapse. Double-click navigates to the Agent Monitor
+// (F-140) with the child instance pre-selected — the route 404s until F-140
+// lands.
+//
+// Phase-3 deferred (per spec §6): model + tool-count chips require wire
+// fields (`model`, `tool_count`) the orchestrator does not forward today;
+// the state chip becomes an interactive popover trigger at the same time.
 //
 // Backend gap (flagged in the PR body): today no step events ride the
 // child's `instance_id` so live step streaming is wired through props but


### PR DESCRIPTION
Closes forge-ide/forge#409

## Summary

- Align `docs/ui-specs/sub-agent-banner.md §6` with the Phase-2 SubAgentBanner UI that actually ships: glyph, name, `delegated at HH:MM`, passive state chip, chevron.
- Document the deferred Phase-3 chip work (`[model]` + `[N tools]` chips + interactive state-chip popover) inline so the spec carries both shapes side-by-side.
- Update the TSX header comment in `SubAgentBanner.tsx` to match the updated §6 anatomy. No behavioral code change.
- Filed follow-up [F-448](https://github.com/forge-ide/forge/issues/475) for the Phase-3 chip + popover implementation.

## DoD → resolution

- [x] Spec and code are single-sourced on header anatomy → §6 Phase-2 anatomy now matches shipped TSX exactly
- [x] State chip click opens the details popover if the code path is chosen (or spec says deferred) → §6 marks popover as Phase-3 deferred (tracked in F-448)
- [x] "delegated at" removed or relocated per spec → spec §6 now documents the timestamp (least-invasive resolution; UI + tests already render it)
- [x] Tests pass in CI → 733/733 web tests pass locally (16 SubAgentBanner tests unchanged)

## Test plan

- `pnpm test` in `web/` — 733 pass, 0 fail
- `pnpm typecheck` in `web/` — clean
- No Rust files touched; Rust workspace unaffected

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
