### PR TITLE
fix(app): voice/terminology drift sweep across app surface (F-411)

### DIFF
--- a/docs/design/voice-terminology.md
+++ b/docs/design/voice-terminology.md
@@ -21,7 +21,8 @@ It is not: Casual, vague, simplified, apologetic, or verbose.
 - Button labels: verb + noun in display caps. `CONNECT PROVIDER` not `Connect to your AI provider`.
 - Section labels: noun only in mono uppercase. `PROVIDERS` not `Your AI Providers`.
 - Toast titles: state + subject. `AI backend connected` not `Successfully connected to your AI backend`.
-- Empty-state copy: noun phrase describing what would be here, plus an optional verb-noun CTA. `No agents running` or `No agents running · start agent`, never `There are no agents currently running`. See [AI Patterns](ai-patterns.md) §"Interaction states" for the surrounding treatment.
+- Empty-state copy: noun phrase describing what would be here, rendered as a mono comment in the canonical form `// <noun phrase>`. Examples: `// no matching commands`, `// no active sessions`, `// no agents`. Skip the leading `//` only when the surface already prints the token in a mono comment frame (code blocks, terminals). Pair with an optional verb-noun CTA when an action recovers the state: `// no agents · start agent`. Never `There are no agents currently running`. See [AI Patterns](ai-patterns.md) §"Interaction states" for the surrounding treatment.
+- Menu items: action rows in a context or overflow menu are buttons, so they obey the verb+noun display-caps rule. When the selected row already supplies the noun (e.g. a file tree row scoping the menu to a single path), a single-word verb is sufficient: `OPEN`, `RENAME`, `DELETE`. Otherwise include the noun: `DELETE VARIANT`, `EXPORT ALL`. Write the source text in literal UPPERCASE so screen readers announce the casing — CSS `text-transform: uppercase` only repaints glyphs.
 
 ### Terminology
 
@@ -36,7 +37,17 @@ Always use these terms, never the alternatives:
 | Tool call | Function call, API call |
 | Streaming | Live, real-time |
 | Pane | Window, panel (for canvas divisions) |
+| Panel | Pane (for Dashboard sections) |
 | Canvas | Editor area, main area |
+
+### Panel vs pane
+
+Forge splits a single-word distinction that DESIGN.md elides. Use each term for exactly one surface:
+
+- **Panel** — a bordered Dashboard section that renders a single status domain (`ProviderPanel`, `SessionsPanel`, `AgentMonitor`). Panels live outside an active session and are chrome-like. Labels that identify a panel use `NOUN` mono-uppercase (`PROVIDER`, `SESSIONS`, `AGENTS`).
+- **Pane** — a resizable canvas division inside an active session (chat pane, files sidebar, editor canvas). Panes carry live work, not status; they always show an active provider badge per §9.
+
+Never call a Dashboard section a "pane" and never call an in-session canvas division a "panel". If a surface is neither — e.g. a toast, a popover, a command palette — call it by its specific component name, not either of these two.
 
 ### Numbers and codes
 

--- a/web/packages/app/src/commands/CommandPalette.test.tsx
+++ b/web/packages/app/src/commands/CommandPalette.test.tsx
@@ -166,6 +166,19 @@ describe('CommandPalette entries + selection (F-157)', () => {
     expect(runA).not.toHaveBeenCalled();
     expect(runB).toHaveBeenCalledTimes(1);
   });
+
+  // F-411 (V9): canonical empty-state form is `// <noun phrase>` per
+  // voice-terminology.md §8, matching the dominant pattern already used by
+  // SessionsPanel (// no active sessions) and AgentMonitor (// no agents).
+  it('empty-state row reads "// no matching commands" when no commands match', async () => {
+    registerCommand({ id: 'a', title: 'Alpha', run: vi.fn() });
+    const { findByTestId } = render(() => <CommandPalette />);
+    openWithCtrlK();
+    const input = (await findByTestId('command-palette-input')) as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'zzzzz-no-match' } });
+    const empty = await findByTestId('command-palette-empty');
+    expect(empty.textContent?.trim()).toBe('// no matching commands');
+  });
 });
 
 // F-402: dialog contract — aria-modal, focus trap on Tab, focus restore on

