### PR TITLE
fix(forge-lsp,forge-mcp): dedup truncate helper and port to lsp (F-375)

### DIFF
--- a/crates/forge-lsp/src/server.rs
+++ b/crates/forge-lsp/src/server.rs
@@ -588,6 +588,7 @@ impl Server {
                                     target: "forge_lsp::server",
                                     server_id = %reader_server_id.display(),
                                     error = %err,
+                                    line = %truncate(&line, 512),
                                     "dropping malformed stdout frame",
                                 );
                             }
@@ -620,6 +621,27 @@ fn backoff_delay(policy: &BackoffPolicy, attempt: u32) -> Duration {
     } else {
         scaled
     }
+}
+
+/// Cap a log field at `max` bytes so a runaway frame can't flood the log
+/// ring. `line` is guaranteed UTF-8 here, but we still slice on a char
+/// boundary via `char_indices` to avoid panicking on multi-byte glyphs.
+///
+/// Ported from `forge-mcp`'s `transport::truncate` (F-375). Once the
+/// Phase-3 `forge_core::process::ManagedStdioChild` extraction lands, this
+/// helper will move there and both crates will share a single copy.
+fn truncate(line: &str, max: usize) -> String {
+    if line.len() <= max {
+        return line.to_string();
+    }
+    let mut end = max;
+    for (i, _) in line.char_indices() {
+        if i > max {
+            break;
+        }
+        end = i;
+    }
+    format!("{}…", &line[..end])
 }
 
 /// Byte-transparent stdio transport implementing [`MessageTransport`]. The
@@ -1336,5 +1358,78 @@ mod tests {
         );
 
         let _ = tokio::time::timeout(Duration::from_secs(2), sup).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // F-375: malformed-frame warn must carry a size-capped `line` field so
+    // a runaway stdout frame can't flood the log ring. Ported from
+    // forge-mcp's `truncate` pattern.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn truncate_is_utf8_safe() {
+        // Long ASCII + one multi-byte glyph at the tail forces the slice to
+        // land on a char boundary. A naive byte-index slice would panic.
+        let s = "a".repeat(600) + "é";
+        let out = truncate(&s, 300);
+        assert!(out.ends_with('…'));
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    /// A malformed stdout frame longer than the 512-byte cap must be
+    /// logged with a truncated `line` field, not the raw bytes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)]
+    async fn malformed_frame_warn_carries_truncated_line_field() {
+        let _guard = capture_test_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        install_capture_subscriber();
+        let _ = drain_capture();
+
+        let policy = BackoffPolicy {
+            max_attempts: 1,
+            window: Duration::from_secs(600),
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(1),
+        };
+        // 2000-byte non-JSON line — well past the 512-byte cap.
+        let long_bad_line = "x".repeat(2000);
+        let mut server = Server::with_policy_and_clock(
+            PathBuf::from("/bin/sh"),
+            vec!["-c".to_string(), format!("printf '{long_bad_line}\\n'")],
+            policy,
+            Arc::new(SystemClock),
+        );
+        let mut rx = server.take_events().expect("event rx");
+        let sup = tokio::spawn(async move { server.start().await });
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_secs(2), rx.recv()).await {
+                Ok(Some(ServerEvent::GaveUp { .. })) | Ok(None) | Err(_) => break,
+                _ => continue,
+            }
+        }
+        let _ = tokio::time::timeout(Duration::from_secs(2), sup).await;
+
+        let logs = drain_capture();
+        assert!(
+            logs.contains("dropping malformed stdout frame"),
+            "expected the malformed-frame warn to fire, got:\n{logs}"
+        );
+        assert!(
+            logs.contains("line="),
+            "malformed-frame warn must carry a structured `line` field, got:\n{logs}"
+        );
+        assert!(
+            logs.contains('…'),
+            "the `line` field must be truncated with the ellipsis marker, got:\n{logs}"
+        );
+        // The raw 2000-byte line must not reach the log ring intact.
+        assert!(
+            !logs.contains(&"x".repeat(1000)),
+            "the untruncated 2000-byte line must not appear in logs"
+        );
     }
 }

--- a/crates/forge-mcp/src/transport/http.rs
+++ b/crates/forge-mcp/src/transport/http.rs
@@ -186,7 +186,7 @@ impl Http {
                 "POST {} returned HTTP {}: {}",
                 self.url,
                 status,
-                truncate(&body, 512),
+                super::truncate(&body, 512),
             ));
         }
 
@@ -205,7 +205,7 @@ impl Http {
             format!(
                 "parsing POST {} response as JSON: {}",
                 self.url,
-                truncate(&String::from_utf8_lossy(&body), 512),
+                super::truncate(&String::from_utf8_lossy(&body), 512),
             )
         })?;
 
@@ -373,7 +373,7 @@ async fn open_and_read_sse(
                         tracing::warn!(
                             target: "forge_mcp::transport::http",
                             error = %err,
-                            payload = %truncate(&payload, 512),
+                            payload = %super::truncate(&payload, 512),
                             "dropping malformed SSE JSON frame",
                         );
                     }
