### PR TITLE
test(branch-gutter): guard --color-ember-300 token contract (F-418)

### DIFF
--- a/web/packages/app/src/components/BranchGutter.css.test.ts
+++ b/web/packages/app/src/components/BranchGutter.css.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// BranchGutter thread-line token (F-145 / F-418):
+// docs/ui-specs/branching.md §15.4 and the BranchGutter.tsx docstring both
+// assert the 2px vertical line uses `--color-ember-300`. Guard the CSS
+// source against silent drift to a hardcoded hex or a different ember
+// shade — jsdom can't resolve var() against the external design sheet,
+// so a string-level contract test is the practical regression gate.
+
+const cssPath = resolve(__dirname, 'BranchGutter.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+function ruleBody(selector: string): string {
+  const at = css.indexOf(selector);
+  if (at < 0) throw new Error(`selector not found in BranchGutter.css: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  if (open < 0 || close < 0) {
+    throw new Error(`malformed rule block for selector: ${selector}`);
+  }
+  return css.slice(open + 1, close).trim();
+}
+
+describe('BranchGutter.css `.branch-gutter` (F-418 docstring/token contract)', () => {
+  const body = ruleBody('.branch-gutter').replace(/\s+/g, ' ');
+
+  it('paints the thread-line via `var(--color-ember-300, ...)` per branching.md §15.4', () => {
+    expect(body).toMatch(/background:\s*var\(--color-ember-300/);
+  });
+
+  it('no longer hardcodes the #ff7a30 hex without going through the token', () => {
+    // A raw `background: #ff7a30;` would bypass the design-token surface
+    // and re-introduce the docstring-drift risk F-418 guards against.
+    expect(body).not.toMatch(/background:\s*#ff7a30\s*;/i);
+  });
+});


### PR DESCRIPTION
Closes forge-ide/forge#419

## Summary
- All four F-418 sources already agree on `--color-ember-300` resolving to `#ff7a30`:
  - `web/packages/app/src/components/BranchGutter.tsx:8-18` docstring
  - `web/packages/app/src/components/BranchGutter.css` (uses `var(--color-ember-300, #ff7a30)`)
  - `web/packages/design/src/tokens.css` (defines `--color-ember-300: #ff7a30`)
  - `docs/ui-specs/branching.md` §15.4
- Added a CSS-source contract test mirroring `ApprovalPrompt.css.test.ts` / `PaneHeader.css.test.ts` so a future drift (hardcoded hex or different ember shade) is caught in CI.

## Test plan
- `pnpm -r test` passes (726/726, including the new 2 assertions)
- `pnpm -r typecheck` passes
- `pnpm check-tokens` passes
- `cargo fmt --all -- --check` passes (no Rust changes)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)