### PR TITLE
[F-428] docs/frontend/architecture.md §9 — fix store paths, add layout model

### DIFF
--- a/docs/frontend/architecture.md
+++ b/docs/frontend/architecture.md
@@ -16,52 +16,66 @@
 - **Monaco** — loaded in an iframe (see §9.3)
 - **LSP client** — `monaco-languageclient` runs inside the Monaco iframe but never talks to Tauri directly. It forwards JSON-RPC over `postMessage` to the parent webview, which owns the IPC bridge to `forge-lsp` (see §9.3)
 - **Terminal** — xterm.js-compatible rendering driven by byte streams over Tauri events (from `forge-term`)
+- **Layout** — persisted `LayoutTree` (from `@forge/ipc`) rendered by `GridContainer`; `SplitPane` handles resize, `useDragToDock` + `DropZoneOverlay` drive drag-to-dock, `usePaneWidth` yields compactness buckets. See §9.2.1 for the full pipeline.
 
 ### 9.2 State model
 
-Solid signals at the module level. Three main stores:
+Solid signals at the module level, living under `web/packages/app/src/stores/`. Each store is a plain module exporting signals/stores — no framework wrapping. Six stores cover the product surface; a seventh (`sessionTelemetry`) aggregates per-session provider/cost telemetry derived from wire events.
+
+| Store | File | Role |
+|-------|------|------|
+| `session` | `web/packages/app/src/stores/session.ts` | Active session id, per-session summary, last event slot, workspace root |
+| `approvals` | `web/packages/app/src/stores/approvals.ts` | Tool-call approval whitelist keys + persistence bridge |
+| `catalog` | `web/packages/app/src/stores/catalog.ts` | Providers, MCP servers, skills, agents, containers — seeded via `list_*` IPC |
+| `messages` | `web/packages/app/src/stores/messages.ts` | Per-session message tree + streaming deltas + tool-call lifecycle |
+| `settings` | `web/packages/app/src/stores/settings.ts` | Effective (merged user+workspace) settings; writes flow through `setSetting` IPC |
+| `usage` | `web/packages/app/src/stores/usage.ts` | Usage range selector + latest `UsageReport` |
+| `sessionTelemetry` | `web/packages/app/src/stores/sessionTelemetry.ts` | Per-session live provider/model + running tokens/cost (F-395) |
 
 ```ts
-// web/packages/state/src/session.ts
-import { createSignal, createMemo } from 'solid-js';
-import { createStore, produce } from 'solid-js/store';
+// web/packages/app/src/stores/session.ts
+import { createSignal } from 'solid-js';
+import { createStore } from 'solid-js/store';
+import type { SessionId, SessionState } from '@forge/ipc';
 
 export const [activeSessionId, setActiveSessionId] = createSignal<SessionId | null>(null);
-export const [sessions, setSessions] = createStore<Record<SessionId, SessionState>>({});
-
-export const activeSession = createMemo(() => {
-  const id = activeSessionId();
-  return id ? sessions[id] : null;
-});
-
-// actions (each goes through IPC client)
-export async function sendMessage(session: SessionId, text: string, ctx: ContextRef[]) {
-  await ipc.sendMessage(session, text, ctx);
-  // event-driven update via `forge://event` subscription
-}
-
-export async function approveTool(session: SessionId, id: ToolCallId, scope: ApprovalScope) {
-  await ipc.approveToolCall(session, id, scope);
-}
+export const [activeWorkspaceRoot, setActiveWorkspaceRoot] = createSignal<string | null>(null);
+export const [sessions, setSessions] = createStore<Record<SessionId, SessionSummary>>({});
 ```
 
 ```ts
-// web/packages/state/src/catalog.ts
+// web/packages/app/src/stores/catalog.ts
 export const [providers, setProviders] = createStore<ProviderSummary[]>([]);
 export const [mcpServers, setMcpServers] = createStore<McpServerInfo[]>([]);
 export const [skills, setSkills] = createStore<SkillInfo[]>([]);
 export const [agents, setAgents] = createStore<AgentInfo[]>([]);
 export const [containers, setContainers] = createStore<ContainerSummary[]>([]);
-// refreshed on events; bootstrapped via `list_*` commands
+// seeded via `list_*` commands; refreshed on catalog events
 ```
 
 ```ts
