### PR TITLE
[F-382] Duplicate ApprovalPreview type in forge-fs and forge-core

### DIFF
--- a/crates/forge-fs/src/lib.rs
+++ b/crates/forge-fs/src/lib.rs
@@ -8,9 +8,7 @@ mod limits;
 mod mutate;
 mod tree;
 pub use limits::Limits;
-pub use mutate::{
-    delete, edit, edit_preview, rename, write, write_bytes, write_preview, ApprovalPreview, FsError,
-};
+pub use mutate::{delete, edit, edit_preview, rename, write, write_bytes, write_preview, FsError};
 pub use tree::{
     list_tree, list_tree_gitignored, list_tree_gitignored_with_limit, list_tree_with_limit,
     NodeKind, TreeNode, DEFAULT_MAX_ENTRIES,

--- a/crates/forge-fs/src/mutate.rs
+++ b/crates/forge-fs/src/mutate.rs
@@ -37,13 +37,6 @@ pub enum FsError {
     },
 }
 
-/// Minimal approval preview payload for mutation ops. Renderable by the UI
-/// layer (F-027) without depending on this crate.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ApprovalPreview {
-    pub description: String,
-}
-
 /// Atomically write `content` to `path` after validating the path and
 /// rejecting payloads larger than `limits.max_write_bytes`.
 ///
@@ -333,8 +326,9 @@ pub fn edit(
     write(canonical_str, &updated, allowed_paths, limits)
 }
 
-/// `ApprovalPreview` for a prospective write. Returns a content-only preview
-/// of the proposed new bytes — does **not** read the existing file.
+/// Approval-preview description for a prospective write. Returns a
+/// content-only preview of the proposed new bytes — does **not** read the
+/// existing file.
 ///
 /// Reading the target file here would run before `allowed_paths` enforcement
 /// (which happens in [`write()`]) and leak attacker-chosen file contents into
