### PR TITLE
fix(editor-pane): first-class --color-accent-warn so dirty-dot stays visible (F-417)

### DIFF
--- a/docs/design/token-reference.md
+++ b/docs/design/token-reference.md
@@ -45,6 +45,11 @@ These tokens should be defined at `:root` and used throughout. Never use raw val
   --color-error:     #ff4a12;
   --color-info:      #7aaaff;
 
+  /* Accent aliases — stable names for warn/danger signals used across panes.
+   * `--color-accent-warn` pins dirty/unsaved-buffer indicators to ember-100
+   * so the signal stays visually distinctive on `--color-surface-1`. */
+  --color-accent-warn: var(--color-ember-100);
+
   /* Semantic backgrounds */
   --color-success-bg: rgba(61,220,132,0.07);
   --color-warning-bg: rgba(255,170,51,0.07);

--- a/web/packages/app/src/panes/EditorPane.css
+++ b/web/packages/app/src/panes/EditorPane.css
@@ -58,7 +58,10 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--color-accent-warn, var(--color-text-primary));
+  /* F-417: no fallback — the warn token is first-class in tokens.css.
+   * A fallback here previously masked drift with a near-white text color
+   * that defeated the dirty-dot signal against --color-surface-1. */
+  background: var(--color-accent-warn);
   margin-left: var(--sp-1);
   flex: 0 0 auto;
 }

--- a/web/packages/app/src/panes/EditorPane.css.test.ts
+++ b/web/packages/app/src/panes/EditorPane.css.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// F-417: dirty-dot indicator must remain visually distinctive against
+// `--color-surface-1`. Previously `.editor-pane__dirty-dot` used
+// `background: var(--color-accent-warn, var(--color-text-primary))` — the
+// warn token was undefined, so the fallback resolved to near-white text
+// primary, indistinguishable from any adjacent text against the dark
+// surface. `--color-accent-warn` is now a first-class ember-100 token in
+// tokens.css + token-reference.md; the fallback is removed so the dot
+// always paints the ember accent.
+//
+// Source-string assertions mirror the F-090 / F-084 pattern
+// (ProviderPanel.css.test.ts) — JSDOM cannot reliably resolve var()
+// chains at the source level.
+
+const cssPath = resolve(__dirname, 'EditorPane.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+const tokensCssPath = resolve(
+  __dirname,
+  '../../../../packages/design/src/tokens.css',
+);
+const tokensCss = readFileSync(tokensCssPath, 'utf-8');
+
+const tokenRefPath = resolve(
+  __dirname,
+  '../../../../../docs/design/token-reference.md',
+);
+const tokenRef = readFileSync(tokenRefPath, 'utf-8');
+
+function ruleBody(selector: string): string {
+  const at = css.indexOf(selector);
+  if (at < 0) throw new Error(`selector not found in EditorPane.css: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  if (open < 0 || close < 0) {
+    throw new Error(`malformed rule block for selector: ${selector}`);
+  }
+  return css.slice(open + 1, close).trim();
+}
+
+describe('EditorPane dirty-dot — F-417 fallback no longer defeats the signal', () => {
+  it('.editor-pane__dirty-dot uses --color-accent-warn with no text-primary fallback', () => {
+    const body = ruleBody('.editor-pane__dirty-dot');
+    const normalised = body.replace(/\s+/g, ' ');
+    expect(normalised).toContain('background: var(--color-accent-warn);');
+    expect(normalised).not.toMatch(/var\(--color-accent-warn,\s*var\(--color-text-primary\)\)/);
+  });
+
+  it('tokens.css defines --color-accent-warn as an ember-100 alias', () => {
+    expect(tokensCss).toMatch(/--color-accent-warn:\s*var\(--color-ember-100\);/);
+  });
+
+  it('docs/design/token-reference.md declares --color-accent-warn alongside tokens.css', () => {
+    expect(tokenRef).toMatch(/--color-accent-warn:\s*var\(--color-ember-100\);/);
+  });
+});

--- a/web/packages/design/src/tokens.css
+++ b/web/packages/design/src/tokens.css
@@ -33,6 +33,11 @@
   --color-error:     #ff4a12;
   --color-info:      #7aaaff;
 
+  /* Accent aliases — stable names for warn/danger signals used across panes.
+   * `--color-accent-warn` pins dirty/unsaved-buffer indicators to ember-100
+   * so the signal stays visually distinctive on `--color-surface-1`. */
+  --color-accent-warn: var(--color-ember-100);
+
   /* Semantic backgrounds */
   --color-success-bg: rgba(61,220,132,0.07);
   --color-warning-bg: rgba(255,170,51,0.07);


### PR DESCRIPTION
Closes forge-ide/forge#418

## Summary
- Promote `--color-accent-warn` to a first-class alias for `--color-ember-100` in `web/packages/design/src/tokens.css` and `docs/design/token-reference.md`.
- Drop the `var(--color-text-primary)` fallback in `.editor-pane__dirty-dot` — drift now fails loudly via `check-tokens.mjs` rather than silently erasing the dirty signal.
- Add `EditorPane.css.test.ts` regression: asserts the token is defined in both the implementation and reference, and that the dirty-dot rule no longer carries the text-primary fallback.

## Test plan
- `pnpm -r typecheck` passes
- `pnpm -r test` passes (751 web tests)
- `node scripts/check-tokens.mjs` passes (58 tokens match reference)
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)