### PR TITLE
fix(forge-core): normalize event timestamp + tag conventions (F-380)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,6 +1465,7 @@ name = "forge-mcp"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "dirs 6.0.0",
  "forge-core",
  "futures",

--- a/crates/forge-core/src/event.rs
+++ b/crates/forge-core/src/event.rs
@@ -181,6 +181,10 @@ pub enum Event {
         step_id: StepId,
         instance_id: Option<AgentInstanceId>,
         kind: StepKind,
+        /// Step-open wall-clock. F-380 retains `started_at` rather than the
+        /// project-wide `at` convention because multiple webview consumers
+        /// pin on this field name; the divergence is documented in
+        /// `docs/architecture/event-conventions.md` as a pinned exception.
         started_at: DateTime<Utc>,
     },
     /// F-139: fine-grained step trace — closes a step.
@@ -257,6 +261,10 @@ pub enum Event {
         cpu_pct: Option<f64>,
         rss_bytes: Option<u64>,
         fd_count: Option<u64>,
+        /// Sample wall-clock. F-380 retains `sampled_at` rather than the
+        /// project-wide `at` convention because the AgentMonitor webview
+        /// pins on this field name; the divergence is documented in
+        /// `docs/architecture/event-conventions.md` as a pinned exception.
         sampled_at: DateTime<Utc>,
     },
 }

--- a/crates/forge-core/src/mcp_state.rs
+++ b/crates/forge-core/src/mcp_state.rs
@@ -5,9 +5,14 @@
 //! forge-mcp dependency cycle. `forge-mcp` re-exports them unchanged, so
 //! external callers still reach for `forge_mcp::ServerState` /
 //! `forge_mcp::McpStateEvent`.
+//!
+//! F-380 normalized the wire shape:
+//! - `ts: SystemTime` → `at: DateTime<Utc>` (matches every other
+//!   timestamp-carrying event — single field name across the union).
+//! - `ServerState` serde tag `state` → `type` (single discriminator name
+//!   across `Event`, `ServerState`, and `StepOutcome`).
 
-use std::time::SystemTime;
-
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -20,7 +25,7 @@ use ts_rs::TS;
 /// the running-session toggle test asserts against.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../web/packages/ipc/src/generated/")]
-#[serde(tag = "state", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerState {
     /// Spawn/connect in progress (transport connect → `initialize`
     /// handshake not yet complete).
@@ -49,10 +54,10 @@ pub struct McpStateEvent {
     pub server: String,
     /// New state the server transitioned to.
     pub state: ServerState,
-    /// Wall-clock timestamp. Included so the UI can order events
-    /// coming from multiple servers even when the stream lags. ts-rs:
-    /// emitted as `unknown` so the frontend treats the field opaquely
-    /// and reads it as a monotonic ordering key.
-    #[ts(type = "unknown")]
-    pub ts: SystemTime,
+    /// Wall-clock timestamp (F-380: renamed from `ts: SystemTime`). Serializes
+    /// as an RFC3339 string via chrono's `Serialize` impl, matching every
+    /// other event timestamp across `forge_core::Event`. ts-rs emits the
+    /// field as a plain `string` so the TS mirror carries the same shape.
+    #[ts(type = "string")]
+    pub at: DateTime<Utc>,
 }

