### PR TITLE
[F-371] Structured tracing across forge-shell and forge-session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,8 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "windows-sys 0.61.2",
 ]
 
@@ -1561,6 +1563,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.8.23",
+ "tracing",
+ "tracing-subscriber",
  "ts-rs",
  "wiremock",
 ]

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -36,6 +36,9 @@ serde_json = "1"
 sha2 = "0.10"
 thiserror = "1"
 tokio = { version = "1", features = ["net", "io-util", "fs", "rt-multi-thread", "macros", "sync", "process", "time", "signal"] }
+# F-371: structured tracing across daemon-side emit failures, turn errors,
+# and MCP lifecycle. Emission only — no subscriber is installed in `forged`.
+tracing = "0.1"
 
 # F-156: macOS resource sampler. `libproc` wraps the Apple
 # `proc_pidinfo` syscalls used to read task CPU time, resident-size, and
@@ -63,6 +66,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 similar = "2"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros", "time", "net", "process"] }
+# F-371: capture subscriber in integration tests pins target + field shape
+# for each tracing emission site.
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 [[bench]]
 name = "orchestrator"
@@ -128,3 +134,11 @@ path = "tests/agent_spawn_live.rs"
 [[test]]
 name = "step_events"
 path = "tests/step_events.rs"
+
+[[test]]
+name = "bg_agents_tracing"
+path = "tests/bg_agents_tracing.rs"
+
+[[test]]
+name = "eprintln_audit"
+path = "tests/eprintln_audit.rs"

--- a/crates/forge-session/src/bg_agents.rs
+++ b/crates/forge-session/src/bg_agents.rs
@@ -201,12 +201,26 @@ impl BackgroundAgentRegistry {
         agent_name: &str,
         prompt: InitialPrompt,
     ) -> Result<AgentInstanceId, BgAgentError> {
-        let def = self
+        let def = match self
             .agent_defs
             .iter()
             .find(|d| d.name == agent_name)
             .cloned()
-            .ok_or_else(|| BgAgentError::UnknownAgent(agent_name.to_string()))?;
+        {
+            Some(d) => d,
+            None => {
+                // F-371: every Err branch emits a structured warning with the
+                // `agent_name` field so operators can trace a misdirected
+                // `start_background_agent` call back to the offending UI
+                // without having to correlate stderr lines by timestamp.
+                tracing::warn!(
+                    target: "forge_session::bg_agents",
+                    agent_name = %agent_name,
+                    "rejected start: unknown agent",
+                );
+                return Err(BgAgentError::UnknownAgent(agent_name.to_string()));
+            }
+        };
 
         // Subscribe BEFORE spawn. `Orchestrator::state_stream` is a bounded
         // broadcast — a late subscriber (e.g. `spawn → tokio::spawn(listener)`)
@@ -218,10 +232,35 @@ impl BackgroundAgentRegistry {
             scope: AgentScope::User,
             initial_prompt: Some(prompt),
         };
-        let instance: AgentInstance = self.orchestrator.spawn(def, ctx).await?;
+        let instance: AgentInstance = match self.orchestrator.spawn(def, ctx).await {
+            Ok(inst) => inst,
+            Err(e) => {
+                // F-371: orchestrator-side spawn rejection (e.g. isolation
+                // violation) ends the background-agent lifecycle before it
+                // starts. Emit so operators see both the user's `start`
+                // attempt and the orchestrator's refusal in one log.
+                tracing::warn!(
+                    target: "forge_session::bg_agents",
+                    agent_name = %agent_name,
+                    error = %e,
+                    "rejected start: orchestrator spawn failed",
+                );
+                return Err(BgAgentError::Spawn(e));
+            }
+        };
         let id = instance.id.clone();
 
         self.tracked.lock().await.insert(id.clone());
+
+        // F-371: lifecycle transition — `start` succeeded. Mirrors the
+        // `forge_agents::orchestrator` "spawned" info log so a downstream
+        // filter on `instance_id` correlates both sides of the wiring.
+        tracing::info!(
+            target: "forge_session::bg_agents",
+            instance_id = %id,
+            agent_name = %instance.def.name,
+            "started",
+        );
 
         // F-152: start per-instance resource sampling. No per-agent
         // sidecar process exists yet, so we sample the daemon's own PID
@@ -258,27 +297,57 @@ impl BackgroundAgentRegistry {
                     // silently dropping the row.
                     Err(_) => return,
                 };
-                let (terminal_id, is_terminal) = match &event {
-                    forge_agents::AgentEvent::Completed { id, .. } => (id.clone(), true),
-                    forge_agents::AgentEvent::Failed { id, .. } => (id.clone(), true),
+                let (terminal_id, is_failed) = match &event {
+                    forge_agents::AgentEvent::Completed { id, .. } => (id.clone(), false),
+                    forge_agents::AgentEvent::Failed { id, reason, .. } => {
+                        if *id == target_id {
+                            // F-371: failure log carries the reason so an
+                            // operator doesn't need to cross-reference the
+                            // orchestrator's own event stream to find it.
+                            tracing::warn!(
+                                target: "forge_session::bg_agents",
+                                instance_id = %id,
+                                reason = %reason,
+                                "failed",
+                            );
+                        }
+                        (id.clone(), true)
+                    }
                     _ => continue,
                 };
                 if terminal_id != target_id {
                     continue;
                 }
-                if is_terminal {
-                    tracked.lock().await.remove(&target_id);
-                    // F-152: stop sampling for the terminated instance so
-                    // the UI pills clear back to `—` (no further
-                    // `ResourceSample` events reach the webview for this
-                    // id).
-                    monitor.untrack(&target_id).await;
-                    let _ = events.send(Event::BackgroundAgentCompleted {
-                        id: target_id.clone(),
-                        at: Utc::now(),
-                    });
-                    return;
+                // F-152: stop sampling for the terminated instance so
+                // the UI pills clear back to `—` (no further
+                // `ResourceSample` events reach the webview for this
+                // id).
+                tracked.lock().await.remove(&target_id);
+                monitor.untrack(&target_id).await;
+                if !is_failed {
+                    // F-371: `Completed` path gets its own info log. Failed
+                    // already logged above with the reason attached.
+                    tracing::info!(
+                        target: "forge_session::bg_agents",
+                        instance_id = %target_id,
+                        "completed",
+                    );
                 }
+                if let Err(e) = events.send(Event::BackgroundAgentCompleted {
+                    id: target_id.clone(),
+                    at: Utc::now(),
+                }) {
+                    // F-371: broadcast-send errors only happen when the
+                    // session has dropped every subscriber. Log at warn so
+                    // a teardown race is observable without panicking.
+                    tracing::warn!(
+                        target: "forge_session::bg_agents",
+                        instance_id = %target_id,
+                        error = %e,
+                        "completion emit failed: no subscribers",
+                    );
+                }
+                return;
             }
         });
 

--- a/crates/forge-session/src/lib.rs
+++ b/crates/forge-session/src/lib.rs
@@ -2,6 +2,7 @@ pub mod archive;
 pub mod bg_agents;
 pub mod byte_budget;
 pub mod error;
+pub mod log_fields;
 pub mod orchestrator;
 pub mod pid_file;
 pub mod provider_spec;

--- a/crates/forge-session/src/log_fields.rs
+++ b/crates/forge-session/src/log_fields.rs
@@ -14,7 +14,7 @@
 //! (F-373). Concretely:
 //!
 //! - `forge_shell::ipc::authz` — label-gate rejection in
-//!   [`require_window_label`] / [`require_window_label_in`]
+//!   `require_window_label` / `require_window_label_in`
 //! - `forge_shell::ipc` — Tauri emit failures (session, terminal, LSP)
 //! - `forge_session::server` — connection loop, turn errors, archive
 //! - `forge_session::mcp` — `.mcp.json` load + server start