-// web/packages/state/src/usage.ts
+// web/packages/app/src/stores/usage.ts
 export const [usageRange, setUsageRange] = createSignal<UsageRange>({ kind: 'last_days', days: 7 });
 export const [usageReport, setUsageReport] = createSignal<UsageReport | null>(null);
 ```
 
-Components subscribe by calling the signal as a function (Solid idiom): `{sessions[id].messages.map(m => ...)}`.
+Components subscribe by calling the signal as a function (Solid idiom): `{messages[sessionId].map(m => ...)}`. Actions that mutate remote state go through the IPC client in `web/packages/app/src/ipc/`; wire-event handlers call `setSessions` / `setMessages` / `setTelemetry` etc. via `produce` or `reconcile` so fine-grained reactivity survives each delta.
+
+### 9.2.1 Layout model
+
+Pane grid, split resizing, and drag-to-dock live under `web/packages/app/src/layout/`. The model is driven by a persisted `LayoutTree` shape (from `@forge/ipc`) so a tree can round-trip to disk without closure-stripping, and consumed by `GridContainer` which delegates leaf rendering to the caller. See `docs/ui-specs/shell.md` (window shell) and `docs/ui-specs/layout-panes.md` (pane model, drop zones, minimum widths) for the behavioral spec.
+
+| Module | File | Role |
+|--------|------|------|
+| `GridContainer` | `web/packages/app/src/layout/GridContainer.tsx` | Renders a `LayoutTree` recursively; dispatches leaves through a caller `renderLeaf(leaf)` prop (pane-agnostic) |
+| `SplitPane` | `web/packages/app/src/layout/SplitPane.tsx` | Two-child resizable split; 4px snap drag, double-click reset, ARIA window-splitter keyboard step |
+| `DropZoneOverlay` | `web/packages/app/src/layout/DropZoneOverlay.tsx` | Presentational top/bottom/left/right/center zones painted during drag (F-118) |
+| `layoutStore` | `web/packages/app/src/layout/layoutStore.ts` | Owns the per-workspace `Layouts` record; debounced persistence via `read_layouts` / `write_layouts` IPC (F-120, F-150) |
+| `useDragToDock` | `web/packages/app/src/layout/useDragToDock.ts` | Pointer-driven drag hook — emits mutated `LayoutTree` on drop, exposes `DragState` for overlays |
+| `usePaneWidth` | `web/packages/app/src/layout/usePaneWidth.ts` | Observes pane content-box width; buckets into `full` / `compact` / `icon-only` per `layout-panes.md §3.7` |
+| `dockDrop` | `web/packages/app/src/layout/dockDrop.ts` | Pure tree-mutation kernel — computes the new `LayoutTree` from (source, target, zone) |
+
+Pane bodies (the `renderLeaf` consumers) live under `web/packages/app/src/panes/` — e.g. `EditorPane.tsx`, `TerminalPane.tsx`. Each pane keeps its own effects; the layout layer stays pane-agnostic.
 
 ### 9.3 Monaco hosting
 - Monaco runs in `<iframe src="/monaco-host.html">` inside the session pane. The iframe is renderer-only; it never talks to Tauri directly
@@ -77,12 +91,12 @@ Components subscribe by calling the signal as a function (Solid idiom): `{sessio
 
 ### 9.5 Streaming in the UI
 
-Streaming is where Solid shines. The event handler for `SessionEvent::AssistantDelta` updates the target message's text buffer via `produce`:
+Streaming is where Solid shines. The event handler for `SessionEvent::AssistantDelta` updates the target message's text buffer via `produce` on the `messages` store (`web/packages/app/src/stores/messages.ts`):
 
 ```ts
 // event handler for AssistantDelta
 case 'AssistantDelta':
-  setSessions(e.session, 'messages', e.id, produce(m => {
+  setMessages(e.session, e.id, produce(m => {
     m.text += e.delta;
   }));
   break;


### PR DESCRIPTION
Closes forge-ide/forge#429

## Summary
- Fix every store path in §9.2 from nonexistent `web/packages/state/*` to real `web/packages/app/src/stores/*`
- Enumerate all six product stores (session, approvals, catalog, messages, settings, usage) plus the seventh `sessionTelemetry` store (F-395)
- Add §9.2.1 "Layout model" covering GridContainer, SplitPane, DropZoneOverlay, layoutStore, useDragToDock, usePaneWidth, dockDrop; link to `docs/ui-specs/shell.md` and `docs/ui-specs/layout-panes.md`
- Add Layout bullet to §9.1 stack list so onboarders see the pane/layout model alongside the Solid, Monaco, terminal bullets
- Refresh §9.5 streaming snippet to target the real `messages` store instead of the nonexistent `sessions[].messages` shape

## Test plan
- `cargo check --workspace` clean (docs-only change; no Rust touched)
- `grep -c "web/packages/state/" docs/frontend/architecture.md` → 0 (nonexistent path fully removed)
- `grep -c "web/packages/app/src/stores/" docs/frontend/architecture.md` → 12 (all stores + streaming snippet use real path)
- All six DoD-enumerated stores present in the §9.2 table, verified against `ls web/packages/app/src/stores/`

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code