### PR TITLE
[F-405] Assistant bubble lacks aria-busy during streaming

### DIFF
--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -90,6 +90,39 @@ describe('ChatPane rendering', () => {
     expect(queryByTestId('streaming-cursor')).not.toBeInTheDocument();
   });
 
+  // F-405: assistive tech suppresses partial announcements when the
+  // in-progress message carries aria-busy="true". The attribute must be
+  // present only while the turn is streaming, then drop when it finalises.
+  it('sets aria-busy="true" on a streaming assistant bubble', () => {
+    pushEvent(SID, { kind: 'AssistantDelta', delta: 'Typing...', message_id: 'a-busy-1' });
+    const { getByTestId } = render(() => <ChatPane />);
+    const cursor = getByTestId('streaming-cursor');
+    const bubble = cursor.closest('article');
+    expect(bubble).not.toBeNull();
+    expect(bubble).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('does not set aria-busy on a finalised assistant bubble', () => {
+    pushEvent(SID, { kind: 'AssistantMessage', text: 'Done streaming', message_id: 'a-busy-2' });
+    const { getByText } = render(() => <ChatPane />);
+    const bubble = getByText('Done streaming').closest('article');
+    expect(bubble).not.toBeNull();
+    expect(bubble).not.toHaveAttribute('aria-busy');
+  });
+
+  it('aria-busy cycles on the same turn: present while streaming, gone once finalised', () => {
+    pushEvent(SID, { kind: 'AssistantDelta', delta: 'Hello', message_id: 'a-busy-3' });
+    const { container } = render(() => <ChatPane />);
+    const streamingBubble = container.querySelector('article.turn--assistant');
+    expect(streamingBubble).not.toBeNull();
+    expect(streamingBubble).toHaveAttribute('aria-busy', 'true');
+
+    pushEvent(SID, { kind: 'AssistantMessage', text: 'Hello world', message_id: 'a-busy-3' });
+    const finalisedBubble = container.querySelector('article.turn--assistant');
+    expect(finalisedBubble).not.toBeNull();
+    expect(finalisedBubble).not.toHaveAttribute('aria-busy');
+  });
+
   it('renders a tool call card', () => {
     pushEvent(SID, {
       kind: 'ToolCallStarted',

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -325,7 +325,10 @@ const UserBubble: Component<{ turn: Extract<ChatTurn, { type: 'user' }> }> = (pr
 const AssistantBubble: Component<{ turn: Extract<ChatTurn, { type: 'assistant' }> }> = (
   props,
 ) => (
-  <article class="turn turn--assistant">
+  // F-405: aria-busy="true" while the turn is still streaming lets AT
+  // suppress partial announcements from the ancestor aria-live region,
+  // then drops once isStreaming flips so the final text announces cleanly.
+  <article class="turn turn--assistant" aria-busy={props.turn.isStreaming ? 'true' : undefined}>
     <header class="turn__author">● assistant</header>
     <p class="turn__body">
       {props.turn.text}


### PR DESCRIPTION
Closes forge-ide/forge#406

## Summary
- AssistantBubble `<article>` now carries `aria-busy="true"` while `isStreaming`; attribute is dropped (undefined) when the turn finalises.
- Ancestor `role="log" aria-live="polite"` is unchanged; this fix adds the WAI-ARIA leaf signal that lets AT suppress partial announcements during token streaming.
- Regression tests assert the attribute is present on a streaming turn, absent on a finalised turn, and cycles correctly within a single turn's lifecycle.

## Test plan
- `pnpm -r test` — 845 web tests pass (includes 3 new aria-busy tests in `ChatPane.test.tsx`).
- `pnpm -r typecheck` — clean.
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` — all green.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)