--- a/crates/forge-session/src/log_fields.rs
+++ b/crates/forge-session/src/log_fields.rs
@@ -1,0 +1,70 @@
+//! F-371: central tracing field-name schema for `forge-session` and
+//! `forge-shell`.
+//!
+//! Every structured log emitted from those two crates uses a field name
+//! exported by this module. Pinning the names in one place keeps the
+//! schema consistent across crates so operators can filter reliably
+//! (e.g. `| jq 'select(.session_id == "…")'`) without having to know
+//! which crate produced the event.
+//!
+//! # Target naming
+//!
+//! Targets follow the `forge_<crate>::<module>` scheme already established
+//! by `forge_mcp::*` / `forge_lsp::*` and extended by `forge_agents::*`
+//! (F-373). Concretely:
+//!
+//! - `forge_shell::ipc::authz` — label-gate rejection in
+//!   [`require_window_label`] / [`require_window_label_in`]
+//! - `forge_shell::ipc` — Tauri emit failures (session, terminal, LSP)
+//! - `forge_session::server` — connection loop, turn errors, archive
+//! - `forge_session::mcp` — `.mcp.json` load + server start
+//! - `forge_session::bg_agents` — background-agent lifecycle transitions
+//!
+//! # Field names
+//!
+//! Prefer the constants below to raw string literals at emission sites so
+//! a rename (e.g. `session_id` → `session`) ripples through `cargo check`
+//! instead of silently diverging. Field semantics:
+//!
+//! - [`SESSION_ID`] — the daemon-side session id (`SessionId` string form)
+//! - [`WINDOW_LABEL`] — the calling webview's label (`session-<id>` or `dashboard`)
+//! - [`COMMAND`] — the Tauri command name for authz rejections
+//! - [`EXPECTED`] / [`ACTUAL`] — the label an authz gate wanted vs. what it got
+//! - [`TERMINAL_ID`] — PTY identifier in `forge_term` commands
+//! - [`SERVER_ID`] — LSP server id (F-353) or MCP server name
+//! - [`INSTANCE_ID`] — `AgentInstanceId` for background-agent lifecycle
+//! - [`AGENT_NAME`] — `AgentDef.name` (matches F-373's `forge-agents` schema)
+
+/// Daemon-side session id. Threaded into every `forge-session` emission
+/// that happens in the context of one session.
+pub const SESSION_ID: &str = "session_id";
+
+/// Calling webview label (`session-<id>` or `dashboard`). Present on every
+/// `forge-shell` emit-failure log so the operator can identify the window
+/// whose event sink rejected the payload.
+pub const WINDOW_LABEL: &str = "window_label";
+
+/// Tauri command name on the authz-rejection path (F-051).
+pub const COMMAND: &str = "command";
+
+/// Label an authz gate required.
+pub const EXPECTED: &str = "expected";
+
+/// Label the authz gate actually observed on the webview.
+pub const ACTUAL: &str = "actual";
+
+/// PTY identifier from `forge_term` (F-125).
+pub const TERMINAL_ID: &str = "terminal_id";
+
+/// LSP server id (F-353) or MCP server name. Both surfaces log under
+/// `server_id` so a downstream filter works uniformly.
+pub const SERVER_ID: &str = "server_id";
+
+/// `AgentInstanceId` for background-agent and orchestrator lifecycle logs.
+/// Matches the field `forge-agents` emits under `forge_agents::orchestrator`
+/// (F-373), so joining shell-side and daemon-side records is a single
+/// field match.
+pub const INSTANCE_ID: &str = "instance_id";
+
+/// `AgentDef.name` (e.g. `"writer"`, `"reviewer"`).
+pub const AGENT_NAME: &str = "agent_name";

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -41,6 +41,12 @@ async fn main() -> Result<()> {
         .filter(|s| !s.is_empty())
         .map(PathBuf::from)
         .map(|p| std::path::absolute(&p).unwrap_or(p));
+    // F-371: daemon startup banners stay on stderr rather than going through
+    // `tracing::info!`. The `forged` binary intentionally installs no
+    // subscriber (emission-only crate per the scope contract), so the only
+    // way these lines reach an operator today is direct stderr. The
+    // `eprintln_audit` integration test excludes `main.rs` for this reason;
+    // see the comment on `is_bin_main` there.
     eprintln!("forged: listening on {}", socket_path.display());
 
     // F-049: persistent-mode forged owns the pid-file lifecycle. Created
@@ -98,6 +104,9 @@ async fn main() -> Result<()> {
                 let url = forge_providers::ollama::validate_base_url(raw.as_deref(), allow_remote)?;
                 // Loudly surface the resolved URL so env-var redirection is
                 // visible in logs. Remote-opt-in is called out explicitly.
+                // F-371: `forged` installs no tracing subscriber (scope
+                // contract: emission-only), so these operator banners go
+                // directly to stderr. `eprintln_audit` exempts main.rs.
                 if allow_remote
                     && !matches!(
                         url.host_str(),
@@ -105,12 +114,12 @@ async fn main() -> Result<()> {
                     )
                 {
                     eprintln!(
-                        "forged: WARN ollama base_url = {} (remote endpoint enabled via {}=1)",
+                        "WARN ollama base_url targets a remote endpoint (allow-remote opt-in) base_url={} env_var={}",
                         url,
-                        forge_providers::ollama::ALLOW_REMOTE_ENV
+                        forge_providers::ollama::ALLOW_REMOTE_ENV,
                     );
                 } else {
-                    eprintln!("forged: ollama base_url = {}", url);
+                    eprintln!("ollama base_url {}", url);
                 }
                 let provider = Arc::new(OllamaProvider::new(url.as_str(), model));
                 serve_with_session(

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -79,7 +79,15 @@ async fn build_agent_runtime(workspace_path: Option<&Path>) -> Option<AgentRunti
     let defs = match defs {
         Ok(d) => d,
         Err(e) => {
-            eprintln!("agent runtime: skipping (load_agents failed: {e})");
+            // F-371: emission-only structured log; no subscriber is
+            // installed in the daemon binary, so a consumer (forge-ide or
+            // an operator piping through `tracing-subscriber`) attaches
+            // upstream.
+            tracing::warn!(
+                target: "forge_session::server",
+                error = %e,
+                "agent runtime: skipping (load_agents failed)",
+            );
             return None;
         }
     };
@@ -103,7 +111,11 @@ async fn build_agent_runtime(workspace_path: Option<&Path>) -> Option<AgentRunti
     {
         Ok(inst) => inst,
         Err(e) => {
-            eprintln!("agent runtime: session-root spawn failed: {e}");
+            tracing::warn!(
+                target: "forge_session::server",
+                error = %e,
+                "agent runtime: session-root spawn failed",
+            );
             return None;
         }
     };
@@ -206,13 +218,21 @@ async fn load_mcp_manager(workspace_path: Option<&Path>) -> Option<Arc<forge_mcp
                     merged
                 }
                 (Err(e), _) | (_, Err(e)) => {
-                    eprintln!("mcp: failed to load .mcp.json: {e:#}; continuing without MCP");
+                    tracing::warn!(
+                        target: "forge_session::mcp",
+                        error = %format!("{e:#}"),
+                        "failed to load .mcp.json; continuing without MCP",
+                    );
                     return None;
                 }
             },
             (None, Ok(ws_specs)) => ws_specs,
             (None, Err(e)) => {
-                eprintln!("mcp: failed to load workspace .mcp.json: {e:#}");
+                tracing::warn!(
+                    target: "forge_session::mcp",
+                    error = %format!("{e:#}"),
+                    "failed to load workspace .mcp.json",
+                );
                 return None;
             }
         },
@@ -220,7 +240,11 @@ async fn load_mcp_manager(workspace_path: Option<&Path>) -> Option<Arc<forge_mcp
             Some(home) => match forge_mcp::config::load_user_from(home) {
                 Ok(specs) => specs,
                 Err(e) => {
-                    eprintln!("mcp: failed to load user .mcp.json: {e:#}");
+                    tracing::warn!(
+                        target: "forge_session::mcp",
+                        error = %format!("{e:#}"),
+                        "failed to load user .mcp.json",
+                    );
                     return None;
                 }
             },
@@ -241,7 +265,12 @@ async fn load_mcp_manager(workspace_path: Option<&Path>) -> Option<Arc<forge_mcp
     let names: Vec<String> = mgr.list().await.into_iter().map(|s| s.name).collect();
     for name in names {
         if let Err(e) = mgr.start(&name).await {
-            eprintln!("mcp: start({name}) failed: {e:#}");
+            tracing::warn!(
+                target: "forge_session::mcp",
+                server_id = %name,
+                error = %format!("{e:#}"),
+                "mcp server start failed",
+            );
         }
     }
     Some(mgr)
@@ -575,7 +604,11 @@ pub async fn serve_with_session<P: Provider + 'static>(
             Ok(Some(content)) => Some(Arc::from(content)),
             Ok(None) => None,
             Err(e) => {
-                eprintln!("AGENTS.md: skipping injection: {e}");
+                tracing::warn!(
+                    target: "forge_session::server",
+                    error = %e,
+                    "AGENTS.md: skipping injection",
+                );
                 None
             }
         },
