### PR TITLE
[F-392] frontend: StatusBar background honors ember-400 spec-lock

### DIFF
--- a/web/packages/app/src/shell/StatusBar.css
+++ b/web/packages/app/src/shell/StatusBar.css
@@ -1,15 +1,28 @@
 /* F-138 status bar.
  *
- * Lives at the bottom of the Session window per docs/ui-specs/shell.md §2.
- * Thin strip, neutral chrome; the `BgAgentsBadge` is the only interactive
- * element today — room reserved for workspace/provider/cost pills in
- * follow-ups.
+ * Lives at the bottom of the Session window per `docs/ui-specs/shell.md` §2.
+ * Thin strip, always rendered on the ember-400 brand surface — this is the
+ * most visible branded surface in daily use. `docs/design/component-principles.md`
+ * §Status bar is a hard spec-lock:
+ *
+ *   "The status bar is always ember-400 background with white text … Do not
+ *    change the status bar color under any circumstances, including in light
+ *    mode."
+ *
+ * F-392 pins this invariant in `StatusBar.css.test.ts` — background MUST be
+ * `var(--color-ember-400)` with no `--color-surface-*` or `--fg-surface-*`
+ * fallback anywhere in the root rule.
  *
  * All colors, spacing, radii, and typography resolve to canonical tokens
  * declared in `web/packages/design/src/tokens.css` and mirrored in
  * `docs/design/token-reference.md`. Do not introduce new namespaces or
  * raw-hex fallbacks — see `docs/design/color-system.md` for the rules and
- * `StatusBar.css.test.ts` for the regression guard (F-427).
+ * `StatusBar.css.test.ts` for the regression guard (F-427 + F-392).
+ *
+ * Interaction surfaces on the bar (`__bg-badge`, `__bg-row-action`) use
+ * translucent white overlays to stay legible on the ember background; the
+ * popover rises off the bar onto a normal iron surface so the agent list
+ * keeps its dense, dark presentation.
  */
 
 .status-bar {
@@ -20,13 +33,16 @@
   padding: 2px 8px;
   min-height: 22px;
   font-size: 12px;
-  background: var(--color-surface-1);
-  border-top: 1px solid var(--color-border-1);
-  color: var(--color-text-secondary);
+  font-weight: 500;
+  background: var(--color-ember-400);
+  color: var(--color-text-inverted);
   position: relative;
   flex-shrink: 0;
 }
 
+/* Pill-shaped badge that opens the running-agents popover. Rendered on ember,
+ * so the surface is a translucent white overlay rather than a warning-tinted
+ * pill — warning-on-ember would all but vanish. */
 .status-bar__bg-badge {
   all: unset;
   display: inline-flex;
@@ -35,19 +51,19 @@
   padding: 0 8px;
   height: 18px;
   border-radius: 10px;
-  background: var(--color-warning-bg);
-  color: var(--color-warning);
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--color-text-inverted);
   font-weight: 600;
   cursor: pointer;
   transition: background 120ms ease;
 }
 
 .status-bar__bg-badge:hover {
-  background: var(--color-warning-border);
+  background: rgba(255, 255, 255, 0.25);
 }
 
 .status-bar__bg-badge:focus-visible {
-  outline: 2px solid var(--color-info);
+  outline: 2px solid var(--color-text-inverted);
   outline-offset: 2px;
 }
 
@@ -60,6 +76,10 @@
   opacity: 0.9;
 }
 
+/* The popover escapes the ember surface back onto the canonical iron scale
+ * — a dense list on top of pure ember would fatigue the eye. Per
+ * `color-system.md`, iron-800 (surface-2) is the correct token for
+ * dropdowns / popovers. */
 .status-bar__bg-popover {
   position: absolute;
   right: 8px;
@@ -70,6 +90,7 @@
   border: 1px solid var(--color-border-2);
   border-radius: 6px;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  color: var(--color-text-primary);
   z-index: 40;
 }
 

--- a/web/packages/app/src/shell/StatusBar.css.test.ts
+++ b/web/packages/app/src/shell/StatusBar.css.test.ts
@@ -1,4 +1,4 @@
-// F-427 drift guard for StatusBar.css.
+// F-427 drift guard + F-392 ember-400 spec-lock for StatusBar.css.
 //
 // The file previously referenced a `--fg-*` token namespace that was never
 // declared in `web/packages/design/src/tokens.css` or
@@ -8,6 +8,15 @@
 // used in the file must belong to the canonical `--color-*` / `--sp-*` /
 // `--r-*` / `--font-*` / `--ease` namespace, and no raw color fallbacks
 // may be supplied to `var(...)`.
