### PR TITLE
[F-413] Provider health indicator ignores provider accent color

### DIFF
--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.css
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.css
@@ -55,9 +55,15 @@
   flex-shrink: 0;
 }
 
+/*
+ * F-413: reachable dot follows the active provider accent. Callers set
+ * `--provider-accent` inline (see `providerAccent.ts`); the steel
+ * `--color-provider-local` fallback is the Phase-1 default. The same token
+ * drives both the fill and the §11.3 live-connected glow.
+ */
 .provider-panel__health--ok {
-  background: var(--color-success);
-  box-shadow: 0 0 6px var(--color-success-border);
+  background: var(--provider-accent, var(--color-provider-local));
+  box-shadow: 0 0 6px var(--provider-accent, var(--color-provider-local));
 }
 
 .provider-panel__health--down {

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.css.test.ts
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.css.test.ts
@@ -37,3 +37,37 @@ describe('ProviderPanel — design-token adherence (F-090)', () => {
     expect(body).not.toMatch(/color:\s*#ffffff\b/i);
   });
 });
+
+// F-413: the reachable (live-connected) dot must follow the provider accent
+// per ai-patterns.md §Provider identity and carry the §11.3 glow. The --down
+// rule keeps its error tint. Contract is asserted on the source string because
+// jsdom can't resolve var() against a separate sheet.
+describe('ProviderPanel health indicator — provider accent + live-connected glow (F-413)', () => {
+  it('.provider-panel__health--ok paints from --provider-accent with a steel fallback', () => {
+    const body = ruleBody('.provider-panel__health--ok');
+    const normalised = body.replace(/\s+/g, ' ');
+    expect(normalised).toContain(
+      'background: var(--provider-accent, var(--color-provider-local));',
+    );
+  });
+
+  it('.provider-panel__health--ok renders the §11.3 live-connected glow from the same accent', () => {
+    const body = ruleBody('.provider-panel__health--ok');
+    const normalised = body.replace(/\s+/g, ' ');
+    expect(normalised).toContain(
+      'box-shadow: 0 0 6px var(--provider-accent, var(--color-provider-local));',
+    );
+  });
+
+  it('.provider-panel__health--ok no longer hardcodes --color-success (would re-introduce F-413)', () => {
+    const body = ruleBody('.provider-panel__health--ok');
+    expect(body).not.toMatch(/background:\s*var\(--color-success\)/);
+  });
+
+  it('.provider-panel__health--down keeps the error tint for unreachable providers', () => {
+    const body = ruleBody('.provider-panel__health--down');
+    const normalised = body.replace(/\s+/g, ' ');
+    expect(normalised).toContain('background: var(--color-ember-400);');
+    expect(normalised).toContain('box-shadow: 0 0 6px var(--color-error-border);');
+  });
+});

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.test.tsx
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.test.tsx
@@ -62,6 +62,29 @@ describe('ProviderPanel', () => {
     expect(await findByLabelText(/reachable/i)).toBeInTheDocument();
   });
 
+  // F-413: when reachable, the health dot must be tinted with the provider
+  // accent (steel for Ollama) via an inline `--provider-accent` custom property
+  // so the CSS rule can paint both the fill and the §11.3 glow from one token.
+  it('tints the reachable dot with the Ollama (steel) accent via --provider-accent', async () => {
+    setInvokeForTesting((vi.fn().mockResolvedValue(reachable)) as never);
+
+    const { findByLabelText } = render(() => <ProviderPanel />);
+    const dot = (await findByLabelText(/reachable/i)) as HTMLElement;
+    expect(dot.style.getPropertyValue('--provider-accent')).toBe(
+      'var(--color-provider-local)',
+    );
+  });
+
+  // F-413: the unreachable dot falls back to the error tint — no provider
+  // accent is plumbed, so the CSS default (error) takes over.
+  it('does not plumb a provider accent when unreachable', async () => {
+    setInvokeForTesting((vi.fn().mockResolvedValue(unreachable)) as never);
+
+    const { findByLabelText } = render(() => <ProviderPanel />);
+    const dot = (await findByLabelText(/unreachable/i)) as HTMLElement;
+    expect(dot.style.getPropertyValue('--provider-accent')).toBe('');
+  });
+
   it('shows a voice-compliant Start Ollama message when unreachable', async () => {
     setInvokeForTesting((vi.fn().mockResolvedValue(unreachable)) as never);
 

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.tsx
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.tsx
@@ -1,5 +1,7 @@
 import { type Component, createResource, createSignal, For, Show } from 'solid-js';
+import type { ProviderId } from '@forge/ipc';
 import { invoke } from '../../lib/tauri';
+import { providerAccent } from '../Session/providerAccent';
 import './ProviderPanel.css';
 
 export interface ProviderStatus {
@@ -11,6 +13,10 @@ export interface ProviderStatus {
 }
 
 const fetchStatus = () => invoke<ProviderStatus>('provider_status');
+
+// Phase-1 ships a single provider. Centralising the id here keeps the accent
+// mapping, label, and future multi-provider swap in one spot.
+const PHASE_1_PROVIDER: ProviderId = 'ollama' as ProviderId;
 
 export const ProviderPanel: Component = () => {
   const [status, { refetch }] = createResource<ProviderStatus>(fetchStatus);
@@ -41,7 +47,7 @@ export const ProviderPanel: Component = () => {
           {(s) => (
             <>
               <div class="provider-panel__row">
-                <HealthIndicator reachable={s().reachable} />
+                <HealthIndicator reachable={s().reachable} providerId={PHASE_1_PROVIDER} />
                 <code class="provider-panel__url">{s().base_url}</code>
               </div>
 
@@ -69,13 +75,18 @@ export const ProviderPanel: Component = () => {
   );
 };
 
-const HealthIndicator: Component<{ reachable: boolean }> = (props) => (
+// F-413: when reachable, pass the provider accent via an inline CSS custom
+// property so the `.provider-panel__health--ok` rule can paint the dot and the
+// §11.3 live-connected glow from one token. When unreachable, the inline
+// custom property is omitted and the error tint stays in charge.
+const HealthIndicator: Component<{ reachable: boolean; providerId: ProviderId }> = (props) => (
   <span
     class="provider-panel__health"
     classList={{
       'provider-panel__health--ok': props.reachable,
       'provider-panel__health--down': !props.reachable,
     }}
+    style={props.reachable ? { '--provider-accent': providerAccent(props.providerId) } : undefined}
     role="img"
     aria-label={props.reachable ? 'reachable' : 'unreachable'}
   />


### PR DESCRIPTION
Closes forge-ide/forge#414

## Summary
- Reachable health dot now tints with the active provider accent via an inline `--provider-accent` custom property (reuses the existing `providerAccent` helper, steel for Ollama).
- Adds the `streaming-states.md §11.3` live-connected glow by driving `box-shadow` from the same token.
- Unreachable dot keeps the error tint (`--color-ember-400` + `--color-error-border`).
- Regression tests at both the CSS source level (accent fallback + glow + no-regression guards) and the component level (inline custom property set when reachable, absent when unreachable).

## Test plan
- `pnpm --filter app test -- --run ProviderPanel` passes
- `pnpm -r test` (whole web workspace) passes — 815 tests
- `pnpm -r typecheck` passes
- `node scripts/check-tokens.mjs` passes (no token changes, only new CSS custom property that doesn't live in `tokens.css`)
- `cargo fmt --check && cargo check --workspace && cargo clippy --all-targets -- -D warnings` clean

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)