@@ -598,6 +631,12 @@ pub async fn serve_with_session<P: Provider + 'static>(
     // affects running tool-call dispatch immediately.
     let mcp = load_mcp_manager(workspace_path.as_deref()).await;
 
+    // F-371: build `session_id` before spawning the MCP state forwarder so
+    // the forwarder can carry it on every structured log line. Moved up
+    // from its original position near `socket_path`; other consumers
+    // (`agent_runtime`) still read it below through the `Arc` clone.
+    let session_id = Arc::new(session_id.unwrap_or_else(|| SessionId::new().to_string()));
+
     // F-155: fan out `McpManager::state_stream()` onto the session event
     // log. Every `Starting / Healthy / Degraded / Failed / Disabled`
     // transition becomes an `Event::McpState(McpStateEvent)` on the log,
@@ -607,12 +646,18 @@ pub async fn serve_with_session<P: Provider + 'static>(
     // and the session event log is the sole canonical destination.
     if let Some(mcp_mgr) = mcp.as_ref() {
         let session_for_mcp = Arc::clone(&session);
+        let session_id_for_mcp = Arc::clone(&session_id);
         let mut stream = mcp_mgr.state_stream();
         tokio::spawn(async move {
             use futures::StreamExt;
             while let Some(ev) = stream.next().await {
                 if let Err(e) = session_for_mcp.emit(forge_core::Event::McpState(ev)).await {
-                    eprintln!("mcp: state-event emit failed: {e}");
+                    tracing::error!(
+                        target: "forge_session::mcp",
+                        session_id = %session_id_for_mcp,
+                        error = %e,
+                        "mcp state-event emit failed",
+                    );
                 }
             }
         });
@@ -637,7 +682,8 @@ pub async fn serve_with_session<P: Provider + 'static>(
             .map(|w| w.display().to_string())
             .unwrap_or_default(),
     );
-    let session_id = Arc::new(session_id.unwrap_or_else(|| SessionId::new().to_string()));
+    // `session_id` already constructed above (F-371) so the MCP forwarder
+    // could attach it to its structured logs.
 
     let socket_path = Arc::new(path.to_path_buf());
     // Session-scoped registry of sandboxed child process groups. Killed on
@@ -729,6 +775,9 @@ pub async fn serve_with_session<P: Provider + 'static>(
                 let mcp = mcp.clone();
                 let agent_runtime = Arc::clone(&agent_runtime);
                 tokio::spawn(async move {
+                    // F-371: capture session_id for logging *before* the move
+                    // into `handle_connection` consumes the Arc.
+                    let session_id_for_log = Arc::clone(&session_id);
                     if let Err(e) = handle_connection(
                         stream,
                         session,
@@ -748,7 +797,12 @@ pub async fn serve_with_session<P: Provider + 'static>(
                     )
                     .await
                     {
-                        eprintln!("connection error: {e}");
+                        tracing::error!(
+                            target: "forge_session::server",
+                            session_id = %session_id_for_log,
+                            error = %e,
+                            "connection error",
+                        );
                     }
                 });
             }
@@ -891,7 +945,12 @@ async fn handle_connection<P: Provider + 'static>(
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Closed) => break,
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        eprintln!("subscriber dropped {n} events; closing connection");
+                        tracing::warn!(
+                            target: "forge_session::server",
+                            session_id = %session_id,
+                            dropped = n,
+                            "subscriber dropped events; closing connection",
+                        );
                         break;
                     }
                 }
@@ -911,6 +970,7 @@ async fn handle_connection<P: Provider + 'static>(
                         let agents_md = agents_md.clone();
                         let mcp = mcp.clone();
                         let agent_runtime = (*agent_runtime).clone();
+                        let session_id_for_turn = Arc::clone(&session_id);
                         tokio::spawn(async move {
                             let result = run_turn(
                                 Arc::clone(&session),
@@ -927,7 +987,12 @@ async fn handle_connection<P: Provider + 'static>(
                                 mcp,
                             ).await;
                             if let Err(e) = &result {
-                                eprintln!("turn error: {e}");
+                                tracing::warn!(
+                                    target: "forge_session::server",
+                                    session_id = %session_id_for_turn,
+                                    error = %e,
+                                    "turn error",
+                                );
                             }
                             if ephemeral {
                                 let reason = match result {
@@ -939,7 +1004,12 @@ async fn handle_connection<P: Provider + 'static>(
                                     reason,
                                     archived: false,
                                 }).await {
-                                    eprintln!("failed to emit SessionEnded: {e}");
+                                    tracing::error!(
+                                        target: "forge_session::server",
+                                        session_id = %session_id_for_turn,
+                                        error = %e,
+                                        "failed to emit SessionEnded",
+                                    );
                                 }
                             }
                         });
@@ -965,9 +1035,11 @@ async fn handle_connection<P: Provider + 'static>(
                             let decision = match parsed {
                                 Ok(scope) => ApprovalDecision::Approved(scope),
                                 Err(_) => {
-                                    eprintln!(
-                                        "ToolCallApproved: unknown scope {:?}, rejecting approval",
-                                        a.scope
+                                    tracing::warn!(
+                                        target: "forge_session::server",
+                                        session_id = %session_id,
+                                        scope = ?a.scope,
+                                        "ToolCallApproved: unknown scope, rejecting approval",
                                     );
                                     ApprovalDecision::Rejected
                                 }
@@ -1004,6 +1076,7 @@ async fn handle_connection<P: Provider + 'static>(
                         // one). No pre-validation here.
                         let target = MessageId::from_string(r.msg_id.clone());
                         let variant = r.variant;
+                        let session_id_for_rerun = Arc::clone(&session_id);
                         tokio::spawn(async move {
                             let orch = Orchestrator::new();
                             if let Err(e) = orch
@@ -1022,7 +1095,12 @@ async fn handle_connection<P: Provider + 'static>(
                                 )
                                 .await
                             {
-                                eprintln!("rerun error: {e}");
+                                tracing::warn!(
+                                    target: "forge_session::server",
+                                    session_id = %session_id_for_rerun,
+                                    error = %e,
+                                    "rerun error",
+                                );
                             }
                         });
                     }
@@ -1035,12 +1113,18 @@ async fn handle_connection<P: Provider + 'static>(
                         let session = Arc::clone(&session);
                         let parent = MessageId::from_string(s.parent_id.clone());
                         let variant_index = s.variant_index;
+                        let session_id_for_select = Arc::clone(&session_id);
                         tokio::spawn(async move {
                             let orch = Orchestrator::new();
                             if let Err(e) =
                                 orch.select_branch(session, parent, variant_index).await
                             {
-                                eprintln!("select_branch error: {e}");
+                                tracing::warn!(
+                                    target: "forge_session::server",
+                                    session_id = %session_id_for_select,
+                                    error = %e,
+                                    "select_branch error",
+                                );
                             }
                         });
                     }
@@ -1053,12 +1137,18 @@ async fn handle_connection<P: Provider + 'static>(
                         let session = Arc::clone(&session);
                         let parent = MessageId::from_string(d.parent_id.clone());
                         let variant_index = d.variant_index;
+                        let session_id_for_delete = Arc::clone(&session_id);
                         tokio::spawn(async move {
                             let orch = Orchestrator::new();
                             if let Err(e) =
                                 orch.delete_branch(session, parent, variant_index).await
                             {
-                                eprintln!("delete_branch error: {e}");
+                                tracing::warn!(
+                                    target: "forge_session::server",
+                                    session_id = %session_id_for_delete,
+                                    error = %e,
+                                    "delete_branch error",
+                                );
                             }
                         });
                     }