--- a/web/packages/app/src/commands/CommandPalette.tsx
+++ b/web/packages/app/src/commands/CommandPalette.tsx
@@ -204,7 +204,7 @@ export const CommandPalette: Component = () => {
                 role="option"
                 aria-disabled="true"
               >
-                No matching commands
+                // no matching commands
               </li>
             </Show>
           </ul>

--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.test.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.test.tsx
@@ -569,3 +569,42 @@ describe('Persistence level toggle (F-036)', () => {
     expect(getByTestId('level-user-btn')).toHaveAttribute('aria-checked', 'true');
   });
 });
+
+// ---------------------------------------------------------------------------
+// F-411: voice + terminology — source strings must be literal UPPERCASE so
+// screen readers announce uppercase (voice-terminology.md §8, V13). CSS
+// `text-transform: uppercase` only re-paints the glyph; assistive tech reads
+// the underlying text node.
+// ---------------------------------------------------------------------------
+
+describe('F-411 voice/terminology — literal UPPERCASE source strings', () => {
+  it('level-toggle buttons carry SESSION / WORKSPACE / USER as literal text', () => {
+    const { getByTestId } = renderPrompt();
+    expect(getByTestId('level-session-btn').textContent).toContain('SESSION');
+    expect(getByTestId('level-workspace-btn').textContent).toContain('WORKSPACE');
+    expect(getByTestId('level-user-btn').textContent).toContain('USER');
+  });
+
+  it('action buttons carry verb+noun display caps labels', () => {
+    const { getByTestId } = renderPrompt();
+    expect(getByTestId('reject-btn').textContent).toContain('REJECT CALL');
+    expect(getByTestId('approve-once-btn').textContent).toContain('APPROVE ONCE');
+  });
+
+  it('scope menu items carry APPROVE <NOUN> labels', () => {
+    const { getByTestId } = renderPrompt({ toolName: 'fs.edit', argsJson: FS_EDIT_ARGS });
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    expect(getByTestId('scope-once-btn').textContent).toContain('APPROVE ONCE');
+    expect(getByTestId('scope-file-btn').textContent).toContain('APPROVE FILE');
+    expect(getByTestId('scope-pattern-btn').textContent).toContain('APPROVE PATTERN');
+    expect(getByTestId('scope-tool-btn').textContent).toContain('APPROVE TOOL');
+  });
+
+  it('pattern-editor buttons carry CONFIRM PATTERN / CANCEL as literal text', () => {
+    const { getByTestId } = renderPrompt();
+    fireEvent.click(getByTestId('approve-dropdown-btn'));
+    fireEvent.click(getByTestId('scope-pattern-btn'));
+    expect(getByTestId('pattern-confirm-btn').textContent).toContain('CONFIRM PATTERN');
+    expect(getByTestId('pattern-cancel-btn').textContent).toContain('CANCEL');
+  });
+});

--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tsx
@@ -172,7 +172,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
           role="radiogroup"
           aria-label="Persistence level"
         >
-          <span class="approval-prompt__level-label">Persist:</span>
+          <span class="approval-prompt__level-label">PERSIST:</span>
           <button
             type="button"
             class="approval-prompt__level-btn"
@@ -182,7 +182,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
             aria-checked={level() === 'session'}
             onClick={() => setLevel('session')}
           >
-            Session
+            SESSION
           </button>
           <button
             type="button"
@@ -193,7 +193,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
             aria-checked={level() === 'workspace'}
             onClick={() => setLevel('workspace')}
           >
-            Workspace
+            WORKSPACE
           </button>
           <button
             type="button"
@@ -204,7 +204,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
             aria-checked={level() === 'user'}
             onClick={() => setLevel('user')}
           >
-            User
+            USER
           </button>
         </div>
       </Show>
@@ -213,7 +213,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
       <Show when={patternMode()}>
         <div class="approval-prompt__pattern-editor" data-testid="pattern-editor">
           <label class="approval-prompt__pattern-label" for="approval-pattern-input">
