### PR TITLE
[F-385] sessionId mixed pattern (props + global signal)

### DIFF
--- a/docs/architecture/frontend-state.md
+++ b/docs/architecture/frontend-state.md
@@ -1,0 +1,82 @@
+# Frontend state: session identity is signal-sourced
+
+## Decision
+
+The active Forge session's identity (`sessionId`) and its workspace root
+(`workspaceRoot`) live in two global Solid signals in
+`web/packages/app/src/stores/session.ts`:
+
+- `activeSessionId: Signal<SessionId | null>`
+- `activeWorkspaceRoot: Signal<string | null>`
+
+Every webview component that depends on the active session reads these
+signals directly. Components **do not** accept `sessionId` as a prop.
+
+The signals are written in exactly one place: `SessionWindow.onMount`, which
+sets them from its route params and from the `HelloAck.workspace` reply.
+`SessionWindow.onCleanup` clears them. No other module writes.
+
+## Status
+
+Accepted — F-385.
+
+## Rationale
+
+Before this decision the codebase carried a mixed pattern:
+
+- `StatusBar`, `FilesSidebar`, `EditorPane`, and `ChatPane`'s
+  `BranchedAssistantTurn` sub-component required `sessionId: SessionId` as
+  a prop, passed down from `SessionWindow`.
+- `ChatPane` itself, `ToolCallCard`, the `ChatPane` composer, and the chat
+  send path read `activeSessionId()` directly from the signal.
+
+When the prop source and the signal drifted — e.g. during a tab-swap where
+`SessionWindow` updates the signal on the *new* id while a ticking
+microtask still holds a closure over the prop value of the *old* id — the
+two paths could disagree for a frame. The frame of drift is small, but the
+same pattern is also unsafe for the roadmap: multi-session-per-window (a
+window hosting more than one session) and background-render of an inactive
+session both require each pane to name the session it is bound to without
+assuming it equals "the signal's current value." The mixed pattern locks
+those features out because half the tree can't tell one session from
+another.
+
+Routing everything through the signal was chosen over threading a uniform
+prop (or adding a `createContext`) because:
+
+1. **One writer, one reader.** `SessionWindow` is the only writer of the
+   signal. Every consumer reads the same signal. There is nowhere for
+   drift to occur.
+2. **Net code reduction.** Every consumer shed a prop and a matching type
+   field. `SessionWindow` dropped the forwarding sites.
+3. **Reactivity is correct by construction.** Reads inside event handlers
+   and effects see the current value when they run, not a mount-time
+   snapshot.
+
+A `createContext` would have solved the drift too, but it adds a layer of
+indirection that no other pane needs today; the signal is already the
+single source, so the context would just wrap it.
+
+## Future work when multi-session-per-window lands
+
+When a single webview needs to render panes bound to *different* sessions
+at once — not the Phase 2 shape, but a roadmap item — the signal pattern
+will have to change. At that point introduce a `SessionScope` provider
+(a `createContext<SessionId>`) that a component instance can be bound to;
+panes read the scope's `sessionId` instead of `activeSessionId()`. The
+global signal stays as "the foreground session" for UI chrome that is
+inherently single-valued (window title, activity bar, etc.). Every pane
+that moves onto the scope must drop its implicit dependence on
+`activeSessionId()` — and the DoD invariant from F-385 stays in force:
+no pane both reads the scope and accepts `sessionId` as a prop.
+
+## How to enforce
+
+- Do not add a `sessionId` prop to pane/shell components. If a pane needs
+  it, read `activeSessionId()` inside the function body or the effect
+  that consumes it.
+- Do not write to `setActiveSessionId` outside `SessionWindow`.
+- The per-component F-385 tests (`StatusBar.test.tsx`,
+  `FilesSidebar.test.tsx`, `EditorPane.test.tsx`) pin the invariant by
+  mounting without the prop and asserting the component reads the signal
+  value. Keep them green.

--- a/web/packages/app/src/panes/EditorPane.test.tsx
+++ b/web/packages/app/src/panes/EditorPane.test.tsx
@@ -17,6 +17,7 @@ import {
   breadcrumbFromPath,
   trimmedBreadcrumb,
 } from './EditorPane';
+import { setActiveSessionId } from '../stores/session';
 
 const SID = 'session-editor-test' as SessionId;
 const FILE = '/workspace/demo/src/main.ts';