@@ -1076,7 +1166,12 @@ async fn handle_connection<P: Provider + 'static>(
                             forge_ipc::McpServersList { servers },
                         );
                         if let Err(e) = forge_ipc::write_frame(&mut writer, &frame).await {
-                            eprintln!("McpServersList write failed: {e}");
+                            tracing::error!(
+                                target: "forge_session::mcp",
+                                session_id = %session_id,
+                                error = %e,
+                                "McpServersList write failed",
+                            );
                             break;
                         }
                     }
@@ -1134,7 +1229,12 @@ async fn handle_connection<P: Provider + 'static>(
                             },
                         );
                         if let Err(e) = forge_ipc::write_frame(&mut writer, &frame).await {
-                            eprintln!("McpToggleResult write failed: {e}");
+                            tracing::error!(
+                                target: "forge_session::mcp",
+                                session_id = %session_id,
+                                error = %e,
+                                "McpToggleResult write failed",
+                            );
                             break;
                         }
                     }
@@ -1152,7 +1252,12 @@ async fn handle_connection<P: Provider + 'static>(
                         )
                         .await;
                         if let Err(e) = forge_ipc::write_frame(&mut writer, &frame).await {
-                            eprintln!("McpImportResult write failed: {e}");
+                            tracing::error!(
+                                target: "forge_session::mcp",
+                                session_id = %session_id,
+                                error = %e,
+                                "McpImportResult write failed",
+                            );
                             break;
                         }
                     }
@@ -1176,9 +1281,11 @@ async fn handle_connection<P: Provider + 'static>(
                         | IpcMessage::McpServersList(_)
                         | IpcMessage::McpToggleResult(_)
                         | IpcMessage::McpImportResult(_))) => {
-                        eprintln!(
-                            "session: ignoring unexpected client frame {}",
-                            ipc_message_kind(&other)
+                        tracing::warn!(
+                            target: "forge_session::server",
+                            session_id = %session_id,
+                            frame = ipc_message_kind(&other),
+                            "ignoring unexpected client frame",
                         );
                     }
                     None => break,
@@ -1199,7 +1306,12 @@ async fn handle_connection<P: Provider + 'static>(
             if let Err(e) =
                 archive_or_purge(session_dir, SessionPersistence::Ephemeral, &socket_path).await
             {
-                eprintln!("archive_or_purge failed: {e}");
+                tracing::error!(
+                    target: "forge_session::server",
+                    session_id = %session_id,
+                    error = %e,
+                    "archive_or_purge failed",
+                );
             }
         }
     }

--- a/crates/forge-session/tests/bg_agents_tracing.rs
+++ b/crates/forge-session/tests/bg_agents_tracing.rs
@@ -1,0 +1,180 @@
+//! F-371: structured tracing across `BackgroundAgentRegistry` lifecycle.
+//!
+//! Pins target + field shape for each emission site so a future rename or
+//! a silent regression breaks the test instead of operator log filters.
+//! Pattern mirrors `forge-agents/tests/orchestrator.rs` (F-373).
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use forge_agents::{AgentDef, Isolation, Orchestrator};
+use forge_session::BackgroundAgentRegistry;
+
+fn def(name: &str) -> AgentDef {
+    AgentDef {
+        name: name.to_string(),
+        description: None,
+        body: String::new(),
+        allowed_paths: vec![],
+        isolation: Isolation::Process,
+    }
+}
+
+fn registry() -> BackgroundAgentRegistry {
+    let orch = Arc::new(Orchestrator::new());
+    let defs = Arc::new(vec![def("writer")]);
+    BackgroundAgentRegistry::new(orch, defs)
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn start_emits_lifecycle_log_with_instance_id_and_agent_name() {
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let reg = registry();
+    let id = reg.start("writer", Arc::from("go")).await.unwrap();
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("forge_session::bg_agents"),
+        "expected target forge_session::bg_agents, got logs: {logs}"
+    );
+    assert!(
+        logs.contains(&format!("instance_id={id}")),
+        "expected instance_id field, got logs: {logs}"
+    );
+    assert!(
+        logs.contains("agent_name=\"writer\"") || logs.contains("agent_name=writer"),
+        "expected agent_name field, got logs: {logs}"
+    );
+    assert!(
+        logs.contains("started"),
+        "expected lifecycle marker 'started', got logs: {logs}"
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn unknown_agent_emits_warn_with_agent_name() {
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let reg = registry();
+    let _ = reg.start("missing-agent", Arc::from("p")).await;
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("forge_session::bg_agents"),
+        "expected target forge_session::bg_agents, got logs: {logs}"
+    );
+    assert!(
+        logs.contains("WARN"),
+        "expected WARN level on unknown-agent rejection, got: {logs}"
+    );
+    assert!(
+        logs.contains("missing-agent"),
+        "expected the unknown agent name in the log, got: {logs}"
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn completion_event_emits_lifecycle_log() {
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let reg = registry();
+    let id = reg.start("writer", Arc::from("p")).await.unwrap();
+
+    // Drain any spawn-side logs so the next capture is the completion path only.
+    let _ = common::drain_capture();
+
+    reg.orchestrator().stop(&id).await.unwrap();
+
+    // Give the forwarder task a tick to receive the terminal event and emit.
+    let mut logs = String::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let snapshot = common::drain_capture();
+        logs.push_str(&snapshot);
+        if logs.contains("completed") && logs.contains(&format!("instance_id={id}")) {
+            break;
+        }
+    }
+
+    assert!(
+        logs.contains("forge_session::bg_agents"),
+        "expected target forge_session::bg_agents, got: {logs}"
+    );
+    assert!(
+        logs.contains(&format!("instance_id={id}")),
+        "expected instance_id field on completion log, got: {logs}"
+    );
+    assert!(
+        logs.contains("completed"),
+        "expected lifecycle marker 'completed', got: {logs}"
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn failure_path_emits_warn_lifecycle_log() {
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let reg = registry();
+    let id = reg.start("writer", Arc::from("p")).await.unwrap();
+
+    let _ = common::drain_capture();
+    reg.orchestrator()
+        .fail(&id, "boom".to_string())
+        .await
+        .unwrap();
+
+    let mut logs = String::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let snapshot = common::drain_capture();
+        logs.push_str(&snapshot);
+        if logs.contains("failed") && logs.contains(&format!("instance_id={id}")) {
+            break;
+        }
+    }
+
+    assert!(
+        logs.contains("forge_session::bg_agents"),
+        "expected target forge_session::bg_agents, got: {logs}"
+    );
+    assert!(
+        logs.contains("WARN"),
+        "expected WARN level on the failure log, got: {logs}"
+    );
+    assert!(
+        logs.contains("failed"),
+        "expected lifecycle marker 'failed', got: {logs}"
+    );
+    assert!(
+        logs.contains(&format!("instance_id={id}")),
+        "expected instance_id field on failure log, got: {logs}"
+    );
+}
+
+// Source-level eprintln! audit lives in `eprintln_audit.rs` so it can cover
+// every file in `src/` (server.rs, bg_agents.rs, …) behind one assertion.

--- a/crates/forge-session/tests/common/mod.rs
+++ b/crates/forge-session/tests/common/mod.rs
@@ -1,0 +1,58 @@
+//! F-371: shared tracing-capture subscriber for `forge-session` integration tests.
+//!
+//! Mirrors `forge-shell/tests/common/mod.rs` — install once, drain on demand,
+//! serialize across capture-reading tests with the static lock.
+
+use std::{
+    io,
+    sync::{Mutex as StdMutex, Once, OnceLock},
+};
+
+use tracing_subscriber::fmt::MakeWriter;
+
+fn capture_buf() -> &'static StdMutex<Vec<u8>> {
+    static BUF: OnceLock<StdMutex<Vec<u8>>> = OnceLock::new();
+    BUF.get_or_init(|| StdMutex::new(Vec::new()))
+}
+
+pub fn capture_test_lock() -> &'static StdMutex<()> {
+    static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| StdMutex::new(()))
+}
+
+pub struct CaptureWriter;
+impl io::Write for CaptureWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        capture_buf().lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+impl<'a> MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        CaptureWriter
+    }
+}
+
+pub fn install_capture_subscriber() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_ansi(false)
+            .with_target(true)
+            .with_writer(CaptureWriter)
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).expect("install capture subscriber");
+    });
+}
+
+pub fn drain_capture() -> String {
+    let mut buf = capture_buf().lock().unwrap();
+    let out = String::from_utf8(buf.clone()).expect("utf-8 logs");
+    buf.clear();
+    out
+}

