### PR TITLE
[F-409] Dashboard renders forbidden nav link per spec D.1

### DIFF
--- a/web/packages/app/src/routes/Dashboard.css
+++ b/web/packages/app/src/routes/Dashboard.css
@@ -17,34 +17,3 @@
   color: var(--color-text-secondary);
   margin: 0;
 }
-
-.dashboard__nav {
-  margin: var(--sp-4) 0 var(--sp-6) 0;
-  display: flex;
-  gap: var(--sp-4);
-}
-
-.dashboard__nav-link {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--color-text-secondary);
-  text-decoration: none;
-  padding: var(--sp-2) var(--sp-3);
-  border: 1px solid var(--color-border-1);
-  border-radius: var(--r-sm);
-  transition:
-    color var(--ease),
-    border-color var(--ease);
-}
-
-.dashboard__nav-link:hover {
-  color: var(--color-text-primary);
-  border-color: var(--color-ember-400);
-}
-
-.dashboard__nav-link:focus-visible {
-  outline: 2px solid var(--color-ember-400);
-  outline-offset: 2px;
-}

--- a/web/packages/app/src/routes/Dashboard.test.tsx
+++ b/web/packages/app/src/routes/Dashboard.test.tsx
@@ -23,9 +23,8 @@ describe('Dashboard', () => {
     cleanup();
   });
 
-  // F-140: Dashboard now renders a router-aware `<A>` link to the Agent
-  // Monitor, so it must mount under a `<MemoryRouter>` for the link to
-  // resolve its route context without erroring.
+  // Dashboard is wrapped in a router-capable context so any descendant
+  // router primitives resolve cleanly, matching the shell's runtime.
   function renderDashboard() {
     return render(() => (
       <MemoryRouter>
@@ -40,9 +39,12 @@ describe('Dashboard', () => {
     expect(heading.textContent).toBe('Forge — Dashboard');
   });
 
-  it('exposes an Agent Monitor link in the app navigation', () => {
-    const { getByRole } = renderDashboard();
-    const link = getByRole('link', { name: /agent monitor/i });
-    expect(link.getAttribute('href')).toBe('/agents');
+  // F-409: spec dashboard.md §D.1 mandates a single flat surface — no tab
+  // bar, no sidebar, no pane splits. A <nav> element violates the flatness
+  // rule; AgentMonitor access is already provided by the StatusBar badge
+  // and session-roster entry.
+  it('renders no <nav> element (spec D.1 flat surface)', () => {
+    const { container } = renderDashboard();
+    expect(container.querySelector('nav')).toBeNull();
   });
 });

--- a/web/packages/app/src/routes/Dashboard.tsx
+++ b/web/packages/app/src/routes/Dashboard.tsx
@@ -1,5 +1,4 @@
 import type { Component } from 'solid-js';
-import { A } from '@solidjs/router';
 import { ProviderPanel } from './Dashboard/ProviderPanel';
 import { SessionsPanel } from './Dashboard/SessionsPanel';
 import './Dashboard.css';
@@ -8,11 +7,6 @@ export const Dashboard: Component = () => {
   return (
     <main class="dashboard">
       <h1 class="dashboard__title">Forge — Dashboard</h1>
-      <nav class="dashboard__nav" aria-label="App navigation">
-        <A href="/agents" class="dashboard__nav-link">
-          Agent Monitor
-        </A>
-      </nav>
       <ProviderPanel />
       <SessionsPanel />
     </main>


### PR DESCRIPTION
Closes forge-ide/forge#410

## Summary
- Dashboard.tsx: remove the `<nav class="dashboard__nav">` block and the now-unused `A` import from `@solidjs/router`.
- Dashboard.css: remove the `.dashboard__nav` / `.dashboard__nav-link` rules.
- Dashboard.test.tsx: replace the obsolete "Agent Monitor link" assertion with a regression test that asserts the rendered Dashboard contains no `<nav>` element (spec `dashboard.md §D.1` — single flat surface).

AgentMonitor remains reachable via the StatusBar badge and session-roster entry, matching the approved remediation in the issue.

## Test plan
- `pnpm -C web/packages/app test` — full app vitest suite (733/733 passing), including the new no-`<nav>` regression.
- `pnpm -C web/packages/app typecheck` passes.
- `pnpm -C web/packages/app build` passes.
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` all pass.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).