### PR TITLE
[F-397] AgentMonitor StepKind missing mcp kind during MCP milestone

### DIFF
--- a/crates/forge-core/src/types.rs
+++ b/crates/forge-core/src/types.rs
@@ -76,6 +76,9 @@ pub enum RerunVariant {
 ///
 /// `model` — one pass through the provider stream (text deltas, tool calls).
 /// `tool`  — one tool invocation (start → invoke → return → complete).
+/// `mcp`   — one MCP server tool call; rendered with `info-bg` chip so the
+///           Agent Monitor separates MCP traffic from local tool calls at a
+///           glance (see `docs/ui-specs/agent-monitor.md §9.2`).
 /// `plan`  — reserved for future agent planning phases; not emitted today.
 /// `wait`  — reserved for approval/idle gaps; not emitted today.
 /// `spawn` — reserved for sub-agent spawn steps (F-140); not emitted today.
@@ -85,6 +88,7 @@ pub enum RerunVariant {
 pub enum StepKind {
     Plan,
     Tool,
+    Mcp,
     Model,
     Wait,
     Spawn,
@@ -209,6 +213,7 @@ mod tests {
         for (kind, wire) in [
             (StepKind::Plan, "\"plan\""),
             (StepKind::Tool, "\"tool\""),
+            (StepKind::Mcp, "\"mcp\""),
             (StepKind::Model, "\"model\""),
             (StepKind::Wait, "\"wait\""),
             (StepKind::Spawn, "\"spawn\""),

--- a/crates/forge-core/tests/schema_snapshot.rs
+++ b/crates/forge-core/tests/schema_snapshot.rs
@@ -94,6 +94,7 @@ fn step_kind_wire_labels_are_snake_case() {
     for (kind, expected) in [
         (StepKind::Plan, "plan"),
         (StepKind::Tool, "tool"),
+        (StepKind::Mcp, "mcp"),
         (StepKind::Model, "model"),
         (StepKind::Wait, "wait"),
         (StepKind::Spawn, "spawn"),

--- a/web/packages/app/src/routes/AgentMonitor.css
+++ b/web/packages/app/src/routes/AgentMonitor.css
@@ -349,6 +349,14 @@
   color: var(--color-ember-100);
 }
 
+/* F-397: MCP tool calls get their own chip palette so MCP traffic is
+ * visually distinct from local tool invocations during the MCP milestone
+ * (see `docs/ui-specs/agent-monitor.md §9.2`). */
+.agent-monitor__step-chip[data-kind='mcp'] {
+  background: var(--color-info-bg);
+  color: var(--color-info);
+}
+
 .agent-monitor__step-chip[data-kind='model'] {
   background: var(--color-surface-2);
   color: var(--color-text-secondary);

--- a/web/packages/app/src/routes/AgentMonitor.test.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.test.tsx
@@ -558,6 +558,40 @@ describe('<AgentTrace>', () => {
     expect(kinds).toEqual(['model', 'tool', 'spawn']);
   });
 
+  // F-397: MCP-kind step renders with its own chip selector so the
+  // `info-bg` palette from `agent-monitor.md §9.2` attaches. An
+  // `Event::StepStarted { kind: StepKind::Mcp }` flowing through
+  // `applyEventToState` must land in the trace column with
+  // `data-kind='mcp'` — regression guard for the MCP milestone.
+  it('routes a StepStarted{kind:mcp} through applyEventToState into an mcp-kind chip', () => {
+    const empty: LiveAgentState = {
+      subAgents: [],
+      stepsByAgent: {},
+      resourcesByAgent: {},
+    };
+    const after = applyEventToState(empty, {
+      event: {
+        type: 'step_started',
+        step_id: 'mcp-step-1',
+        kind: 'mcp',
+        instance_id: 'agent-mcp',
+        started_at: '2026-04-22T00:00:00Z',
+      },
+    });
+    const steps = after.stepsByAgent['agent-mcp'] ?? [];
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.kind).toBe('mcp');
+
+    const { container } = render(() => (
+      <AgentTrace agent={row()} steps={steps} onStepClick={() => {}} />
+    ));
+    const chip = container.querySelector(
+      '.agent-monitor__step-chip',
+    ) as HTMLElement | null;
+    expect(chip).toBeTruthy();
+    expect(chip?.getAttribute('data-kind')).toBe('mcp');
+  });
+
   it('renders a running-state dot so pulsing-ring CSS attaches', () => {
     const { container } = render(() => (
       <AgentTrace agent={row()} steps={[step({ status: 'running' })]} onStepClick={() => {}} />

--- a/web/packages/app/src/routes/AgentMonitor.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.tsx
@@ -932,7 +932,14 @@ export const AgentMonitor: Component = () => {
 
 function normaliseKind(raw: string): StepKind {
   const k = raw.toLowerCase();
-  if (k === 'plan' || k === 'tool' || k === 'model' || k === 'wait' || k === 'spawn') {
+  if (
+    k === 'plan' ||
+    k === 'tool' ||
+    k === 'mcp' ||
+    k === 'model' ||
+    k === 'wait' ||
+    k === 'spawn'
+  ) {
     return k;
   }
   return 'model';

--- a/web/packages/ipc/src/generated/StepKind.ts
+++ b/web/packages/ipc/src/generated/StepKind.ts
@@ -7,8 +7,11 @@
  *
  * `model` — one pass through the provider stream (text deltas, tool calls).
  * `tool`  — one tool invocation (start → invoke → return → complete).
+ * `mcp`   — one MCP server tool call; rendered with `info-bg` chip so the
+ *           Agent Monitor separates MCP traffic from local tool calls at a
+ *           glance (see `docs/ui-specs/agent-monitor.md §9.2`).
  * `plan`  — reserved for future agent planning phases; not emitted today.
  * `wait`  — reserved for approval/idle gaps; not emitted today.
  * `spawn` — reserved for sub-agent spawn steps (F-140); not emitted today.
  */
-export type StepKind = "plan" | "tool" | "model" | "wait" | "spawn";
+export type StepKind = "plan" | "tool" | "mcp" | "model" | "wait" | "spawn";


### PR DESCRIPTION
Closes forge-ide/forge#398

## Summary

- Adds `StepKind::Mcp` to the Rust enum in `crates/forge-core/src/types.rs`; ts-rs (F-381) auto-flows the variant into the generated `web/packages/ipc/src/generated/StepKind.ts` binding.
- Extends `normaliseKind` in `AgentMonitor.tsx` to pass `'mcp'` through instead of coercing it to `'model'`.
- Adds the `.agent-monitor__step-chip[data-kind='mcp']` rule with the `info-bg` palette per `docs/ui-specs/agent-monitor.md §9.2`.
- Regression test: feeds `Event::StepStarted { kind: 'mcp' }` through `applyEventToState`, renders the trace, and asserts the chip's `data-kind='mcp'` attribute.
- Scope held tight to `crates/forge-core/src/types.rs` and `web/packages/app/src/routes/AgentMonitor*` (plus the auto-regenerated TS binding and the adjacent `schema_snapshot` wire-lock test that enumerates every variant).

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (88 test suites, 0 failures)
- `cargo clippy --all-targets -- -D warnings` passes
- `pnpm --filter app run test` passes (856 tests); the new MCP regression test is named `<AgentTrace> > routes a StepStarted{kind:mcp} through applyEventToState into an mcp-kind chip`
- `just ts-check` will be clean after merge — the generated TS file is committed in sync with the Rust change

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)