--- a/crates/forge-session/tests/eprintln_audit.rs
+++ b/crates/forge-session/tests/eprintln_audit.rs
@@ -1,0 +1,87 @@
+//! F-371: shipped forge-session code must not `eprintln!`.
+//!
+//! Source-level audit so a post-F-371 regression (someone reintroduces
+//! ad-hoc stderr in `server.rs`, `bg_agents.rs`, etc.) fails CI instead of
+//! silently routing around the structured-logging contract. Test-only
+//! `eprintln!` inside `#[cfg(test)] mod …` blocks is tolerated.
+//!
+//! `main.rs` is exempted: `forged` intentionally installs no tracing
+//! subscriber (scope contract — emission-only crate), so startup banners
+//! and operator-facing URL disclosure stay on stderr. Runtime surface
+//! (`server.rs`, `mcp.rs`, `bg_agents.rs`) is fully instrumented.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Walk every `.rs` file under `src/` and assert no top-level `eprintln!`.
+/// Lines inside `#[cfg(test)] mod tests { … }` blocks are allowed — they
+/// only compile under `cargo test`, not in the shipped binary.
+#[test]
+fn no_eprintln_in_shipped_session_sources() {
+    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let offenders = collect_eprintln_offenders(&src_dir);
+    assert!(
+        offenders.is_empty(),
+        "eprintln! found in shipped forge-session surface:\n{}",
+        offenders.join("\n")
+    );
+}
+
+/// `main.rs` hosts the daemon startup banners and the ollama base_url
+/// disclosure. `forged` installs no tracing subscriber (emission-only
+/// scope contract), so these operator-facing lines must reach stderr
+/// directly — the `ollama_url_validation` integration tests scrape for
+/// them. Runtime surface remains audited.
+fn is_bin_main(path: &std::path::Path) -> bool {
+    path.file_name().and_then(|n| n.to_str()) == Some("main.rs")
+}
+
+fn collect_eprintln_offenders(dir: &std::path::Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let entries = fs::read_dir(dir).expect("read src dir");
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(collect_eprintln_offenders(&path));
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        if is_bin_main(&path) {
+            continue;
+        }
+        let src = fs::read_to_string(&path).expect("read rs file");
+        let mut in_cfg_test = false;
+        let mut depth: i32 = 0;
+        for (idx, line) in src.lines().enumerate() {
+            // Detect `#[cfg(test)]` and `#[cfg(all(test, …))]` attributes that
+            // gate the immediately-following item (typically `mod tests { … }`).
+            let trimmed = line.trim_start();
+            if !in_cfg_test
+                && (trimmed.starts_with("#[cfg(test)]")
+                    || (trimmed.starts_with("#[cfg(all(") && trimmed.contains("test")))
+            {
+                in_cfg_test = true;
+                depth = 0;
+                continue;
+            }
+            if in_cfg_test {
+                let opens = line.matches('{').count() as i32;
+                let closes = line.matches('}').count() as i32;
+                depth += opens;
+                depth -= closes;
+                // The first `{` enters the gated item; once depth returns to 0
+                // after we've entered (at least one `{` seen) we exit the block.
+                if depth <= 0 && opens > 0 {
+                    in_cfg_test = false;
+                }
+                continue;
+            }
+            if line.contains("eprintln!") {
+                out.push(format!("{}:{}: {}", path.display(), idx + 1, line.trim()));
+            }
+        }
+    }
+    out
+}

--- a/crates/forge-shell/Cargo.toml
+++ b/crates/forge-shell/Cargo.toml
@@ -60,6 +60,10 @@ tokio = { version = "1", features = ["fs", "net", "io-util", "sync", "time", "rt
 # `settings.toml` and round-trips through the canonical serializer to land
 # on disk.
 toml = "0.8"
+# F-371: structured tracing across authz rejections, emit failures, and
+# background-agent lifecycle transitions. No subscriber is installed in
+# production; emission sites only.
+tracing = "0.1"
 ts-rs = "12"
 
 [dev-dependencies]
@@ -67,6 +71,9 @@ ts-rs = "12"
 # own a `BackgroundAgentRegistry` per session.
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "net", "time"] }
+# F-371: capture subscriber in integration tests pins target + field shape
+# for each tracing emission site.
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 wiremock = "0.6"
 
 [features]

--- a/crates/forge-shell/src/dashboard.rs
+++ b/crates/forge-shell/src/dashboard.rs
@@ -155,7 +155,7 @@ pub async fn provider_status<R: tauri::Runtime>(
     webview: tauri::Webview<R>,
     cache: tauri::State<'_, ProviderStatusCache>,
 ) -> std::result::Result<ProviderStatus, String> {
-    crate::ipc::require_window_label(&webview, "dashboard")?;
+    crate::ipc::require_window_label(&webview, "dashboard", "provider_status")?;
     Ok(cache.get_or_probe(DEFAULT_OLLAMA_URL, PROBE_TIMEOUT).await)
 }
 

--- a/crates/forge-shell/src/dashboard_sessions.rs
+++ b/crates/forge-shell/src/dashboard_sessions.rs
@@ -358,7 +358,7 @@ mod session_id_validation_tests {
 pub async fn session_list<R: tauri::Runtime>(
     webview: tauri::Webview<R>,
 ) -> Result<Vec<SessionSummary>, String> {
-    crate::ipc::require_window_label(&webview, "dashboard")?;
+    crate::ipc::require_window_label(&webview, "dashboard", "session_list")?;
     collect_sessions(&default_workspaces_toml(), &UdsPinger)
         .await
         .map_err(|e| e.to_string())
@@ -378,7 +378,7 @@ pub async fn open_session<R: tauri::Runtime>(
     webview: tauri::Webview<R>,
     id: String,
 ) -> Result<(), String> {
-    crate::ipc::require_window_label(&webview, "dashboard")?;
+    crate::ipc::require_window_label(&webview, "dashboard", "open_session")?;
     if !is_valid_session_id(&id) {
         return Err(INVALID_SESSION_ID_ERROR.to_string());
     }

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -105,15 +105,48 @@ fn payload_too_large(field: &str, limit_bytes: usize) -> String {
 /// Assert the calling webview's label equals `expected`. Used at the top of
 /// every session/dashboard `#[tauri::command]` to reject cross-window invokes
 /// before the bridge sees the frame.
+///
+/// F-371: on rejection emits a `warn!` under target `forge_shell::ipc::authz`
+/// with structured `expected`, `actual`, `command` fields so authz refusals
+/// leave an audit trail instead of disappearing into silence. `command` is
+/// the Tauri command name — each call site passes its own literal so the
+/// filter `command == "session_send_message"` works reliably.
 pub(crate) fn require_window_label<R: Runtime>(
     webview: &Webview<R>,
     expected: &str,
+    command: &'static str,
 ) -> Result<(), String> {
-    if webview.label() == expected {
-        Ok(())
-    } else {
-        Err(LABEL_MISMATCH_ERROR.to_string())
+    authz_check(webview.label(), expected, command)
+}
+
+/// Bridge between the `Runtime`-generic `require_window_label` and a plain
+/// string-based test harness. Keeps the emission logic identical across
+/// production and tests — the only thing the generic helper does is
+/// extract `webview.label()`.
+fn authz_check(actual: &str, expected: &str, command: &'static str) -> Result<(), String> {
+    if actual == expected {
+        return Ok(());
     }
+    tracing::warn!(
+        target: "forge_shell::ipc::authz",
+        expected = %expected,
+        actual = %actual,
+        command = %command,
+        "authz rejection: window label mismatch",
+    );
+    Err(LABEL_MISMATCH_ERROR.to_string())
+}
+
+/// F-371 test seam: drives the same authz emission logic as
+/// [`require_window_label`] without needing a live Tauri `Webview`. Public
+/// so integration tests under `tests/` can pin the schema.
+#[doc(hidden)]
+pub fn require_window_label_for_test(
+    actual: &str,
+    expected: &str,
+    command: &'static str,
+) -> Result<(), String> {
+    authz_check(actual, expected, command)
 }
 
 /// F-068 / L4 (T7): reject payloads whose byte length exceeds `limit_bytes`.
@@ -215,7 +248,15 @@ impl<R: Runtime> EventSink for AppHandleSink<R> {
         // redirect delivery.
         let target = EventTarget::webview_window(format!("session-{}", self.session_id));
         if let Err(e) = self.app.emit_to(target, "session:event", payload) {
-            eprintln!("session:event emit failed: {e}");
+            // F-371: structured emit-failure log with the session id so an
+            // operator can correlate dropped events to a specific window.
+            tracing::error!(
+                target: "forge_shell::ipc",
+                session_id = %self.session_id,
+                event = "session:event",
+                error = %e,
+                "Tauri emit failed",
+            );
         }
     }
 }
@@ -237,7 +278,7 @@ pub async fn session_hello<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<HelloAck, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "session_hello")?;
     // F-052 (H11 / T7): the socket path is never taken from the invoke
     // payload — a webview cannot redirect this connection to an arbitrary
     // UDS. Production always resolves through `default_socket_path`; tests
@@ -261,7 +302,11 @@ pub async fn session_subscribe<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "session_subscribe",
+    )?;
     let sink: Arc<dyn EventSink> = Arc::new(AppHandleSink {
         app,
         session_id: session_id.clone(),
@@ -280,7 +325,11 @@ pub async fn session_send_message<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "session_send_message",
+    )?;
     // F-068 / L4 (T7): bound `text` before the bridge allocates a frame or
     // the provider is billed. Runs after authz so unauthorized windows
     // don't learn the cap value.
@@ -305,7 +354,7 @@ pub async fn session_cancel<R: Runtime>(
     webview: Webview<R>,
     _state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "session_cancel")?;
     Ok(())
 }
 
@@ -317,7 +366,11 @@ pub async fn session_approve_tool<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "session_approve_tool",
+    )?;
     // F-068 / L4 (T7): tool_call_id is a short opaque handle; bound it here.
     // F-069 / L5 (T7): `scope` is typed as `forge_core::ApprovalScope` — serde
     // rejects any non-variant string at Tauri arg-deserialization (before this
@@ -343,7 +396,7 @@ pub async fn rerun_message<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "rerun_message")?;
     // F-068 / L4: bound `msg_id` before the bridge allocates a frame.
     require_size("msg_id", &msg_id, MAX_MESSAGE_ID_BYTES)?;
     state
