### PR TITLE
[F-389] Design-token CI gate does not scan .tsx raw-value sites

### DIFF
--- a/scripts/check-tokens.mjs
+++ b/scripts/check-tokens.mjs
@@ -8,14 +8,21 @@
 // Invoked via `pnpm --filter forge-web run check-tokens` or directly:
 // `node scripts/check-tokens.mjs`.
 
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
 const refPath = resolve(repoRoot, 'docs/design/token-reference.md');
 const cssPath = resolve(repoRoot, 'web/packages/design/src/tokens.css');
+// Scope for the inline-style scan (F-389): the webview's own TSX sources.
+// Any raw px/hex value inside a JSX `style={...}` block here should live in
+// tokens.css or a `.css` class instead.
+const tsxScanRoots = [
+  resolve(repoRoot, 'web/packages/app/src'),
+  resolve(repoRoot, 'web/packages/design/src'),
+];
 
 /**
  * Extract `--name: value;` declarations from a CSS string, preserving
@@ -63,6 +70,98 @@ for (const [name, value] of referenceTokens) {
 for (const name of cssTokens.keys()) {
   if (!referenceTokens.has(name)) {
     errors.push(`extra in tokens.css (not in reference): ${name}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// F-389: scan .tsx files for raw px/hex literals inside JSX `style={...}`
+// blocks. Inline styling is the escape hatch that lets raw values bypass
+// tokens.css, so the gate must cover it.
+//
+// Heuristic: `\d+px` / `\d*\.\d+px` matches *adjacent* digit+unit pairs only,
+// so template-literal interpolations like `${expr}px` (runtime-computed
+// positions) don't trip it. Hex: `#[0-9a-fA-F]{3,8}` catches static colors.
+// ---------------------------------------------------------------------------
+
+/** Recursively yield absolute paths of `.tsx` files under `dir`. */
+function* walkTsx(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkTsx(full);
+    } else if (entry.isFile() && entry.name.endsWith('.tsx')) {
+      yield full;
+    }
+  }
+}
+
+/**
+ * Yield every JSX `style={...}` block body (the text between the outer
+ * braces) as `{ body, offset }` where `offset` is the start index in the
+ * source. Handles nested braces inside object literals / template strings.
+ */
+function* extractStyleBlocks(source) {
+  const re = /style\s*=\s*\{/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    const start = m.index + m[0].length; // position just after the opening `{`
+    let depth = 1;
+    let i = start;
+    while (i < source.length && depth > 0) {
+      const ch = source[i];
+      if (ch === '{') depth += 1;
+      else if (ch === '}') depth -= 1;
+      i += 1;
+    }
+    if (depth === 0) yield { body: source.slice(start, i - 1), offset: start };
+  }
+}
+
+/** 1-based (line, column) for a character offset in `source`. */
+function locate(source, offset) {
+  let line = 1;
+  let col = 1;
+  for (let i = 0; i < offset; i += 1) {
+    if (source[i] === '\n') {
+      line += 1;
+      col = 1;
+    } else {
+      col += 1;
+    }
+  }
+  return { line, col };
+}
+
+const rawPx = /\d+(?:\.\d+)?px/;
+const rawHex = /#[0-9a-fA-F]{3,8}\b/;
+
+for (const root of tsxScanRoots) {
+  for (const file of walkTsx(root)) {
+    const source = readFileSync(file, 'utf-8');
+    for (const { body, offset } of extractStyleBlocks(source)) {
+      const pxMatch = body.match(rawPx);
+      const hexMatch = body.match(rawHex);
+      const rel = relative(repoRoot, file);
+      if (pxMatch) {
+        const { line } = locate(source, offset + pxMatch.index);
+        errors.push(
+          `raw px in inline style (use tokens.css or a CSS class): ${rel}:${line} — ${pxMatch[0]}`,
+        );
+      }
+      if (hexMatch) {
+        const { line } = locate(source, offset + hexMatch.index);
+        errors.push(
+          `raw hex in inline style (use tokens.css or a CSS class): ${rel}:${line} — ${hexMatch[0]}`,
+        );
+      }
+    }
   }
 }
 

