### PR TITLE
[F-401] AgentMonitor and SessionsPanel swallow fetch errors silently

### DIFF
--- a/docs/ui-specs/agent-monitor.md
+++ b/docs/ui-specs/agent-monitor.md
@@ -67,6 +67,15 @@ Five sections:
 
 **Actions (Phase 3 — deferred to [F-449](https://github.com/forge-ide/forge/issues/504)).** `Pause agent`, `Interrupt + refine` (opens a refine composer in context), `Export transcript` (JSONL), `Promote to pane` (background only). Blocked on backend primitives for pause, refine, transcript export, and pane promotion.
 
+### 9.4 States
+
+The agent list (§9.1) renders all four `component-principles.md` states distinctly — a `list_background_agents` rejection must never collapse into the empty placeholder:
+
+- **Loading:** placeholder line `agents · probing` (noun + state per `voice-terminology.md` §8) while `list_background_agents` resolves.
+- **Error:** visible block inside the list column with heading `AGENT LIST UNAVAILABLE`, the verbatim error detail (preserved exactly per `voice-terminology.md` §8 "show technical identifiers verbatim"), and a `RETRY` button that re-invokes `list_background_agents`.
+- **Empty:** `// no agents` mono-comment placeholder once the fetch succeeds with zero rows.
+- **Ready:** the filtered + sorted row list from §9.1.
+
 **Doesn't do.**
 - Does not let you edit agent definitions inline (opens the source file instead)
 - Does not surface prompts verbatim — use `Export transcript` for the full record

--- a/docs/ui-specs/dashboard.md
+++ b/docs/ui-specs/dashboard.md
@@ -57,13 +57,14 @@ The Dashboard renders three children in order: `<h1>` title, `<ProviderPanel/>`,
 
 ### D.5 States
 
-The Dashboard itself has no global loading or error state — it always renders the title and both panels. The panels each handle their own state:
+The Dashboard itself has no global loading or error state — it always renders the title and both panels. The panels each handle their own state per `component-principles.md`'s four-state rule (loading / error / empty / ready):
 
-- **Provider panel — loading:** placeholder line `PROBING` while `provider_status` resolves.
+- **Provider panel — loading:** placeholder line `ollama · probing` (noun + state per `voice-terminology.md` §8) while `provider_status` resolves.
 - **Provider panel — unreachable:** error line + remediation hint + `START OLLAMA` CTA.
+- **Sessions panel — loading:** placeholder line `sessions · probing` while `session_list` resolves.
 - **Sessions panel — empty (active tab):** `// no active sessions`.
 - **Sessions panel — empty (archived tab):** `// archive is empty`.
-- **Sessions panel — fetch failure:** treated as empty (the resource swallows errors and yields `[]`).
+- **Sessions panel — fetch failure:** visible error block with heading `SESSIONS UNAVAILABLE`, the verbatim error detail (preserved exactly per `voice-terminology.md` §8 "show technical identifiers verbatim"), and a `RETRY` button that re-invokes `session_list`. The error state is distinct from empty — the `session_list` rejection must not collapse to `// no active sessions`.
 
 ### D.6 Cross-spec references
 

--- a/web/packages/app/src/routes/AgentMonitor.css
+++ b/web/packages/app/src/routes/AgentMonitor.css
@@ -188,6 +188,69 @@
   margin: var(--sp-4) 0;
 }
 
+/* F-401: loading + error branches for the list column. `component-principles.md`
+ * requires four distinct async states; the mono-noun+state loading line and
+ * the UNAVAILABLE block mirror ProviderPanel's exemplar. */
+.agent-monitor__loading {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  margin: var(--sp-4) 0;
+}
+
+.agent-monitor__error {
+  margin: var(--sp-3) 0;
+}
+
+.agent-monitor__error-body {
+  border: 1px solid var(--color-error-border);
+  background: var(--color-error-bg);
+  padding: var(--sp-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.agent-monitor__error-title {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-error);
+  margin: 0;
+}
+
+.agent-monitor__error-detail {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-primary);
+  margin: 0;
+  word-break: break-word;
+}
+
+.agent-monitor__retry {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--color-error-border);
+  color: var(--color-error);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: var(--sp-1) var(--sp-3);
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.agent-monitor__retry:hover {
+  background: var(--color-error-bg);
+}
+
+.agent-monitor__retry:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}
+
 /* ─── Middle column: trace ─────────────────────────────────────────────── */
 
 .agent-monitor__trace {

--- a/web/packages/app/src/routes/AgentMonitor.test.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.test.tsx
@@ -898,3 +898,106 @@ describe('AgentMonitor — instance query-param pre-selection (F-153)', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// F-401: four-state async-coverage for the bg-agent list column.
+//
+// Previously the route swallowed `list_background_agents` rejections and
+// returned `[]`, so a backend error was indistinguishable from "zero agents".
+// The list column must now expose loading, error, empty, and ready as
+// distinct rendered states — per `component-principles.md`'s async-coverage
+// rule and `agent-monitor.md §9.4`.
+// ---------------------------------------------------------------------------
+describe('AgentMonitor — list column async states (F-401)', () => {
+  function renderAt(path: string) {
+    listenMock.mockResolvedValue(() => {});
+    const history = createMemoryHistory();
+    history.set({ value: path });
+    return render(() => (
+      <MemoryRouter history={history}>
+        <Route path="/agents/:id" component={AgentMonitor} />
+      </MemoryRouter>
+    ));
+  }
+
+  afterEach(() => {
+    setInvokeForTesting(null);
+    listenMock.mockReset();
+  });
+
+  it('renders the mono-noun+state loading line while list_background_agents is in-flight', async () => {
+    // Never-resolving promise so the resource stays in its loading branch.
+    setInvokeForTesting(
+      (async (cmd: string) => {
+        if (cmd === 'list_background_agents') {
+          return new Promise(() => {});
+        }
+        return undefined;
+      }) as never,
+    );
+    const { findByText } = renderAt('/agents/sess-a');
+    // Noun + state per voice-terminology.md §8 — matches ProviderPanel's
+    // `ollama · probing` exemplar. Guard against verb-state regression.
+    const loading = await findByText('agents · probing');
+    expect(loading).toBeTruthy();
+  });
+
+  it('renders the error block with verbatim detail when list_background_agents rejects', async () => {
+    setInvokeForTesting(
+      (async (cmd: string) => {
+        if (cmd === 'list_background_agents') {
+          throw new Error('authz denied: agent-monitor');
+        }
+        return undefined;
+      }) as never,
+    );
+    const { findByText, queryByText } = renderAt('/agents/sess-a');
+    // Noun-state heading, matching PROVIDER UNAVAILABLE exemplar.
+    expect(await findByText('AGENT LIST UNAVAILABLE')).toBeTruthy();
+    // Verbatim technical detail — String(new Error('x')) is "Error: x".
+    expect(await findByText(/Error: authz denied: agent-monitor/)).toBeTruthy();
+    // Error state must be distinct from empty — the comment-syntax empty
+    // placeholder must NOT render when the fetch rejected.
+    expect(queryByText('// no agents')).toBeNull();
+  });
+
+  it('renders // no agents when list_background_agents resolves with an empty list', async () => {
+    setInvokeForTesting(
+      (async (cmd: string) => {
+        if (cmd === 'list_background_agents') return [];
+        return undefined;
+      }) as never,
+    );
+    const { findByText, queryByText } = renderAt('/agents/sess-a');
+    expect(await findByText('// no agents')).toBeTruthy();
+    // Ready-but-empty must NOT render the error UI.
+    expect(queryByText('AGENT LIST UNAVAILABLE')).toBeNull();
+  });
+
+  it('retry button on the error state re-invokes list_background_agents and recovers', async () => {
+    let calls = 0;
+    setInvokeForTesting(
+      (async (cmd: string) => {
+        if (cmd === 'list_background_agents') {
+          calls += 1;
+          if (calls === 1) throw new Error('transient');
+          return [{ id: 'aaaa1111', agent_name: 'writer', state: 'Running' }];
+        }
+        return undefined;
+      }) as never,
+    );
+    const { findByRole, findByText, container } = renderAt('/agents/sess-a');
+    // Error state lands first.
+    expect(await findByText('AGENT LIST UNAVAILABLE')).toBeTruthy();
+    const retry = await findByRole('button', { name: /^retry$/i });
+    fireEvent.click(retry);
+    // Recovery: error clears, row list renders.
+    await waitFor(() => {
+      expect(calls).toBe(2);
+    });
+    await waitFor(() => {
+      const rows = container.querySelectorAll('.agent-monitor__row');
+      expect(rows.length).toBe(1);
+    });
+  });
+});

--- a/web/packages/app/src/routes/AgentMonitor.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.tsx
@@ -357,14 +357,41 @@ function toBgRow(s: BgAgentSummary): AgentRow {
 // Left column — agent list
 // ---------------------------------------------------------------------------
 
+/**
+ * F-401: four-state async coverage for the agent list column.
+ *
+ * `status` drives the list column's sole render branch per
+ * `agent-monitor.md §9.4` — loading / error / empty / ready must each be
+ * visually distinct. Collapsing "backend rejected" into "zero agents" was
+ * the precise regression F-401 flagged.
+ *
+ * - `loading` — `list_background_agents` is in flight. Renders `agents · probing`
+ *   (noun + state per `voice-terminology.md` §8).
+ * - `error`   — the resource rejected. Renders the `AGENT LIST UNAVAILABLE`
+ *   block with the verbatim error detail and a RETRY action.
+ * - `empty`   — the resource resolved with zero rows. Renders `// no agents`.
+ * - `ready`   — the row list (already filtered + sorted by the caller).
+ *
+ * The loading / error / empty branches also carry the tabpanel wiring from
+ * F-416 so the filter tabs' `aria-controls` always resolves to a
+ * `role="tabpanel"` element regardless of which branch renders.
+ */
+export type AgentListStatus =
+  | { kind: 'loading' }
+  | { kind: 'error'; detail: string; onRetry: () => void }
+  | { kind: 'ready' };
+
 export const AgentList: Component<{
   rows: AgentRow[];
   filter: AgentFilter;
   onFilter: (f: AgentFilter) => void;
   selectedId: string | null;
   onSelect: (id: string) => void;
+  /** Optional — when omitted the list behaves as pre-F-401: ready / empty. */
+  status?: AgentListStatus;
 }> = (props) => {
   const visible = createMemo(() => sortAgents(filterAgents(props.rows, props.filter)));
+  const status = (): AgentListStatus => props.status ?? { kind: 'ready' };
 
   // F-416: tabs ↔ tabpanel association (WAI-ARIA APG tabs pattern). A
   // single tabpanel hosts the row list; its aria-labelledby always points
@@ -393,35 +420,72 @@ export const AgentList: Component<{
           )}
         </For>
       </div>
-      <Show
-        when={visible().length > 0}
-        fallback={
-          <p
-            class="agent-monitor__empty"
-            id={rowsPanelId}
-            role="tabpanel"
-            aria-labelledby={filterTabId(props.filter)}
-          >
-            // no agents
-          </p>
-        }
-      >
-        <ul
-          class="agent-monitor__rows"
+      <Show when={status().kind === 'loading'}>
+        <p
+          class="agent-monitor__loading"
           id={rowsPanelId}
           role="tabpanel"
           aria-labelledby={filterTabId(props.filter)}
         >
-          <For each={visible()}>
-            {(row) => (
-              <AgentListRow
-                row={row}
-                active={props.selectedId === row.id}
-                onSelect={props.onSelect}
-              />
-            )}
-          </For>
-        </ul>
+          agents · probing
+        </p>
+      </Show>
+      <Show when={status().kind === 'error'}>
+        {(() => {
+          const err = status() as Extract<AgentListStatus, { kind: 'error' }>;
+          return (
+            <div
+              class="agent-monitor__error"
+              id={rowsPanelId}
+              role="tabpanel"
+              aria-labelledby={filterTabId(props.filter)}
+            >
+              <div class="agent-monitor__error-body" role="alert">
+                <p class="agent-monitor__error-title">AGENT LIST UNAVAILABLE</p>
+                <p class="agent-monitor__error-detail">{err.detail}</p>
+                <button
+                  type="button"
+                  class="agent-monitor__retry"
+                  onClick={() => err.onRetry()}
+                >
+                  RETRY
+                </button>
+              </div>
+            </div>
+          );
+        })()}
+      </Show>
+      <Show when={status().kind === 'ready'}>
+        <Show
+          when={visible().length > 0}
+          fallback={
+            <p
+              class="agent-monitor__empty"
+              id={rowsPanelId}
+              role="tabpanel"
+              aria-labelledby={filterTabId(props.filter)}
+            >
+              // no agents
+            </p>
+          }
+        >
+          <ul
+            class="agent-monitor__rows"
+            id={rowsPanelId}
+            role="tabpanel"
+            aria-labelledby={filterTabId(props.filter)}
+          >
+            <For each={visible()}>
+              {(row) => (
+                <AgentListRow
+                  row={row}
+                  active={props.selectedId === row.id}
+                  onSelect={props.onSelect}
+                />
+              )}
+            </For>
+          </ul>
+        </Show>
       </Show>
     </aside>
   );
@@ -717,16 +781,18 @@ export const StepDrawer: Component<{
 // Route shell — assembles columns + data sources
 // ---------------------------------------------------------------------------
 
+// F-401: surface backend failure as a distinct resource state. Previously
+// this swallowed all `list_background_agents` rejections and returned `[]`,
+// which collapsed "backend failed" into "zero agents" and violated
+// `component-principles.md`'s four-state coverage rule. Now the rejection
+// propagates to the SolidJS resource's `error` field, and the list column
+// renders `AGENT LIST UNAVAILABLE <detail>` per `agent-monitor.md §9.4`.
 async function fetchBgAgents(sessionId: string | null): Promise<BgAgentSummary[]> {
   if (!sessionId) return [];
-  try {
-    const result = await invoke<BgAgentSummary[]>('list_background_agents', {
-      sessionId,
-    });
-    return Array.isArray(result) ? result : [];
-  } catch {
-    return [];
-  }
+  const result = await invoke<BgAgentSummary[]>('list_background_agents', {
+    sessionId,
+  });
+  return Array.isArray(result) ? result : [];
 }
 
 /**
@@ -808,10 +874,11 @@ export const AgentMonitor: Component = () => {
   const [selectedId, setSelectedId] = createSignal<string | null>(null);
   const [openStep, setOpenStep] = createSignal<AgentStep | null>(null);
 
-  // Background agents — refetched when the session id changes.
-  const [bgAgents, { refetch }] = createResource(sessionId, fetchBgAgents, {
-    initialValue: [],
-  });
+  // Background agents — refetched when the session id changes. F-401: no
+  // `initialValue` here so the resource reports `loading` while the first
+  // fetch is in flight; otherwise loading collapses into the ready-empty
+  // branch and the four-state coverage regresses.
+  const [bgAgents, { refetch }] = createResource(sessionId, fetchBgAgents);
 
   // Live rows observed via session:event — session-root and sub-agents. The
   // helper upserts a session row the first time `StepStarted.instance_id`
@@ -825,10 +892,32 @@ export const AgentMonitor: Component = () => {
     Record<string, ResourceSnapshot>
   >({});
 
-  const rows = createMemo<AgentRow[]>(() => [
-    ...bgAgents().map(toBgRow),
-    ...subAgents(),
-  ]);
+  const rows = createMemo<AgentRow[]>(() => {
+    // F-401: reading `bgAgents()` while the resource is in its `errored`
+    // state re-throws in the reactive scope. Gate on the resource's state
+    // so a rejected fetch stays observable via `listStatus` without
+    // crashing the route; sub-agents from session events still render.
+    const fetched = bgAgents.state === 'ready' ? bgAgents() ?? [] : [];
+    return [...fetched.map(toBgRow), ...subAgents()];
+  });
+
+  // F-401: discriminated async state for the list column. Loading only shows
+  // until the resource has a first outcome; error wins over empty so a
+  // rejected fetch never renders as "zero agents". Session-event-driven
+  // sub-agents still render when they arrive in the error branch — those
+  // rows live in `subAgents()` independent of the bg-agent fetch.
+  const listStatus = createMemo<AgentListStatus>(() => {
+    if (bgAgents.loading) return { kind: 'loading' };
+    const err = bgAgents.error;
+    if (err) {
+      return {
+        kind: 'error',
+        detail: err instanceof Error ? `Error: ${err.message}` : String(err),
+        onRetry: () => void refetch(),
+      };
+    }
+    return { kind: 'ready' };
+  });
 
   onMount(async () => {
     // Subscribe to session events to update sub-agents + step timelines.
@@ -918,6 +1007,7 @@ export const AgentMonitor: Component = () => {
         onFilter={setFilter}
         selectedId={selectedId()}
         onSelect={setSelectedId}
+        status={listStatus()}
       />
       <AgentTrace
         agent={selected()}

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.css
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.css
@@ -75,6 +75,69 @@
   margin: var(--sp-6) 0;
 }
 
+/* F-401: loading + error branches for the session list. Mono-noun+state
+ * loading line and `SESSIONS UNAVAILABLE` block mirror ProviderPanel's
+ * four-state coverage exemplar. */
+.sessions__loading {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  margin: var(--sp-6) 0;
+}
+
+.sessions__list-error {
+  margin: var(--sp-4) 0;
+}
+
+.sessions__list-error-body {
+  border: 1px solid var(--color-error-border);
+  background: var(--color-error-bg);
+  padding: var(--sp-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.sessions__list-error-title {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-error);
+  margin: 0;
+}
+
+.sessions__list-error-detail {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-primary);
+  margin: 0;
+  word-break: break-word;
+}
+
+.sessions__retry {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--color-error-border);
+  color: var(--color-error);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: var(--sp-1) var(--sp-3);
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.sessions__retry:hover {
+  background: var(--color-error-bg);
+}
+
+.sessions__retry:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}
+
 /* F-079: inline error surface for failed open_session invokes. */
 .sessions__error {
   font-family: var(--font-mono);

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.test.tsx
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.test.tsx
@@ -111,11 +111,37 @@ describe('SessionsPanel', () => {
     expect(pip?.classList.contains('session-card__pip--stopped')).toBe(true);
   });
 
-  it('treats session_list failure as an empty list', async () => {
+  // F-401: `session_list` rejection must surface a visible error block
+  // (noun + state heading + verbatim detail + RETRY), distinct from the
+  // comment-syntax empty placeholder. Previous behavior swallowed the error
+  // and returned `[]`, making "backend failed" visually identical to "zero
+  // sessions". `dashboard.md D.5` is now the source of truth on this — see
+  // the `SESSIONS UNAVAILABLE` block spec.
+  it('renders the error block with verbatim detail when session_list rejects', async () => {
     invokeMock.mockRejectedValueOnce(new Error('disk exploded'));
-    const { findByText } = render(() => <SessionsPanel />);
+    const { findByText, queryByText } = render(() => <SessionsPanel />);
     await waitForFetch();
-    expect(await findByText('// no active sessions')).toBeTruthy();
+    // Noun-state heading, matching PROVIDER UNAVAILABLE exemplar.
+    expect(await findByText('SESSIONS UNAVAILABLE')).toBeTruthy();
+    // Verbatim technical detail — String(new Error('x')) is "Error: x".
+    expect(await findByText(/Error: disk exploded/)).toBeTruthy();
+    // Error is distinct from empty — the comment-syntax placeholder must NOT
+    // render when the fetch rejected.
+    expect(queryByText('// no active sessions')).toBeNull();
+  });
+
+  it('retry button on the error state re-invokes session_list and recovers', async () => {
+    invokeMock
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce([
+        sample({ id: 'r1', subject: 'recovered', state: 'active' }),
+      ]);
+    const { findByRole, findByText } = render(() => <SessionsPanel />);
+    await waitForFetch();
+    const retry = await findByRole('button', { name: /^retry$/i });
+    fireEvent.click(retry);
+    await waitForFetch();
+    expect(await findByText('recovered')).toBeTruthy();
   });
 
   // F-092: the stopped-pip pulse animation must be gated behind

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.tsx
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.tsx
@@ -18,13 +18,15 @@ export interface SessionSummary {
 
 type Tab = 'active' | 'archived';
 
+// F-401: surface backend failure as a distinct resource state. Previously
+// this swallowed all `session_list` rejections and returned `[]`, which
+// collapsed "backend failed" into "zero sessions" and violated
+// `component-principles.md`'s four-state coverage rule. Now the rejection
+// propagates to the SolidJS resource's `error` field, and the panel
+// renders a `SESSIONS UNAVAILABLE <detail>` block per `dashboard.md D.5`.
 async function fetchSessions(): Promise<SessionSummary[]> {
-  try {
-    const result = await invoke<SessionSummary[]>('session_list');
-    return Array.isArray(result) ? result : [];
-  } catch {
-    return [];
-  }
+  const result = await invoke<SessionSummary[]>('session_list');
+  return Array.isArray(result) ? result : [];
 }
 
 function partition(sessions: SessionSummary[]): Record<Tab, SessionSummary[]> {
@@ -44,14 +46,27 @@ function count(n: number): string {
  * card clicks dispatch `open_session` to reopen the Session window.
  */
 export const SessionsPanel: Component = () => {
-  const [sessions] = createResource(fetchSessions, { initialValue: [] });
+  // F-401: no `initialValue` here so the resource reports `loading` while the
+  // first fetch is in flight; otherwise loading collapses into the ready-empty
+  // branch and the four-state coverage regresses.
+  const [sessions, { refetch }] = createResource(fetchSessions);
   const [tab, setTab] = createSignal<Tab>('active');
   // F-079: inline error surface when `open_session` rejects (IPC auth fail,
   // missing window, validation error, etc.). Previously a fire-and-forget
   // `void invoke(...)` swallowed all rejections silently.
   const [openError, setOpenError] = createSignal<string | null>(null);
-  const groups = () => partition(sessions() ?? []);
+  // F-401: reading `sessions()` while the resource is in its `errored` state
+  // re-throws in the reactive scope. Gate on the resource's state so the
+  // fetch rejection stays observable via the error block without crashing
+  // the panel.
+  const rows = () => (sessions.state === 'ready' ? sessions() ?? [] : []);
+  const groups = () => partition(rows());
   const current = () => groups()[tab()];
+  const listErrorDetail = () => {
+    const err = sessions.error;
+    if (!err) return null;
+    return err instanceof Error ? `Error: ${err.message}` : String(err);
+  };
 
   const handleOpen = (id: string) => {
     setOpenError(null);
@@ -85,30 +100,70 @@ export const SessionsPanel: Component = () => {
           </p>
         )}
       </Show>
-      <Show
-        when={current().length > 0}
-        fallback={
-          <p
-            class="sessions__empty"
-            id={panelId()}
-            role="tabpanel"
-            aria-labelledby={tabId(tab())}
-          >
-            {tab() === 'active' ? '// no active sessions' : '// archive is empty'}
-          </p>
-        }
-      >
-        <div
-          ref={setGridRef}
-          class="sessions__grid"
+      {/* F-401: loading / error branches before the ready tabpanel so the
+          Dashboard panel renders four distinct async states per
+          `dashboard.md D.5`. Loading shows the mono-noun+state line;
+          error shows the `SESSIONS UNAVAILABLE` block with verbatim
+          detail and a RETRY action. Ready delegates to the existing
+          empty-or-grid split. */}
+      <Show when={sessions.loading}>
+        <p
+          class="sessions__loading"
           id={panelId()}
           role="tabpanel"
           aria-labelledby={tabId(tab())}
         >
-          <For each={current()}>
-            {(session) => <SessionCard session={session} onOpen={handleOpen} />}
-          </For>
-        </div>
+          sessions · probing
+        </p>
+      </Show>
+      <Show when={listErrorDetail()}>
+        {(detail) => (
+          <div
+            class="sessions__list-error"
+            id={panelId()}
+            role="tabpanel"
+            aria-labelledby={tabId(tab())}
+          >
+            <div class="sessions__list-error-body" role="alert">
+              <p class="sessions__list-error-title">SESSIONS UNAVAILABLE</p>
+              <p class="sessions__list-error-detail">{detail()}</p>
+              <button
+                type="button"
+                class="sessions__retry"
+                onClick={() => void refetch()}
+              >
+                RETRY
+              </button>
+            </div>
+          </div>
+        )}
+      </Show>
+      <Show when={sessions.state === 'ready'}>
+        <Show
+          when={current().length > 0}
+          fallback={
+            <p
+              class="sessions__empty"
+              id={panelId()}
+              role="tabpanel"
+              aria-labelledby={tabId(tab())}
+            >
+              {tab() === 'active' ? '// no active sessions' : '// archive is empty'}
+            </p>
+          }
+        >
+          <div
+            ref={setGridRef}
+            class="sessions__grid"
+            id={panelId()}
+            role="tabpanel"
+            aria-labelledby={tabId(tab())}
+          >
+            <For each={current()}>
+              {(session) => <SessionCard session={session} onOpen={handleOpen} />}
+            </For>
+          </div>
+        </Show>
       </Show>
     </section>
   );


### PR DESCRIPTION
Closes forge-ide/forge#402

## Summary
- AgentMonitor `fetchBgAgents` and SessionsPanel `fetchSessions` no longer swallow rejections; errors propagate to the SolidJS resource's `error` field.
- List columns now render four distinct states per `component-principles.md` async-coverage and `voice-terminology.md` §8 noun+state voice: loading (`agents · probing` / `sessions · probing`), error (`AGENT LIST UNAVAILABLE` / `SESSIONS UNAVAILABLE` + verbatim detail + RETRY), empty, ready.
- `dashboard.md D.5` tightened to require a visible error block on `session_list` rejection; `agent-monitor.md` gains a new 9.4 States section.
- Regression tests added per component covering loading / error (with verbatim detail) / empty / retry-recovery.

## Test plan
- `pnpm --filter app test` — 866/866 passing (70/70 across AgentMonitor + SessionsPanel suites, including 6 new F-401 regressions)
- `pnpm -r typecheck` — clean
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` — clean

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)