### PR TITLE
[F-436] docs(architecture): ADR-002 and ADR-003 for Phase 2 decisions

### DIFF
--- a/docs/architecture/ADR-002-mcp-integration-scope-and-manager-consolidation.md
+++ b/docs/architecture/ADR-002-mcp-integration-scope-and-manager-consolidation.md
@@ -1,0 +1,66 @@
+# ADR-002: MCP Integration — Scope and Manager Consolidation
+
+**Status:** Accepted
+**Date:** 2026-04-21
+
+---
+
+## Context
+
+Phase 2 introduced first-class MCP server lifecycle management into `forged`. Three decisions made under F-155 set the shape of that integration and are load-bearing for every downstream consumer (the session dispatcher, the IPC event stream, the GUI state pills, the CLI `forge mcp` commands).
+
+This ADR records them so future contributors do not re-litigate the layering, re-split the manager, or drop `Disabled` as "just another failure mode."
+
+Cross-references: `crate-architecture.md §3.3` (forge-mcp responsibilities), `ipc-contracts.md` (the `Event::McpState` wire form).
+
+---
+
+## Decisions
+
+### 1. MCP lifecycle types live in `forge-core`, not `forge-mcp`
+
+**Decision.** `ServerState` and `McpStateEvent` are defined in `crates/forge-core/src/mcp_state.rs` and re-exported unchanged from `forge-mcp` so external callers keep reading `forge_mcp::ServerState` / `forge_mcp::McpStateEvent`.
+
+**Rationale.** `forge_core::Event` needs an `McpState(McpStateEvent)` variant (see the `Event` enum in `crate-architecture.md §3.1`) because the session event log is the single source of truth for every observable session transition and MCP lifecycle transitions have to ride the same log. If the types lived in `forge-mcp`, `forge-core` would need a `forge-mcp` dependency to construct the variant — but `forge-mcp` already depends on `forge-core` for the shared type vocabulary, which is a cycle. Moving the two enums up the stack into `forge-core` breaks the cycle without forcing `forge-mcp` callers to re-import from a new path. The re-export preserves the existing public surface.
+
+See `crates/forge-core/src/mcp_state.rs:1-8` for the module-level doc that records this rationale inline.
+
+---
+
+### 2. Single `McpManager` per daemon
+
+**Decision.** `forged` instantiates exactly one `McpManager` at startup; every session and every agent orchestrator shares that instance via an `Arc<McpManager>`. There is no per-session manager, no per-agent manager, and no per-scope manager.
+
+**Rationale.** MCP servers are OS processes (stdio transport) or HTTP endpoints (http transport) with non-trivial spawn cost and stateful handshakes. A per-session manager would:
+
+- re-spawn the same server for every session in the workspace, multiplying process count by session count
+- fight itself on the user-scope `~/.mcp.json` — two managers trying to own the same stdio pipe
+- make the restart-policy bookkeeping (5 tries per 10 minutes, see `§3.3`) per-session instead of per-server, which does not match user intent
+
+A single manager per daemon lets servers be shared across sessions, keeps restart accounting server-scoped, and matches the mental model of "the MCP servers for this workspace" rather than "the MCP servers for this session."
+
+Scope separation — workspace vs. user-scope servers — is handled inside the manager via `Scope`, not by instantiating multiple managers.
+
+---
+
+### 3. `ServerState::Disabled` is distinct from `Failed`
+
+**Decision.** `ServerState` has five variants: `Starting`, `Healthy`, `Degraded`, `Failed`, `Disabled`. `Disabled` is not modelled as `Failed { reason: "stopped" }` or `Failed { reason: "disabled" }` — it is its own variant.
+
+**Rationale.** `Disabled` carries semantics that `Failed` cannot:
+
+- **User intent.** `Disabled` means the user explicitly toggled the server off. `Failed` means the runtime gave up on it (restart window exhausted, crash beyond policy). Collapsing both into `Failed` erases the intent signal the UI needs to render them differently (a disabled toggle vs. a red error banner).
+- **Error string contract.** `McpManager::call` on a disabled server must return the literal string `"MCP server <name> is disabled"`. The running-session toggle test asserts against that exact text so the CLI and GUI render a consistent message. `Failed` servers produce transport-specific error strings; reusing that path would break the contract.
+- **Re-enable transition.** `toggle_mcp_server(name, true)` needs to know whether to transition `Disabled → Starting` (the re-enable path) or to leave `Failed` alone (the user must explicitly restart a crashed server). A single discriminant on the state enum makes this an exhaustive match instead of a string parse on `reason`.
+
+See `crates/forge-core/src/mcp_state.rs:14-42` for the variant-level doc comments that pin each of these semantics to the enum definition.
+
+---
+
+## Consequences
+
+- `forge-mcp` keeps its public surface (`pub use forge_core::mcp_state::*`) — existing callers do not move.
+- Every `Event::McpState` in the event log is constructed in `forge-core` code paths; `forge-mcp` produces values but the enum definition stays upstream.
+- Adding a new `ServerState` variant is a breaking change to the TS-generated type and must bump the IPC protocol version per `ADR-001 §3`.
+- A future multi-tenant daemon (multiple workspaces served by one `forged`) would need to revisit decision 2 — but that scope expansion is not currently planned.
+- `toggle_mcp_server(name, false)` writes `Disabled` to the state stream; it does not shadow-delete the server from `forge_mcp::McpManager::list()`. The list entry stays visible so the GUI can render the "off" toggle next to the server name.

