### PR TITLE
[F-442] docs/frontend/monaco-hosting.md doesn't exist

### DIFF
--- a/.claude/skills/forge-milestone-docs-audit/SKILL.md
+++ b/.claude/skills/forge-milestone-docs-audit/SKILL.md
@@ -35,7 +35,7 @@ Delegate to an `Explore` subagent. Brief:
 >    - **Code areas** (first two path segments of each changed file): `crates/forge_ipc`, `web/packages/app`, `scripts`, etc.
 >    - **Doc surfaces implicated** — for each code area, return the matching doc surfaces that *should* describe it. Forge's mapping:
 >      - `crates/<crate>` → `docs/architecture/*.md` (by topic), that crate's `README.md`, and its rustdoc
->      - `web/packages/<pkg>` → `docs/frontend/*.md` and that package's `README.md`
+>      - `web/packages/<pkg>` → `docs/frontend/*.md` and that package's `README.md`. When a package's contract is co-located with its source (e.g. `web/packages/monaco-host/README.md` holds the authoritative postMessage protocol next to `src/protocol.ts`), treat the package README as canonical and expect `docs/frontend/*.md` to cross-reference it rather than duplicate the tables
 >      - Any UI component under `web/packages/app/src/features/*` → `docs/ui-specs/<component>.md`
 >      - Design tokens → `docs/design/token-reference.md` (authoritative) vs `web/packages/design/src/tokens.css` (derived)
 >      - Any milestone adds a testing story → `docs/testing/phase<N>-uat.md` should cover it

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,8 @@ Navigation hub for all Forge documentation. One topic per file; use the table be
 | [architecture.md](frontend/architecture.md) | Solid signals, state model, Monaco iframe hosting, streaming |
 | [generation-pipelines.md](frontend/generation-pipelines.md) | Design token drift check and ts-rs Rust to TypeScript IPC type generation, both CI-enforced |
 
+> Monaco hosting's authoritative postMessage protocol and LSP lifecycle live in [`web/packages/monaco-host/README.md`](../web/packages/monaco-host/README.md), co-located with `src/protocol.ts`. `frontend/architecture.md §9.3` summarizes and cross-refs it.
+
 ## design/
 
 | File | Description |

--- a/docs/frontend/architecture.md
+++ b/docs/frontend/architecture.md
@@ -64,8 +64,11 @@ export const [usageReport, setUsageReport] = createSignal<UsageReport | null>(nu
 Components subscribe by calling the signal as a function (Solid idiom): `{sessions[id].messages.map(m => ...)}`.
 
 ### 9.3 Monaco hosting
+
+> **Authoritative protocol reference:** [`web/packages/monaco-host/README.md`](../../web/packages/monaco-host/README.md). This section summarizes the hosting model; the full `kind`-tagged postMessage contract and LSP lifecycle live with the package so they stay in lockstep with `src/protocol.ts`. Do not duplicate the message tables here.
+
 - Monaco runs in `<iframe src="/monaco-host.html">` inside the session pane. The iframe is renderer-only; it never talks to Tauri directly
-- Communicates with the Solid app via `window.postMessage` using a typed protocol (mirrors IPC types). See [`web/packages/monaco-host/README.md`](../../web/packages/monaco-host/README.md) for the full `kind`-tagged message table
+- Communicates with the Solid app via `window.postMessage` using a typed protocol (mirrors IPC types) — see the monaco-host README for the message table
 - `monaco-languageclient` runs inside the iframe but the **parent webview owns the LSP bridge**. The iframe emits outbound LSP frames as `client.message` / `client.notification` postMessage envelopes; the parent relays them to `forge-lsp` via the `lsp_send` Tauri command and pipes inbound frames back as `client.message` (bound to the owner webview via the `lsp_message` event — F-062 discipline). Lifecycle is driven from the parent through `lsp_start` / `lsp_stop` in `crates/forge-shell/src/ipc.rs` (F-123; PR #286)
 - Reasons: Monaco's AMD loader, web workers, and global scope assumptions don't play well with modern bundlers, and keeping it isolated makes the editor replaceable later. Sandbox-wise, routing LSP through the parent keeps Tauri capabilities off the iframe origin so server output can never touch the filesystem
 - **Considered alternatives.** Spawning language servers directly from the iframe (as an earlier draft of this section described) would save one hop of latency, but it requires exposing Tauri process-spawn capability inside the iframe sandbox. That violates the isolation rationale above, so the parent-relay model won


### PR DESCRIPTION
Closes forge-ide/forge#443

## Summary
- Promote the `web/packages/monaco-host/README.md` reference in `docs/frontend/architecture.md §9.3` to an explicit "authoritative protocol reference" callout (no duplication of the postMessage tables).
- Add a note in `docs/README.md` under the `frontend/` table that makes the authoritative Monaco protocol location discoverable from the docs index.
- Tighten the `forge-milestone-docs-audit` skill's `web/packages/<pkg>` mapping so future audits recognize source-co-located contracts (like monaco-host) as canonical in the package README, not in `docs/frontend/`.

Takes option (b) from the finding — preserves the single-source-of-truth principle at the package README and prevents the drift that would follow from creating a duplicate `docs/frontend/monaco-hosting.md`.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (pre-existing flakiness in `forge-mcp` `post_roundtrip_and_sse_notification` unrelated to this pure-docs change; passes on retry)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)