### PR TITLE
[F-434] docs(architecture): add §6.4 MCP tool variant conventions

### DIFF
--- a/docs/architecture/provider-abstraction.md
+++ b/docs/architecture/provider-abstraction.md
@@ -41,3 +41,19 @@ Each provider implementation has a `translate.rs` module that maps `Block::Refer
 Every tool has a `read_only: bool` bit. Built-in tools (`fs.read`, `fs.list`, `fs.write`, `shell.exec`, `agent.spawn`, etc.) declare this at definition time. MCP tools inherit from the server's `readOnly` hint when advertised; otherwise default to `false` (mutating, safe).
 
 Forge uses this to decide whether a batch of tool calls in one turn can run in parallel.
+
+### 6.4 MCP tools
+
+MCP-advertised tools are adapted to the session `Tool` trait by `McpTool` (`crates/forge-session/src/tools/mcp.rs`). One adapter instance is registered per advertised tool at turn-start from an `McpManager::list()` snapshot, so a mid-turn `tools/list` refresh cannot change the dispatch table under the running loop.
+
+Conventions the adapter enforces — any MCP-specific handling elsewhere in the stack should assume these shapes:
+
+1. **Naming (`<server>.<tool>`, split at the first dot).** The adapter's `name()` returns the fully-namespaced string that providers see on the wire and that `ToolDispatcher` keys on. `McpTool::new` splits once at the first `.` — everything after belongs to the tool, so MCP tool names may themselves contain dots (e.g. `srv.nested.tool.name` → server `srv`, tool `nested.tool.name`). A name with no dot is rejected (returns `None`) rather than panicking.
+
+2. **Adapter location.** `crates/forge-session/src/tools/mcp.rs` — wraps a single namespaced MCP tool behind `Tool`, holds an `Arc<McpManager>`, and delegates every `invoke` to `manager.call(server, tool, args)`.
+
+3. **`readOnlyHint` inheritance.** `read_only()` is a pass-through of the `readOnlyHint` annotation `McpManager` extracts when caching `tools/list` (see `forge_mcp::manager::parse_tools_list`). A missing annotation defaults to `false` (treated as mutating — the conservative choice for parallel-tool-call eligibility). The adapter does no re-inspection.
+
+4. **Approval-preview format.** `approval_preview` emits `"MCP <server>.<tool>: <description>"` (or just `"MCP <server>.<tool>"` when the description is empty) so the approval UI can distinguish an MCP-sourced prompt from a built-in one at a glance. The description is deliberately terse — the approval UI renders the full args payload separately.
+
+5. **Error envelope.** `invoke` uniformizes JSON-RPC failures into `{ "error": "mcp: <detail>" }`. Success-path payloads are passed through verbatim. The envelope shape matches built-in tool errors so the session-turn loop's `StepOutcome::Error` classification treats MCP errors identically to built-in errors downstream.


### PR DESCRIPTION
Closes forge-ide/forge#435

## Summary
- Add §6.4 MCP tools to `docs/architecture/provider-abstraction.md` — fills the documentation gap flagged in F-434 where §6.3 had only a one-line mention of MCP despite MCP being a first-class Phase-2 capability
- Documents the five conventions the `McpTool` adapter enforces (naming, adapter location, `readOnlyHint` inheritance, approval-preview format, error envelope) with code pointers into `crates/forge-session/src/tools/mcp.rs`

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (one pre-existing flaky test `forge-mcp::http_roundtrip::post_roundtrip_and_sse_notification` failed on first run, passed on re-run — unrelated to this docs-only change)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)