### PR TITLE
[F-440] docs/build/testing.md coverage targets missing Phase-2 crates

### DIFF
--- a/docs/build/testing.md
+++ b/docs/build/testing.md
@@ -21,5 +21,22 @@
 A `--auto-approve-unsafe` flag on the session binary (dev-only; refused if released binary) for scripted tests.
 
 ### 11.4 Coverage targets
-- `forge-core`, `forge-providers`, `forge-agents`, `forge-session`: 80% line coverage
+
+Every first-class workspace crate carries an explicit target. Bands reflect how the crate is exercised, not how important it is.
+
+| Crate | Target | Rationale |
+|---|---|---|
+| `forge-core` | 80% line | Pure logic, config, credential resolution |
+| `forge-providers` | 80% line | Provider adapters + mock |
+| `forge-agents` | 80% line | Agent orchestration logic |
+| `forge-session` | 80% line | Session lifecycle, IPC server |
+| `forge-mcp` | 80% line | MCP client/server surface (Phase 2) |
+| `forge-lsp` | 80% line | LSP multiplexer (Phase 2) |
+| `forge-fs` | 80% line | Workspace FS abstractions (Phase 2) |
+| `forge-term` | 80% line | Terminal/PTY logic (Phase 2) |
+| `forge-ipc` | Integration only | Protocol definitions; exercised end-to-end via `forge-session` + `forge-shell` IPC tests |
+| `forge-oci` | Integration only | Container runtime glue; exercised via session-level tests |
+| `forge-cli` | Integration only | Thin entrypoint; exercised via `tests/cli_smoke/` |
+| `forge-shell` | Smoke only | Tauri host; exercised via `just test-rust-webview` and the web Playwright lane — no line-coverage number |
+
 - UI: smoke tests only in v1 (no snapshot tests — they rot)


### PR DESCRIPTION
Closes forge-ide/forge#441

## Summary
- §11.4 now covers all 12 workspace members (was 4). Organized into three explicit bands with rationale per crate:
  - **80% line coverage**: `forge-core`, `forge-providers`, `forge-agents`, `forge-session`, `forge-mcp`, `forge-lsp`, `forge-fs`, `forge-term`
  - **Integration only**: `forge-ipc`, `forge-oci`, `forge-cli`
  - **Smoke only**: `forge-shell` (exercised via `just test-rust-webview` + Playwright — no line-coverage number)
- `forge-shell`'s smoke-test posture now explicit in the table row.
- Pure docs change; no code surface touched.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)