### PR TITLE
[F-384] Context resolvers duplicate list/filter/slice/map and tree recursion

### DIFF
--- a/web/packages/app/src/context/agent.ts
+++ b/web/packages/app/src/context/agent.ts
@@ -13,6 +13,7 @@
 import type { SessionId } from '@forge/ipc';
 import type { Candidate, ContextBlock, Resolver } from './types';
 import { fuzzyMatch } from './types';
+import { makeCandidateList } from './helpers';
 
 export interface AgentCandidateSource {
   id: SessionId;
@@ -58,19 +59,20 @@ export function createAgentResolver(deps: AgentResolverDeps): Resolver<string> {
 
   return {
     async list(query: string): Promise<Candidate[]> {
-      const all = deps.listAgents();
-      const withLabels = all.map((a) => ({
+      const withLabels = deps.listAgents().map((a) => ({
         id: a.id,
         label: a.label ?? String(a.id),
       }));
-      const matched = withLabels.filter(
-        (a) => fuzzyMatch(query, a.label) || fuzzyMatch(query, String(a.id)),
-      );
-      return matched.map((a) => ({
-        category: 'agent' as const,
-        label: a.label,
-        value: String(a.id),
-      }));
+      return makeCandidateList({
+        items: withLabels,
+        match: (a) =>
+          fuzzyMatch(query, a.label) || fuzzyMatch(query, String(a.id)),
+        toCandidate: (a) => ({
+          category: 'agent',
+          label: a.label,
+          value: String(a.id),
+        }),
+      });
     },
 
     async resolve(id: string): Promise<ContextBlock> {

--- a/web/packages/app/src/context/directory.ts
+++ b/web/packages/app/src/context/directory.ts
@@ -11,6 +11,7 @@ import {
 } from '../ipc/fs';
 import type { Candidate, ContextBlock, Resolver } from './types';
 import { fuzzyMatch } from './types';
+import { makeCandidateList, walkTree } from './helpers';
 
 /** Spec-mandated cap: directory snapshots include at most this many paths. */
 export const DIRECTORY_RESOLVER_MAX_PATHS = 200;
@@ -24,19 +25,18 @@ export interface DirectoryResolverDeps {
   tree?: typeof defaultTree;
 }
 
-/** Emit `[path, name]` pairs for directory nodes only (root included). */
+/** Emit `[path, name]` pairs for directory nodes only (root included).
+ *  `kind` is the Rust-side enum 'File' | 'Dir' | 'Symlink' | 'Other'. */
 export function flattenDirectories(
   node: TreeNodeDto,
   out: Array<{ path: string; name: string }> = [],
 ): Array<{ path: string; name: string }> {
-  // `kind` is the Rust-side enum 'File' | 'Dir' | 'Symlink' | 'Other'.
-  if (node.kind === 'Dir') {
-    out.push({ path: node.path, name: node.name });
-  }
-  if (node.children) {
-    for (const child of node.children) flattenDirectories(child, out);
-  }
-  return out;
+  return walkTree(
+    node,
+    (n) => n.kind === 'Dir',
+    (n) => ({ path: n.path, name: n.name }),
+    out,
+  );
 }
 
 /**
@@ -48,11 +48,7 @@ export function flattenAllPaths(
   node: TreeNodeDto,
   out: string[] = [],
 ): string[] {
-  out.push(node.path);
-  if (node.children) {
-    for (const child of node.children) flattenAllPaths(child, out);
-  }
-  return out;
+  return walkTree(node, () => true, (n) => n.path, out);
 }
 
 export function createDirectoryResolver(deps: DirectoryResolverDeps): Resolver<string> {
@@ -61,13 +57,16 @@ export function createDirectoryResolver(deps: DirectoryResolverDeps): Resolver<s
   return {
     async list(query: string): Promise<Candidate[]> {
       const node = await treeFn(deps.sessionId, deps.workspaceRoot);
-      const dirs = flattenDirectories(node);
-      const matched = dirs.filter((d) => fuzzyMatch(query, d.path));
-      return matched.slice(0, DIRECTORY_RESOLVER_MAX_RESULTS).map((d) => ({
-        category: 'directory' as const,
-        label: d.name || d.path,
-        value: d.path,
-      }));
+      return makeCandidateList({
+        items: flattenDirectories(node),
+        match: (d) => fuzzyMatch(query, d.path),
+        toCandidate: (d) => ({
+          category: 'directory',
+          label: d.name || d.path,
+          value: d.path,
+        }),
+        max: DIRECTORY_RESOLVER_MAX_RESULTS,
+      });
     },
 
     async resolve(dirPath: string): Promise<ContextBlock> {

--- a/web/packages/app/src/context/file.ts
+++ b/web/packages/app/src/context/file.ts
@@ -18,6 +18,7 @@ import {
 } from '../ipc/fs';
 import type { Candidate, ContextBlock, Resolver } from './types';
 import { fuzzyMatch } from './types';
+import { makeCandidateList, walkTree } from './helpers';
 
 /** Maximum bytes included in a resolved file block. Larger files are
  *  truncated with a trailing marker so the model can see the cut happened. */
@@ -39,21 +40,21 @@ export interface FileResolverDeps {
 /**
  * Flatten a tree node into `[path, name]` pairs for file entries only.
  * Directories are descended but not emitted. Exported for test visibility.
+ *
+ * `kind` is the Rust-side enum: 'File' | 'Dir' | 'Symlink' | 'Other'. Only
+ * plain files go into the picker — symlinks and special files are skipped
+ * so the resolver cannot accidentally tunnel outside the gitignore filter.
  */
 export function flattenFiles(
   node: TreeNodeDto,
   out: Array<{ path: string; name: string }> = [],
 ): Array<{ path: string; name: string }> {
-  // `kind` is the Rust-side enum: 'File' | 'Dir' | 'Symlink' | 'Other'. Only
-  // plain files go into the picker — symlinks and special files are skipped
-  // so the resolver cannot accidentally tunnel outside the gitignore filter.
-  if (node.kind === 'File') {
-    out.push({ path: node.path, name: node.name });
-  }
-  if (node.children) {
-    for (const child of node.children) flattenFiles(child, out);
-  }
-  return out;
+  return walkTree(
+    node,
+    (n) => n.kind === 'File',
+    (n) => ({ path: n.path, name: n.name }),
+    out,
+  );
 }
 
 /** Truncate content to `maxBytes` UTF-8 bytes. Appends a visible marker when
@@ -77,13 +78,12 @@ export function createFileResolver(deps: FileResolverDeps): Resolver<string> {
   return {
     async list(query: string): Promise<Candidate[]> {
       const node = await treeFn(deps.sessionId, deps.workspaceRoot);
-      const files = flattenFiles(node);
-      const matched = files.filter((f) => fuzzyMatch(query, f.path));
-      return matched.slice(0, FILE_RESOLVER_MAX_RESULTS).map((f) => ({
-        category: 'file' as const,
-        label: f.name,
-        value: f.path,
-      }));
+      return makeCandidateList({
+        items: flattenFiles(node),
+        match: (f) => fuzzyMatch(query, f.path),
+        toCandidate: (f) => ({ category: 'file', label: f.name, value: f.path }),
+        max: FILE_RESOLVER_MAX_RESULTS,
+      });
     },
 
     async resolve(path: string): Promise<ContextBlock> {

--- a/web/packages/app/src/context/helpers.test.ts
+++ b/web/packages/app/src/context/helpers.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type { TreeNodeDto } from '../ipc/fs';
+import { makeCandidateList, walkTree } from './helpers';
+import { fuzzyMatch } from './types';
+
+function fileNode(path: string, name: string): TreeNodeDto {
+  return { path, name, kind: 'File', children: null };
+}
+function dirNode(path: string, name: string, children: TreeNodeDto[]): TreeNodeDto {
+  return { path, name, kind: 'Dir', children };
+}
+
+describe('walkTree', () => {
+  it('collects entries matching the predicate in DFS order', () => {
+    const tree = dirNode('/ws', 'ws', [
+      fileNode('/ws/a.ts', 'a.ts'),
+      dirNode('/ws/sub', 'sub', [fileNode('/ws/sub/b.ts', 'b.ts')]),
+    ]);
+    const files = walkTree(
+      tree,
+      (n) => n.kind === 'File',
+      (n) => n.path,
+    );
+    expect(files).toEqual(['/ws/a.ts', '/ws/sub/b.ts']);
+  });
+
+  it('accepts-all predicate emits every node', () => {
+    const tree = dirNode('/ws', 'ws', [
+      fileNode('/ws/a.ts', 'a.ts'),
+      dirNode('/ws/sub', 'sub', [fileNode('/ws/sub/b.ts', 'b.ts')]),
+    ]);
+    const paths = walkTree(
+      tree,
+      () => true,
+      (n) => n.path,
+    );
+    expect(paths).toEqual(['/ws', '/ws/a.ts', '/ws/sub', '/ws/sub/b.ts']);
+  });
+
+  it('skips nodes whose predicate is false but still descends', () => {
+    const tree = dirNode('/ws', 'ws', [
+      fileNode('/ws/a.ts', 'a.ts'),
+      dirNode('/ws/sub', 'sub', [fileNode('/ws/sub/b.ts', 'b.ts')]),
+    ]);
+    const dirs = walkTree(
+      tree,
+      (n) => n.kind === 'Dir',
+      (n) => n.path,
+    );
+    expect(dirs).toEqual(['/ws', '/ws/sub']);
+  });
+
+  it('handles nodes with null children without recursing', () => {
+    const tree = fileNode('/ws/lone.ts', 'lone.ts');
+    const out = walkTree(tree, () => true, (n) => n.path);
+    expect(out).toEqual(['/ws/lone.ts']);
+  });
+});
+
+describe('makeCandidateList', () => {
+  const items = [
+    { path: '/ws/app.ts', name: 'app.ts' },
+    { path: '/ws/lib.ts', name: 'lib.ts' },
+    { path: '/ws/README.md', name: 'README.md' },
+  ];
+
+  it('filters, slices, and maps items into Candidates', () => {
+    const out = makeCandidateList({
+      items,
+      match: (i) => fuzzyMatch('lib', i.path),
+      toCandidate: (i) => ({ category: 'file', label: i.name, value: i.path }),
+    });
+    expect(out).toEqual([{ category: 'file', label: 'lib.ts', value: '/ws/lib.ts' }]);
+  });
+
+  it('caps results at the provided max', () => {
+    const many = Array.from({ length: 100 }, (_, i) => ({
+      path: `/ws/f${i}.ts`,
+      name: `f${i}.ts`,
+    }));
+    const out = makeCandidateList({
+      items: many,
+      match: () => true,
+      toCandidate: (i) => ({ category: 'file', label: i.name, value: i.path }),
+      max: 10,
+    });
+    expect(out).toHaveLength(10);
+  });
+
+  it('returns all matching items when max is omitted', () => {
+    const out = makeCandidateList({
+      items,
+      match: () => true,
+      toCandidate: (i) => ({ category: 'file', label: i.name, value: i.path }),
+    });
+    expect(out).toHaveLength(3);
+  });
+
+  it('passes the filtered item to toCandidate (not the raw index)', () => {
+    const out = makeCandidateList({
+      items,
+      match: (i) => i.path.endsWith('.md'),
+      toCandidate: (i) => ({ category: 'file', label: i.name, value: i.path }),
+    });
+    expect(out).toEqual([
+      { category: 'file', label: 'README.md', value: '/ws/README.md' },
+    ]);
+  });
+});

--- a/web/packages/app/src/context/helpers.ts
+++ b/web/packages/app/src/context/helpers.ts
@@ -1,0 +1,48 @@
+// F-384: shared pipeline + tree-walk helpers for context resolvers.
+//
+// Every list-style resolver applies the same `filter → slice → map` pipeline
+// against an in-memory candidate set, and the file/directory resolvers both
+// walk the same TreeNodeDto with different predicates. These helpers unify
+// those patterns so an 8th resolver plugs in without re-deriving either.
+//
+// Budget policy — a single unified cap is deliberately NOT imposed. The
+// tree-sourced resolvers (file/directory) cap at `FILE_RESOLVER_MAX_RESULTS`
+// / `DIRECTORY_RESOLVER_MAX_RESULTS` (50 each) because `tree` can return
+// thousands of nodes. The registry-sourced resolvers (agent/skill) pass no
+// `max` because the in-memory catalogs are bounded at the source (session
+// count, skill count) and any cap here would be cosmetic.
+
+import type { TreeNodeDto } from '../ipc/fs';
+import type { Candidate } from './types';
+
+/** Recursively collect entries from a `TreeNodeDto`. `predicate` selects
+ *  which nodes are emitted; `toItem` projects a matching node into the
+ *  caller's item shape. Children are always descended — a false predicate
+ *  skips the node itself, not its subtree. */
+export function walkTree<T>(
+  node: TreeNodeDto,
+  predicate: (n: TreeNodeDto) => boolean,
+  toItem: (n: TreeNodeDto) => T,
+  out: T[] = [],
+): T[] {
+  if (predicate(node)) out.push(toItem(node));
+  if (node.children) {
+    for (const child of node.children) walkTree(child, predicate, toItem, out);
+  }
+  return out;
+}
+
+export interface MakeCandidateListArgs<T> {
+  items: readonly T[];
+  match: (item: T) => boolean;
+  toCandidate: (item: T) => Candidate;
+  /** Optional ceiling; omit for unlimited. */
+  max?: number;
+}
+
+/** Canonical `filter → slice → map` pipeline for candidate lists. */
+export function makeCandidateList<T>(args: MakeCandidateListArgs<T>): Candidate[] {
+  const matched = args.items.filter(args.match);
+  const limited = args.max === undefined ? matched : matched.slice(0, args.max);
+  return limited.map(args.toCandidate);
+}

--- a/web/packages/app/src/context/skill.ts
+++ b/web/packages/app/src/context/skill.ts
@@ -12,6 +12,7 @@
 
 import type { Candidate, ContextBlock, Resolver } from './types';
 import { fuzzyMatch } from './types';
+import { makeCandidateList } from './helpers';
 
 export interface SkillCandidateSource {
   name: string;
@@ -26,20 +27,20 @@ export interface SkillResolverDeps {
 export function createSkillResolver(deps: SkillResolverDeps): Resolver<string> {
   return {
     async list(query: string): Promise<Candidate[]> {
-      const skills = deps.listSkills();
-      const matched = skills.filter(
-        (s) =>
+      return makeCandidateList({
+        items: deps.listSkills(),
+        match: (s) =>
           fuzzyMatch(query, s.name) ||
           (s.description !== undefined && fuzzyMatch(query, s.description)),
-      );
-      return matched.map((s) => ({
-        category: 'skill' as const,
-        label:
-          s.description !== undefined && s.description.length > 0
-            ? `${s.name} — ${s.description}`
-            : s.name,
-        value: s.name,
-      }));
+        toCandidate: (s) => ({
+          category: 'skill',
+          label:
+            s.description !== undefined && s.description.length > 0
+              ? `${s.name} — ${s.description}`
+              : s.name,
+          value: s.name,
+        }),
+      });
     },
 
     async resolve(name: string): Promise<ContextBlock> {


### PR DESCRIPTION
Closes forge-ide/forge#385

## Summary

- New `web/packages/app/src/context/helpers.ts` exporting `makeCandidateList<T>` (canonical filter → slice → map pipeline) and `walkTree<T>` (single TreeNodeDto recursion with `predicate` + `toItem`).
- Migrated `file.ts`, `directory.ts`, `agent.ts`, `skill.ts` onto the helpers. Public API (`flattenFiles`, `flattenDirectories`, `flattenAllPaths`, all `*_MAX_*` constants, resolver factories) is unchanged — existing resolver tests pass unmodified.
- Budget policy documented in `helpers.ts` header: tree-sourced resolvers (file/directory) keep their 50-item cap; registry-sourced resolvers (agent/skill) pass no `max` because their in-memory catalogs are bounded at the source.
- 8 new helper unit tests cover `walkTree` (predicate + descent semantics, null children, accepts-all) and `makeCandidateList` (filter, cap, unlimited, projection correctness).

## Test plan

- `pnpm -r typecheck` passes (all four `web/packages/*`)
- Frontend vitest suite: 864 tests across 67 files, all green (including 68 context/ tests)
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)