-            Approve this pattern:
+            APPROVE THIS PATTERN:
           </label>
           <div class="approval-prompt__pattern-row">
             <input
@@ -230,7 +230,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
               data-testid="pattern-confirm-btn"
               onClick={() => approveWithScope('ThisPattern', pattern())}
             >
-              Confirm
+              CONFIRM PATTERN
             </button>
             <button
               type="button"
@@ -238,7 +238,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
               data-testid="pattern-cancel-btn"
               onClick={() => setPatternMode(false)}
             >
-              Cancel
+              CANCEL
             </button>
           </div>
         </div>
@@ -253,7 +253,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
             data-testid="reject-btn"
             onClick={() => props.onReject()}
           >
-            Reject
+            REJECT CALL
             <kbd class="approval-prompt__kbd">R</kbd>
           </button>
 
@@ -265,7 +265,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
               data-testid="approve-once-btn"
               onClick={() => approveWithScope('Once')}
             >
-              Approve
+              APPROVE ONCE
               <kbd class="approval-prompt__kbd">A</kbd>
             </button>
 
@@ -291,7 +291,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
                   role="menuitem"
                   onClick={() => approveWithScope('Once')}
                 >
-                  Once
+                  APPROVE ONCE
                   <kbd class="approval-prompt__kbd">A</kbd>
                 </button>
 
@@ -303,7 +303,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
                     role="menuitem"
                     onClick={() => approveWithScope('ThisFile')}
                   >
-                    This file
+                    APPROVE FILE
                     <kbd class="approval-prompt__kbd">F</kbd>
                   </button>
 
@@ -314,7 +314,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
                     role="menuitem"
                     onClick={openPatternEditor}
                   >
-                    This pattern
+                    APPROVE PATTERN
                     <kbd class="approval-prompt__kbd">P</kbd>
                   </button>
                 </Show>
@@ -326,7 +326,7 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
                   role="menuitem"
                   onClick={() => approveWithScope('ThisTool')}
                 >
-                  This tool
+                  APPROVE TOOL
                   <kbd class="approval-prompt__kbd">T</kbd>
                 </button>
               </div>

--- a/web/packages/app/src/components/BranchMetadataPopover.test.tsx
+++ b/web/packages/app/src/components/BranchMetadataPopover.test.tsx
@@ -201,4 +201,22 @@ describe('BranchMetadataPopover', () => {
     fireEvent.mouseDown(getByTestId('branch-popover-row-1'));
     expect(onDismiss).not.toHaveBeenCalled();
   });
+
+  // F-411 (V4): per voice-terminology.md §8, action buttons use verb+noun
+  // display caps. Per-row "Delete" becomes "DELETE VARIANT"; footer "Export
+  // all" becomes "EXPORT ALL".
+  it('row delete + footer export buttons carry verb+noun display-caps labels', () => {
+    const { getByTestId } = render(() => (
+      <BranchMetadataPopover
+        variants={rows}
+        activeVariantId="var-1"
+        onSelect={() => {}}
+        onDelete={() => {}}
+        onExportAll={() => {}}
+        onDismiss={() => {}}
+      />
+    ));
+    expect(getByTestId('branch-popover-delete-1').textContent).toContain('DELETE VARIANT');
+    expect(getByTestId('branch-popover-export').textContent).toContain('EXPORT ALL');
+  });
 });

--- a/web/packages/app/src/components/BranchMetadataPopover.tsx
+++ b/web/packages/app/src/components/BranchMetadataPopover.tsx
@@ -178,7 +178,7 @@ export const BranchMetadataPopover: Component<BranchMetadataPopoverProps> = (pro
                   disabled={!canDelete(row)}
                   onClick={() => props.onDelete(row.index)}
                 >
-                  Delete
+                  DELETE VARIANT
                 </button>
               </li>
             );