+//
+// F-392 additionally pins the ember-400 spec-lock from
+// `docs/design/component-principles.md §Status bar` and `shell.md §2`:
+// "The status bar is always ember-400 background with white text … Do not
+// change the status bar color under any circumstances." The `.status-bar`
+// root rule must set `background: var(--color-ember-400)` and must NOT
+// reintroduce any `--color-surface-*` or `--fg-surface-*` fallback on the
+// background. Mirrors the `ActivityBar.css.test.ts` targeted-rule-match
+// pattern (PR #469).
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -59,5 +68,41 @@ describe('StatusBar.css token hygiene (F-427)', () => {
       .filter(({ fallback }) => fallback !== null && rawValue.test(fallback!))
       .map(({ raw }) => raw);
     expect(offenders).toEqual([]);
+  });
+});
+
+describe('StatusBar.css ember-400 spec-lock (F-392)', () => {
+  // Targeted-rule-match pattern mirroring ActivityBar.css.test.ts (PR #469):
+  // parse the `.status-bar { ... }` root rule body directly and assert against
+  // it. jsdom does not resolve external stylesheets at render time, so the
+  // CSS source file is the contract.
+  const rootMatch = source.match(/\.status-bar\s*\{([^}]*)\}/);
+
+  it('declares a root `.status-bar` rule', () => {
+    expect(rootMatch).not.toBeNull();
+  });
+
+  it('sets background to --color-ember-400 (spec-lock)', () => {
+    const body = rootMatch?.[1] ?? '';
+    expect(body).toMatch(/background\s*:\s*var\(--color-ember-400\)/);
+  });
+
+  it('does not fall back to a neutral surface token on background', () => {
+    const body = rootMatch?.[1] ?? '';
+    // No --color-surface-*, --fg-surface-*, or --color-bg anywhere in the
+    // root rule — the ember background must be unconditional.
+    expect(body).not.toMatch(/--color-surface-/);
+    expect(body).not.toMatch(/--fg-surface-/);
+    expect(body).not.toMatch(/--color-bg\b/);
+  });
+
+  it('uses --color-text-inverted (white) for the bar text color', () => {
+    const body = rootMatch?.[1] ?? '';
+    expect(body).toMatch(/color\s*:\s*var\(--color-text-inverted\)/);
+  });
+
+  it('does not reintroduce a neutral top border (redundant on ember)', () => {
+    const body = rootMatch?.[1] ?? '';
+    expect(body).not.toMatch(/border-top\s*:/);
   });
 });


### PR DESCRIPTION
Closes forge-ide/forge#393

## Summary

`docs/design/component-principles.md §Status bar` and `docs/ui-specs/shell.md §2` are both hard spec-locks:
> "The status bar is always ember-400 background with white text … Do not change the status bar color under any circumstances, including in light mode."

`.status-bar` was rendering on neutral iron (`--color-surface-1`), losing the single most visible brand surface. This PR swaps the root rule to `background: var(--color-ember-400)` + `color: var(--color-text-inverted)` and reworks the dependent interaction surfaces so they stay legible on ember.

## Changes

- `.status-bar`: background → `var(--color-ember-400)`, text → `var(--color-text-inverted)`, `font-weight: 500` for emphasis, top border removed (redundant on ember).
- `.status-bar__bg-badge`: translucent-white-on-ember pill (`rgba(255,255,255,0.15)` → `0.25` on hover) instead of the old warning-tinted pill. Focus ring switched to `var(--color-text-inverted)`.
- `.status-bar__bg-popover`: kept on `--color-surface-2` (iron-800) per `color-system.md` — a dense running-agents list on pure ember fatigues the eye. Explicit `color: var(--color-text-primary)` so row styles don't inherit white from the ember parent.

## Contract test (F-392)

Extends `StatusBar.css.test.ts` with four new assertions, mirroring the `ActivityBar.css.test.ts` targeted-rule-match pattern from PR #469:
1. `.status-bar` root rule sets `background: var(--color-ember-400)`.
2. Root rule has NO `--color-surface-*`, `--fg-surface-*`, or `--color-bg` reference (spec-lock guard).
3. Root rule sets `color: var(--color-text-inverted)`.
4. Root rule has no `border-top` (redundant on ember).

The pre-existing F-427 drift guard (no `--fg-*` namespace, no raw-hex `var()` fallbacks) is untouched.

## Design note: contrast

Measured contrast of `#fff` on `#ff4a12` is **~3.37:1**, below the WCAG AA 4.5:1 threshold for normal-sized text. The spec-lock explicitly mandates white text despite this (`component-principles.md §Status bar`: "always ember-400 background with white text … Do not change … under any circumstances"). The DoD item "Contrast ≥ 4.5:1 verified" is therefore in direct tension with the spec-lock.

Two compliant-in-isolation alternatives were considered and rejected:
- Darker-on-ember (`--color-ember-900` text → 4.79:1): violates the "white text" spec-lock clause.
- Shift background off ember: violates the spec-lock outright.

Bumping the bar text to `font-weight: 500` partially compensates but does not move it across the 4.5:1 threshold. Flagging this for reviewer attention so the tension surfaces explicitly — not burying it. If the contrast constraint is binding, the right resolution is a spec amendment (e.g. allow `ember-900` text, or require `ember-500` background with white text which computes at 4.55:1), not a silent deviation in StatusBar.css.

## Test plan

- `pnpm --filter app test` — 738/738 pass (60 files).
- `pnpm -r typecheck` — clean.
- `node scripts/check-tokens.mjs` — ok: 57 tokens match.
- `just check-web` — clean end-to-end.
- `cargo fmt --check` + `cargo check --workspace` — clean (no Rust touched).
- RED-first TDD: 4 new tests in `StatusBar.css.test.ts` failed before the CSS change, all 8 pass after.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)