--- a/web/packages/app/src/check-tokens.test.ts
+++ b/web/packages/app/src/check-tokens.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const repoRoot = resolve(__dirname, '../../../..');
@@ -24,6 +24,59 @@ describe('scripts/check-tokens.mjs', () => {
       expect(result.stderr + result.stdout).toMatch(/drift|mismatch|--color-ember-400/i);
     } finally {
       writeFileSync(tokensCss, original);
+    }
+  });
+
+  // F-389: the gate must also scan `.tsx` files for raw px/hex literals inside
+  // inline `style={...}` blocks. Inline styling is the escape hatch that lets
+  // raw values bypass tokens.css; the gate catches that class of drift.
+  it('exits non-zero when a .tsx inline style contains a raw px value', () => {
+    const fixture = resolve(
+      repoRoot,
+      'web/packages/app/src/__f389_rawpx_fixture__.tsx',
+    );
+    writeFileSync(
+      fixture,
+      [
+        "import type { Component } from 'solid-js';",
+        'export const Bad: Component = () => (',
+        "  <div style={{ 'min-width': '360px' }} />",
+        ');',
+        '',
+      ].join('\n'),
+    );
+    try {
+      const result = spawnSync('node', [script], { cwd: repoRoot, encoding: 'utf-8' });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr + result.stdout).toMatch(/__f389_rawpx_fixture__\.tsx/);
+      expect(result.stderr + result.stdout).toMatch(/360px/);
+    } finally {
+      unlinkSync(fixture);
+    }
+  });
+
+  it('exits non-zero when a .tsx inline style contains a raw #hex color', () => {
+    const fixture = resolve(
+      repoRoot,
+      'web/packages/app/src/__f389_rawhex_fixture__.tsx',
+    );
+    writeFileSync(
+      fixture,
+      [
+        "import type { Component } from 'solid-js';",
+        'export const Bad: Component = () => (',
+        "  <div style={{ color: '#ff00aa' }} />",
+        ');',
+        '',
+      ].join('\n'),
+    );
+    try {
+      const result = spawnSync('node', [script], { cwd: repoRoot, encoding: 'utf-8' });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr + result.stdout).toMatch(/__f389_rawhex_fixture__\.tsx/);
+      expect(result.stderr + result.stdout).toMatch(/#ff00aa/i);
+    } finally {
+      unlinkSync(fixture);
     }
   });
 });

--- a/web/packages/app/src/components/ContextPicker.tsx
+++ b/web/packages/app/src/components/ContextPicker.tsx
@@ -156,7 +156,6 @@ export interface ContextPickerProps {
 }
 
 const POPUP_MAX_HEIGHT = 360;
-const POPUP_MIN_WIDTH = 360;
 
 // Stable id prefix for option rows. The combobox root's
 // `aria-activedescendant` points at `<prefix>-<index>` so assistive tech can
@@ -286,9 +285,6 @@ export const ContextPicker: Component<ContextPickerProps> = (props) => {
       aria-haspopup="listbox"
       aria-activedescendant={activeDescendantId()}
       ref={rootRef}
-      style={{
-        'min-width': `${POPUP_MIN_WIDTH}px`,
-      }}
     >
       {/* Search field — echoes the live `@`-query from the composer. */}
       <div class="context-picker__search">


### PR DESCRIPTION
Closes forge-ide/forge#390

## Summary
- Extend `scripts/check-tokens.mjs` to scan `web/packages/{app,design}/src/**/*.tsx`, extract each JSX `style={...}` block, and fail on raw `px` / `#hex` literals inside. Adjacent digit+unit only, so `${expr}px` interpolations (runtime positions) still pass.
- Remove the redundant inline `min-width: 360px` from `ContextPicker.tsx` — `.context-picker` already sets it via `ContextPicker.css`.
- New vitest cases in `web/packages/app/src/check-tokens.test.ts` prove the gate catches raw px and raw hex literals in inline styles.

## Test plan
- `just check-web` passes (typecheck + token gate green)
- `just test-web` passes (831 tests)
- New `check-tokens.test.ts` cases exercise raw-px and raw-hex slippage end-to-end against the real script

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).