@@ -370,7 +423,7 @@ pub async fn select_branch<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "select_branch")?;
     require_size("parent_id", &parent_id, MAX_MESSAGE_ID_BYTES)?;
     state
         .bridge
@@ -387,7 +440,11 @@ pub async fn session_reject_tool<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "session_reject_tool",
+    )?;
     // F-068 / L4 (T7): bound tool_call_id and — only when present — reason.
     // `None` reason is the common case and must skip the size check.
     require_size("tool_call_id", &tool_call_id, MAX_TOOL_CALL_ID_BYTES)?;
@@ -614,7 +671,7 @@ pub async fn get_persistent_approvals<R: Runtime>(
     // default capability glob allows `session-*` and `dashboard`; per-command
     // label authz would add nothing here (the data is user-scoped, not
     // per-session), so we accept any window that cleared the ACL.
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "get_persistent_approvals")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
 
     let workspace_cfg = load_workspace_config(std::path::Path::new(&workspace_root))
@@ -663,7 +720,7 @@ pub async fn save_approval<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "save_approval")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     require_size("scope_key", &entry.scope_key, MAX_SCOPE_KEY_BYTES)?;
     let total = entry.scope_key.len() + entry.tool_name.len() + entry.label.len();
@@ -708,7 +765,7 @@ pub async fn remove_approval<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "remove_approval")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     require_size("scope_key", &scope_key, MAX_SCOPE_KEY_BYTES)?;
 
@@ -765,15 +822,49 @@ pub(crate) fn require_window_label_in<R: Runtime>(
     webview: &Webview<R>,
     exact: &[&str],
     allow_session_prefix: bool,
+    command: &'static str,
 ) -> Result<(), String> {
-    let label = webview.label();
-    if exact.contains(&label) {
+    authz_check_in(webview.label(), exact, allow_session_prefix, command)
+}
+
+fn authz_check_in(
+    actual: &str,
+    exact: &[&str],
+    allow_session_prefix: bool,
+    command: &'static str,
+) -> Result<(), String> {
+    if exact.contains(&actual) {
         return Ok(());
     }
-    if allow_session_prefix && label.starts_with("session-") {
+    if allow_session_prefix && actual.starts_with("session-") {
         return Ok(());
     }
+    // F-371: render the accept list so operators can diagnose which command
+    // expected which set without chasing the literal in source.
+    let expected = if allow_session_prefix {
+        format!("{:?} or session-*", exact)
+    } else {
+        format!("{:?}", exact)
+    };
+    tracing::warn!(
+        target: "forge_shell::ipc::authz",
+        expected = %expected,
+        actual = %actual,
+        command = %command,
+        "authz rejection: window label mismatch",
+    );
     Err(LABEL_MISMATCH_ERROR.to_string())
+}
+
+/// F-371 test seam for `require_window_label_in`.
+#[doc(hidden)]
+pub fn require_window_label_in_for_test(
+    actual: &str,
+    exact: &[&str],
+    allow_session_prefix: bool,
+    command: &'static str,
+) -> Result<(), String> {
+    authz_check_in(actual, exact, allow_session_prefix, command)
 }
 
 // ---------------------------------------------------------------------------
@@ -948,7 +1039,17 @@ fn spawn_event_forwarder<R: Runtime>(
                     };
                     let target = EventTarget::webview_window(&owner_label);
                     if let Err(e) = app.emit_to(target, TERMINAL_BYTES_EVENT, payload) {
-                        eprintln!("terminal:bytes emit failed: {e}");
+                        // F-371: structured emit-failure with window + terminal
+                        // ids so one stuck PTY can be traced without grep on
+                        // a timestamp.
+                        tracing::error!(
+                            target: "forge_shell::ipc",
+                            window_label = %owner_label,
+                            terminal_id = %terminal_id,
+                            event = "terminal:bytes",
+                            error = %e,
+                            "Tauri emit failed",
+                        );
                     }
                 }
                 TerminalEvent::Exit(status) => {
@@ -959,7 +1060,14 @@ fn spawn_event_forwarder<R: Runtime>(
                     };
                     let target = EventTarget::webview_window(&owner_label);
                     if let Err(e) = app.emit_to(target, TERMINAL_EXIT_EVENT, payload) {
-                        eprintln!("terminal:exit emit failed: {e}");
+                        tracing::error!(
+                            target: "forge_shell::ipc",
+                            window_label = %owner_label,
+                            terminal_id = %terminal_id,
+                            event = "terminal:exit",
+                            error = %e,
+                            "Tauri emit failed",
+                        );
                     }
                 }
             }
@@ -986,7 +1094,7 @@ pub async fn terminal_spawn<R: Runtime>(
 ) -> Result<(), String> {
     // F-125: terminals are session-scoped. Dashboard and any other label is
     // rejected. This mirrors the chat-pane authz shape on the terminal axis.
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "terminal_spawn")?;
 
     require_size("cwd", &args.cwd, MAX_TERMINAL_CWD_BYTES)?;
     if let Some(shell) = args.shell.as_deref() {
@@ -1040,7 +1148,7 @@ pub async fn terminal_write<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, TerminalState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "terminal_write")?;
 
     if data.len() > MAX_TERMINAL_WRITE_BYTES {
         return Err(payload_too_large("data", MAX_TERMINAL_WRITE_BYTES));
@@ -1061,7 +1169,7 @@ pub async fn terminal_resize<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, TerminalState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "terminal_resize")?;
     let caller_label = webview.label().to_string();
     state.with_owned_session_mut(&terminal_id, &caller_label, |session| {
         session.resize(cols, rows).map_err(|e| e.to_string())
@@ -1076,7 +1184,7 @@ pub async fn terminal_kill<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, TerminalState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "terminal_kill")?;
     let caller_label = webview.label().to_string();
     // Removing the entry drops its `TerminalSession` — forge-term's `impl Drop`
     // SIGTERMs the child and joins the reaper thread, which emits the final
@@ -1287,7 +1395,7 @@ pub async fn read_layouts<R: Runtime>(
     workspace_root: String,
     webview: Webview<R>,
 ) -> Result<Layouts, String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "read_layouts")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     Ok(load_layouts_from_disk(std::path::Path::new(&workspace_root)).await)
 }
