### PR TITLE
[F-373] forge-agents emits zero tracing across all 8 milestone PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/forge-agents/Cargo.toml
+++ b/crates/forge-agents/Cargo.toml
@@ -13,8 +13,10 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
+tracing = "0.1"
 
 [dev-dependencies]
 futures = "0.3"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/crates/forge-agents/src/def.rs
+++ b/crates/forge-agents/src/def.rs
@@ -57,15 +57,36 @@ struct Frontmatter {
 }
 
 pub(crate) fn parse_agent_file(path: &Path) -> Result<AgentDef> {
-    let raw = fs::read_to_string(path)
-        .with_context(|| format!("reading {}", path.display()))
-        .map_err(Error::from)?;
+    let raw = match fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))
+    {
+        Ok(raw) => raw,
+        Err(err) => {
+            tracing::warn!(
+                target: "forge_agents::def",
+                path = %path.display(),
+                error = %err,
+                "failed to read agent file",
+            );
+            return Err(Error::from(err));
+        }
+    };
 
     let matter = Matter::<YAML>::new();
-    let parsed: ParsedEntity<Frontmatter> = matter
+    let parsed: ParsedEntity<Frontmatter> = match matter
         .parse(&raw)
         .with_context(|| format!("parsing frontmatter in {}", path.display()))
-        .map_err(Error::from)?;
+    {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            tracing::warn!(
+                target: "forge_agents::def",
+                path = %path.display(),
+                error = %err,
+                "failed to parse YAML frontmatter",
+            );
+            return Err(Error::from(err));
+        }
+    };
 
     let stem = path
         .file_stem()
