### PR TITLE
[F-436] docs(design): interaction-states model for ai-patterns

### DIFF
--- a/docs/design/ai-patterns.md
+++ b/docs/design/ai-patterns.md
@@ -47,3 +47,12 @@ The agent monitor shows a list of all agents with a progress bar (3px height, `i
 ### MCP servers
 
 MCP servers in the panel show a 7px status dot with a glow shadow when connected: `box-shadow: 0 0 6px rgba(61,220,132,0.5)`. This glow is the only glow used in the UI — it specifically communicates live network connectivity, which is a meaningfully different state than simple "active".
+
+### Interaction states
+
+Every component that fetches, renders, or mutates data resolves into one of four states. Use the shapes below — do not invent alternatives. New components that omit a state must justify the omission in review.
+
+- **loading:** skeleton placeholder matching the final layout, or the streaming cursor (see §"Streaming state"). Never a spinner.
+- **empty:** `iron-300` copy in a noun-phrase form describing what would appear here, plus an optional primary action (see [Voice & Terminology](voice-terminology.md) §8 "Empty-state copy" for the canonical phrasing). No illustration.
+- **error:** `ember-400` border on the affected surface plus a persistent toast (see [Component Principles](component-principles.md) §"Toasts"). The toast carries the technical identifier verbatim; the border marks the scope of the failure.
+- **success:** implicit. No banner, no toast, no checkmark unless the action is dismissable (e.g. a confirmation the user must acknowledge before the surface returns to its default state).

--- a/docs/design/voice-terminology.md
+++ b/docs/design/voice-terminology.md
@@ -21,6 +21,7 @@ It is not: Casual, vague, simplified, apologetic, or verbose.
 - Button labels: verb + noun in display caps. `CONNECT PROVIDER` not `Connect to your AI provider`.
 - Section labels: noun only in mono uppercase. `PROVIDERS` not `Your AI Providers`.
 - Toast titles: state + subject. `AI backend connected` not `Successfully connected to your AI backend`.
+- Empty-state copy: noun phrase describing what would be here, plus an optional verb-noun CTA. `No agents running` or `No agents running · start agent`, never `There are no agents currently running`. See [AI Patterns](ai-patterns.md) §"Interaction states" for the surrounding treatment.
 
 ### Terminology
 


### PR DESCRIPTION
Closes forge-ide/forge#437

## Summary
- Add ai-patterns.md §"Interaction states" prescribing the four state shapes (loading / empty / error / success) so new components stop inventing ad-hoc treatments (F-399/F-400 flagged 8 offenders).
- Add the empty-state copy formatting rule to voice-terminology.md §8 — canonical form is a noun phrase + optional verb-noun CTA.
- Cross-link both directions; link the error sub-state to component-principles.md §"Toasts" and the loading sub-state to ai-patterns §"Streaming state".

## Test plan
- `cargo test --workspace` passes (681 tests, 0 failures)
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` clean
- Cross-link targets verified — all linked files and section anchors exist

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Note: this supersedes the scope that PR #481 was originally meant to cover for issue #437. PR #481 carried an ADR-002/003 payload under the same F-436 slot; issue #437's ai-patterns.md DoD was never addressed and is finished here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)