@@ -1309,7 +1417,7 @@ pub async fn write_layouts<R: Runtime>(
     layouts: Layouts,
     webview: Webview<R>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "write_layouts")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
 
     let forge_dir = std::path::Path::new(&workspace_root).join(".forge");
@@ -1461,7 +1569,7 @@ pub async fn read_file<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<FileContent, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "read_file")?;
     require_size("path", &path, MAX_FS_PATH_BYTES)?;
 
     let workspace = cached_workspace_root(&state, &session_id).await?;
@@ -1484,7 +1592,7 @@ pub async fn write_file<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "write_file")?;
     require_size("path", &path, MAX_FS_PATH_BYTES)?;
     // Pre-check before `forge-fs` copies the buffer into the atomic-write
     // temp file. `forge-fs` also enforces; belt-and-braces keeps the error
@@ -1514,7 +1622,7 @@ pub async fn tree<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<TreeNodeDto, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "tree")?;
     require_size("root", &root, MAX_FS_PATH_BYTES)?;
 
     let workspace = cached_workspace_root(&state, &session_id).await?;
@@ -1704,7 +1812,17 @@ fn spawn_lsp_forwarder<R: Runtime>(
                 };
                 let target = EventTarget::webview_window(&owner_label);
                 if let Err(e) = app.emit_to(target, LSP_MESSAGE_EVENT, payload) {
-                    eprintln!("lsp_message emit failed: {e}");
+                    // F-371: structured emit-failure with window + server
+                    // ids so a webview-gone race against a live LSP is
+                    // visible in the log without parsing free-form strings.
+                    tracing::error!(
+                        target: "forge_shell::ipc",
+                        window_label = %owner_label,
+                        server_id = %server_id,
+                        event = "lsp_message",
+                        error = %e,
+                        "Tauri emit failed",
+                    );
                 }
             }
             // `Exited` / `GaveUp` events are observable only server-side
@@ -1742,7 +1860,7 @@ pub async fn lsp_start<R: Runtime>(
 ) -> Result<(), String> {
     // LSP servers are session-scoped. Dashboard and any other label is
     // rejected — mirrors the terminal authz shape on the LSP axis.
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "lsp_start")?;
 
     require_size("server", &args.server, MAX_LSP_SERVER_ID_BYTES)?;
 
@@ -1809,7 +1927,7 @@ pub async fn lsp_stop<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, LspState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "lsp_stop")?;
     require_size("server", &server, MAX_LSP_SERVER_ID_BYTES)?;
     let caller_label = webview.label().to_string();
     let entry = state.remove_owned_by(&server, &caller_label)?;
@@ -1828,7 +1946,7 @@ pub async fn lsp_send<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, LspState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "lsp_send")?;
     require_size("server", &server, MAX_LSP_SERVER_ID_BYTES)?;
     // Rough byte cap: serialize once and check length. Avoids building a
     // serialized frame twice (send path also serializes) by short-circuiting
@@ -2129,7 +2247,11 @@ pub async fn start_background_agent<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<String, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "start_background_agent",
+    )?;
     require_size("agent_name", &agent_name, MAX_AGENT_NAME_BYTES)?;
     require_size("prompt", &prompt, MAX_BG_PROMPT_BYTES)?;
 
@@ -2155,7 +2277,11 @@ pub async fn promote_background_agent<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "promote_background_agent",
+    )?;
     require_size("instance_id", &instance_id, MAX_AGENT_INSTANCE_ID_BYTES)?;
 
     let entry = resolve_bg_session(&app, &state, &bg_state, &session_id).await?;
@@ -2173,7 +2299,11 @@ pub async fn list_background_agents<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<Vec<BgAgentSummary>, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "list_background_agents",
+    )?;
 
     let entry = resolve_bg_session(&app, &state, &bg_state, &session_id).await?;
     let rows = entry.registry.list().await;
@@ -2214,7 +2344,7 @@ pub async fn rename_path<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "rename_path")?;
     require_size("from", &from, MAX_FS_PATH_BYTES)?;
     require_size("to", &to, MAX_FS_PATH_BYTES)?;
 
@@ -2235,7 +2365,7 @@ pub async fn delete_path<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "delete_path")?;
     require_size("path", &path, MAX_FS_PATH_BYTES)?;
 
     let workspace = cached_workspace_root(&state, &session_id).await?;
@@ -2306,7 +2436,7 @@ pub async fn get_settings<R: Runtime>(
 ) -> Result<AppSettings, String> {
     // Same authz model as F-036's approval commands: dashboard + any
     // session-* window may read.
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "get_settings")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
 
     let user_dir = resolve_user_config_dir(&state);
@@ -2324,7 +2454,7 @@ pub async fn set_setting<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "set_setting")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     require_size("key", &key, MAX_SETTING_KEY_BYTES)?;
 
@@ -2413,7 +2543,11 @@ pub async fn stop_background_agent<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "stop_background_agent",
+    )?;
     require_size("instance_id", &instance_id, MAX_AGENT_INSTANCE_ID_BYTES)?;
 
     let entry = resolve_bg_session(&app, &state, &bg_state, &session_id).await?;
@@ -2481,7 +2615,7 @@ pub async fn delete_branch<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "delete_branch")?;
     require_size("parent_id", &parent_id, MAX_MESSAGE_ID_BYTES)?;
     state
         .bridge
@@ -2550,7 +2684,11 @@ pub async fn list_mcp_servers<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<Vec<forge_ipc::McpServerInfo>, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "list_mcp_servers",
+    )?;
     state
         .bridge
         .list_mcp_servers(&session_id)
@@ -2577,7 +2715,11 @@ pub async fn toggle_mcp_server<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<forge_ipc::McpToggleResult, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "toggle_mcp_server",
+    )?;
     require_size("name", &name, MAX_MCP_SERVER_NAME_BYTES)?;
     state
         .bridge
@@ -2603,7 +2745,11 @@ pub async fn import_mcp_config<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<forge_ipc::McpImportResult, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "import_mcp_config",
+    )?;
     require_size("source", &source, MAX_MCP_SLUG_BYTES)?;
     state
         .bridge

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -1977,7 +1977,7 @@ pub async fn lsp_list<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, LspState>,
 ) -> Result<Vec<LspServerInfo>, String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "lsp_list")?;
     let caller_label = webview.label().to_string();
     let handles = state.list_owned_state_handles(&caller_label);
     let mut out = Vec::with_capacity(handles.len());

--- a/crates/forge-shell/src/lib.rs
+++ b/crates/forge-shell/src/lib.rs
@@ -21,7 +21,7 @@
 //! # Structured tracing (F-371)
 //!
 //! All `tracing` emissions from this crate — authz rejections in
-//! [`ipc::require_window_label`] / [`ipc::require_window_label_in`], Tauri
+//! `ipc::require_window_label` / `ipc::require_window_label_in`, Tauri
 //! emit-target failures in [`ipc`], and the terminal / LSP forwarders —
 //! use the field-name and target schema pinned in
 //! [`forge_session::log_fields`]. That module is the authoritative

--- a/crates/forge-shell/src/lib.rs
+++ b/crates/forge-shell/src/lib.rs
@@ -17,6 +17,16 @@
 //! `window_manager` is gated behind the `webview` feature (on by default) so
 //! that `window_spec` can be unit-tested on hosts without WebKitGTK via
 //! `cargo test -p forge-shell --no-default-features`.
+//!
+//! # Structured tracing (F-371)
+//!
+//! All `tracing` emissions from this crate — authz rejections in
+//! [`ipc::require_window_label`] / [`ipc::require_window_label_in`], Tauri
+//! emit-target failures in [`ipc`], and the terminal / LSP forwarders —
+//! use the field-name and target schema pinned in
+//! [`forge_session::log_fields`]. That module is the authoritative
+//! reference for operators writing log filters; do not introduce new
+//! ad-hoc field names at emission sites.
 
 pub mod bridge;
 pub mod dashboard;

