### PR TITLE
[F-406] ContextPicker tabs layout diverges from spec mixed-list

### DIFF
--- a/docs/ui-specs/context-picker.md
+++ b/docs/ui-specs/context-picker.md
@@ -14,22 +14,21 @@
 
 **Placement.** Viewport-aware and computed by the pure `computePopupPlacement` helper in `web/packages/app/src/components/ContextPicker.tsx`. The popup prefers anchoring *below* the caret/composer when there is room — specifically, when `viewportHeight − anchorBottom − gap ≥ popupHeight` (gap defaults to 4px, popup height is capped at 360px). When that space is not available, placement flips to *above* the anchor so the popup is never clipped by the viewport bottom. In the standard chat layout the composer is pinned to the bottom of its pane, so the flip-above branch is the one that renders in practice; the below branch is what keeps the popup from being clipped when the composer is embedded in pickers or other non-bottom-pinned hosts. Either way the composer itself remains visible.
 
-**Structure.**
+**Structure.** Three stacked rows: an `@`-echo search row, a horizontal strip of seven category tabs, then the results list for the active category. Only the active category's results render; switching tabs swaps the list.
+
 ```
 ┌──────────────────────────────────────────┐
-│ SEARCH…              │ Cmd+K             │
+│ @ src/foo                                │  ← search row echoes the live @-query
 ├──────────────────────────────────────────┤
-│ CATEGORY             │ (recent)          │
-│ [📄] file            client.ts           │
-│ [📄] file            processor.ts        │
-│ [📁] directory       tests/payments      │
-│ [↳]  selection       editor @ ln 14-22   │
-│ [≡]  terminal        last 20 lines       │
-│ [🤖] agent           refactor-bot thread │
-│ [🧩] skill           typescript-review   │
-│ [🌐] url             https://...          │
+│ [F] FILE  [D] DIR  [S] SEL  [T] TERM …   │  ← tablist; active tab is ember-bordered
+├──────────────────────────────────────────┤
+│ ▸ client.ts                              │  ← results for the active category only
+│   processor.ts                           │     (or "No <category> results" when empty)
+│   payments/handler.ts                    │
 └──────────────────────────────────────────┘
 ```
+
+The tab strip renders all seven categories in order: `file`, `directory`, `selection`, `terminal`, `agent`, `skill`, `url`. Each tab shows a bracketed glyph (`[F]`, `[D]`, `[S]`, `[T]`, `[A]`, `[K]`, `[U]`) plus a lowercase mono label that is rendered uppercase via CSS. The active tab is highlighted with an ember border and elevated surface; the active result row carries an ember left border.
 
 **Categories.**
 - `file` — any file in workspace. Uses `.gitignore`.
@@ -40,14 +39,18 @@
 - `skill` — a skill definition (reference, not content — the agent will load it)
 - `url` — paste or type a URL; Forge fetches at send time (respecting allowed hosts)
 
-**Interaction.**
-- Up/down: navigate
-- Enter: insert as chip
-- Tab: insert and refine (replaces last token, cursor remains in picker)
-- Esc: close, retain typed text
+**Interaction.** DOM focus stays in the composer textarea while the popup is open; the combobox root carries `aria-activedescendant` pointing at the active result row (WAI-ARIA combobox pattern).
+
+- Up / Down: move the cursor within the active category's results (wraps at ends).
+- Tab: cycle to the next category. Shift+Tab cycles to the previous category. Both wrap at the ends. The result cursor resets to the first row of the newly-active category.
+- Enter: insert the active result as a chip and close the picker. The `@`-token in the textarea is replaced by the chip.
+- Esc: close the picker. Any typed `@`-text is retained in the textarea.
+- Mouse: clicking a tab activates its category; clicking a result inserts that result as a chip. Both use `mousedown` with `preventDefault` so the composer never loses focus.
+
+> **Note on "insert and refine".** An earlier draft of this spec defined Tab as "insert and refine" — inserting the current candidate while keeping the picker open for follow-up refinement. That behavior is deferred (tracked as a possible v1.1 enhancement) and is not a current requirement. Tab currently switches categories.
 
 **On insert.**
-- A chip appears in the ctx-chips row above the textarea: `[📄 processor.ts ×]`
+- A chip appears in the ctx-chips row above the textarea: `[F] processor.ts ×` (icon glyph matches the picker tab: `[F]`, `[D]`, `[S]`, `[T]`, `[A]`, `[K]`, `[U]`)
 - The `@text` is removed from the textarea
 - At send, each chip resolves to an appropriate context block per-provider (XML tags for Anthropic, function-style for OpenAI, etc.)
 


### PR DESCRIPTION
Closes forge-ide/forge#407

## Summary
- Rewrites `docs/ui-specs/context-picker.md §7` Structure to show the shipped tabbed layout (search row + 7 category tabs + active-category results) instead of the mixed-list mock.
- Rewrites the Interaction block so Tab/Shift+Tab cycle categories (matching the F-141 implementation), Enter inserts a chip, Esc retains typed text, and WAI-ARIA combobox semantics are documented.
- Notes the deferred "insert and refine" Tab behavior as a possible v1.1 item rather than a current requirement.
- Updates the "On insert" chip example to match the `[F]`/`[D]`/... ASCII glyphs shipped by `ContextChip`.

No source changes. The component remained authoritative; the spec was brought into alignment.

## Test plan
- `pnpm --filter app exec vitest run` → 845 tests pass (including 31 ContextPicker tests).
- `cargo fmt --check` passes.
- `cargo check --workspace` passes.
- `cargo test --workspace` passes.
- `cargo clippy --all-targets -- -D warnings` passes.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)