@@ -51,7 +52,6 @@ describe('EditorPane render', () => {
   it('renders EDITOR type label, breadcrumb leaf, and close button', () => {
     const { getByTestId, getByText, getByRole } = render(() => (
       <EditorPane
-        sessionId={SID}
         path={FILE}
         src="about:blank"
         readFile={vi.fn().mockResolvedValue({
@@ -73,7 +73,6 @@ describe('EditorPane render', () => {
   it('does not render the dirty dot initially', () => {
     const { queryByTestId } = render(() => (
       <EditorPane
-        sessionId={SID}
         path={FILE}
         src="about:blank"
         readFile={vi.fn().mockResolvedValue({
@@ -101,7 +100,6 @@ describe('open-on-ready flow', () => {
     const posted: unknown[] = [];
     const { getByTestId } = render(() => (
       <EditorPane
-        sessionId={SID}
         path={FILE}
         src="about:blank"
         readFile={readFile}
@@ -131,7 +129,6 @@ describe('open-on-ready flow', () => {
     const readFile = vi.fn().mockRejectedValue(new Error('path denied'));
     const { getByTestId, queryByTestId } = render(() => (
       <EditorPane
-        sessionId={SID}
         path={FILE}
         src="about:blank"
         readFile={readFile}
@@ -163,7 +160,6 @@ describe('dirty state + save flow', () => {
     });
     const rendered = render(() => (
       <EditorPane
-        sessionId={SID}
         path={FILE}
         src="about:blank"
         readFile={readFile}
@@ -285,6 +281,66 @@ describe('dirty state + save flow', () => {
   });
 });
 
+// F-385: single source of truth for sessionId. EditorPane reads the id
+// from the global `activeSessionId` signal; no `sessionId` prop is accepted.
+// Proven by asserting readFile / writeFile are called with the signal's
+// value, not a value plumbed through props.
+describe('EditorPane — sessionId sourced from activeSessionId signal (F-385)', () => {
+  it('readFile is called with the signal value (no sessionId prop)', async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      path: FILE,
+      content: 'x',
+      bytes: 1,
+      sha256: 'sha',
+    });
+    const posted: unknown[] = [];
+    const { getByTestId } = render(() => (
+      <EditorPane
+        path={FILE}
+        src="about:blank"
+        readFile={readFile}
+        writeFile={vi.fn().mockResolvedValue(undefined)}
+        postToIframe={(m) => posted.push(m)}
+        onClose={vi.fn()}
+      />
+    ));
+    const iframe = getByTestId('editor-pane-iframe') as HTMLIFrameElement;
+    fireFromIframe(iframe, { kind: 'ready' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(readFile).toHaveBeenCalledWith(SID, FILE);
+  });
+
+  it('writeFile is called with the signal value on save', async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      path: FILE,
+      content: 'v1',
+      bytes: 2,
+      sha256: 'sha',
+    });
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+    const posted: unknown[] = [];
+    const { getByTestId } = render(() => (
+      <EditorPane
+        path={FILE}
+        src="about:blank"
+        readFile={readFile}
+        writeFile={writeFile}
+        postToIframe={(m) => posted.push(m)}
+        onClose={vi.fn()}
+      />
+    ));
+    const iframe = getByTestId('editor-pane-iframe') as HTMLIFrameElement;
+    fireFromIframe(iframe, { kind: 'ready' });
+    await Promise.resolve();
+    await Promise.resolve();
+    fireFromIframe(iframe, { kind: 'save', uri: `file://${FILE}`, value: 'v2' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writeFile).toHaveBeenCalledWith(SID, FILE, 'v2');
+  });
+});
+
 describe('message origin isolation', () => {
   it('ignores messages from windows other than the hosted iframe', async () => {
     const readFile = vi.fn().mockResolvedValue({
@@ -296,7 +352,6 @@ describe('message origin isolation', () => {
     const posted: unknown[] = [];
     render(() => (
       <EditorPane
-        sessionId={SID}
         path={FILE}
         src="about:blank"
         readFile={readFile}
@@ -333,7 +388,6 @@ describe('message origin isolation', () => {
     const posted: unknown[] = [];
     const { getByTestId } = render(() => (
       <EditorPane
-        sessionId={SID}
         path={FILE}
         src="about:blank"
         expectedIframeOrigin="https://editor.forge.local"
@@ -368,7 +422,6 @@ describe('message origin isolation', () => {
     const posted: unknown[] = [];
     const { getByTestId } = render(() => (
       <EditorPane
-        sessionId={SID}
         path={FILE}
         src="about:blank"
         expectedIframeOrigin="https://editor.forge.local"
@@ -406,7 +459,6 @@ describe('message origin isolation', () => {
     });
     const { unmount } = render(() => (
       <EditorPane
-        sessionId={SID}
         path={FILE}
         src="about:blank"
         expectedIframeOrigin="https://editor.forge.local"
@@ -437,11 +489,15 @@ describe('message origin isolation', () => {
   });
 });
 
-afterEach(() => {
-  // Nothing global to reset — the pane uses injected helpers and attaches
-  // its own window listener, which is cleaned up onCleanup.
+beforeEach(() => {
+  // F-385: EditorPane reads the session id from the global `activeSessionId`
+  // signal. Tests mount outside of SessionWindow, so we seed the signal
+  // directly before each mount and clear it in afterEach.
+  setActiveSessionId(SID);
 });
 
-beforeEach(() => {
-  // Reset has no cross-test state today; future-proof.
+afterEach(() => {
+  setActiveSessionId(null);
+  // The pane uses injected helpers and attaches its own window listener,
+  // which is cleaned up onCleanup.
 });

--- a/web/packages/app/src/panes/EditorPane.tsx
+++ b/web/packages/app/src/panes/EditorPane.tsx
@@ -25,11 +25,11 @@ import {
   onCleanup,
   onMount,
 } from 'solid-js';
-import type { SessionId } from '@forge/ipc';
 import {
   readFile as defaultReadFile,
   writeFile as defaultWriteFile,
 } from '../ipc/fs';
+import { activeSessionId } from '../stores/session';
 import './EditorPane.css';
 
 /** Default URL the iframe loads. Relative so it resolves under both the
@@ -56,7 +56,6 @@ type IframeMessage =
   | { kind: 'client.notification'; payload: unknown };
 
 export interface EditorPaneProps {
-  sessionId: SessionId;
   /** Absolute path of the file to edit. Required — the pane is one-file-per-
    *  instance today; the tab bar (F-126) will mount multiple EditorPanes. */
   path: string;
@@ -184,8 +183,10 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
   };
 
   const sendOpen = async (): Promise<void> => {
+    const sid = activeSessionId();
+    if (sid === null) return;
     try {
-      const file = await readFile(props.sessionId, props.path);
+      const file = await readFile(sid, props.path);
       lastSavedValue = file.content;
       currentValue = file.content;
       setIsDirty(false);
@@ -202,8 +203,10 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
   };
 
   const persist = async (value: string): Promise<void> => {
+    const sid = activeSessionId();
+    if (sid === null) return;
     try {
-      await writeFile(props.sessionId, props.path, value);
+      await writeFile(sid, props.path, value);
       lastSavedValue = value;
       currentValue = value;
       setIsDirty(false);

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -26,6 +26,9 @@ import {
   type VariantRow,
 } from '../../components/BranchMetadataPopover';
 import type { ApprovalLevel, ApprovalScope, SessionId } from '@forge/ipc';
+// `SessionId` is retained solely for `reportInvokeError`'s internal signature;
+// components in this file no longer accept a `sessionId` prop — they read
+// from the `activeSessionId` signal per the frontend-state decision doc.
 import {
   getApprovalWhitelist,
   addWhitelistEntry,
@@ -360,7 +363,6 @@ const BranchedAssistantTurn: Component<{
    * inactive variants from other branch points into the exported JSON.
    */
   visibleTurns: ChatTurn[];
-  sessionId: SessionId;
 }> = (props) => {
   const [popoverOpen, setPopoverOpen] = createSignal(false);
 
@@ -380,21 +382,25 @@ const BranchedAssistantTurn: Component<{
   const dispatchSelect = (messageId: string): void => {
     // Spec §15.3: switching variants dispatches `select_branch` with the
     // variant's index. Find that index from the group.
+    const sid = activeSessionId();
+    if (sid === null) return;
     const idx = props.group.variantIds.indexOf(messageId);
     if (idx < 0) return;
     invoke('select_branch', {
-      sessionId: props.sessionId,
+      sessionId: sid,
       parentId: rootId(),
       variantIndex: idx,
-    }).catch((err) => reportInvokeError(props.sessionId, 'select_branch', err));
+    }).catch((err) => reportInvokeError(sid, 'select_branch', err));
   };
 
   const dispatchDelete = (variantIndex: number): void => {
+    const sid = activeSessionId();
+    if (sid === null) return;
     invoke('delete_branch', {
-      sessionId: props.sessionId,
+      sessionId: sid,
       parentId: rootId(),
       variantIndex,
-    }).catch((err) => reportInvokeError(props.sessionId, 'delete_branch', err));
+    }).catch((err) => reportInvokeError(sid, 'delete_branch', err));
     setPopoverOpen(false);
   };
 
@@ -412,6 +418,7 @@ const BranchedAssistantTurn: Component<{
    * tool-call trees and deep provider metadata are out of scope for v1.
    */
   const handleExportAll = async (): Promise<void> => {
+    const sid = activeSessionId();
     const payload = props.visibleTurns
       .map((t) => {
         if (t.type === 'user') {
@@ -439,7 +446,14 @@ const BranchedAssistantTurn: Component<{
         await navigator.clipboard.writeText(json);
       }
     } catch (err) {
-      reportInvokeError(props.sessionId, 'clipboard.writeText', err);
+      // The clipboard path is session-scoped only for error reporting; if
+      // the signal is cleared (e.g. unmount race) we fall back to logging
+      // rather than invent a SessionId.
+      if (sid !== null) {
+        reportInvokeError(sid, 'clipboard.writeText', err);
+      } else {
+        console.error('clipboard.writeText failed', err);
+      }
     }
     setPopoverOpen(false);
   };
@@ -1092,18 +1106,14 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
                 const rootId = turn.branch_parent ?? turn.message_id;
                 const group = state().branchGroups[rootId];
                 if (group && liveVariantCount(group) > 1) {
-                  const id = sessionId();
-                  if (id !== null) {
-                    return (
-                      <BranchedAssistantTurn
-                        turn={turn}
-                        group={group}
-                        turns={state().turns}
-                        visibleTurns={visibleTurns()}
-                        sessionId={id}
-                      />
-                    );
-                  }
+                  return (
+                    <BranchedAssistantTurn
+                      turn={turn}
+                      group={group}
+                      turns={state().turns}
+                      visibleTurns={visibleTurns()}
+                    />
+                  );
                 }
                 return <AssistantBubble turn={turn} />;
               }

--- a/web/packages/app/src/routes/Session/SessionWindow.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.tsx
@@ -323,7 +323,6 @@ export const SessionWindow: Component = () => {
     return (
       <LeafHost
         leaf={leaf}
-        sessionId={sessionId()}
         subject={subject()}
         providerId={providerId()}
         providerLabel={providerLabel()}
@@ -344,7 +343,6 @@ export const SessionWindow: Component = () => {
         />
         <Show when={activeActivity() === 'files' && activeWorkspaceRoot() !== null}>
           <FilesSidebar
-            sessionId={sessionId()}
             workspaceRoot={activeWorkspaceRoot() as string}
             onOpen={onFileOpen}
           />
@@ -364,7 +362,7 @@ export const SessionWindow: Component = () => {
       {/* F-138: status bar lives at the bottom of the session chrome.
           Subscribes to `session:event` for background-agent lifecycle
           events and surfaces the running count + Promote/Stop popover. */}
-      <StatusBar sessionId={sessionId()} />
+      <StatusBar />
     </main>
   );
 };
@@ -377,7 +375,6 @@ export const SessionWindow: Component = () => {
  */
 interface LeafHostProps {
   leaf: LayoutLeaf;
-  sessionId: SessionId;
   subject: string;
   providerId: ProviderId;
   providerLabel: string;
@@ -447,7 +444,6 @@ const LeafHost: Component<LeafHostProps> = (props) => {
         </Show>
         <Show when={props.leaf.pane_type === 'editor' && props.activeFile !== null}>
           <EditorPane
-            sessionId={props.sessionId}
             path={props.activeFile as string}
             onClose={props.onCloseLeaf}
             onHeaderPointerDown={props.onPointerDownHeader}

--- a/web/packages/app/src/shell/FilesSidebar.test.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.test.tsx
@@ -15,10 +15,11 @@
 //     exercised in the Rust integration test; here we just confirm the
 //     component renders whatever the tree call returns).
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, waitFor } from '@solidjs/testing-library';
 import type { SessionId, TreeNodeDto } from '@forge/ipc';
 import { FilesSidebar } from './FilesSidebar';
+import { setActiveSessionId } from '../stores/session';
 
 const SID = 'session-sidebar-test' as SessionId;
 const WS = '/workspace/demo';
@@ -67,14 +68,23 @@ function treeWithoutIgnored(): TreeNodeDto {
   );
 }
 
-afterEach(() => cleanup());
+// F-385: FilesSidebar reads the session id from the global `activeSessionId`
+// signal. Tests mount outside of SessionWindow, so we seed the signal
+// directly before each mount and clear it in afterEach.
+beforeEach(() => {
+  setActiveSessionId(SID);
+});
+
+afterEach(() => {
+  setActiveSessionId(null);
+  cleanup();
+});
 
 describe('FilesSidebar render', () => {
   it('renders EXPLORER header and the root children on mount', async () => {
     const loadTree = vi.fn().mockResolvedValue(demoTree());
     const { findByText, getByText } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -90,7 +100,6 @@ describe('FilesSidebar render', () => {
     const loadTree = vi.fn().mockResolvedValue(demoTree());
     const { findByText, queryByText } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -110,7 +119,6 @@ describe('FilesSidebar render', () => {
     const onOpen = vi.fn();
     const { findByText } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={onOpen}
         loadTree={loadTree}
@@ -125,7 +133,6 @@ describe('FilesSidebar render', () => {
     const loadTree = vi.fn().mockResolvedValue(treeWithoutIgnored());
     const { findByText, queryByText } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -142,7 +149,6 @@ describe('FilesSidebar render', () => {
       .mockRejectedValue(new Error('tauri invoke unavailable (command=tree)'));
     const { findByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -158,7 +164,6 @@ describe('FilesSidebar context menu', () => {
     const loadTree = vi.fn().mockResolvedValue(demoTree());
     const { findByText, findByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -178,7 +183,6 @@ describe('FilesSidebar context menu', () => {
     const onOpen = vi.fn();
     const { findByText, findByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={onOpen}
         loadTree={loadTree}
@@ -195,7 +199,6 @@ describe('FilesSidebar context menu', () => {
     const renamePath = vi.fn().mockResolvedValue(undefined);
     const { findByText, findByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -223,7 +226,6 @@ describe('FilesSidebar context menu', () => {
     const renamePath = vi.fn().mockResolvedValue(undefined);
     const { findByText, findByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -242,7 +244,6 @@ describe('FilesSidebar context menu', () => {
     const deletePath = vi.fn().mockResolvedValue(undefined);
     const { findByText, findByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -264,7 +265,6 @@ describe('FilesSidebar context menu', () => {
     const deletePath = vi.fn().mockResolvedValue(undefined);
     const { findByText, findByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -278,6 +278,35 @@ describe('FilesSidebar context menu', () => {
     expect(deletePath).not.toHaveBeenCalled();
   });
 
+  // F-385: single source of truth for sessionId. Panes read it from the
+  // global `activeSessionId` signal; no `sessionId` prop is accepted. The
+  // test flips the signal mid-render and asserts the next refresh uses the
+  // new id — proving the component reads the signal live, not a prop
+  // captured at mount.
+  it('uses the live activeSessionId signal when calling loadTree (no sessionId prop)', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const { findByText } = render(() => (
+      <FilesSidebar
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    await findByText('README.md');
+    expect(loadTree).toHaveBeenCalledWith(SID, WS);
+    // Flip the signal and trigger a refresh via the header button; the next
+    // load call must carry the new session id.
+    const nextSid = 'session-sidebar-next' as SessionId;
+    setActiveSessionId(nextSid);
+    const refreshBtn = document.querySelector(
+      '.files-sidebar__refresh',
+    ) as HTMLButtonElement | null;
+    expect(refreshBtn).not.toBeNull();
+    loadTree.mockClear();
+    refreshBtn!.click();
+    await waitFor(() => expect(loadTree).toHaveBeenCalledWith(nextSid, WS));
+  });
+
   // F-411 (V8): context-menu items are buttons executing an action on the
   // selected tree row — per voice-terminology.md §8, they carry verb(+noun)
   // labels in display caps as literal text so screen readers announce them
@@ -286,7 +315,6 @@ describe('FilesSidebar context menu', () => {
     const loadTree = vi.fn().mockResolvedValue(demoTree());
     const { findByText, findByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}

--- a/web/packages/app/src/shell/FilesSidebar.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.tsx
@@ -27,16 +27,16 @@ import {
   onCleanup,
   onMount,
 } from 'solid-js';
-import type { SessionId, TreeNodeDto } from '@forge/ipc';
+import type { TreeNodeDto } from '@forge/ipc';
 import {
   tree as defaultTree,
   renamePath as defaultRenamePath,
   deletePath as defaultDeletePath,
 } from '../ipc/fs';
+import { activeSessionId } from '../stores/session';
 import './FilesSidebar.css';
 
 export interface FilesSidebarProps {
-  sessionId: SessionId;
   /** Absolute workspace root; passed as the `tree(root)` argument. */
   workspaceRoot: string;
   /** Called when the user activates a file (double-click or context-menu
@@ -75,8 +75,10 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
   const [menu, setMenu] = createSignal<ContextMenuTarget | null>(null);
 
   const refresh = async (): Promise<void> => {
+    const sid = activeSessionId();
+    if (sid === null) return;
     try {
-      const next = await load()(props.sessionId, props.workspaceRoot);
+      const next = await load()(sid, props.workspaceRoot);
       setRootNode(next);
       // Auto-expand the root so the first level of children is visible.
       const rootPath = next.path;
@@ -97,7 +99,7 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
 
   createEffect(
     on(
-      () => [props.sessionId, props.workspaceRoot] as const,
+      () => [activeSessionId(), props.workspaceRoot] as const,
       () => {
         void refresh();
       },
@@ -154,12 +156,14 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
     const target = menu();
     dismissMenu();
     if (!target) return;
+    const sid = activeSessionId();
+    if (sid === null) return;
     const fresh = askRename()(target.name);
     if (fresh === null || fresh === '' || fresh === target.name) return;
     const parent = target.path.slice(0, target.path.lastIndexOf('/'));
     const nextPath = `${parent}/${fresh}`;
     try {
-      await rename()(props.sessionId, target.path, nextPath);
+      await rename()(sid, target.path, nextPath);
       await refresh();
     } catch (err) {
       setError(errorToString(err));
@@ -170,9 +174,11 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
     const target = menu();
     dismissMenu();
     if (!target) return;
+    const sid = activeSessionId();
+    if (sid === null) return;
     if (!askDelete()(target.name)) return;
     try {
-      await remove()(props.sessionId, target.path);
+      await remove()(sid, target.path);
       await refresh();
     } catch (err) {
       setError(errorToString(err));

--- a/web/packages/app/src/shell/StatusBar.test.tsx
+++ b/web/packages/app/src/shell/StatusBar.test.tsx
@@ -30,6 +30,7 @@ import type {
   NotificationAdapter,
 } from './StatusBar';
 import type { SessionEventPayload } from '../ipc/session';
+import { setActiveSessionId } from '../stores/session';
 import { resetSettingsStore, seedSettings } from '../stores/settings';
 
 const SID = 'test-session-1' as SessionId;
@@ -126,10 +127,17 @@ function fakeNotifier(): NotificationAdapter & {
 }
 
 beforeEach(() => {
+  // F-385: StatusBar reads the session id from the global `activeSessionId`
+  // signal. Tests mount outside of SessionWindow, so we seed the signal
+  // directly before each mount and clear it in afterEach.
+  setActiveSessionId(SID);
   resetSettingsStore();
 });
 
-afterEach(() => cleanup());
+afterEach(() => {
+  setActiveSessionId(null);
+  cleanup();
+});
 
 describe('StatusBar — badge visibility + count', () => {
   it('hides the badge when there are zero running agents', async () => {
@@ -137,7 +145,6 @@ describe('StatusBar — badge visibility + count', () => {
     const list = vi.fn().mockResolvedValue([]);
     const { queryByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
       />
@@ -155,7 +162,6 @@ describe('StatusBar — badge visibility + count', () => {
       .mockResolvedValue([running('a1'), running('a2', 'reviewer')]);
     const { findByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
       />
@@ -169,7 +175,6 @@ describe('StatusBar — badge visibility + count', () => {
     const list = vi.fn().mockResolvedValue([running('a1')]);
     const { findByTestId, queryByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
       />
@@ -213,7 +218,6 @@ describe('StatusBar — badge visibility + count', () => {
     const list = vi.fn().mockResolvedValue([running('a1')]);
     const { findByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
       />
@@ -241,7 +245,6 @@ describe('StatusBar — popover interaction', () => {
       .mockResolvedValue([running('a1', 'writer'), running('a2', 'reviewer')]);
     const { findByTestId, queryByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
       />
@@ -262,7 +265,6 @@ describe('StatusBar — popover interaction', () => {
     const stop = vi.fn().mockResolvedValue(undefined);
     const { findByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
         promoteBackgroundAgent={promote}
@@ -284,7 +286,6 @@ describe('StatusBar — popover interaction', () => {
     const stop = vi.fn().mockResolvedValue(undefined);
     const { findByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
         promoteBackgroundAgent={promote}
@@ -307,7 +308,6 @@ describe('StatusBar — popover interaction', () => {
     const list = vi.fn().mockResolvedValue([running('a1', 'writer')]);
     const { findByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
       />
@@ -337,7 +337,6 @@ describe('StatusBar — notification modes', () => {
     const list = vi.fn().mockResolvedValue([running('a1', 'writer')]);
     const result = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
         notificationAdapter={opts.notifier}
@@ -424,13 +423,56 @@ describe('StatusBar — notification modes', () => {
   });
 });
 
+// F-385: single source of truth for sessionId. The StatusBar reads the id
+// from the global `activeSessionId` signal; no `sessionId` prop is accepted.
+// Proven by asserting (a) the initial `list` call carries the signal's
+// value, and (b) an event payload whose `session_id` matches the signal is
+// processed while a payload for a foreign id is ignored — the routing
+// decision is signal-sourced.
+describe('StatusBar — sessionId sourced from activeSessionId signal (F-385)', () => {
+  it('initial list_background_agents call uses the signal value', async () => {
+    const bus = fakeBus();
+    const list = vi.fn().mockResolvedValue([]);
+    render(() => (
+      <StatusBar listBackgroundAgents={list} subscribe={bus.subscribe} />
+    ));
+    await waitFor(() => expect(list).toHaveBeenCalledWith(SID));
+  });
+
+  it('event routing keys off the signal, not a prop', async () => {
+    const bus = fakeBus();
+    const list = vi.fn().mockResolvedValue([]);
+    const { findByTestId, queryByTestId } = render(() => (
+      <StatusBar listBackgroundAgents={list} subscribe={bus.subscribe} />
+    ));
+    await waitFor(() => expect(list).toHaveBeenCalled());
+
+    // A started event for a DIFFERENT session id must be ignored.
+    bus.emit({
+      session_id: 'other-session',
+      seq: 1,
+      event: { type: 'background_agent_started', id: 'x', agent: 'w', at: 'now' },
+    });
+    await Promise.resolve();
+    expect(queryByTestId('bg-agents-badge')).toBeNull();
+
+    // A started event for the signal's session id must land.
+    bus.emit({
+      session_id: SID,
+      seq: 2,
+      event: { type: 'background_agent_started', id: 'y', agent: 'w', at: 'now' },
+    });
+    const badge = await findByTestId('bg-agents-badge');
+    expect(badge).toHaveTextContent('1 bg');
+  });
+});
+
 describe('StatusBar — cleanup', () => {
   it('unsubscribes from the event bus on unmount', async () => {
     const bus = fakeBus();
     const list = vi.fn().mockResolvedValue([]);
     const { unmount } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
       />
@@ -470,7 +512,6 @@ describe('StatusBar — AgentMonitor entry points (F-153)', () => {
     const navigate = vi.fn();
     const { findByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
         navigate={navigate}
@@ -491,7 +532,6 @@ describe('StatusBar — AgentMonitor entry points (F-153)', () => {
     const navigate = vi.fn();
     const { findByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
         navigate={navigate}
@@ -513,7 +553,6 @@ describe('StatusBar — AgentMonitor entry points (F-153)', () => {
     const navigate = vi.fn();
     const { findByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
         navigate={navigate}
@@ -537,7 +576,6 @@ describe('StatusBar — AgentMonitor entry points (F-153)', () => {
     const navigate = vi.fn();
     const { findByTestId } = render(() => (
       <StatusBar
-        sessionId={SID}
         listBackgroundAgents={list}
         subscribe={bus.subscribe}
         navigate={navigate}
@@ -569,7 +607,6 @@ describe('StatusBar — AgentMonitor entry points (F-153)', () => {
           path="/"
           component={() => (
             <StatusBar
-              sessionId={SID}
               listBackgroundAgents={list}
               subscribe={bus.subscribe}
             />
@@ -595,7 +632,6 @@ describe('StatusBar — AgentMonitor entry points (F-153)', () => {
           path="/"
           component={() => (
             <StatusBar
-              sessionId={SID}
               listBackgroundAgents={list}
               subscribe={bus.subscribe}
             />

--- a/web/packages/app/src/shell/StatusBar.tsx
+++ b/web/packages/app/src/shell/StatusBar.tsx
@@ -26,7 +26,7 @@ import {
   onMount,
 } from 'solid-js';
 import { useNavigate } from '@solidjs/router';
-import type { BgAgentSummary, SessionId } from '@forge/ipc';
+import type { BgAgentSummary } from '@forge/ipc';
 import {
   isPermissionGranted as pluginIsPermissionGranted,
   requestPermission as pluginRequestPermission,
@@ -39,6 +39,7 @@ import {
   stopBackgroundAgent as defaultStopBackgroundAgent,
   type SessionEventPayload,
 } from '../ipc/session';
+import { activeSessionId } from '../stores/session';
 import { settings } from '../stores/settings';
 import { pushToast } from '../components/toast';
 import './StatusBar.css';
@@ -97,7 +98,6 @@ const defaultSubscribe: BgAgentsSubscribe = (handler) =>
 export type StatusBarNavigate = (to: string) => void;
 
 export interface StatusBarProps {
-  sessionId: SessionId;
   /** Initial snapshot provider. Defaults to the real Tauri command. */
   listBackgroundAgents?: typeof defaultListBackgroundAgents;
   /** Promote IPC wrapper. */
@@ -224,7 +224,7 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
   };
 
   const handlePayload = (payload: SessionEventPayload): void => {
-    if (payload.session_id !== props.sessionId) return;
+    if (payload.session_id !== activeSessionId()) return;
     const ev = classifyEvent(payload.event);
     if (ev === null) return;
     if (ev.type === 'background_agent_started') {
@@ -264,8 +264,10 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
       }
     })();
     void (async () => {
+      const id = activeSessionId();
+      if (id === null) return;
       try {
-        const snapshot = await listBg()(props.sessionId);
+        const snapshot = await listBg()(id);
         if (mounted && Array.isArray(snapshot)) {
           const runningRows = snapshot.filter((r) => r.state === 'Running');
           setRunning(runningRows);
@@ -294,7 +296,9 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
   // running" rather than inspect a specific agent.
   const onBadgeDoubleClick = (e: MouseEvent): void => {
     e.preventDefault();
-    navigate(`/agents/${props.sessionId}`);
+    const id = activeSessionId();
+    if (id === null) return;
+    navigate(`/agents/${id}`);
   };
 
   // F-153: popover-row double-click / right-click is the primary "open this
@@ -304,16 +308,22 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
   // popover.
   const onRowDoubleClick = (instanceId: string) => (e: MouseEvent): void => {
     e.preventDefault();
-    navigate(`/agents/${props.sessionId}?instance=${instanceId}`);
+    const sid = activeSessionId();
+    if (sid === null) return;
+    navigate(`/agents/${sid}?instance=${instanceId}`);
   };
   const onRowContextMenu = (instanceId: string) => (e: MouseEvent): void => {
     e.preventDefault();
-    navigate(`/agents/${props.sessionId}?instance=${instanceId}`);
+    const sid = activeSessionId();
+    if (sid === null) return;
+    navigate(`/agents/${sid}?instance=${instanceId}`);
   };
 
   const onPromote = async (id: string): Promise<void> => {
+    const sid = activeSessionId();
+    if (sid === null) return;
     try {
-      await promoteBg()(props.sessionId, id);
+      await promoteBg()(sid, id);
       setRunning((prev) => prev.filter((r) => r.id !== id));
     } catch (err) {
       console.error('promote_background_agent failed', err);
@@ -321,8 +331,10 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
   };
 
   const onStop = async (id: string): Promise<void> => {
+    const sid = activeSessionId();
+    if (sid === null) return;
     try {
-      await stopBg()(props.sessionId, id);
+      await stopBg()(sid, id);
       // Don't pre-remove: the completion event will clear the row and fire
       // the notification on the same path as any other terminal transition.
     } catch (err) {


### PR DESCRIPTION
Closes forge-ide/forge#386

## Summary

- Route `sessionId` through the `activeSessionId` signal everywhere. `StatusBar`, `FilesSidebar`, `EditorPane`, and `ChatPane`'s `BranchedAssistantTurn` no longer accept `sessionId` as a prop; they read `activeSessionId()` live inside the function/effect/handler that needs it.
- `SessionWindow` remains the single writer of `activeSessionId` / `activeWorkspaceRoot`. Stopped forwarding `sessionId` down to `FilesSidebar`, `StatusBar`, `LeafHost`, and `EditorPane`.
- Recorded the decision in `docs/architecture/frontend-state.md` (Accepted — F-385) with rationale, enforcement rules, and future work for multi-session-per-window.
- Pinned the invariant with new tests in `StatusBar.test.tsx`, `FilesSidebar.test.tsx`, and `EditorPane.test.tsx` that mount without the prop and assert each consumer reads the live signal — including a signal-flip test that proves the read is reactive, not captured at mount.

## Test plan

- `pnpm -r typecheck` passes (all four `web/packages/*`)
- Frontend vitest suite: 860 tests across 66 files, all green
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)