@@ -78,18 +99,30 @@ pub(crate) fn parse_agent_file(path: &Path) -> Result<AgentDef> {
             let name = fm.name.unwrap_or_else(|| stem.clone());
             let isolation = match fm.isolation.as_deref() {
                 Some("trusted") => {
+                    tracing::warn!(
+                        target: "forge_agents::def",
+                        path = %path.display(),
+                        agent_name = %name,
+                        "rejected agent: isolation=trusted not allowed for user-defined agents",
+                    );
                     return Err(Error::IsolationViolation {
                         name,
                         path: Some(path.to_path_buf()),
-                    })
+                    });
                 }
                 Some("container") => Isolation::Container,
                 Some("process") | None => Isolation::Process,
                 Some(other) => {
+                    tracing::warn!(
+                        target: "forge_agents::def",
+                        path = %path.display(),
+                        isolation = %other,
+                        "unknown isolation level in agent frontmatter",
+                    );
                     return Err(Error::Other(anyhow::anyhow!(
                         "unknown isolation level '{other}' in {}",
                         path.display()
-                    )))
+                    )));
                 }
             };
             Ok(AgentDef {

--- a/crates/forge-agents/src/orchestrator.rs
+++ b/crates/forge-agents/src/orchestrator.rs
@@ -197,6 +197,11 @@ impl Orchestrator {
     /// for programmatically-constructed defs that bypass the parser.
     pub async fn spawn(&self, def: AgentDef, ctx: SpawnContext) -> Result<AgentInstance> {
         if ctx.scope == AgentScope::User && def.isolation == Isolation::Trusted {
+            tracing::warn!(
+                target: "forge_agents::orchestrator",
+                agent_name = %def.name,
+                "rejected spawn: isolation=trusted not allowed under user scope",
+            );
             return Err(Error::IsolationViolation {
                 name: def.name,
                 path: None,
@@ -228,6 +233,13 @@ impl Orchestrator {
             at: now,
         });
 
+        tracing::info!(
+            target: "forge_agents::orchestrator",
+            agent_id = %instance.id,
+            agent_name = %instance.def.name,
+            "spawned",
+        );
+
         Ok(instance)
     }
 
@@ -245,6 +257,11 @@ impl Orchestrator {
                     id: id.clone(),
                     at: now,
                 });
+                tracing::debug!(
+                    target: "forge_agents::orchestrator",
+                    agent_id = %id,
+                    "stopped",
+                );
             }
         }
         Ok(())
@@ -261,6 +278,12 @@ impl Orchestrator {
                     reason: reason.clone(),
                 };
                 let now = Utc::now();
+                tracing::debug!(
+                    target: "forge_agents::orchestrator",
+                    agent_id = %id,
+                    reason = %reason,
+                    "failed",
+                );
                 let _ = self.tx.send(AgentEvent::Failed {
                     id: id.clone(),
                     reason,
@@ -274,6 +297,12 @@ impl Orchestrator {
     /// Emit a `StepStarted` event against an instance. Does not mutate
     /// `InstanceState` — steps are transitions, not states.
     pub async fn record_step_started(&self, id: &AgentInstanceId, step: String) -> Result<()> {
+        tracing::trace!(
+            target: "forge_agents::orchestrator",
+            agent_id = %id,
+            step = %step,
+            "step started",
+        );
         let _ = self.tx.send(AgentEvent::StepStarted {
             id: id.clone(),
             step,
@@ -284,6 +313,12 @@ impl Orchestrator {
 
     /// Emit a `StepFinished` event against an instance.
     pub async fn record_step_finished(&self, id: &AgentInstanceId, step: String) -> Result<()> {
+        tracing::trace!(
+            target: "forge_agents::orchestrator",
+            agent_id = %id,
+            step = %step,
+            "step finished",
+        );
         let _ = self.tx.send(AgentEvent::StepFinished {
             id: id.clone(),
             step,

--- a/crates/forge-agents/tests/agent_loader.rs
+++ b/crates/forge-agents/tests/agent_loader.rs
@@ -2,6 +2,8 @@ use forge_agents::{load_agents, load_agents_md, load_workspace_agents, AgentDef,
 use std::fs;
 use tempfile::tempdir;
 
+mod common;
+
 fn write_agent(dir: &std::path::Path, filename: &str, content: &str) {
     fs::create_dir_all(dir).unwrap();
     fs::write(dir.join(filename), content).unwrap();
@@ -174,6 +176,39 @@ fn rejects_isolation_trusted_for_user_home_agents() {
     assert!(
         msg.contains("trusted"),
         "error should mention trusted: {msg}"
+    );
+}
+
+// ---- Tracing emission tests (F-373) --------------------------------------
+
+#[test]
+fn parse_error_emits_warn() {
+    let _guard = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let workspace = tempdir().unwrap();
+    let agents_dir = workspace.path().join(".agents");
+    // Unknown isolation value is the simplest deterministic parse-error path.
+    write_agent(
+        &agents_dir,
+        "broken.md",
+        "---\nname: broken\nisolation: bogus\n---\n\nbody",
+    );
+
+    let result = load_workspace_agents(workspace.path());
+    assert!(result.is_err(), "bogus isolation should fail parsing");
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("WARN") && logs.contains("forge_agents::def"),
+        "parse error should log WARN under forge_agents::def, got: {logs}"
+    );
+    assert!(
+        logs.contains("broken.md"),
+        "parse-error log should include the offending path; got: {logs}"
     );
 }
 

--- a/crates/forge-agents/tests/common/mod.rs
+++ b/crates/forge-agents/tests/common/mod.rs
@@ -1,0 +1,64 @@
+//! Shared tracing-capture subscriber for integration tests.
+//!
+//! Tests drain a global `MakeWriter` buffer and scan for formatted output.
+//! The subscriber is installed exactly once; a mutex serializes tests that
+//! read the buffer so concurrent test threads don't interleave assertions.
+
+use std::{
+    io,
+    sync::{Mutex as StdMutex, Once, OnceLock},
+};
+
+use tracing_subscriber::fmt::MakeWriter;
+
+fn capture_buf() -> &'static StdMutex<Vec<u8>> {
+    static BUF: OnceLock<StdMutex<Vec<u8>>> = OnceLock::new();
+    BUF.get_or_init(|| StdMutex::new(Vec::new()))
+}
+
+/// Lock held for the duration of a capture-reading test. Other tracing
+/// tests block on this so the drained buffer is attributable to one test.
+pub fn capture_test_lock() -> &'static StdMutex<()> {
+    static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| StdMutex::new(()))
+}
+
+pub struct CaptureWriter;
+impl io::Write for CaptureWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        capture_buf().lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+impl<'a> MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        CaptureWriter
+    }
+}
+
+/// Install a fmt subscriber that writes every event (TRACE and up) into the
+/// shared buffer. Subsequent calls are no-ops.
+pub fn install_capture_subscriber() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_ansi(false)
+            .with_target(true)
+            .with_writer(CaptureWriter)
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).expect("install capture subscriber");
+    });
+}
+
+/// Drain the shared buffer and return the captured output as UTF-8.
+pub fn drain_capture() -> String {
+    let mut buf = capture_buf().lock().unwrap();
+    let out = String::from_utf8(buf.clone()).expect("utf-8 logs");
+    buf.clear();
+    out
+}

--- a/crates/forge-agents/tests/orchestrator.rs
+++ b/crates/forge-agents/tests/orchestrator.rs
@@ -12,6 +12,8 @@ use forge_agents::{
 };
 use futures::StreamExt;
 
+mod common;
+
 fn process_def(name: &str) -> AgentDef {
     AgentDef {
         name: name.to_string(),
@@ -247,4 +249,165 @@ async fn scope_marker_is_independent_of_parse_time_check() {
         )
         .await;
     assert!(matches!(result, Err(Error::IsolationViolation { .. })));
+}
+
+// ---- Tracing emission tests (F-373) --------------------------------------
+//
+// The orchestrator shipped without any `tracing::` calls; these tests pin
+// every lifecycle transition to a concrete emission site + target + field
+// set so future refactors can't silently drop observability again.
+
+// Capture-subscriber tests read a shared global buffer; a test-level mutex
+// prevents two tests from interleaving log output into one another's drain.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn spawn_emits_info_with_agent_id_and_name() {
+    let _guard = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let orch = Orchestrator::new();
+    let inst = orch
+        .spawn(process_def("tracer"), SpawnContext::user())
+        .await
+        .unwrap();
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("forge_agents::orchestrator"),
+        "spawn should log under forge_agents::orchestrator target, got: {logs}"
+    );
+    assert!(
+        logs.contains(&format!("agent_id={}", inst.id)),
+        "spawn log should carry agent_id={}; got: {logs}",
+        inst.id
+    );
+    assert!(
+        logs.contains("agent_name=\"tracer\"") || logs.contains("agent_name=tracer"),
+        "spawn log should carry agent_name=tracer; got: {logs}"
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn spawn_isolation_violation_emits_warn() {
+    let _guard = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let orch = Orchestrator::new();
+    let _ = orch
+        .spawn(trusted_def("evil"), SpawnContext::user())
+        .await
+        .expect_err("trusted under user scope must be rejected");
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("WARN") && logs.contains("forge_agents::orchestrator"),
+        "isolation rejection should log WARN under forge_agents::orchestrator, got: {logs}"
+    );
+    assert!(
+        logs.contains("agent_name=\"evil\"") || logs.contains("agent_name=evil"),
+        "isolation-rejection log should carry agent_name=evil; got: {logs}"
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn stop_emits_debug_with_agent_id() {
+    let _guard = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    common::install_capture_subscriber();
+
+    let orch = Orchestrator::new();
+    let inst = orch
+        .spawn(process_def("stopper"), SpawnContext::user())
+        .await
+        .unwrap();
+    // Drain spawn output so the assertions below inspect only the stop event.
+    let _ = common::drain_capture();
+
+    orch.stop(&inst.id).await.unwrap();
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("DEBUG") && logs.contains("forge_agents::orchestrator"),
+        "stop should log DEBUG under forge_agents::orchestrator, got: {logs}"
+    );
+    assert!(
+        logs.contains(&format!("agent_id={}", inst.id)),
+        "stop log should carry agent_id={}; got: {logs}",
+        inst.id
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn fail_emits_debug_with_reason() {
+    let _guard = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    common::install_capture_subscriber();
+
+    let orch = Orchestrator::new();
+    let inst = orch
+        .spawn(process_def("failer"), SpawnContext::user())
+        .await
+        .unwrap();
+    let _ = common::drain_capture();
+
+    orch.fail(&inst.id, "boom".to_string()).await.unwrap();
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("DEBUG") && logs.contains("forge_agents::orchestrator"),
+        "fail should log DEBUG under forge_agents::orchestrator, got: {logs}"
+    );
+    assert!(
+        logs.contains(&format!("agent_id={}", inst.id)),
+        "fail log should carry agent_id={}; got: {logs}",
+        inst.id
+    );
+    assert!(
+        logs.contains("reason=\"boom\"") || logs.contains("reason=boom"),
+        "fail log should carry reason=boom; got: {logs}"
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn step_events_emit_trace_with_step_label() {
+    let _guard = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    common::install_capture_subscriber();
+
+    let orch = Orchestrator::new();
+    let inst = orch
+        .spawn(process_def("stepper"), SpawnContext::user())
+        .await
+        .unwrap();
+    let _ = common::drain_capture();
+
+    orch.record_step_started(&inst.id, "think".to_string())
+        .await
+        .unwrap();
+    orch.record_step_finished(&inst.id, "think".to_string())
+        .await
+        .unwrap();
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("TRACE") && logs.contains("forge_agents::orchestrator"),
+        "step events should log TRACE under forge_agents::orchestrator, got: {logs}"
+    );
+    assert!(
+        logs.contains("step=\"think\"") || logs.contains("step=think"),
+        "step log should carry step=think; got: {logs}"
+    );
 }


### PR DESCRIPTION
Closes forge-ide/forge#374

## Summary
- `Orchestrator::{spawn, stop, fail, record_step_started, record_step_finished}` now emit `tracing` events under target `forge_agents::orchestrator` with structured `agent_id` / `agent_name` / `step` / `reason` fields.
- Spawn-time `IsolationViolation` rejection emits `warn!` before returning.
- `def::parse_agent_file` emits `warn!` under target `forge_agents::def` on every `Err` path (read failure, YAML parse failure, isolation violation, unknown isolation level).
- Target naming follows the `forge_<crate>::<module>` scheme already used by `forge-mcp` / `forge-lsp`.
- New shared `tests/common/mod.rs` capture-subscriber helper (pattern borrowed from `forge-lsp/src/server.rs`) drives six new behavioral tests that pin each emission site's target + field set.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (6 new tracing-emission tests green; all prior tests still green)
- [x] `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)