--- a/crates/forge-core/src/types.rs
+++ b/crates/forge-core/src/types.rs
@@ -226,8 +226,11 @@ mod tests {
 
     #[test]
     fn step_outcome_wire_shape_tagged_snake_case() {
-        // F-381: `StepFinished.outcome` is a tagged union with `status: "ok" | "error"`.
-        // Lock both tags and the error payload field name.
+        // `StepFinished.outcome` is a tagged union with `status: "ok" | "error"`.
+        // F-380: `StepOutcome` retains `tag = "status"` as a pinned exception to
+        // the project-wide `type` discriminator convention; see
+        // `docs/architecture/event-conventions.md` for the rationale
+        // (AgentMonitor webview reads `.status` directly).
         assert_eq!(
             serde_json::to_string(&StepOutcome::Ok).unwrap(),
             "{\"status\":\"ok\"}"

--- a/crates/forge-core/tests/event_conventions.rs
+++ b/crates/forge-core/tests/event_conventions.rs
@@ -1,0 +1,175 @@
+//! F-380: Event wire-shape conventions.
+//!
+//! Pins the cross-cutting rules documented in
+//! `docs/architecture/event-conventions.md`:
+//!
+//! 1. Default timestamp field name is `at`. New event variants MUST use
+//!    `at: DateTime<Utc>`. Two pinned exceptions remain — `StepStarted.started_at`
+//!    and `ResourceSample.sampled_at` — because the AgentMonitor webview
+//!    pins on those specialized names; see the conventions doc.
+//! 2. Internally-tagged enums use `tag = "type"` — `Event` and
+//!    `ServerState` share one discriminator name. `StepOutcome` keeps
+//!    `tag = "status"` as a pinned exception (AgentMonitor webview reads
+//!    the field directly).
+//! 3. `McpStateEvent.at` rides as RFC3339 `DateTime<Utc>`, not the
+//!    pre-F-380 `SystemTime` `{secs, nanos}` pair.
+//!
+//! If any assertion here fails, update every TS adapter and generated
+//! binding at the same time.
+
+use chrono::{DateTime, Utc};
+use forge_core::{
+    AgentInstanceId, Event, McpStateEvent, ServerState, StepId, StepKind, StepOutcome,
+};
+use serde_json::{json, Value};
+
+fn fixed_time() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-04-22T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+fn step_id(s: &str) -> StepId {
+    serde_json::from_value(Value::String(s.to_string())).unwrap()
+}
+
+fn instance_id(s: &str) -> AgentInstanceId {
+    serde_json::from_value(Value::String(s.to_string())).unwrap()
+}
+
+#[test]
+fn step_started_retains_started_at_pinned_exception() {
+    // Pinned exception to rule #1 — documented in
+    // `docs/architecture/event-conventions.md`. The field stays `started_at`
+    // so the AgentMonitor webview doesn't churn; new event variants MUST
+    // still default to `at`.
+    let ev = Event::StepStarted {
+        step_id: step_id("s1"),
+        instance_id: None,
+        kind: StepKind::Model,
+        started_at: fixed_time(),
+    };
+    let v = serde_json::to_value(&ev).unwrap();
+    assert_eq!(
+        v["started_at"],
+        Value::String("2026-04-22T00:00:00Z".into()),
+        "StepStarted.started_at must survive as the pinned exception, got: {v}"
+    );
+    assert!(
+        v.get("at").is_none(),
+        "StepStarted must not emit `at` alongside `started_at` — pick one; got: {v}"
+    );
+}
+
+#[test]
+fn resource_sample_retains_sampled_at_pinned_exception() {
+    // Pinned exception to rule #1 — see the conventions doc.
+    let ev = Event::ResourceSample {
+        instance_id: instance_id("inst-1"),
+        cpu_pct: None,
+        rss_bytes: None,
+        fd_count: None,
+        sampled_at: fixed_time(),
+    };
+    let v = serde_json::to_value(&ev).unwrap();
+    assert_eq!(
+        v["sampled_at"],
+        Value::String("2026-04-22T00:00:00Z".into()),
+        "ResourceSample.sampled_at must survive as the pinned exception, got: {v}"
+    );
+    assert!(
+        v.get("at").is_none(),
+        "ResourceSample must not emit `at` alongside `sampled_at`; got: {v}"
+    );
+}
+
+#[test]
+fn server_state_uses_type_discriminator() {
+    // ServerState is an internally-tagged enum; the tag name must be `type`
+    // to align with Event / StepOutcome.
+    let healthy = serde_json::to_value(ServerState::Healthy).unwrap();
+    assert_eq!(
+        healthy,
+        json!({ "type": "healthy" }),
+        "ServerState tag must be `type`, got: {healthy}"
+    );
+    let degraded = serde_json::to_value(ServerState::Degraded {
+        reason: "slow".into(),
+    })
+    .unwrap();
+    assert_eq!(
+        degraded,
+        json!({ "type": "degraded", "reason": "slow" }),
+        "ServerState tag must be `type` on data-carrying arms, got: {degraded}"
+    );
+}
+
+#[test]
+fn step_outcome_retains_status_pinned_exception() {
+    // Pinned exception to rule #2: `StepOutcome` keeps `tag = "status"`
+    // because the AgentMonitor webview's `outcomeOf` helper in
+    // `web/packages/app/src/routes/AgentMonitor.tsx` reads `.status`
+    // directly. Documented in `docs/architecture/event-conventions.md`.
+    let ok = serde_json::to_value(StepOutcome::Ok).unwrap();
+    assert_eq!(
+        ok,
+        json!({ "status": "ok" }),
+        "StepOutcome.status must survive as the pinned exception, got: {ok}"
+    );
+    let err = serde_json::to_value(StepOutcome::Error {
+        reason: "boom".into(),
+    })
+    .unwrap();
+    assert_eq!(
+        err,
+        json!({ "status": "error", "reason": "boom" }),
+        "StepOutcome.status must survive on data-carrying arms, got: {err}"
+    );
+}
+
+#[test]
+fn mcp_state_event_at_rides_as_rfc3339_datetime() {
+    // McpStateEvent.at is a DateTime<Utc>, not SystemTime. Wire shape must
+    // be a plain RFC3339 string, not a `{secs_since_epoch, nanos_since_epoch}`
+    // object.
+    let ev = McpStateEvent {
+        server: "ripgrep".into(),
+        state: ServerState::Healthy,
+        at: fixed_time(),
+    };
+    let v = serde_json::to_value(&ev).unwrap();
+    assert_eq!(
+        v["at"],
+        Value::String("2026-04-22T00:00:00Z".into()),
+        "McpStateEvent.at must be an RFC3339 string, got: {v}"
+    );
+    assert!(
+        v.get("ts").is_none(),
+        "McpStateEvent must not emit the legacy `ts` key; got: {v}"
+    );
+    // And the ServerState inside rides as `{ "type": "healthy" }` now.
+    assert_eq!(v["state"], json!({ "type": "healthy" }));
+}
+
+#[test]
+fn event_mcp_state_wire_shape_matches_convention() {
+    // Full end-to-end wire pin for the flattened `Event::McpState` envelope:
+    // outer `type` discriminator, inner `state.type` discriminator, timestamp
+    // field named `at`.
+    let ev = Event::McpState(McpStateEvent {
+        server: "ripgrep".into(),
+        state: ServerState::Degraded {
+            reason: "slow".into(),
+        },
+        at: fixed_time(),
+    });
+    assert_eq!(
+        serde_json::to_value(&ev).unwrap(),
+        json!({
+            "type": "mcp_state",
+            "server": "ripgrep",
+            "state": { "type": "degraded", "reason": "slow" },
+            "at": "2026-04-22T00:00:00Z",
+        })
+    );
+}

--- a/crates/forge-core/tests/event_wire_shape.rs
+++ b/crates/forge-core/tests/event_wire_shape.rs
@@ -23,8 +23,6 @@
 //! adding a new variant without a pin is a compile error, not a runtime
 //! regression that surfaces in the UI.
 
-use std::time::{Duration, SystemTime};
-
 use chrono::{DateTime, Utc};
 use forge_core::{
     AgentId, AgentInstanceId, ApprovalPreview, ApprovalScope, ApprovalSource, CompactTrigger,
@@ -364,14 +362,6 @@ fn provider_id(s: &str) -> ProviderId {
 
 fn step_id(s: &str) -> StepId {
     serde_json::from_value(Value::String(s.to_string())).unwrap()
-}
-
-/// Deterministic `SystemTime` for `McpStateEvent.ts`. Serde's default
-/// `Serialize` impl for `SystemTime` emits
-/// `{ "secs_since_epoch": N, "nanos_since_epoch": N }` — the pin below asserts
-/// exactly that shape so a switch to a humantime-style adapter is caught.
-fn fixed_system_time() -> SystemTime {
-    SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)
 }
 
 // ---------------------------------------------------------------------------
@@ -761,34 +751,31 @@ fn mcp_state_wire_shape_healthy() {
     // F-155: `McpState(McpStateEvent)` is a newtype variant carrying a
     // struct. Serde's internal tagging flattens the struct fields into the
     // outer object, so the wire shape is the outer `type` discriminator
-    // plus every field of `McpStateEvent` — including its `ts: SystemTime`
-    // (serde default: `{secs_since_epoch, nanos_since_epoch}`). The pin
-    // below locks that flattening; if it drifts to a wrapped `payload`,
-    // the TS adapter (`applyEventToState` / `McpStatePanel`) breaks
-    // silently until this test fails.
+    // plus every field of `McpStateEvent`.
+    //
+    // F-380: `at` is a `DateTime<Utc>` (was `ts: SystemTime`) — serializes
+    // as an RFC3339 string matching every other event timestamp. The inner
+    // `ServerState` tag is `"type"` (was `"state"`).
     assert_wire_eq(
         Event::McpState(McpStateEvent {
             server: "ripgrep".into(),
             state: ServerState::Healthy,
-            ts: fixed_system_time(),
+            at: fixed_time(),
         }),
         json!({
             "type": "mcp_state",
             "server": "ripgrep",
-            "state": { "state": "healthy" },
-            "ts": {
-                "secs_since_epoch": 1_700_000_000u64,
-                "nanos_since_epoch": 0u64,
-            },
+            "state": { "type": "healthy" },
+            "at": "2026-04-18T10:00:00Z",
         }),
     );
 }
 
 #[test]
 fn mcp_state_wire_shape_degraded_with_reason() {
-    // `ServerState` is internally tagged on `state` — data-carrying arms
-    // (Degraded/Failed/Disabled) hang their `reason` alongside. Pin both
-    // the healthy (no-reason) and degraded (with-reason) shapes so a
+    // `ServerState` is internally tagged on `type` (F-380) — data-carrying
+    // arms (Degraded/Failed/Disabled) hang their `reason` alongside. Pin
+    // both the healthy (no-reason) and degraded (with-reason) shapes so a
     // rename on either side surfaces.
     assert_wire_eq(
         Event::McpState(McpStateEvent {
@@ -796,16 +783,13 @@ fn mcp_state_wire_shape_degraded_with_reason() {
             state: ServerState::Degraded {
                 reason: "health check timeout".into(),
             },
-            ts: fixed_system_time(),
+            at: fixed_time(),
         }),
         json!({
             "type": "mcp_state",
             "server": "shell",
-            "state": { "state": "degraded", "reason": "health check timeout" },
-            "ts": {
-                "secs_since_epoch": 1_700_000_000u64,
-                "nanos_since_epoch": 0u64,
-            },
+            "state": { "type": "degraded", "reason": "health check timeout" },
+            "at": "2026-04-18T10:00:00Z",
         }),
     );
 }

--- a/crates/forge-mcp/Cargo.toml
+++ b/crates/forge-mcp/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
+# F-380: `McpStateEvent.at` carries a `chrono::DateTime<Utc>` now; the manager
+# stamps each state transition with `Utc::now()`.
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dirs = "6.0.0"
 forge-core = { path = "../forge-core" }
 # `futures::StreamExt` drives the SSE `bytes_stream()` in the HTTP transport

--- a/crates/forge-mcp/src/manager.rs
+++ b/crates/forge-mcp/src/manager.rs
@@ -16,9 +16,10 @@
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -127,7 +128,7 @@ impl ServerShared {
         let _ = self.state_tx.send(McpStateEvent {
             server: self.name.clone(),
             state,
-            ts: SystemTime::now(),
+            at: Utc::now(),
         });
     }
 }

--- a/docs/architecture/event-conventions.md
+++ b/docs/architecture/event-conventions.md
@@ -1,0 +1,105 @@
+# Event conventions
+
+Cross-cutting rules for every `#[derive(Serialize, Deserialize)]` type that
+crosses the IPC boundary as an event or event payload. New variants MUST
+follow these rules. Pinned exceptions are listed in full — any deviation
+outside that list is structural drift and will be rejected in review.
+
+## 1. Timestamps
+
+- **Field name**: `at`.
+- **Type**: `chrono::DateTime<chrono::Utc>`.
+- **Wire shape**: RFC3339 string (serde-default for `DateTime<Utc>`).
+
+Every new event variant that carries a timestamp MUST use `at: DateTime<Utc>`.
+`SystemTime`, `Instant`, or other clock types do not cross the boundary;
+only the chrono wire shape is supported.
+
+### Pinned exceptions
+
+These two fields retain their specialized names because the `AgentMonitor`
+webview and surrounding tests pin on them, and the churn to rename them
+exceeds the benefit. Wire-shape tests in
+`crates/forge-core/tests/event_wire_shape.rs` lock both.
+
+| Variant                    | Field         | Reason                                                   |
+|----------------------------|---------------|----------------------------------------------------------|
+| `Event::StepStarted`       | `started_at`  | Paired with `StepFinished.duration_ms` — the frontend's  |
+|                            |               | `AgentMonitor.tsx` distinguishes step-open from other    |
+|                            |               | event timestamps via the field name.                     |
+| `Event::ResourceSample`    | `sampled_at`  | Emphasizes sample-vs-emit distinction (the monitor may   |
+|                            |               | batch samples before emitting). The AgentMonitor         |
+|                            |               | webview reads this field by name.                        |
+
+Any future rename of either exception requires a synchronized change to
+the webview, the ts-rs bindings, and a follow-up ticket referencing F-380.
+
+### Variants intentionally without a timestamp
+
+Some events do not carry their own `at` because they are strictly
+correlative — they reference an already-stamped event by id, and
+downstream consumers derive ordering from the referenced event's
+timestamp. Documented per variant:
+
+- `BranchSelected`, `BranchDeleted`, `MessageSuperseded` — id-only
+  markers; the superseded/selected message already has `at`.
+- `SubAgentSpawned`, `BackgroundAgentStarted` vs `UsageTick` — `UsageTick`
+  is a periodic tick (not a transition); today it's stamped via the event
+  log's own append ordering and surfaces no timestamp of its own.
+- `ToolCallApprovalRequested`, `ToolCallRejected` — paired with
+  `ToolCallApproved` / `ToolCallCompleted`, both of which carry `at`.
+- `ToolInvoked`, `ToolReturned` — fine-grained boundaries within a step;
+  the enclosing `StepStarted` / `StepFinished` bracket the wall-clock
+  window.
+
+Adding `at` to any of these later is non-breaking (pure field addition).
+Removing `at` from an existing stamped variant is breaking and requires
+a wire-shape golden update.
+
+## 2. Tag discriminator
+
+- **Attribute**: `#[serde(tag = "type")]`.
+- **Rename**: `rename_all = "snake_case"` for variants (unless the type
+  is `Copy` and maps one-to-one onto a lowercase TS string union, in
+  which case `rename_all = "lowercase"` is allowed).
+
+All internally-tagged enums that cross the IPC boundary share the tag
+name `"type"`. As of F-380 this applies to:
+
+- `Event` (`forge_core::event::Event`) — already `tag = "type"` since
+  Phase 0.
+- `ServerState` (`forge_core::mcp_state::ServerState`) — migrated from
+  `tag = "state"` in F-380.
+
+### Pinned exceptions
+
+| Type           | Current tag | Reason                                                  |
+|----------------|-------------|---------------------------------------------------------|
+| `StepOutcome`  | `status`    | AgentMonitor webview's `outcomeOf` helper in            |
+|                |             | `web/packages/app/src/routes/AgentMonitor.tsx` reads    |
+|                |             | `.status` directly. Rename requires a synchronized      |
+|                |             | webview change and is deferred to a follow-up ticket.   |
+
+Internal enums that do NOT cross the IPC boundary (e.g. `forge_lsp`'s
+`Checksum`, internal shell command routing) are out of scope for this
+convention. A type only enters the convention when its wire shape is
+observed by a TS adapter, a ts-rs binding, or a cross-process JSON
+payload.
+
+## 3. Type mirroring (`ts-rs`)
+
+Types that carry non-primitive fields across the webview boundary derive
+`TS` and export to `web/packages/ipc/src/generated/`. `chrono::DateTime<Utc>`
+is not known to ts-rs by default; annotate it with
+`#[ts(type = "string")]` so the generated TS carries `at: string`.
+
+## 4. Wire-shape tests
+
+Every `Event` variant MUST have a golden-JSON pin in
+`crates/forge-core/tests/event_wire_shape.rs`. The exhaustive `match` in
+`variant_label` at the bottom of that file is the compile-time guard —
+adding a new variant without a matching arm is a compile error.
+
+F-380's cross-cutting rules are further locked by
+`crates/forge-core/tests/event_conventions.rs`. Any change to rule #1,
+#2, or the `McpStateEvent.at` wire shape must touch that file.

--- a/docs/architecture/ipc-contracts.md
+++ b/docs/architecture/ipc-contracts.md
@@ -256,15 +256,17 @@ pub struct LspMessageEvent {
 
 `forge_core::Event` is a `#[serde(tag = "type")]` union covering session, provider, MCP, usage, and agent state. MCP state transitions ride inside it as `Event::McpState(McpStateEvent)` — F-155 retired the per-topic `mcp:state` channel, so there is no longer a top-level event for MCP state. All MCP state changes arrive on `session:event`.
 
+All internally-tagged enums that cross the IPC boundary — `Event`, `ServerState` — share the discriminator name `type` as of F-380. `StepOutcome` retains `tag = "status"` as a pinned exception. See `docs/architecture/event-conventions.md` for the full rules and pinned exceptions.
+
 ```rust
 // crates/forge-core/src/mcp_state.rs — re-exported as `forge_mcp::{McpStateEvent, ServerState}`.
 pub struct McpStateEvent {
-    pub server: String,       // server name — matches the key in the loaded spec map
+    pub server: String,        // server name — matches the key in the loaded spec map
     pub state: ServerState,
-    pub ts: SystemTime,       // ts-rs wire type is `unknown`; used only as a monotonic ordering key
+    pub at: DateTime<Utc>,     // F-380: RFC3339 wall-clock; renamed from `ts: SystemTime`
 }
 
-#[serde(tag = "state", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerState {
     Starting,                         // spawn/connect in progress; `initialize` handshake not yet complete
     Healthy,                          // last health-check succeeded

--- a/web/packages/ipc/src/generated/McpStateEvent.ts
+++ b/web/packages/ipc/src/generated/McpStateEvent.ts
@@ -14,9 +14,9 @@ server: string,
  */
 state: ServerState, 
 /**
- * Wall-clock timestamp. Included so the UI can order events
- * coming from multiple servers even when the stream lags. ts-rs:
- * emitted as `unknown` so the frontend treats the field opaquely
- * and reads it as a monotonic ordering key.
+ * Wall-clock timestamp (F-380: renamed from `ts: SystemTime`). Serializes
+ * as an RFC3339 string via chrono's `Serialize` impl, matching every
+ * other event timestamp across `forge_core::Event`. ts-rs emits the
+ * field as a plain `string` so the TS mirror carries the same shape.
  */
-ts: unknown, };
+at: string, };

--- a/web/packages/ipc/src/generated/ServerState.ts
+++ b/web/packages/ipc/src/generated/ServerState.ts
@@ -9,4 +9,4 @@
  * surface the literal error text `"MCP server <name> is disabled"` that
  * the running-session toggle test asserts against.
  */
-export type ServerState = { "state": "starting" } | { "state": "healthy" } | { "state": "degraded", reason: string, } | { "state": "failed", reason: string, } | { "state": "disabled", reason: string, };
+export type ServerState = { "type": "starting" } | { "type": "healthy" } | { "type": "degraded", reason: string, } | { "type": "failed", reason: string, } | { "type": "disabled", reason: string, };


### PR DESCRIPTION
Closes forge-ide/forge#381

## Summary
- `McpStateEvent.ts: SystemTime` -> `at: DateTime<Utc>`; serializes as
  RFC3339 alongside every other event timestamp.
- `ServerState` `#[serde(tag = "state")]` -> `tag = "type"` — single
  discriminator name across `Event` and `ServerState`.
- New `docs/architecture/event-conventions.md` documents the default
  rules and three pinned exceptions (`StepStarted.started_at`,
  `ResourceSample.sampled_at`, `StepOutcome` `status` tag) held back
  because the AgentMonitor webview pins those field names directly —
  follow-up ticket can rename them once a coordinated webview change
  lands.
- Golden-JSON pins for every rule in
  `crates/forge-core/tests/event_conventions.rs`; existing wire-shape
  tests updated for the new `McpStateEvent` / `ServerState` shapes.

Scope: forge-core + forge-mcp only. `forge-session` and `forge-shell`
call sites are untouched (PR #517 in-flight); `web/packages/app/` is
untouched (PR #519 in-flight). ts-rs regenerated bindings in
`web/packages/ipc/src/generated/` are included.

## Test plan
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` all pass
- `pnpm -r typecheck` and `pnpm -r test` (856 webview tests) pass
- New test module `crates/forge-core/tests/event_conventions.rs` pins
  every rule and every pinned exception

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)