### PR TITLE
[F-416] a11y: wire Dashboard tabs to tabpanels and ship grid roving focus

### DIFF
--- a/web/packages/app/src/lib/useRovingTabindex.test.ts
+++ b/web/packages/app/src/lib/useRovingTabindex.test.ts
@@ -1,0 +1,187 @@
+// F-416: WAI-ARIA roving-tabindex hook.
+//
+// Contract (WAI-ARIA APG grid / toolbar pattern):
+//   - Exactly one descendant matching the item selector has tabindex="0"
+//     at any time; the rest are tabindex="-1" so Tab enters the container
+//     once and exits once.
+//   - ArrowRight / ArrowDown move the active index forward (wrap); ArrowLeft /
+//     ArrowUp move it backward (wrap). Home jumps to first, End to last.
+//   - Clicking (or focusing via a pointer) an item makes it the new active
+//     tab stop.
+//   - Adding or removing items re-syncs the single-tab-stop invariant.
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createRoot } from 'solid-js';
+import { useRovingTabindex } from './useRovingTabindex';
+
+function makeGrid(labels: string[]): HTMLDivElement {
+  const div = document.createElement('div');
+  for (const label of labels) {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.setAttribute('data-label', label);
+    btn.setAttribute('data-roving-item', '');
+    div.appendChild(btn);
+  }
+  document.body.appendChild(div);
+  return div;
+}
+
+function dispatchKey(target: HTMLElement, key: string): KeyboardEvent {
+  const ev = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(ev);
+  return ev;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('useRovingTabindex — initial tab-stop', () => {
+  it('sets tabindex=0 on the first item and tabindex=-1 on the rest on mount', () => {
+    const grid = makeGrid(['a', 'b', 'c']);
+    createRoot(() => {
+      useRovingTabindex(() => grid, '[data-roving-item]');
+    });
+    const items = grid.querySelectorAll('[data-roving-item]');
+    expect(items[0]?.getAttribute('tabindex')).toBe('0');
+    expect(items[1]?.getAttribute('tabindex')).toBe('-1');
+    expect(items[2]?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('is a no-op when the container has no matching items', () => {
+    const grid = document.createElement('div');
+    document.body.appendChild(grid);
+    expect(() => {
+      createRoot(() => {
+        useRovingTabindex(() => grid, '[data-roving-item]');
+      });
+    }).not.toThrow();
+  });
+});
+
+describe('useRovingTabindex — arrow navigation', () => {
+  it('ArrowRight from the first item focuses the second and moves the tab stop', () => {
+    const grid = makeGrid(['a', 'b', 'c']);
+    createRoot(() => {
+      useRovingTabindex(() => grid, '[data-roving-item]');
+    });
+    const first = grid.querySelector<HTMLButtonElement>('[data-label="a"]')!;
+    const second = grid.querySelector<HTMLButtonElement>('[data-label="b"]')!;
+    first.focus();
+    const ev = dispatchKey(first, 'ArrowRight');
+    expect(document.activeElement).toBe(second);
+    expect(first.getAttribute('tabindex')).toBe('-1');
+    expect(second.getAttribute('tabindex')).toBe('0');
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('ArrowDown behaves the same as ArrowRight (2-D wrap grid)', () => {
+    const grid = makeGrid(['a', 'b', 'c']);
+    createRoot(() => {
+      useRovingTabindex(() => grid, '[data-roving-item]');
+    });
+    const first = grid.querySelector<HTMLButtonElement>('[data-label="a"]')!;
+    const second = grid.querySelector<HTMLButtonElement>('[data-label="b"]')!;
+    first.focus();
+    dispatchKey(first, 'ArrowDown');
+    expect(document.activeElement).toBe(second);
+  });
+
+  it('ArrowLeft from the first item wraps to the last', () => {
+    const grid = makeGrid(['a', 'b', 'c']);
+    createRoot(() => {
+      useRovingTabindex(() => grid, '[data-roving-item]');
+    });
+    const first = grid.querySelector<HTMLButtonElement>('[data-label="a"]')!;
+    const last = grid.querySelector<HTMLButtonElement>('[data-label="c"]')!;
+    first.focus();
+    dispatchKey(first, 'ArrowLeft');
+    expect(document.activeElement).toBe(last);
+    expect(last.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('ArrowRight from the last item wraps to the first', () => {
+    const grid = makeGrid(['a', 'b', 'c']);
+    createRoot(() => {
+      useRovingTabindex(() => grid, '[data-roving-item]');
+    });
+    const first = grid.querySelector<HTMLButtonElement>('[data-label="a"]')!;
+    const last = grid.querySelector<HTMLButtonElement>('[data-label="c"]')!;
+    last.focus();
+    dispatchKey(last, 'ArrowRight');
+    expect(document.activeElement).toBe(first);
+  });
+});
+
+describe('useRovingTabindex — Home and End', () => {
+  it('Home jumps focus to the first item', () => {
+    const grid = makeGrid(['a', 'b', 'c']);
+    createRoot(() => {
+      useRovingTabindex(() => grid, '[data-roving-item]');
+    });
+    const middle = grid.querySelector<HTMLButtonElement>('[data-label="b"]')!;
+    const first = grid.querySelector<HTMLButtonElement>('[data-label="a"]')!;
+    middle.focus();
+    const ev = dispatchKey(middle, 'Home');
+    expect(document.activeElement).toBe(first);
+    expect(first.getAttribute('tabindex')).toBe('0');
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('End jumps focus to the last item', () => {
+    const grid = makeGrid(['a', 'b', 'c']);
+    createRoot(() => {
+      useRovingTabindex(() => grid, '[data-roving-item]');
+    });
+    const middle = grid.querySelector<HTMLButtonElement>('[data-label="b"]')!;
+    const last = grid.querySelector<HTMLButtonElement>('[data-label="c"]')!;
+    middle.focus();
+    dispatchKey(middle, 'End');
+    expect(document.activeElement).toBe(last);
+    expect(last.getAttribute('tabindex')).toBe('0');
+  });
+});
+
+describe('useRovingTabindex — focus adoption', () => {
+  it('focusing an item via pointer makes it the new tab stop', () => {
+    const grid = makeGrid(['a', 'b', 'c']);
+    createRoot(() => {
+      useRovingTabindex(() => grid, '[data-roving-item]');
+    });
+    const first = grid.querySelector<HTMLButtonElement>('[data-label="a"]')!;
+    const third = grid.querySelector<HTMLButtonElement>('[data-label="c"]')!;
+    // Simulate the focus-by-click path (jsdom does not fire focus on click
+    // automatically for buttons without focusing them first).
+    third.focus();
+    third.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    expect(first.getAttribute('tabindex')).toBe('-1');
+    expect(third.getAttribute('tabindex')).toBe('0');
+  });
+});
+
+describe('useRovingTabindex — dynamic item sets', () => {
+  it('re-syncs the tab stop when items are added after mount', () => {
+    const grid = makeGrid(['a']);
+    createRoot(() => {
+      useRovingTabindex(() => grid, '[data-roving-item]');
+    });
+    // Append a new item; the hook must keep exactly one tabindex=0 item.
+    const added = document.createElement('button');
+    added.setAttribute('data-label', 'b');
+    added.setAttribute('data-roving-item', '');
+    grid.appendChild(added);
+    // Drive a keypress so the hook recomputes (MutationObserver would be
+    // async; we accept an explicit recompute path on next interaction).
+    const first = grid.querySelector<HTMLButtonElement>('[data-label="a"]')!;
+    first.focus();
+    dispatchKey(first, 'ArrowRight');
+    const tabStops = grid.querySelectorAll('[data-roving-item][tabindex="0"]');
+    expect(tabStops).toHaveLength(1);
+    expect(document.activeElement).toBe(added);
+  });
+});

--- a/web/packages/app/src/lib/useRovingTabindex.ts
+++ b/web/packages/app/src/lib/useRovingTabindex.ts
@@ -1,0 +1,110 @@
+// F-416: WAI-ARIA roving-tabindex hook.
+//
+// Implements the WAI-ARIA APG pattern for a group of related items (grid,
+// toolbar, listbox-like surfaces) where keyboard users should Tab into the
+// group once, then navigate within it with arrow keys:
+//
+//   - Exactly one item has tabindex="0" at any time; the rest are
+//     tabindex="-1". Tab enters and exits the group as a single stop.
+//   - ArrowRight / ArrowDown advance the tab stop; ArrowLeft / ArrowUp go
+//     back; both wrap at the boundaries. Home / End jump to first / last.
+//   - A pointer focus (mouse click) on any item makes it the new tab stop.
+//
+// The hook queries items on every interaction so appending / removing items
+// after mount stays consistent without a MutationObserver. The container
+// accessor is evaluated reactively — a component can defer ref assignment
+// behind a <Show> gate and the hook will attach as soon as the element
+// appears in the DOM.
+
+import { createEffect, onCleanup } from 'solid-js';
+
+const NAV_KEYS = new Set([
+  'ArrowRight',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowUp',
+  'Home',
+  'End',
+]);
+
+export function useRovingTabindex(
+  getContainer: () => HTMLElement | undefined,
+  itemSelector: string,
+): void {
+  let attached: HTMLElement | null = null;
+
+  const itemsOf = (root: HTMLElement): HTMLElement[] =>
+    Array.from(root.querySelectorAll<HTMLElement>(itemSelector));
+
+  const sync = (root: HTMLElement, activeIndex: number): void => {
+    const list = itemsOf(root);
+    list.forEach((el, i) => {
+      el.setAttribute('tabindex', i === activeIndex ? '0' : '-1');
+    });
+  };
+
+  const indexOf = (root: HTMLElement, target: EventTarget | null): number => {
+    if (!(target instanceof HTMLElement)) return -1;
+    return itemsOf(root).indexOf(target);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent): void => {
+    if (!NAV_KEYS.has(e.key)) return;
+    const root = attached;
+    if (!root) return;
+    const list = itemsOf(root);
+    if (list.length === 0) return;
+    const current = indexOf(root, e.target);
+    if (current === -1) return;
+
+    let next = current;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        next = (current + 1) % list.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        next = (current - 1 + list.length) % list.length;
+        break;
+      case 'Home':
+        next = 0;
+        break;
+      case 'End':
+        next = list.length - 1;
+        break;
+    }
+    if (next === current) return;
+    e.preventDefault();
+    sync(root, next);
+    list[next]?.focus();
+  };
+
+  const handleFocusIn = (e: FocusEvent): void => {
+    const root = attached;
+    if (!root) return;
+    const idx = indexOf(root, e.target);
+    if (idx === -1) return;
+    sync(root, idx);
+  };
+
+  const detach = (): void => {
+    if (!attached) return;
+    attached.removeEventListener('keydown', handleKeyDown);
+    attached.removeEventListener('focusin', handleFocusIn);
+    attached = null;
+  };
+
+  createEffect(() => {
+    const root = getContainer();
+    if (root === attached) return;
+    detach();
+    if (!root) return;
+    attached = root;
+    if (itemsOf(root).length > 0) sync(root, 0);
+    root.addEventListener('keydown', handleKeyDown);
+    root.addEventListener('focusin', handleFocusIn);
+  });
+
+  onCleanup(detach);
+}

--- a/web/packages/app/src/routes/AgentMonitor.test.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.test.tsx
@@ -495,6 +495,47 @@ describe('<AgentList>', () => {
     fireEvent.click(getByLabelText(/Select agent reviewer/i));
     expect(onSelect).toHaveBeenCalledWith('x');
   });
+
+  // F-416: filter tabs are the WAI-ARIA tabs pattern; each tab must carry
+  // aria-controls pointing at the row-list tabpanel, and the tabpanel must
+  // reciprocate via aria-labelledby on the currently-selected tab.
+  describe('F-416 — filter tabs ↔ rows tabpanel association', () => {
+    it('every filter tab has a non-empty aria-controls and id', () => {
+      const { getAllByRole } = render(() => (
+        <AgentList
+          rows={[row()]}
+          filter="all"
+          onFilter={() => {}}
+          selectedId={null}
+          onSelect={() => {}}
+        />
+      ));
+      const tabs = getAllByRole('tab');
+      for (const tab of tabs) {
+        expect(tab.id).toBeTruthy();
+        expect(tab.getAttribute('aria-controls')).toBeTruthy();
+      }
+    });
+
+    it('the rows tabpanel is labelled by the currently-selected filter tab', () => {
+      const { getAllByRole, container } = render(() => (
+        <AgentList
+          rows={[row()]}
+          filter="running"
+          onFilter={() => {}}
+          selectedId={null}
+          onSelect={() => {}}
+        />
+      ));
+      const tabs = getAllByRole('tab');
+      const selected = tabs.find((t) => t.getAttribute('aria-selected') === 'true');
+      expect(selected).toBeTruthy();
+      const panel = container.querySelector('[role="tabpanel"]') as HTMLElement | null;
+      expect(panel).not.toBeNull();
+      expect(panel!.id).toBe(selected!.getAttribute('aria-controls'));
+      expect(panel!.getAttribute('aria-labelledby')).toBe(selected!.id);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/packages/app/src/routes/AgentMonitor.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.tsx
@@ -364,6 +364,13 @@ export const AgentList: Component<{
 }> = (props) => {
   const visible = createMemo(() => sortAgents(filterAgents(props.rows, props.filter)));
 
+  // F-416: tabs ↔ tabpanel association (WAI-ARIA APG tabs pattern). A
+  // single tabpanel hosts the row list; its aria-labelledby always points
+  // at the currently-selected filter tab so assistive tech can announce
+  // the panel's context when filter selection changes.
+  const filterTabId = (f: AgentFilter) => `agent-filter-tab-${f}`;
+  const rowsPanelId = 'agent-filter-rows-panel';
+
   return (
     <aside class="agent-monitor__list" aria-label="Agents">
       <div role="tablist" class="agent-monitor__filters">
@@ -372,6 +379,8 @@ export const AgentList: Component<{
             <button
               type="button"
               role="tab"
+              id={filterTabId(f)}
+              aria-controls={rowsPanelId}
               aria-selected={props.filter === f}
               class="agent-monitor__filter"
               classList={{ 'agent-monitor__filter--active': props.filter === f }}
@@ -384,9 +393,23 @@ export const AgentList: Component<{
       </div>
       <Show
         when={visible().length > 0}
-        fallback={<p class="agent-monitor__empty">// no agents</p>}
+        fallback={
+          <p
+            class="agent-monitor__empty"
+            id={rowsPanelId}
+            role="tabpanel"
+            aria-labelledby={filterTabId(props.filter)}
+          >
+            // no agents
+          </p>
+        }
       >
-        <ul class="agent-monitor__rows">
+        <ul
+          class="agent-monitor__rows"
+          id={rowsPanelId}
+          role="tabpanel"
+          aria-labelledby={filterTabId(props.filter)}
+        >
           <For each={visible()}>
             {(row) => (
               <AgentListRow

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.test.tsx
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.test.tsx
@@ -195,4 +195,136 @@ describe('SessionsPanel', () => {
     const alert = await findByRole('alert');
     expect(alert.textContent ?? '').toMatch(/open denied/);
   });
+
+  // F-416: tabs ↔ tabpanel association. Each role="tab" must reference its
+  // panel via aria-controls; the matching role="tabpanel" must
+  // reciprocate via aria-labelledby. This is the WAI-ARIA APG tabs pattern
+  // and is the specific association axe-core flags when missing.
+  describe('F-416 — tabs ↔ tabpanel association', () => {
+    it('each tab carries an aria-controls pointing at an existing tabpanel', async () => {
+      invokeMock.mockResolvedValueOnce([
+        sample({ id: '1', state: 'active' }),
+        sample({ id: '2', state: 'archived' }),
+      ]);
+      const { container, findByRole } = render(() => <SessionsPanel />);
+      await waitForFetch();
+      await findByRole('tab', { name: /active/i });
+
+      const tabs = container.querySelectorAll<HTMLElement>('[role="tab"]');
+      expect(tabs.length).toBeGreaterThanOrEqual(2);
+      for (const tab of Array.from(tabs)) {
+        const panelId = tab.getAttribute('aria-controls');
+        expect(panelId, `tab "${tab.textContent}" missing aria-controls`).toBeTruthy();
+        // The panel referenced by aria-controls only needs to exist when the
+        // tab is selected; inactive tabs may reference a panel id that is
+        // mounted only on selection. Selected tab's panel must be in-DOM now.
+        if (tab.getAttribute('aria-selected') === 'true') {
+          const panel = document.getElementById(panelId!);
+          expect(panel, `panel ${panelId} not found for selected tab`).not.toBeNull();
+          expect(panel!.getAttribute('role')).toBe('tabpanel');
+          expect(panel!.getAttribute('aria-labelledby')).toBe(tab.id);
+          expect(tab.id).toBeTruthy();
+        }
+      }
+    });
+
+    it('clicking a different tab swaps which tabpanel is labelled by which tab', async () => {
+      invokeMock.mockResolvedValueOnce([
+        sample({ id: '1', state: 'active' }),
+        sample({ id: '2', state: 'archived' }),
+      ]);
+      const { container, findByRole } = render(() => <SessionsPanel />);
+      await waitForFetch();
+
+      const archivedTab = await findByRole('tab', { name: /archived/i });
+      fireEvent.click(archivedTab);
+
+      const panels = container.querySelectorAll<HTMLElement>('[role="tabpanel"]');
+      expect(panels.length).toBeGreaterThanOrEqual(1);
+      const panel = panels[0]!;
+      expect(panel.getAttribute('aria-labelledby')).toBe(archivedTab.id);
+      expect(archivedTab.getAttribute('aria-controls')).toBe(panel.id);
+    });
+  });
+
+  // F-416: roving tabindex on the session grid. Tab enters the grid at
+  // whichever card is the current tab stop; arrows, Home, and End move
+  // focus within the grid without leaving it.
+  describe('F-416 — session grid roving tabindex', () => {
+    it('renders exactly one card with tabindex=0; the rest are tabindex=-1', async () => {
+      invokeMock.mockResolvedValueOnce([
+        sample({ id: '1', subject: 'alpha', state: 'active' }),
+        sample({ id: '2', subject: 'beta', state: 'active' }),
+        sample({ id: '3', subject: 'gamma', state: 'active' }),
+      ]);
+      const { container } = render(() => <SessionsPanel />);
+      await waitForFetch();
+
+      const cards = container.querySelectorAll<HTMLElement>('.session-card');
+      expect(cards.length).toBe(3);
+      const tabStops = Array.from(cards).filter(
+        (c) => c.getAttribute('tabindex') === '0',
+      );
+      expect(tabStops.length).toBe(1);
+      const inactive = Array.from(cards).filter(
+        (c) => c.getAttribute('tabindex') === '-1',
+      );
+      expect(inactive.length).toBe(2);
+    });
+
+    it('ArrowRight moves focus to the next card', async () => {
+      invokeMock.mockResolvedValueOnce([
+        sample({ id: '1', subject: 'alpha', state: 'active' }),
+        sample({ id: '2', subject: 'beta', state: 'active' }),
+      ]);
+      const { container } = render(() => <SessionsPanel />);
+      await waitForFetch();
+
+      const cards = container.querySelectorAll<HTMLElement>('.session-card');
+      const first = cards[0]!;
+      const second = cards[1]!;
+      first.focus();
+      first.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowRight',
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      expect(document.activeElement).toBe(second);
+      expect(second.getAttribute('tabindex')).toBe('0');
+      expect(first.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('End moves focus to the last card; Home moves it back to the first', async () => {
+      invokeMock.mockResolvedValueOnce([
+        sample({ id: '1', subject: 'alpha', state: 'active' }),
+        sample({ id: '2', subject: 'beta', state: 'active' }),
+        sample({ id: '3', subject: 'gamma', state: 'active' }),
+      ]);
+      const { container } = render(() => <SessionsPanel />);
+      await waitForFetch();
+
+      const cards = container.querySelectorAll<HTMLElement>('.session-card');
+      const first = cards[0]!;
+      const last = cards[2]!;
+      first.focus();
+      first.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'End',
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      expect(document.activeElement).toBe(last);
+      last.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Home',
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      expect(document.activeElement).toBe(first);
+    });
+  });
 });

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.tsx
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.tsx
@@ -1,5 +1,6 @@
 import { createResource, createSignal, For, Show, type Component } from 'solid-js';
 import { invoke } from '../../lib/tauri';
+import { useRovingTabindex } from '../../lib/useRovingTabindex';
 import './SessionsPanel.css';
 
 export type SessionWireState = 'active' | 'archived' | 'stopped';
@@ -60,6 +61,17 @@ export const SessionsPanel: Component = () => {
     });
   };
 
+  // F-416: roving tabindex on the session grid. The hook keeps exactly one
+  // card as the tab stop and handles ArrowRight/Left/Up/Down/Home/End so
+  // the grid is a single Tab stop with internal arrow navigation per
+  // WAI-ARIA APG grid pattern. The ref is a signal so the hook's effect
+  // re-attaches whenever <Show> toggles between grid and fallback.
+  const [gridRef, setGridRef] = createSignal<HTMLDivElement | undefined>();
+  useRovingTabindex(gridRef, '.session-card');
+
+  const panelId = () => `sessions-panel-${tab()}`;
+  const tabId = (t: Tab) => `sessions-tab-${t}`;
+
   return (
     <section class="sessions" aria-label="Sessions">
       <div role="tablist" class="sessions__tabs">
@@ -76,12 +88,23 @@ export const SessionsPanel: Component = () => {
       <Show
         when={current().length > 0}
         fallback={
-          <p class="sessions__empty">
+          <p
+            class="sessions__empty"
+            id={panelId()}
+            role="tabpanel"
+            aria-labelledby={tabId(tab())}
+          >
             {tab() === 'active' ? '// no active sessions' : '// archive is empty'}
           </p>
         }
       >
-        <div class="sessions__grid">
+        <div
+          ref={setGridRef}
+          class="sessions__grid"
+          id={panelId()}
+          role="tabpanel"
+          aria-labelledby={tabId(tab())}
+        >
           <For each={current()}>
             {(session) => <SessionCard session={session} onOpen={handleOpen} />}
           </For>
@@ -104,6 +127,8 @@ const TabButton: Component<TabButtonProps> = (props) => {
     <button
       type="button"
       role="tab"
+      id={`sessions-tab-${props.tab}`}
+      aria-controls={`sessions-panel-${props.tab}`}
       class="sessions__tab"
       classList={{ 'sessions__tab--active': selected() }}
       aria-selected={selected()}


### PR DESCRIPTION
Closes forge-ide/forge#417

## Summary
- Add `aria-controls` + `id` to SessionsPanel and AgentMonitor filter tabs; wire reciprocating `role="tabpanel"` + `aria-labelledby` on the panels (WAI-ARIA APG tabs pattern).
- Ship `useRovingTabindex` hook implementing the WAI-ARIA APG grid/toolbar pattern — ArrowRight/Left/Up/Down/Home/End + wrap + single-tab-stop invariant — and apply it to the SessionsPanel session grid.
- Pin both invariants with structural tests on disk — the specific attributes axe-core flags when missing.

## Test plan
- `pnpm --filter app test` passes (826 tests; 10 new for the hook, 4 new for SessionsPanel a11y, 2 new for AgentMonitor a11y)
- `pnpm --filter app typecheck` passes
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` all pass

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>