@@ -192,7 +192,7 @@ export const BranchMetadataPopover: Component<BranchMetadataPopoverProps> = (pro
           data-testid="branch-popover-export"
           onClick={props.onExportAll}
         >
-          Export all
+          EXPORT ALL
         </button>
       </footer>
     </div>

--- a/web/packages/app/src/components/SubAgentBanner.test.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.test.tsx
@@ -107,10 +107,15 @@ describe('SubAgentBanner — expand/collapse', () => {
     );
   });
 
-  it('renders the "No step events yet" placeholder when expanded with no children', () => {
+  it('renders the "// no steps yet" placeholder when expanded with no children', () => {
     const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
     fireEvent.click(getByTestId('sub-agent-banner-header-child-1'));
-    expect(getByTestId('sub-agent-banner-empty-child-1')).toBeInTheDocument();
+    const empty = getByTestId('sub-agent-banner-empty-child-1');
+    expect(empty).toBeInTheDocument();
+    // F-411: canonical empty-state form is `// <noun phrase>` per
+    // voice-terminology.md §8.
+    expect(empty).toHaveTextContent('// no steps yet');
+    expect(empty.textContent).not.toMatch(/No step events yet/i);
   });
 });
 
@@ -135,7 +140,7 @@ describe('SubAgentBanner — nested rendering for sub-of-sub', () => {
     expect(nestedHeader).toHaveTextContent('deep-helper');
   });
 
