### PR TITLE
docs(phase-2): add rustdoc # Examples to public Phase-2 entry points (F-443)

### DIFF
--- a/crates/forge-agents/src/lib.rs
+++ b/crates/forge-agents/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 //! `forge-agents` — agent definitions, the `.agents/*.md` loader, and the
 //! runtime orchestrator.
 //!
@@ -72,6 +73,25 @@ pub struct AgentLoader {
 
 impl AgentLoader {
     /// Load workspace + user agents and the workspace `AGENTS.md` in one pass.
+    ///
+    /// # Examples
+    ///
+    /// Point the loader at empty scratch roots — both `.agents/` dirs are
+    /// absent, so the loader returns an empty bundle rather than failing:
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use forge_agents::AgentLoader;
+    ///
+    /// # fn example() -> anyhow::Result<()> {
+    /// let loader = AgentLoader::load(
+    ///     Path::new("/path/to/workspace"),
+    ///     Path::new("/path/to/home"),
+    /// )?;
+    /// assert!(loader.agents().is_empty());
+    /// assert!(loader.agents_md().is_none());
+    /// # Ok(()) }
+    /// ```
     pub fn load(workspace_root: &Path, user_home: &Path) -> anyhow::Result<Self> {
         Ok(Self {
             agents: load_agents(workspace_root, user_home)?,

--- a/crates/forge-agents/src/orchestrator.rs
+++ b/crates/forge-agents/src/orchestrator.rs
@@ -195,6 +195,29 @@ impl Orchestrator {
     /// Rejects `isolation: trusted` under [`AgentScope::User`] with a typed
     /// [`Error::IsolationViolation`]. This re-enforces the parse-time check
     /// for programmatically-constructed defs that bypass the parser.
+    ///
+    /// # Examples
+    ///
+    /// Spawn a user-scope instance from a programmatically-built def and
+    /// observe the registered [`InstanceState::Running`]:
+    ///
+    /// ```
+    /// use forge_agents::{AgentDef, InstanceState, Isolation, Orchestrator, SpawnContext};
+    ///
+    /// # async fn example() -> forge_agents::Result<()> {
+    /// let def = AgentDef {
+    ///     name: "reviewer".into(),
+    ///     description: Some("code reviewer".into()),
+    ///     body: "You review diffs.".into(),
+    ///     allowed_paths: vec![],
+    ///     isolation: Isolation::Process,
+    /// };
+    /// let orchestrator = Orchestrator::new();
+    /// let instance = orchestrator.spawn(def, SpawnContext::user()).await?;
+    /// assert_eq!(instance.state, InstanceState::Running);
+    /// # Ok(()) }
+    /// # futures::executor::block_on(example()).unwrap();
+    /// ```
     pub async fn spawn(&self, def: AgentDef, ctx: SpawnContext) -> Result<AgentInstance> {
         if ctx.scope == AgentScope::User && def.isolation == Isolation::Trusted {
             tracing::warn!(

--- a/crates/forge-lsp/src/bootstrap.rs
+++ b/crates/forge-lsp/src/bootstrap.rs
@@ -213,6 +213,29 @@ impl Bootstrap {
     /// - [`BootstrapError::Download`] for transport failures.
     /// - [`BootstrapError::SandboxEscape`] for hostile ids.
     /// - [`BootstrapError::Io`] for cache write failures.
+    ///
+    /// # Examples
+    ///
+    /// Resolve the bundled registry's rust-analyzer entry against a
+    /// scratch cache root. The bundled registry ships with
+    /// [`Checksum::Pending`] pins, so `ensure` surfaces
+    /// [`BootstrapError::ChecksumPending`] — the intended safety net
+    /// that prevents an unpinned archive from ever touching disk:
+    ///
+    /// ```no_run
+    /// use forge_lsp::{Bootstrap, BootstrapError, Registry};
+    ///
+    /// # async fn example() -> Result<(), BootstrapError> {
+    /// let bootstrap = Bootstrap::new()?;
+    /// let spec = Registry::bundled()
+    ///     .by_language("rust")
+    ///     .expect("rust-analyzer registered");
+    /// match bootstrap.ensure(spec).await {
+    ///     Err(BootstrapError::ChecksumPending { .. }) => { /* expected until RE pins */ }
+    ///     other => panic!("unexpected result: {other:?}"),
+    /// }
+    /// # Ok(()) }
+    /// ```
     pub async fn ensure(&self, spec: &ServerSpec) -> Result<PathBuf, BootstrapError> {
         let expected = match &spec.checksum {
             Checksum::Sha256(h) => h.clone(),

--- a/crates/forge-lsp/src/registry.rs
+++ b/crates/forge-lsp/src/registry.rs
@@ -77,6 +77,15 @@ pub struct Registry {
 
 impl Registry {
     /// The 16 bundled servers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use forge_lsp::Registry;
+    ///
+    /// let registry = Registry::bundled();
+    /// assert_eq!(registry.all().len(), 16);
+    /// ```
     pub fn bundled() -> Self {
         Self {
             entries: BUNDLED_SERVERS,
@@ -103,6 +112,17 @@ impl Registry {
     /// Look up a spec by Monaco language id (e.g. `"rust"`, `"typescript"`).
     /// Returns the first match; multiple servers may claim a language but
     /// the bundled set is currently one-per-language.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use forge_lsp::{Registry, ServerId};
+    ///
+    /// let registry = Registry::bundled();
+    /// let spec = registry.by_language("rust").expect("rust-analyzer registered");
+    /// assert_eq!(spec.id, ServerId("rust-analyzer"));
+    /// assert!(registry.by_language("nonexistent-lang").is_none());
+    /// ```
     pub fn by_language(&self, language_id: &str) -> Option<&'static ServerSpec> {
         self.entries.iter().find(|s| s.language_id == language_id)
     }

--- a/crates/forge-lsp/src/server.rs
+++ b/crates/forge-lsp/src/server.rs
@@ -432,6 +432,28 @@ impl Server {
     /// uniformly. Event delivery on [`Self::take_events`] continues across
     /// restarts; the receiver yields `None` after `GaveUp` because the
     /// supervisor drops the sender on return.
+    ///
+    /// # Examples
+    ///
+    /// Resolve a bundled spec through [`Bootstrap`], build a supervised
+    /// [`Server`] from the registry, and drive it in a background task
+    /// so the caller can observe lifecycle events:
+    ///
+    /// ```no_run
+    /// use forge_lsp::{Bootstrap, Server, ServerError, ServerId};
+    ///
+    /// # async fn example() -> Result<(), ServerError> {
+    /// let bootstrap = Bootstrap::new().expect("cache root resolved");
+    /// let mut server = Server::from_registry(ServerId("rust-analyzer"), &bootstrap, vec![])?;
+    /// let mut events = server.take_events().expect("event rx");
+    /// tokio::spawn(async move {
+    ///     while let Some(evt) = events.recv().await {
+    ///         tracing::info!(?evt, "lsp event");
+    ///     }
+    /// });
+    /// server.start().await
+    /// # }
+    /// ```
     pub async fn start(&self) -> Result<(), ServerError> {
         let mut attempts = 0u32;
         let mut window_start = self.clock.now();

--- a/crates/forge-mcp/src/lib.rs
+++ b/crates/forge-mcp/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 //! MCP (Model Context Protocol) client crate.
 //!
 //! Owns the universal `.mcp.json` schema — the `mcpServers` object keyed by

--- a/crates/forge-mcp/src/manager.rs
+++ b/crates/forge-mcp/src/manager.rs
@@ -267,6 +267,19 @@ impl McpManager {
     /// entries; [`McpManager::start`] is the explicit trigger. This
     /// matches `forge-lsp` / `forge-providers` where instantiation is
     /// cheap and connect-on-use is the norm.
+    ///
+    /// # Examples
+    ///
+    /// Construct a manager from an empty config (no servers) — the common
+    /// shape on first boot before the user has authored any `.mcp.json`:
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use forge_mcp::McpManager;
+    ///
+    /// let mgr = McpManager::new(BTreeMap::new());
+    /// assert!(futures::executor::block_on(mgr.list()).is_empty());
+    /// ```
     pub fn new(config: BTreeMap<String, McpServerSpec>) -> Self {
         Self::with_tuning(config, LifecycleTuning::default())
     }
@@ -346,6 +359,27 @@ impl McpManager {
     /// and restarts on failure.
     ///
     /// Idempotent: starting an already-running server is a no-op.
+    ///
+    /// # Examples
+    ///
+    /// Build a manager from a single stdio spec and drive its lifecycle:
+    ///
+    /// ```no_run
+    /// use std::collections::BTreeMap;
+    /// use forge_mcp::{McpManager, McpServerSpec, ServerKind};
+    ///
+    /// # async fn example() -> anyhow::Result<()> {
+    /// let spec = McpServerSpec {
+    ///     kind: ServerKind::Stdio {
+    ///         command: "mcp-server-demo".into(),
+    ///         args: vec![],
+    ///         env: BTreeMap::new(),
+    ///     },
+    /// };
+    /// let mgr = McpManager::new(BTreeMap::from([("demo".into(), spec)]));
+    /// mgr.start("demo").await?;
+    /// # Ok(()) }
+    /// ```
     pub async fn start(&self, name: &str) -> Result<()> {
         // Scope the map lock tightly so we don't hold it across the
         // `tokio::spawn` — spawn is non-blocking but keeping the lock


### PR DESCRIPTION
Closes forge-ide/forge#444

## Summary
- Added `# Examples` blocks to eight Phase-2 public entry points: `McpManager::new`, `McpManager::start`, `Bootstrap::ensure`, `Registry::bundled`, `Registry::by_language`, `Server::start`, `Orchestrator::spawn`, `AgentLoader::load`.
- Extended `#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]` to `forge-mcp` and `forge-agents` (`forge-lsp` already had it) so the new intra-doc links are covered by the same safety net.
- Async / side-effecting doctests are `no_run` so they compile without spawning children or hitting the network; pure in-memory examples run for real.

## Test plan
- `cargo test --workspace` passes (8 new doctests: 4 compile-only `no_run`, 4 runnable)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --all -- --check` clean

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)