@@ -453,22 +453,6 @@ fn parse_event_data(event_bytes: &[u8]) -> Option<String> {
     } else {
         None
     }
-}
-
-/// Cap a log field at `max` bytes on a char boundary so a runaway frame
-/// can't flood the log ring.
-fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        return s.to_string();
-    }
-    let mut end = max;
-    for (i, _) in s.char_indices() {
-        if i > max {
-            break;
-        }
-        end = i;
-    }
-    format!("{}…", &s[..end])
 }
 
 #[cfg(test)]
@@ -553,13 +537,5 @@ mod tests {
         assert_eq!(b.delim_len, 4);
 
         assert!(find_event_boundary(b"data: partial\n").is_none());
-    }
-
-    #[test]
-    fn truncate_is_utf8_safe() {
-        let s = "a".repeat(600) + "é";
-        let out = truncate(&s, 300);
-        assert!(out.ends_with('…'));
-        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
     }
 }

--- a/crates/forge-mcp/src/transport/mod.rs
+++ b/crates/forge-mcp/src/transport/mod.rs
@@ -13,3 +13,43 @@ pub mod stdio;
 
 pub use http::{Http, HttpEvent};
 pub use stdio::{Stdio, StdioEvent};
+
+/// Cap a log field at `max` bytes so a runaway frame can't flood the log
+/// ring. Input is assumed UTF-8; slicing is done on a char boundary via
+/// `char_indices` to avoid panicking on multi-byte glyphs.
+///
+/// Shared by both stdio and http transports. F-375 collapsed the previously
+/// byte-identical copies in `stdio.rs` and `http.rs` into this single site.
+pub(crate) fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    for (i, _) in s.char_indices() {
+        if i > max {
+            break;
+        }
+        end = i;
+    }
+    format!("{}…", &s[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate;
+
+    #[test]
+    fn truncate_is_utf8_safe() {
+        let s = "a".repeat(600) + "é";
+        let out = truncate(&s, 300);
+        assert!(out.ends_with('…'));
+        // And it must parse as valid UTF-8 (the slice is on a boundary).
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn truncate_is_noop_below_cap() {
+        let s = "short";
+        assert_eq!(truncate(s, 64), "short");
+    }
+}

--- a/crates/forge-mcp/src/transport/stdio.rs
+++ b/crates/forge-mcp/src/transport/stdio.rs
@@ -217,7 +217,7 @@ impl Stdio {
                                 tracing::warn!(
                                     target: "forge_mcp::transport::stdio",
                                     error = %err,
-                                    line = %truncate(&line, 512),
+                                    line = %super::truncate(&line, 512),
                                     "dropping malformed JSON-RPC frame",
                                 );
                             }
@@ -292,23 +292,6 @@ impl Stdio {
     pub async fn recv(&mut self) -> Option<StdioEvent> {
         self.rx.recv().await
     }
-}
-
-/// Cap a log field at `max` bytes so a runaway frame can't flood the log
-/// ring. `line` is guaranteed UTF-8 here, but we still slice on a char
-/// boundary via `char_indices` to avoid panicking on multi-byte glyphs.
-fn truncate(line: &str, max: usize) -> String {
-    if line.len() <= max {
-        return line.to_string();
-    }
-    let mut end = max;
-    for (i, _) in line.char_indices() {
-        if i > max {
-            break;
-        }
-        end = i;
-    }
-    format!("{}…", &line[..end])
 }
 
 #[cfg(test)]
@@ -413,15 +396,6 @@ mod tests {
             let err2 = t.send(serde_json::json!({"jsonrpc":"2.0","id":2})).await;
             assert!(err2.is_err(), "expected send to fail after child exit");
         }
-    }
-
-    #[test]
-    fn truncate_is_utf8_safe() {
-        let s = "a".repeat(600) + "é";
-        let out = truncate(&s, 300);
-        assert!(out.ends_with('…'));
-        // And it must parse as valid UTF-8 (the slice is on a boundary).
-        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
     }
 
     /// Drain events until the child exits, returning the exit status.


### PR DESCRIPTION
Closes forge-ide/forge#376

## Summary
- Collapse the byte-identical `truncate` previously duplicated in `forge-mcp/src/transport/stdio.rs` and `http.rs` into a single `pub(crate) fn truncate` in `forge-mcp/src/transport/mod.rs`; all three call sites now route through `super::truncate`.
- Port the `truncate` guard into `forge-lsp/src/server.rs` so the malformed-frame WARN no longer logs raw bytes — an unbounded stdout frame could previously flood the log ring.
- File the Phase-3 follow-up (#522) to extract a shared `forge_core::process::ManagedStdioChild` and retire the per-crate helpers entirely.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (includes new `truncate_is_utf8_safe` + `malformed_frame_warn_carries_truncated_line_field` lsp tests)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)