-  it('replaces nested inline children with an "Open in new window" button past max depth (3)', () => {
+  it('replaces nested inline children with an "OPEN MONITOR" button past max depth (3)', () => {
     const grandchild: Extract<ChatTurn, { type: 'sub_agent_banner' }> = {
       type: 'sub_agent_banner',
       child_instance_id: 'too-deep-1',
@@ -212,7 +217,7 @@ describe('SubAgentBanner — double-click to Agent Monitor (F-140)', () => {
     expect(open).toHaveBeenCalledWith('child-1');
   });
 
-  it('invokes the "Open in new window" button when depth exceeds the inline cap', () => {
+  it('invokes the "OPEN MONITOR" button when depth exceeds the inline cap', () => {
     const open = vi.fn();
     const grandchild: Extract<ChatTurn, { type: 'sub_agent_banner' }> = {
       type: 'sub_agent_banner',
@@ -230,7 +235,12 @@ describe('SubAgentBanner — double-click to Agent Monitor (F-140)', () => {
       />
     ));
     fireEvent.click(getByTestId('sub-agent-banner-header-child-1'));
-    fireEvent.click(getByTestId('sub-agent-banner-open-monitor-child-1'));
+    const openBtn = getByTestId('sub-agent-banner-open-monitor-child-1');
+    // F-411: button label must be the sanctioned verb+noun display-caps form
+    // (voice-terminology.md §8).
+    expect(openBtn).toHaveTextContent('OPEN MONITOR');
+    expect(openBtn.textContent).not.toMatch(/Open in new window/);
+    fireEvent.click(openBtn);
     expect(open).toHaveBeenCalledWith('child-1');
   });
 });

--- a/web/packages/app/src/components/SubAgentBanner.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.tsx
@@ -176,7 +176,7 @@ export const SubAgentBanner: Component<SubAgentBannerProps> = (props) => {
                 data-testid={`sub-agent-banner-open-monitor-${props.turn.child_instance_id}`}
                 onClick={openInMonitor}
               >
-                Open in new window
+                OPEN MONITOR
               </button>
             }
           >
@@ -187,7 +187,7 @@ export const SubAgentBanner: Component<SubAgentBannerProps> = (props) => {
                   class="sub-agent-banner__empty"
                   data-testid={`sub-agent-banner-empty-${props.turn.child_instance_id}`}
                 >
-                  No step events yet.
+                  // no steps yet
                 </p>
               }
             >

--- a/web/packages/app/src/routes/AgentMonitor.test.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.test.tsx
@@ -622,7 +622,7 @@ describe('<AgentTrace>', () => {
 // ---------------------------------------------------------------------------
 
 describe('<AgentInspector>', () => {
-  it('renders definition/tools/paths sections and a Stop button', () => {
+  it('renders definition/tools/paths sections and a STOP AGENT button', () => {
     const data = inspector({
       source: 'a.agents/coder.md:12',
       provider: 'anthropic',
@@ -631,14 +631,16 @@ describe('<AgentInspector>', () => {
       allowedPaths: ['/workspace/**'],
       resources: { cpu: 12.5, rss: 128, fds: 4 },
     });
-    const { getByText, getAllByText } = render(() => (
+    const { getByText, getAllByText, queryByText } = render(() => (
       <AgentInspector agent={row()} data={data} onStop={() => {}} />
     ));
     expect(getByText('Definition')).toBeTruthy();
     expect(getByText('Allowed tools')).toBeTruthy();
     expect(getByText('Allowed paths')).toBeTruthy();
     expect(getByText('Resource usage')).toBeTruthy();
-    expect(getByText('Stop agent')).toBeTruthy();
+    // F-411: §8 verb+noun display caps — the sanctioned label is "STOP AGENT".
+    expect(getByText('STOP AGENT')).toBeTruthy();
+    expect(queryByText('Stop agent')).toBeNull();
 
     // Pills rendered literally.
     expect(getByText('fs.read')).toBeTruthy();
@@ -664,7 +666,7 @@ describe('<AgentInspector>', () => {
     const { getByText } = render(() => (
       <AgentInspector agent={row({ id: 'kill-me' })} data={inspector()} onStop={onStop} />
     ));
-    fireEvent.click(getByText('Stop agent'));
+    fireEvent.click(getByText('STOP AGENT'));
     expect(onStop).toHaveBeenCalledWith('kill-me');
   });
 });

--- a/web/packages/app/src/routes/AgentMonitor.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.tsx
@@ -639,7 +639,7 @@ export const AgentInspector: Component<{
             class="agent-monitor__stop"
             onClick={() => props.onStop(props.agent!.id)}
           >
-            Stop agent
+            STOP AGENT
           </button>
         </section>
       </Show>

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.test.tsx
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.test.tsx
@@ -126,6 +126,32 @@ describe('ProviderPanel', () => {
     expect(await findByText(/Error: authz denied: dashboard/)).toBeInTheDocument();
   });
 
+  // F-411 (V11): pre-resolution loading label must follow the noun+state rule
+  // (`ollama · probing`), not the verb-state `PROBING`. voice-terminology.md
+  // §8 is explicit: "Status indicators: noun + state, no verbs."
+  it('shows "ollama · probing" (noun+state) while provider_status is in-flight', async () => {
+    let resolveStatus: ((v: ProviderStatus) => void) | undefined;
+    const invoke = vi.fn().mockImplementation(
+      () =>
+        new Promise<ProviderStatus>((resolve) => {
+          resolveStatus = resolve;
+        }),
+    );
+    setInvokeForTesting(invoke as never);
+
+    const { findByText, queryByText } = render(() => <ProviderPanel />);
+    const loading = await findByText('ollama · probing');
+    expect(loading).toBeInTheDocument();
+    // Guard against regression to the verb-state form.
+    expect(queryByText('PROBING')).toBeNull();
+
+    // Resolve so React-query/Solid resource doesn't leak across tests.
+    resolveStatus?.(reachable);
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalled();
+    });
+  });
+
   it('retry button on the error state re-invokes provider_status and recovers', async () => {
     const invoke = vi
       .fn()

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.tsx
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.tsx
@@ -43,7 +43,7 @@ export const ProviderPanel: Component = () => {
           </div>
         }
       >
-        <Show when={status()} fallback={<p class="provider-panel__loading">PROBING</p>}>
+        <Show when={status()} fallback={<p class="provider-panel__loading">ollama · probing</p>}>
           {(s) => (
             <>
               <div class="provider-panel__row">

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -1490,6 +1490,17 @@ describe('Composer Stop button (F-391)', () => {
     expect(stop.className).toContain('composer__btn--primary');
   });
 
+  // F-411 (V7): per voice-terminology.md §8, button labels are verb+noun in
+  // display caps. The composer's in-stream cancel button must read
+  // "STOP TURN" — naked "STOP" is a verb without a noun object and an
+  // earlier bare "Stop" regressed casing to mixed-case.
+  it('Stop button renders literal "STOP TURN" text for SR/voice parity', () => {
+    setAwaitingResponse(SID, true);
+    const { getByTestId } = render(() => <ChatPane />);
+    const stop = getByTestId('composer-stop-btn');
+    expect(stop.textContent?.trim()).toBe('STOP TURN');
+  });
+
   it('clicking Stop invokes session_cancel with the active sessionId', () => {
     invokeMock.mockReset();
     invokeMock.mockResolvedValue(undefined);

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -882,7 +882,7 @@ export const Composer: Component<ComposerProps> = (props) => {
               data-testid="composer-stop-btn"
               onClick={() => props.onCancel?.()}
             >
-              STOP
+              STOP TURN
             </button>
           </Show>
           {/* F-391: Send is a real primary/ember button, UPPERCASE per

--- a/web/packages/app/src/shell/FilesSidebar.test.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.test.tsx
@@ -277,4 +277,25 @@ describe('FilesSidebar context menu', () => {
     fireEvent.click(await findByTestId('files-sidebar-menu-delete'));
     expect(deletePath).not.toHaveBeenCalled();
   });
+
+  // F-411 (V8): context-menu items are buttons executing an action on the
+  // selected tree row — per voice-terminology.md §8, they carry verb(+noun)
+  // labels in display caps as literal text so screen readers announce them
+  // uppercase.
+  it('context-menu items carry OPEN / RENAME / DELETE as literal text', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const { findByText, findByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    const readme = await findByText('README.md');
+    fireEvent.contextMenu(readme);
+    expect((await findByTestId('files-sidebar-menu-open')).textContent).toContain('OPEN');
+    expect((await findByTestId('files-sidebar-menu-rename')).textContent).toContain('RENAME');
+    expect((await findByTestId('files-sidebar-menu-delete')).textContent).toContain('DELETE');
+  });
 });

--- a/web/packages/app/src/shell/FilesSidebar.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.tsx
@@ -245,7 +245,7 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
                 disabled={target().isDir}
                 onClick={() => doOpen(target().path)}
               >
-                Open
+                OPEN
               </button>
             </li>
             <li role="none">
@@ -257,7 +257,7 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
                   void doRename();
                 }}
               >
-                Rename…
+                RENAME
               </button>
             </li>
             <li role="none">
@@ -269,7 +269,7 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
                   void doDelete();
                 }}
               >
-                Delete
+                DELETE
               </button>
             </li>
           </ul>

--- a/web/packages/app/src/shell/StatusBar.test.tsx
+++ b/web/packages/app/src/shell/StatusBar.test.tsx
@@ -297,6 +297,29 @@ describe('StatusBar — popover interaction', () => {
       expect(stop).toHaveBeenCalledWith(SID, 'a1');
     });
   });
+
+  // F-411 (V5): verb+noun display caps per voice-terminology.md §8.
+  // Popover actions must carry literal UPPERCASE source strings so screen
+  // readers announce the branded phrasing; CSS text-transform alone does not
+  // reach assistive tech.
+  it('popover action buttons carry PROMOTE AGENT / STOP AGENT as literal text', async () => {
+    const bus = fakeBus();
+    const list = vi.fn().mockResolvedValue([running('a1', 'writer')]);
+    const { findByTestId } = render(() => (
+      <StatusBar
+        sessionId={SID}
+        listBackgroundAgents={list}
+        subscribe={bus.subscribe}
+      />
+    ));
+    fireEvent.click(await findByTestId('bg-agents-badge'));
+    const promote = await findByTestId('bg-agents-promote-a1');
+    const stop = await findByTestId('bg-agents-stop-a1');
+    expect(promote.textContent).toContain('PROMOTE AGENT');
+    expect(stop.textContent).toContain('STOP AGENT');
+    expect(promote.textContent).not.toBe('Promote');
+    expect(stop.textContent).not.toBe('Stop');
+  });
 });
 
 describe('StatusBar — notification modes', () => {

--- a/web/packages/app/src/shell/StatusBar.tsx
+++ b/web/packages/app/src/shell/StatusBar.tsx
@@ -377,7 +377,7 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
                     void onPromote(row.id);
                   }}
                 >
-                  Promote
+                  PROMOTE AGENT
                 </button>
                 <button
                   type="button"
@@ -387,7 +387,7 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
                     void onStop(row.id);
                   }}
                 >
-                  Stop
+                  STOP AGENT
                 </button>
               </div>
             )}


### PR DESCRIPTION
## Summary

- Fixes 12 voice/terminology deviations (V1–V12) across ApprovalPrompt, SubAgentBanner, BranchMetadataPopover, StatusBar, AgentMonitor, ChatPane, FilesSidebar, CommandPalette, ProviderPanel. V12 was already resolved by F-395.
- Source strings are written in literal UPPERCASE wherever the rendered glyph is uppercase (addresses V13) — CSS `text-transform: uppercase` only repaints visually; screen readers read the DOM text node, so mixed-case sources silently downgraded a11y.
- Amends `docs/design/voice-terminology.md` with (a) `panel` (Dashboard section) vs `pane` (in-session canvas division) disambiguation, (b) canonical empty-state form `// <noun phrase>`, (c) menu-item casing decision (verb+noun display caps per §8).
- Adds positive and negative regression tests per component asserting the new literal strings and guarding against regression to the old casing/phrasing.

## Deviations applied

| # | file | change |
|---|---|---|
| V1 | `ApprovalPrompt.tsx` | Level toggles: `Session`/`Workspace`/`User` → literal UPPERCASE |
| V2 | `ApprovalPrompt.tsx` | Actions: `Confirm`→`CONFIRM PATTERN`, `Cancel`→`CANCEL`, `Reject`→`REJECT CALL`, scope menu → `APPROVE ONCE`/`APPROVE FILE`/`APPROVE PATTERN`/`APPROVE TOOL`; pattern editor header → `APPROVE THIS PATTERN:` |
| V3 | `SubAgentBanner.tsx` | `Open in new window` → `OPEN MONITOR` |
| V4 | `BranchMetadataPopover.tsx` | `Delete` → `DELETE VARIANT`, `Export all` → `EXPORT ALL` |
| V5 | `StatusBar.tsx` | `Promote`/`Stop` → `PROMOTE AGENT`/`STOP AGENT` |
| V6 | `AgentMonitor.tsx` | `Stop agent` → `STOP AGENT` (source) |
| V7 | `ChatPane.tsx` | `STOP` → `STOP TURN` |
| V8 | `FilesSidebar.tsx` | `Open`/`Rename…`/`Delete` → `OPEN`/`RENAME`/`DELETE` |
| V9 | `CommandPalette.tsx` | `No matching commands` → `// no matching commands` |
| V10 | `SubAgentBanner.tsx` | `No step events yet.` → `// no steps yet` |
| V11 | `ProviderPanel.tsx` | `PROBING` → `ollama · probing` (noun+state) |
| V12 | `SessionWindow.tsx` | Already resolved by F-395 — no change needed |
| V13 | all above | Literal UPPERCASE sources for SR/voice parity |

## Voice-terminology amendments

- Empty-state canonical form documented: `// <noun phrase>` (matches dominant pattern in SessionsPanel + AgentMonitor).
- Menu-item casing documented: action rows are buttons, verb+noun display caps per §8; single-word verb is sufficient when the selected row already supplies the noun (e.g. `OPEN`/`RENAME`/`DELETE` on a file tree).
- Panel vs pane disambiguation: panel = Dashboard section, pane = in-session canvas division. Added as its own sub-section and as a row in the terminology table.

## Test plan

- [x] `pnpm --filter app test` — 855 tests pass across 66 files (includes new regression tests).
- [x] `pnpm --filter app typecheck` — clean.
- [x] `pnpm check-tokens` — 58 tokens match.
- [x] `cargo fmt --check` — clean.
- [x] `cargo check --workspace` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace` — all pass.

Closes #412