@@ -342,18 +336,21 @@ pub fn edit(
 /// is already supplied by the caller, so echoing it back does not expand the
 /// trust surface. If a before/after diff is needed for UX, compute it via an
 /// explicit `fs.read` call that goes through the same approval gate.
-pub fn write_preview(path: &str, content: &str) -> ApprovalPreview {
-    ApprovalPreview {
-        description: format!("Write file {path} ({} bytes)\n{content}", content.len()),
-    }
+///
+/// The returned `String` is meant to populate
+/// `forge_core::ApprovalPreview::description` at the session layer. This crate
+/// deliberately does not depend on forge-core — keeping the preview as a bare
+/// string avoids the duplicate-type footgun F-382 retired.
+pub fn write_preview(path: &str, content: &str) -> String {
+    format!("Write file {path} ({} bytes)\n{content}", content.len())
 }
 
-/// `ApprovalPreview` for a prospective edit. The patch itself is the unified
-/// diff; we just echo it back with a header.
-pub fn edit_preview(path: &str, patch: &str) -> ApprovalPreview {
-    ApprovalPreview {
-        description: format!("Edit file {path}\n{patch}"),
-    }
+/// Approval-preview description for a prospective edit. The patch itself is
+/// the unified diff; we just echo it back with a header. See
+/// [`write_preview`] for why this returns `String` rather than a dedicated
+/// preview type.
+pub fn edit_preview(path: &str, patch: &str) -> String {
+    format!("Edit file {path}\n{patch}")
 }
 
 /// Minimal unified-diff applier. Supports standard `@@ -a,b +c,d @@` hunks

--- a/crates/forge-fs/tests/fs_edit.rs
+++ b/crates/forge-fs/tests/fs_edit.rs
@@ -121,21 +121,12 @@ fn edit_preview_returns_unified_diff_description() {
     f.write_all(b"alpha\nbeta\ngamma\n").unwrap();
     let patch = unified_diff("alpha\nbeta\ngamma\n", "alpha\nBETA\ngamma\n");
 
-    let preview = edit_preview(target.to_str().unwrap(), &patch);
+    let preview: String = edit_preview(target.to_str().unwrap(), &patch);
 
+    assert!(preview.contains("src.txt"), "missing path: {preview}");
     assert!(
-        preview.description.contains("src.txt"),
-        "description missing path: {}",
-        preview.description
+        preview.contains("-beta"),
+        "expected removed line: {preview}"
     );
-    assert!(
-        preview.description.contains("-beta"),
-        "expected removed line: {}",
-        preview.description
-    );
-    assert!(
-        preview.description.contains("+BETA"),
-        "expected added line: {}",
-        preview.description
-    );
+    assert!(preview.contains("+BETA"), "expected added line: {preview}");
 }

--- a/crates/forge-fs/tests/fs_write.rs
+++ b/crates/forge-fs/tests/fs_write.rs
@@ -110,12 +110,11 @@ fn write_preview_does_not_leak_existing_file_contents() {
     let mut f = std::fs::File::create(&target).unwrap();
     f.write_all(secret.as_bytes()).unwrap();
 
-    let preview = write_preview(target.to_str().unwrap(), "replacement\n");
+    let preview: String = write_preview(target.to_str().unwrap(), "replacement\n");
 
     assert!(
-        !preview.description.contains(secret),
-        "preview description leaked existing file contents: {}",
-        preview.description
+        !preview.contains(secret),
+        "preview leaked existing file contents: {preview}"
     );
 }
 
@@ -125,23 +124,15 @@ fn write_preview_describes_path_byte_count_and_proposed_content() {
     let target = dir.path().join("new.txt");
     let content = "line1\nline2\n";
 
-    let preview = write_preview(target.to_str().unwrap(), content);
+    let preview: String = write_preview(target.to_str().unwrap(), content);
 
+    assert!(preview.contains("new.txt"), "missing path: {preview}");
     assert!(
-        preview.description.contains("new.txt"),
-        "description missing path: {}",
-        preview.description
+        preview.contains(&format!("({} bytes)", content.len())),
+        "missing byte count: {preview}"
     );
     assert!(
-        preview
-            .description
-            .contains(&format!("({} bytes)", content.len())),
-        "description missing byte count: {}",
-        preview.description
-    );
-    assert!(
-        preview.description.contains(content),
-        "description missing proposed content: {}",
-        preview.description
+        preview.contains(content),
+        "missing proposed content: {preview}"
     );
 }

--- a/crates/forge-session/src/tools/fs_edit.rs
+++ b/crates/forge-session/src/tools/fs_edit.rs
@@ -27,9 +27,8 @@ impl Tool for FsEditTool {
         // the literal request; `invoke` performs the required-arg check (F-074).
         let path = get_optional_str(args, "path").unwrap_or("");
         let patch = get_optional_str(args, "patch").unwrap_or("");
-        let fs_preview = forge_fs::edit_preview(path, patch);
         ApprovalPreview {
-            description: fs_preview.description,
+            description: forge_fs::edit_preview(path, patch),
         }
     }
 

--- a/crates/forge-session/src/tools/fs_write.rs
+++ b/crates/forge-session/src/tools/fs_write.rs
@@ -27,9 +27,8 @@ impl Tool for FsWriteTool {
         // the literal request; `invoke` performs the required-arg check (F-074).
         let path = get_optional_str(args, "path").unwrap_or("");
         let content = get_optional_str(args, "content").unwrap_or("");
-        let fs_preview = forge_fs::write_preview(path, content);
         ApprovalPreview {
-            description: fs_preview.description,
+            description: forge_fs::write_preview(path, content),
         }
     }
 


### PR DESCRIPTION
Closes forge-ide/forge#383

## Summary
- Delete `forge_fs::ApprovalPreview`; `forge_core::ApprovalPreview` is the single type.
- `forge_fs::{write_preview, edit_preview}` now return `String` (the description body).
- Call sites in `fs_write`/`fs_edit` tools build `forge_core::ApprovalPreview` from the returned string directly — one fewer translation step.

## Test plan
- `cargo test --workspace` passes (368 tests, no regressions)
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code