--- a/docs/architecture/ADR-003-sandbox-resource-enforcement-cgroup-v2-rlimit-hybrid.md
+++ b/docs/architecture/ADR-003-sandbox-resource-enforcement-cgroup-v2-rlimit-hybrid.md
@@ -1,0 +1,71 @@
+# ADR-003: Sandbox Resource Enforcement — cgroup v2 / rlimit Hybrid
+
+**Status:** Accepted
+**Date:** 2026-04-21
+
+---
+
+## Context
+
+`forged` spawns tool subprocesses (shell, fs, LSP helpers, user-approved commands) under the sandbox wrapper in `crates/forge-session/src/sandbox.rs`. Phase 2 (F-149) replaced the historical `RLIMIT_NPROC`-only design with a cgroup v2 primary path plus an rlimit backstop. The three decisions below pin that hybrid so future contributors do not regress to rlimit-only or move enrollment back to the parent side.
+
+Cross-references: `crate-architecture.md §3.5` (forge-session responsibilities), `isolation-model.md §8.2` (Level 1 process isolation).
+
+---
+
+## Decisions
+
+### 1. Per-sandbox cgroup v2 leaf is the authoritative process cap
+
+**Decision.** Each `SandboxedCommand::spawn` creates a fresh cgroup v2 leaf as a sibling of the daemon's own cgroup, writes `pids.max = SandboxConfig::max_processes`, and enrolls the child pid into it. Each sandbox gets its own independent task budget (default 256).
+
+**Rationale.** `RLIMIT_NPROC` is per real-uid, not per-process-tree. On a developer machine the daemon shares a uid with the desktop session and every other process that uid owns; on CI it shares a uid with every other concurrent test. A uid-wide cap cannot give sandbox A a budget of 256 that is independent of sandbox B's budget — the two share the same counter. cgroup v2 `pids.max` is per-cgroup, so a per-sandbox leaf is the only mechanism that gives each sandbox an independent task ceiling.
+
+Sibling-of-daemon placement is deliberate: cgroup v2 forbids a cgroup from containing both processes and child cgroups (the "no internal processes" rule), so nesting leaves under the daemon's own cgroup would violate the rule the moment `pids` is enabled on its subtree. The daemon's parent (typically a systemd `user@<uid>.service/app.slice` path) already has `pids` in `cgroup.subtree_control` thanks to systemd's default delegation, so sibling leaves inherit the controller for free.
+
+See `crates/forge-session/src/sandbox.rs:59-82` for the `SandboxConfig` field-level docs that tie `max_processes` to this mechanism.
+
+---
+
+### 2. Enrollment happens in `pre_exec`, not after `spawn()` returns
+
+**Decision.** The pid is written into `<leaf>/cgroup.procs` from inside a `pre_exec` hook — i.e. from the child process, post-fork but pre-exec — using only async-signal-safe libc calls (`open`, `write`, `close`, `getpid`). A parent-side re-enroll runs after `spawn()` returns as a belt-and-braces backstop.
+
+**Rationale.** A naive implementation would `spawn()` the child and then write its pid into `cgroup.procs` from the parent. That has a fork-escape race: between the moment the kernel returns the child pid to the parent and the moment the parent writes the pid into the leaf, the child can execute arbitrarily many instructions — including `fork()` / `clone()` — and any descendants it spawns before enrollment lands inherit the *parent's* cgroup, not the sandbox leaf. A fork bomb in the first few microseconds of child execution would slip past the cap.
+
+`pre_exec` runs in the child process after `fork()` but before `execve()`. Writing `getpid()` into `cgroup.procs` at that point atomically enrolls the child before it can call `execve` to run user code, let alone fork descendants. All descendants of the child then inherit the sandbox cgroup.
+
+The hook uses only async-signal-safe calls because `pre_exec` runs in the window between `fork` and `execve` where allocator state, locks, and anything not signal-safe is undefined. `format!`, `to_string`, and even `std::fs::write` are unsafe to call there — they allocate or take locks. The hook pre-computes the C-string path outside `pre_exec`, then uses raw libc `open`/`write`/`close` and a hand-rolled `pid_to_decimal` (no allocation, no locks, no locale) inside.
+
+The parent-side re-enroll after `spawn()` returns is a backstop for the narrow case where the pre_exec `open()` fails (e.g., EMFILE under extreme fd pressure). It catches the child but cannot catch any descendants already forked by that point — pre_exec is the load-bearing path, parent-side is a safety net.
+
+See `crates/forge-session/src/sandbox.rs:59-82` and the full `SandboxedCommand::spawn` body for the enrollment sequence and race-analysis comments.
+
+---
+
+### 3. `RLIMIT_NPROC` stays as a uid-wide backstop when cgroup delegation is absent
+
+**Decision.** The sandbox applies `setrlimit(RLIMIT_NPROC, rlimit_nproc_backstop)` — default 4096 — in `pre_exec` on every spawn. When `CgroupLeaf::create` returns `Ok(None)` (non-Linux host, cgroup v1, container without `pids` delegation, user-slice without delegation), the sandbox proceeds with rlimit-only enforcement instead of failing the spawn.
+
+**Rationale.** The cgroup path is the primary enforcement mechanism but it is not universally available:
+
+- Non-Linux hosts do not have cgroups at all (the `imp` submodule itself is `#[cfg(target_os = "linux")]`).
+- Some Linux hosts run cgroup v1 or a hybrid layout where v2's `pids` controller is not exposed.
+- Container environments (docker / podman without `--pids=host`, some Kubernetes pod configurations) expose cgroup v2 but do not delegate the `pids` controller to user slices.
+- Developers running `forged` directly outside systemd's user manager may end up in the root cgroup, which has no writable subtree.
+
+In all of these cases, failing the spawn would make `forged` unusable on environments where users reasonably expect it to work (CI containers, older distros, macOS developer machines under eventual macOS support). The rlimit backstop is not equivalent to the cgroup cap — it is uid-wide, so its numeric value (4096) is tuned to stop runaway fork bombs within milliseconds while leaving headroom for the uid's baseline process count, not to provide per-sandbox isolation. Consumers that need hard per-sandbox isolation check `SandboxedChild::cgroup_path().is_some()` and refuse to run untrusted workloads on hosts where it is `None`.
+
+Graceful degradation is silent because the user cannot meaningfully act on a cgroup-not-available log spam on every spawn; `cgroup_path()` is the introspection hook for code that needs to know.
+
+See `crates/forge-session/src/sandbox.rs:59-82` for the `SandboxConfig::rlimit_nproc_backstop` field doc that pins this rationale to the type.
+
+---
+
+## Consequences
+
+- The regression test `cgroup_pids_max_caps_sandbox_tasks_per_f149` skips on hosts without `pids` delegation rather than silently exercising the rlimit-only path — silent success on a degraded path would let a real regression hide.
+- Teardown of the leaf is best-effort: `SandboxedChild::drop` writes `cgroup.kill` + `rmdir`; orphans from crash paths are reclaimed on reboot. Non-empty leaves EBUSY on rmdir; we accept the orphan rather than busy-wait.
+- The cgroup leaf naming convention `forge-sandbox-<daemon-pid>-<counter>` is unique within a daemon lifetime but not across daemon restarts. Leaves from a crashed prior daemon process are inert (no processes inside) and cleaned by the next kernel reboot.
+- Any future addition to `SandboxConfig` that needs per-sandbox (not per-uid) enforcement must follow the cgroup path; adding more `setrlimit` calls will not deliver per-sandbox isolation.
+- macOS / Windows support for real sandboxing is deferred; the bookkeeping types (`SandboxConfig`, `ChildRegistry`, `BASE_ENV_WHITELIST`) compile everywhere so callers can plumb config through without platform branching.