--- a/crates/forge-shell/tests/common/mod.rs
+++ b/crates/forge-shell/tests/common/mod.rs
@@ -1,0 +1,61 @@
+//! F-371: shared tracing-capture subscriber for `forge-shell` integration tests.
+//!
+//! Pattern borrowed from `forge-agents/tests/common/mod.rs` (F-373) — install
+//! a fmt subscriber once, drain the buffer into a `String`, and scan for the
+//! target/field shape a given test wants to pin.
+
+use std::{
+    io,
+    sync::{Mutex as StdMutex, Once, OnceLock},
+};
+
+use tracing_subscriber::fmt::MakeWriter;
+
+fn capture_buf() -> &'static StdMutex<Vec<u8>> {
+    static BUF: OnceLock<StdMutex<Vec<u8>>> = OnceLock::new();
+    BUF.get_or_init(|| StdMutex::new(Vec::new()))
+}
+
+/// Lock held for the duration of a capture-reading test. Other tracing
+/// tests block on this so the drained buffer is attributable to one test.
+pub fn capture_test_lock() -> &'static StdMutex<()> {
+    static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| StdMutex::new(()))
+}
+
+pub struct CaptureWriter;
+impl io::Write for CaptureWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        capture_buf().lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+impl<'a> MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        CaptureWriter
+    }
+}
+
+pub fn install_capture_subscriber() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_ansi(false)
+            .with_target(true)
+            .with_writer(CaptureWriter)
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).expect("install capture subscriber");
+    });
+}
+
+pub fn drain_capture() -> String {
+    let mut buf = capture_buf().lock().unwrap();
+    let out = String::from_utf8(buf.clone()).expect("utf-8 logs");
+    buf.clear();
+    out
+}

--- a/crates/forge-shell/tests/eprintln_audit.rs
+++ b/crates/forge-shell/tests/eprintln_audit.rs
@@ -1,0 +1,73 @@
+//! F-371: shipped forge-shell code must not `eprintln!`.
+//!
+//! Source-level audit so a post-F-371 regression (someone reintroduces
+//! ad-hoc stderr in `ipc.rs`, `bridge.rs`, etc.) fails CI instead of
+//! silently routing around the structured-logging contract. `#[cfg(test)]
+//! mod …` blocks are excluded.
+
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn no_eprintln_in_shipped_shell_sources() {
+    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let offenders = collect_eprintln_offenders(&src_dir);
+    assert!(
+        offenders.is_empty(),
+        "eprintln! found in shipped forge-shell surface:\n{}",
+        offenders.join("\n")
+    );
+}
+
+/// `main.rs` hosts a single no-webview `std::process::exit(1)` banner that
+/// fires before a `tracing` subscriber could ever run; keep it excluded so
+/// the audit targets the runtime surface, not fail-fast CLI bootstrap.
+fn is_bin_main(path: &std::path::Path) -> bool {
+    path.file_name().and_then(|n| n.to_str()) == Some("main.rs")
+}
+
+fn collect_eprintln_offenders(dir: &std::path::Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let entries = fs::read_dir(dir).expect("read src dir");
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(collect_eprintln_offenders(&path));
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        if is_bin_main(&path) {
+            continue;
+        }
+        let src = fs::read_to_string(&path).expect("read rs file");
+        let mut in_cfg_test = false;
+        let mut depth: i32 = 0;
+        for (idx, line) in src.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if !in_cfg_test
+                && (trimmed.starts_with("#[cfg(test)]")
+                    || (trimmed.starts_with("#[cfg(all(") && trimmed.contains("test")))
+            {
+                in_cfg_test = true;
+                depth = 0;
+                continue;
+            }
+            if in_cfg_test {
+                let opens = line.matches('{').count() as i32;
+                let closes = line.matches('}').count() as i32;
+                depth += opens;
+                depth -= closes;
+                if depth <= 0 && opens > 0 {
+                    in_cfg_test = false;
+                }
+                continue;
+            }
+            if line.contains("eprintln!") {
+                out.push(format!("{}:{}: {}", path.display(), idx + 1, line.trim()));
+            }
+        }
+    }
+    out
+}

--- a/crates/forge-shell/tests/ipc_authz_tracing.rs
+++ b/crates/forge-shell/tests/ipc_authz_tracing.rs
@@ -1,0 +1,99 @@
+//! F-371: authz-rejection tracing.
+//!
+//! Every `require_window_label*` rejection must emit a `warn!` with target
+//! `forge_shell::ipc::authz` and structured `expected`, `actual`, `command`
+//! fields. Pins both the negative path of the helpers and the schema, so a
+//! rename of any field name breaks the test instead of silently diverging.
+
+#![cfg(feature = "webview")]
+
+mod common;
+
+use forge_shell::ipc::{require_window_label_for_test, require_window_label_in_for_test};
+
+#[test]
+fn require_window_label_rejection_emits_warn_with_expected_actual_command() {
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let err = require_window_label_for_test(
+        "dashboard",   // actual label on the webview
+        "session-abc", // required label
+        "session_send_message",
+    )
+    .expect_err("different label must reject");
+    assert!(err.contains("forbidden"));
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("forge_shell::ipc::authz"),
+        "expected authz target, got: {logs}"
+    );
+    assert!(logs.contains("WARN"), "expected WARN level, got: {logs}");
+    assert!(
+        logs.contains("expected=session-abc"),
+        "expected field missing, got: {logs}"
+    );
+    assert!(
+        logs.contains("actual=dashboard"),
+        "actual field missing, got: {logs}"
+    );
+    assert!(
+        logs.contains("command=session_send_message"),
+        "command field missing, got: {logs}"
+    );
+}
+
+#[test]
+fn require_window_label_in_rejection_emits_warn_with_expected_actual_command() {
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let err =
+        require_window_label_in_for_test("some-other", &["dashboard"], false, "list_sessions")
+            .expect_err("non-listed label must reject");
+    assert!(err.contains("forbidden"));
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("forge_shell::ipc::authz"),
+        "expected authz target, got: {logs}"
+    );
+    assert!(logs.contains("WARN"), "expected WARN level, got: {logs}");
+    assert!(
+        logs.contains("actual=some-other"),
+        "actual field missing, got: {logs}"
+    );
+    assert!(
+        logs.contains("command=list_sessions"),
+        "command field missing, got: {logs}"
+    );
+    assert!(
+        logs.contains("dashboard"),
+        "expected field should surface the dashboard allow-list, got: {logs}"
+    );
+}
+
+#[test]
+fn require_window_label_success_does_not_log() {
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    require_window_label_for_test("session-abc", "session-abc", "session_send_message")
+        .expect("matching label must pass");
+
+    let logs = common::drain_capture();
+    assert!(
+        !logs.contains("forge_shell::ipc::authz"),
+        "success path must not emit an authz log, got: {logs}"
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#372

## Summary
- Replace ad-hoc `eprintln!` in `crates/forge-shell/src/ipc.rs` and `crates/forge-session/src/{server,bg_agents}.rs` with `tracing` emissions carrying structured fields (`session_id`, `window_label`, `command`, `terminal_id`, `server_id`, `instance_id`, `agent_name`).
- Instrument `require_window_label` / `require_window_label_in` to emit `tracing::warn!(target: "forge_shell::ipc::authz", expected, actual, command, "authz rejection")` before returning `LABEL_MISMATCH_ERROR`, closing the audit-trail gap from the finding.
- Centralize the field-name schema and target-naming convention in `forge_session::log_fields`; `forge_shell::lib.rs` documents the cross-crate contract.
- `forged` installs no subscriber per the scope contract, so main.rs keeps operator-facing stderr banners (ollama base_url disclosure) on `eprintln!`; `eprintln_audit` exempts `main.rs` and asserts the rest of the shipped surface is clean.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- New source-level audit `eprintln_audit` (both crates) pins the no-`eprintln!` invariant in shipped src.
- New `ipc_authz_tracing` pins warn shape (target, level, `expected`/`actual`/`command` fields) and asserts the success path is silent.
- New `bg_agents_tracing` pins start / unknown-agent / completed / failed lifecycle emission shape.
- Pre-existing `ollama_url_validation` integration tests still green (they scrape stderr for the main.rs startup banner, deliberately bypassing tracing).

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)