### PR TITLE
[F-407] AgentMonitor Inspector and Trace header chrome drift from spec

### DIFF
--- a/docs/ui-specs/agent-monitor.md
+++ b/docs/ui-specs/agent-monitor.md
@@ -31,9 +31,11 @@ running · 3m · $0.09              sonnet-4.5        ← meta row
 
 ### 9.2 Trace (middle)
 
-**Header.** Agent name big, id small, live chip (`running · step 6 of 11`), `Pause` / `Kill` buttons, `Promote to pane` button (for background agents).
+**Header (Phase 2).** Agent name big, id small, live state chip (`running · step N` when running; otherwise the bare state). The chip uses an ember accent while running and the neutral surface chip for `queued` / `done` / `error`.
 
-**Toolbar.** Shows elapsed, token in/out, cost, model, tools-used, spawned-by relationship — all in Fira Code 10px separated by `·`.
+**Header (Phase 3 — deferred to [F-449](https://github.com/forge-ide/forge/issues/504)).** Expand the live chip to `running · step N of M` once the backend broadcasts a total-step count, and add the `Pause` / `Kill` buttons plus a `Promote to pane` button for background agents. Phase-2 surfaces `Stop agent` via the Inspector only (§9.3).
+
+**Toolbar (Phase 3 — deferred to [F-449](https://github.com/forge-ide/forge/issues/504)).** Elapsed, token in/out, cost, model, tools-used, spawned-by relationship — all in Fira Code 10px separated by `·`. Blocked on backend plumbing for cost/token/tool-use aggregation.
 
 **Timeline.** Vertical list of steps. Each step:
 - 16px filled dot, colored by state (done/ok, run/warn, queued/text-tertiary, err/error)
@@ -61,7 +63,9 @@ Five sections:
 2. **Allowed tools.** Pills, each with click-to-view policy.
 3. **Allowed paths.** Pills with mono text; glob patterns rendered verbatim.
 4. **Resource usage.** cpu, rss, fd open, net connections — live, 1Hz update.
-5. **Actions.** `Pause agent`, `Interrupt + refine` (opens a refine composer in context), `Export transcript` (JSONL), `Promote to pane` (background only).
+5. **Actions (Phase 2).** Single `Stop agent` action — wires through the `stop_background_agent` Tauri command onto `Orchestrator::stop(id)`.
+
+**Actions (Phase 3 — deferred to [F-449](https://github.com/forge-ide/forge/issues/504)).** `Pause agent`, `Interrupt + refine` (opens a refine composer in context), `Export transcript` (JSONL), `Promote to pane` (background only). Blocked on backend primitives for pause, refine, transcript export, and pane promotion.
 
 **Doesn't do.**
 - Does not let you edit agent definitions inline (opens the source file instead)

--- a/web/packages/app/src/routes/AgentMonitor.css
+++ b/web/packages/app/src/routes/AgentMonitor.css
@@ -220,6 +220,30 @@
   color: var(--color-text-secondary);
 }
 
+/* F-407: state chip alongside name+id. Running state carries an ember accent
+   so the active agent reads as live at a glance; terminal + queued states use
+   the neutral surface chip. Sized to match step chips and inspector pills. */
+.agent-monitor__trace-chip {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  padding: 2px var(--sp-2);
+  border-radius: 2px;
+  color: var(--color-text-secondary);
+  background: var(--color-surface-2);
+  margin-left: auto;
+}
+
+.agent-monitor__trace-chip[data-state='running'] {
+  color: var(--color-ember-100);
+  background: rgba(255, 209, 102, 0.05);
+}
+
+.agent-monitor__trace-chip[data-state='error'] {
+  color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
 .agent-monitor__steps {
   list-style: none;
   margin: 0;

--- a/web/packages/app/src/routes/AgentMonitor.test.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.test.tsx
@@ -582,6 +582,39 @@ describe('<AgentTrace>', () => {
     ));
     expect(getByText(/select an agent/i)).toBeTruthy();
   });
+
+  // F-407: header chrome Phase-2 subset — live-chip renders alongside name+id
+  // so the user can see at a glance whether the agent is still running and
+  // roughly how far along it is. `step N of M` requires a backend total the
+  // Phase-2 wire doesn't carry, so the chip shows step N only and the spec
+  // footnote defers the full `of M` form to Phase 3.
+  it('renders a live-chip with state and step count when the agent is running', () => {
+    const steps: AgentStep[] = [
+      step({ id: 's1', status: 'done' }),
+      step({ id: 's2', status: 'running' }),
+    ];
+    const { container } = render(() => (
+      <AgentTrace agent={row({ state: 'running' })} steps={steps} onStepClick={() => {}} />
+    ));
+    const chip = container.querySelector(
+      '.agent-monitor__trace-chip',
+    ) as HTMLElement | null;
+    expect(chip).toBeTruthy();
+    expect(chip?.getAttribute('data-state')).toBe('running');
+    expect(chip?.textContent).toMatch(/running\s*·\s*step\s*2/i);
+  });
+
+  it('renders a live-chip with just the state when the agent is not running', () => {
+    const { container } = render(() => (
+      <AgentTrace agent={row({ state: 'done' })} steps={[]} onStepClick={() => {}} />
+    ));
+    const chip = container.querySelector(
+      '.agent-monitor__trace-chip',
+    ) as HTMLElement | null;
+    expect(chip).toBeTruthy();
+    expect(chip?.getAttribute('data-state')).toBe('done');
+    expect(chip?.textContent?.trim()).toBe('done');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/packages/app/src/routes/AgentMonitor.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.tsx
@@ -490,6 +490,22 @@ export const AgentTrace: Component<{
             <header class="agent-monitor__trace-head">
               <h2 class="agent-monitor__trace-name">{agent().name}</h2>
               <span class="agent-monitor__trace-id">{agent().id}</span>
+              {/* F-407: Phase-2 live-chip — name + id + state chip is the
+                  subset of the §9.2 trace header we can render without the
+                  backend-plumbed toolbar (elapsed / tokens / cost / tools /
+                  spawned-by). Running agents show `running · step N` where
+                  N is the observed step count; `step N of M` returns once
+                  the backend ships a total. See F-449 for the Phase-3
+                  follow-up that restores the full chrome. */}
+              <span
+                class="agent-monitor__trace-chip"
+                data-state={agent().state}
+                aria-label={`agent state ${agent().state}`}
+              >
+                {agent().state === 'running'
+                  ? `running · step ${props.steps.length}`
+                  : agent().state}
+              </span>
             </header>
             <Show
               when={props.steps.length > 0}


### PR DESCRIPTION
Closes forge-ide/forge#408

## Summary

Reconciles spec/UI drift in `docs/ui-specs/agent-monitor.md` §9.2 and §9.3 for Phase 2:

- **Trace header (§9.2)** now ships the live state chip the spec calls for: `running · step N` while running, bare state otherwise. Renders right of the id in the trace header; ember accent on `running`, error color on `error`, neutral surface chip elsewhere.
- **Spec §9.2 / §9.3** rewritten as explicit Phase-2 subsets. Phase-3 items (full toolbar with elapsed/tokens/cost/model/tools-used/spawned-by; Pause/Kill/Promote header buttons; Interrupt+refine, Export transcript, Promote to pane inspector actions; `step N of M` total) are footnoted and linked to follow-up issue [#504 (F-449)](https://github.com/forge-ide/forge/issues/504).
- **Naming reconciled** on the spec side: §9.3 now says `Stop agent`, matching the shipped Inspector button and the existing `stop_background_agent` Tauri command (F-138). No backend rename needed.
- **Follow-up ticket filed**: [#504 — F-449 AgentMonitor Phase-3 chrome: Pause/Interrupt/Export/Promote + trace toolbar](https://github.com/forge-ide/forge/issues/504), milestone Phase 3: Breadth.

## Test plan
- `pnpm test` in `web/packages/app` — 831 tests pass, including the 2 new `<AgentTrace>` live-chip assertions
- `pnpm typecheck` passes
- `pnpm build` produces the production bundle cleanly
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` all pass
- `pnpm check-tokens` clean

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)