--- a/docs/architecture/crate-architecture.md
+++ b/docs/architecture/crate-architecture.md
@@ -139,6 +139,8 @@ pub trait Provider: Send + Sync {
 
 MCP client and server lifecycle manager.
 
+> See [ADR-002: MCP Integration — Scope and Manager Consolidation](./ADR-002-mcp-integration-scope-and-manager-consolidation.md) for the rationale behind the lifecycle-types-in-`forge-core` placement, the single-manager-per-daemon decision, and the `ServerState::Disabled` variant.
+
 **Responsibilities.**
 - Parse `.mcp.json` (workspace) and `~/.mcp.json` (user) using the universal `mcpServers` schema
 - Import conversion for other tool formats (`forge mcp import --from ...`)
@@ -236,6 +238,8 @@ When an agent requests `agent.spawn(name, message)`, the orchestrator:
 ### 3.5 `forge-session`
 
 The session process binary — `forged` — the heart of Forge.
+
+> See [ADR-003: Sandbox Resource Enforcement — cgroup v2 / rlimit Hybrid](./ADR-003-sandbox-resource-enforcement-cgroup-v2-rlimit-hybrid.md) for the rationale behind the per-sandbox cgroup v2 leaf, pre_exec enrollment, and rlimit backstop fallback used by `crates/forge-session/src/sandbox.rs`.
 
 **Entrypoint.**
 ```rust


### PR DESCRIPTION
Closes forge-ide/forge#436

## Summary

Two Phase 2 architectural decisions had no ADR coverage. This PR adds them and cross-links them from `crate-architecture.md`.

- `docs/architecture/ADR-002-mcp-integration-scope-and-manager-consolidation.md` — captures F-155: MCP lifecycle types placed in `forge-core` to break a `forge-core` → `forge-mcp` dependency cycle, single-manager-per-daemon, and `ServerState::Disabled` as its own variant (distinct from `Failed`). Evidence: `crates/forge-core/src/mcp_state.rs:1-8`.
- `docs/architecture/ADR-003-sandbox-resource-enforcement-cgroup-v2-rlimit-hybrid.md` — captures F-149: per-sandbox cgroup v2 leaf as the authoritative `pids.max` mechanism, `pre_exec` enrollment closing the fork-escape race, and `RLIMIT_NPROC` backstop for hosts without cgroup `pids` delegation. Evidence: `crates/forge-session/src/sandbox.rs:59-82`.
- `docs/architecture/crate-architecture.md` §3.3 and §3.5 each carry a blockquote link to the relevant ADR.

Both ADRs mirror the shape of `ADR-001-session-uds-protocol.md` (Context / Decisions / Consequences).

## Scope note

Branch was originally named `feat/task-436` due to an F-number / GH-issue-number offset (F-435 → issue #436, F-436 → issue #437). This PR closes **issue #436 (F-435)** which requests ADR-002 / ADR-003. The separate `ai-patterns.md` remediation work described in F-436 (issue #437) remains open and will need its own PR.

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace` passes
- Docs-only change; no new behavioral tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)