### PR TITLE
[F-387] Drop unused wiremock dev-dep from forge-lsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,7 +1457,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "wiremock",
 ]
 
 [[package]]

--- a/crates/forge-lsp/Cargo.toml
+++ b/crates/forge-lsp/Cargo.toml
@@ -24,7 +24,6 @@ tracing = "0.1"
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["process", "io-util", "sync", "macros", "rt", "rt-multi-thread", "time", "test-util", "fs"] }
-wiremock = "0.6"
 
 # Mock stdio LSP fixture. Same pattern as forge-mcp's mock_stdio — a
 # dependency-free stdin/stdout JSON-RPC echo server the integration test

--- a/crates/forge-lsp/src/bootstrap.rs
+++ b/crates/forge-lsp/src/bootstrap.rs
@@ -17,10 +17,9 @@
 //! bootstrap returns [`BootstrapError::ChecksumPending`] so callers learn
 //! fast and release engineering can pin hashes safely.
 //!
-//! **Network seam.** The [`Downloader`] trait lets tests inject a
-//! wiremock-served URL (or an in-memory fixture) without touching the
-//! network — see `bootstrap.rs`'s unit tests and the `tests/` integration
-//! suite.
+//! **Network seam.** The [`Downloader`] trait lets tests inject an
+//! in-memory fixture without touching the network — see `bootstrap.rs`'s
+//! unit tests and the `tests/` integration suite.
 
 use std::path::{Path, PathBuf};
 
@@ -82,7 +81,7 @@ pub enum BootstrapError {
     NoCacheDir,
 }
 
-/// Network seam. Tests inject a wiremock-served URL with a stub impl;
+/// Network seam. Tests inject a stub impl with in-memory fixtures;
 /// production uses [`HttpDownloader`] backed by reqwest.
 #[async_trait]
 pub trait Downloader: Send + Sync {


### PR DESCRIPTION
Closes forge-ide/forge#388

## Summary
- Remove `wiremock = "0.6"` from `crates/forge-lsp/Cargo.toml` dev-dependencies; no code in the crate imports it.
- Rewrite the two "wiremock-served URL" doc mentions in `crates/forge-lsp/src/bootstrap.rs` (module-level and `Downloader` trait) to match the actual test pattern: an in-memory `StubDownloader` fixture.
- Cuts a transitive build on `cargo test -p forge-lsp` and removes actively misleading docs.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)