### PR TITLE
[F-388] README and module-docstring drift sweep across 4 sites

### DIFF
--- a/crates/forge-agents/README.md
+++ b/crates/forge-agents/README.md
@@ -25,7 +25,7 @@ Runtime:
 - `Orchestrator::stop(id)` / `Orchestrator::fail(id, reason)` — terminate an instance, emit the terminal `Completed` / `Failed` event.
 - `Orchestrator::record_step_started(id, step)` / `Orchestrator::record_step_finished(id, step)` — emit step transitions; `InstanceState` is not mutated (steps are events, not states).
 - `Orchestrator::state_stream()` — `BroadcastStream<AgentEvent>` subscribers consume to follow per-instance progress.
-- `AgentInstance { id, def, state, started_at }` — one live instantiation.
+- `AgentInstance { id, def, state, started_at, initial_prompt }` — one live instantiation; `initial_prompt: Option<InitialPrompt>` carries the seed user message threaded from the spawner (F-134 / F-137) for the future step executor to replay as the child's first user turn.
 - `AgentEvent::{Spawned, StepStarted, StepFinished, Completed, Failed}` — per-instance lifecycle vocabulary.
 - `SpawnContext::user()` / `SpawnContext::built_in()` — origin marker that governs the trusted-isolation escape hatch.
 

--- a/crates/forge-mcp/README.md
+++ b/crates/forge-mcp/README.md
@@ -4,8 +4,8 @@ MCP (Model Context Protocol) client and server lifecycle manager. Phase 2 (F-127
 
 ## Role in the workspace
 
-- Depended on by: nothing yet; will be consumed by `forge-session`'s tool dispatcher when MCP support ships.
-- Depends on: `serde`, `serde_json`, `anyhow`, `dirs`, `tokio`, `tracing`.
+- Depended on by: `forge-session`, `forge-shell`, and `forge-ipc` (which re-exports [`McpServerInfo`] for IPC wire types).
+- Depends on: `forge-core` (re-exported `McpStateEvent` / `ServerState`), `serde`, `serde_json`, `anyhow`, `dirs`, `tokio`, `tracing`.
 
 ## Key types / entry points
 
@@ -20,7 +20,12 @@ MCP (Model Context Protocol) client and server lifecycle manager. Phase 2 (F-127
 
 The `mcpServers` schema is the universal proposal (MCP repo discussion #2218). Transport is discriminated by an explicit `"type"` field (`"stdio"` / `"http"`) when present, otherwise inferred from the presence of `command` (stdio) or `url` (http). Unknown fields are rejected.
 
-The remaining planned API (`McpManager`, `Scope`, `ImportSource`, `McpStateEvent`, HTTP transport) lands in F-129 / F-130.
+The lifecycle manager landed in F-130 and has been hardened through F-155:
+
+- `McpManager` — owns per-server state, restart budgets, and the tool-call path.
+- `McpServerInfo` — snapshot shape consumed by `forge-ipc` and the webview.
+- `LifecycleTuning`, `HEALTH_CHECK_INTERVAL`, `MAX_RESTARTS_PER_WINDOW`, `REQUEST_TIMEOUT`, `RESTART_BACKOFF_LADDER`, `RESTART_WINDOW` — tunables for the restart ladder and health loop.
+- `McpStateEvent` / `ServerState` — re-exported from `forge-core` so existing callers keep resolving at `forge_mcp::*`; the types live upstream to break a dependency cycle with `forge-core::Event`.
 
 ## Security: stdio child environment is deny-by-default
 

--- a/crates/forge-mcp/src/manager.rs
+++ b/crates/forge-mcp/src/manager.rs
@@ -402,8 +402,8 @@ impl McpManager {
     /// session toggle test asserts against, and `toggle_mcp_server(name,
     /// true)` knows to treat `Disabled` as restartable (same as `Failed`).
     ///
-    /// Use [`McpManager::enable`] to restart a disabled server — the
-    /// driver resets `restart_history` is *not* cleared, so repeated
+    /// Use [`McpManager::enable`] to restart a disabled server. The
+    /// driver does **not** clear `restart_history` on disable, so repeated
     /// flap-toggles still honour the sliding-window budget.
     pub async fn disable(&self, name: &str) -> Result<()> {
         self.stop_with_terminal(

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -555,9 +555,11 @@ impl LspBootstrapState {
 //
 // Both writes go through `ApprovalConfig` + the atomic-write helper in
 // `forge-core::approvals`, so partial writes cannot produce a corrupted TOML
-// file. Neither command is authz-gated to a specific session window: approval
-// config is a user-level artifact, not per-session. The `session-*` capability
-// glob still bounds who can invoke it at all.
+// file. All three commands are authz-gated to the dashboard window only via
+// `require_window_label_in(&webview, &["dashboard"], true)` — approval config
+// is a user-level artifact, not per-session, so session windows have no
+// business editing it. The `session-*` capability glob still bounds who can
+// invoke at the Tauri-capability layer before the runtime label check runs.
 // ---------------------------------------------------------------------------
 
 /// Wire shape returned by `get_persistent_approvals`. Frontend stores it in


### PR DESCRIPTION
Closes forge-ide/forge#389

## Summary

Four README / module-docstring sites had claims that no longer matched shipped code. Sweeping them together as a single docstring-only PR (no logic changes).

- `crates/forge-mcp/README.md` — "Role in the workspace" now lists the real consumers (`forge-session`, `forge-shell`, `forge-ipc`) and the `forge-core` dep; "remaining planned API" paragraph rewritten to describe the shipped F-130 / F-155 surface (`McpManager`, `McpServerInfo`, tuning consts, re-exported `McpStateEvent` / `ServerState`) instead of claiming F-129 / F-130 are still outstanding.
- `crates/forge-mcp/src/manager.rs:399` — `disable()` docstring grammar fix; the line "the driver resets `restart_history` is *not* cleared" was scrambled.
- `crates/forge-agents/README.md:28` — `AgentInstance` field list updated to include `initial_prompt: Option<InitialPrompt>` (added for F-134 / F-137).
- `crates/forge-shell/src/ipc.rs` — persistent-approvals module comment now describes the real dashboard-only authz gate (`require_window_label_in(&webview, &["dashboard"], true)`) instead of claiming no session-window gate exists.

## Deferred

`crates/forge-lsp/README.md` drift (also called out in #389) is deferred to the concurrent F-387 orchestrator per the agent avoidance list. A short follow-up can pick it up once F-387 lands.

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace --all-targets` passes
- `cargo test --workspace` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `just check-rust` passes (rustdoc builds clean)

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).