### PR TITLE
[F-398] Button IconButton Tab MenuItem primitives missing across 44 sites

### DIFF
--- a/docs/frontend/button-primitives-migration.md
+++ b/docs/frontend/button-primitives-migration.md
@@ -1,0 +1,269 @@
+# Button Primitives Migration Plan
+
+> Phase-3 migration plan for extracting `Button`, `IconButton`, `Tab+Tabs`, and
+> `MenuItem` into `@forge/design` and replacing the 44 raw `<button>` sites
+> catalogued in F-398. Planning-only artifact — no code change in this phase.
+
+**Status:** planning (F-398). Implementation tracked by the Phase-3 sibling
+issue named in F-398's DoD.
+
+**Related docs:** [Component Principles](../design/component-principles.md) ·
+[Voice & Terminology](../design/voice-terminology.md) ·
+[Generation Pipelines](generation-pipelines.md)
+
+---
+
+## Why
+
+`@forge/design` ships `tokens.css` today. Every button in the app re-implements
+`type="button"`, focus-visible outline, hover state, uppercase typography, and
+a11y wiring — 44 sites across 16 files. That is consistency-drift risk, not a
+correctness bug, so the extraction is deferred to Phase 3 per F-398. This doc
+pins the target shape so a Phase-3 PR set can land mechanically.
+
+## Non-goals
+
+- **No runtime behavior change.** Primitives must render byte-equivalent DOM
+  (plus `aria-*` additions where currently missing) so visual regression is
+  zero.
+- **No new design decisions.** The primitive surface mirrors the variants
+  already documented in [Component Principles §Buttons](../design/component-principles.md#buttons).
+  If a site's current styling drifts from the design doc, migration fixes the
+  site — not the primitive.
+- **No tokenization of row/card-as-button patterns** (see allowlist below).
+  Those are content-shaped; wrapping them in a primitive would leak layout
+  concerns into the primitive's API.
+
+---
+
+## Primitives
+
+All primitives live in `web/packages/design/src/button/` and export through
+`web/packages/design/src/index.ts`. Solid components, props typed with
+`ComponentProps<'button'>` extension so `onClick`, `disabled`, `aria-*`, etc.
+pass through. Source label strings must be literal UPPERCASE so screen readers
+announce the casing correctly (per [Voice & Terminology](../design/voice-terminology.md#formatting-rules-for-ui-copy)).
+
+### `Button` — 16 sites
+
+The primary/secondary/ghost/danger archetype. Verb-noun display-caps label
+lives as the component's children.
+
+```tsx
+type ButtonProps = ComponentProps<'button'> & {
+  variant?: 'primary' | 'ghost' | 'danger';  // default: 'primary'
+  size?: 'sm' | 'md';                        // default: 'md'
+  leadingIcon?: JSX.Element;
+  trailingIcon?: JSX.Element;
+  loading?: boolean;                         // renders a spinner, disables click
+  kbd?: string;                              // right-aligned keyboard hint
+};
+```
+
+**Behavioral contract**
+- `type="button"` is baked in — children never pass `type="submit"` accidentally.
+- `disabled` renders the `iron-600` background per [Component Principles](../design/component-principles.md#buttons),
+  never `opacity`.
+- `loading` implies `disabled` and renders `aria-busy="true"`.
+- Focus ring uses `--color-ember-400` outline; never suppressed.
+
+**Migration sites (16):** #1, #2, #3, #17, #18 (button only; row stays raw),
+#20, #21, #22, #24, #25, #28, #29, #30, #31, #34, #36, #37, #38, #39.
+Exact line numbers in F-398 catalog.
+
+### `IconButton` — 8 sites
+
+Icon-only trigger. `label` is required so every IconButton has an accessible
+name — this is the primary lint-rule payoff.
+
+```tsx
+type IconButtonProps = Omit<ComponentProps<'button'>, 'aria-label' | 'children'> & {
+  icon: JSX.Element;
+  label: string;                             // required → aria-label + title
+  variant?: 'ghost' | 'danger';              // default: 'ghost'
+  size?: 'sm' | 'md';                        // default: 'md'
+  pressed?: boolean;                         // toggle state → aria-pressed
+};
+```
+
+**Behavioral contract**
+- `label` is passed through as both `aria-label` and `title`. No string-free
+  escape hatch — the compile error is the point.
+- `pressed` renders `aria-pressed` (toggle affordance for activity-bar icons).
+- Focus ring identical to `Button` — inherited from `.forge-button--focus` class.
+
+**Migration sites (8):** #4, #8, #9, #10, #11, #12, #23, #32, #40.
+
+### `Tab` + `Tabs` — 7 sites
+
+Roving-tabindex tab list. `Tabs` is the container (owns focus management);
+`Tab` is the individual row. `variant="radio"` covers the approval-scope
+pill pattern that currently abuses `role="radio"` on a button.
+
+```tsx
+type TabsProps = ComponentProps<'div'> & {
+  activeId: string;
+  onSelect: (id: string) => void;
+  variant?: 'tab' | 'radio';                 // default: 'tab'
+};
+
+type TabProps = ComponentProps<'button'> & {
+  id: string;
+  label: string;
+  badgeCount?: number;
+};
+```
+
+**Behavioral contract**
+- `<Tabs variant="tab">` renders `role="tablist"`; each `<Tab>` renders
+  `role="tab"` + `aria-selected`.
+- `<Tabs variant="radio">` renders `role="radiogroup"`; each `<Tab>` renders
+  `role="radio"` + `aria-checked`.
+- Arrow-key navigation inside `Tabs` moves focus between enabled children
+  (roving tabindex — one child is tabbable, the rest are `tabindex={-1}`).
+- Enter / Space on a focused tab fires `onSelect`.
+
+**Migration sites (7):** #13, #17, #26, #33, #34, #35 (radio variant), and
+one of the existing `role="tab"` call sites in `AgentMonitor.tsx` filter bar.
+
+### `MenuItem` — 9 sites
+
+Row in a `role="menu"` container. Does not own the menu container itself
+(that stays per-feature — `FilesSidebar` context menu, `ApprovalPrompt`
+scope menu, etc.); just normalises each row.
+
+```tsx
+type MenuItemProps = ComponentProps<'button'> & {
+  label: string;
+  leadingText?: string;                      // left-rail hint (e.g. file path scope)
+  kbd?: string;                              // right-aligned keyboard hint
+  variant?: 'default' | 'danger';            // default: 'default'
+};
+```
+
+**Behavioral contract**
+- `role="menuitem"` baked in — parent `<ul role="menu">` still owned by
+  the feature.
+- Arrow-key navigation is the parent menu's responsibility, not the primitive's.
+- `danger` variant uses `--color-error` text; no separate border.
+- Source label must be literal UPPERCASE (voice rule).
+
+**Migration sites (9):** #5, #6, #7, #15, #16, #41, #42, #43, #44.
+
+---
+
+## Allowlist (row/card-as-button sites — stay raw)
+
+Five files render a raw `<button>` where the entire content is a row or card
+with layout concerns the primitive can't express cleanly. These are
+allowlisted by `scripts/check-raw-buttons.mjs` and stay raw after migration:
+
+| Catalog # | File | Why raw |
+|---|---|---|
+| 1 | `web/packages/app/src/shell/StatusBar.tsx` | bg-agents badge row — content-shape varies with count |
+| 14 | `web/packages/app/src/components/BranchMetadataPopover.tsx` | variant row with chip + timestamp |
+| 18, 19 | `web/packages/app/src/routes/AgentMonitor.tsx` | agent row / trace step — tree affordance |
+| 27 | `web/packages/app/src/routes/Dashboard/SessionsPanel.tsx` | session card |
+
+The _inner_ controls inside these rows (e.g. the stop-button at #3 inside the
+StatusBar row, the delete button at #15 inside BranchMetadataPopover, the
+tabs at #17 above AgentMonitor's agent row) still migrate to primitives.
+Migration diff must keep the outer `<button>` and only rewrite the inner
+controls.
+
+---
+
+## Migration PRs (4, grouped by archetype)
+
+Each PR opens, lands, and ships independently. Hard sequencing: PR 1 must
+merge before PR 2–4 because 2–4 depend on the primitives existing.
+
+### PR 1 — Primitives + Button migration (16 sites)
+
+- **Scope:** Add `Button`, `IconButton`, `Tab+Tabs`, `MenuItem` under
+  `web/packages/design/src/button/`. Export through `@forge/design`.
+  Migrate only the 16 `Button` sites; leave the rest raw for now.
+- **Files:** 1 new directory in `web/packages/design/`, 16 files in
+  `web/packages/app/src/` touched.
+- **Tests:** Solid-testing-library unit tests per primitive (props → DOM
+  shape, focus behavior, aria attrs). Visual parity checked with `@forge/design`
+  Storybook-equivalent smoke route (optional).
+- **CI:** green via existing `just check-web`. Raw-button lint stays
+  disabled — the remaining archetypes still have raw buttons.
+
+### PR 2 — IconButton migration (8 sites)
+
+- **Scope:** Replace 8 icon-only raw buttons with `IconButton`. No primitive
+  changes.
+- **Files:** 8 TSX files touched — `ActivityBar`, `BranchSelectorStrip`
+  (×3), `ContextChip`, `FilesSidebar` (refresh), `EditorPane` (close),
+  `WhitelistedPill`, `ApprovalPrompt` (dropdown toggle).
+- **Tests:** per-site snapshot check that the `aria-label` is present and
+  matches the previous `aria-label` verbatim.
+
+### PR 3 — Tab + MenuItem migration (16 sites)
+
+- **Scope:** Replace 7 `Tab` call sites (including approval-scope
+  `role="radio"` abusers via `<Tabs variant="radio">`) and 9 `MenuItem`
+  rows.
+- **Files:** `ContextPicker`, `AgentMonitor` (filter bar), `SessionsPanel`,
+  `ApprovalPrompt`, `FilesSidebar` (context menu), `BranchMetadataPopover`
+  (inner menu).
+- **Tests:** keyboard-navigation tests for `Tabs` roving focus and
+  menu-open → arrow-key stepping.
+
+### PR 4 — Activate the raw-button lint (cleanup)
+
+- **Scope:**
+  1. Shrink `ALLOWLIST` in `scripts/check-raw-buttons.mjs` to only the five
+     row/card files above.
+  2. Add `node scripts/check-raw-buttons.mjs` to `justfile`'s `check-web`
+     recipe, after `pnpm check-tokens`.
+  3. Add `"check-raw-buttons": "node ../scripts/check-raw-buttons.mjs"` to
+     `web/package.json`.
+  4. Update this doc's header to mark planning as shipped.
+- **Tests:** CI now fails on any new raw button. Nothing else changes.
+
+---
+
+## A11y requirements (cross-primitive)
+
+- **Focus ring never suppressed.** All primitives use
+  `outline: 2px solid var(--color-ember-400)` via a shared `.forge-button`
+  class; no `:focus-visible { outline: none }` without a replacement.
+- **Source-text uppercase, not CSS.** `text-transform: uppercase` remains for
+  letter-spacing cosmetics, but the source text must already be uppercase so
+  screen readers announce the intended casing (voice rule §8).
+- **Disabled is semantic.** `disabled` maps to HTML `disabled` + token-driven
+  `iron-600` background. No pointer-events / opacity escape hatch.
+- **Icon-only always has an accessible name.** `IconButton.label` is required
+  at the type level — this is the single biggest gap the primitives close.
+- **Pressed / selected state.** `pressed`, `aria-checked`, `aria-selected`,
+  `aria-expanded` wired where appropriate; no site should be reaching for
+  `aria-*` directly through the primitive's `...rest` spread.
+
+## Testing strategy
+
+- **Unit (primitive):** Vitest + `@solidjs/testing-library` per primitive.
+  Props → DOM shape, focus trap where relevant, keyboard interaction.
+- **Unit (lint):** `scripts/check-raw-buttons.test.mjs` — fixture-driven, runs
+  via `node scripts/check-raw-buttons.test.mjs`. See file header for how it
+  drives `scanTsxSources`.
+- **Integration:** existing Tauri webview smoke tests keep running; no new
+  suites needed because DOM shape is parity-preserving.
+
+---
+
+## The raw-button lint (drafted, disabled)
+
+Drafted state lives at `scripts/check-raw-buttons.mjs` with unit tests at
+`scripts/check-raw-buttons.test.mjs`. It is **not wired into CI** — activating
+it today fails against the existing 44 sites. Phase-3 migration PR 4 flips the
+switch per the steps above.
+
+The rule itself is a sibling to `scripts/check-tokens.mjs`: a plain-Node
+script, zero new deps, walks `web/packages/app/src/**/*.tsx`, and flags
+any JSX `<button` opening tag whose file is not in `ALLOWLIST`. It does not
+depend on ESLint's TSX parser because the repo has no ESLint wiring today;
+using the same pattern as `check-tokens` keeps the dev dependency surface
+flat.

--- a/docs/frontend/generation-pipelines.md
+++ b/docs/frontend/generation-pipelines.md
@@ -47,6 +47,19 @@ updating both simultaneously.
 
 ---
 
+### Drafted sibling — raw-`<button>` check (F-398, disabled)
+
+`scripts/check-raw-buttons.mjs` mirrors the token-check pattern for raw
+`<button>` JSX under `web/packages/app/src/`. It is **not wired into
+`just check-web`** today because the primitives it steers toward
+(`Button` / `IconButton` / `Tab+Tabs` / `MenuItem` in `@forge/design`)
+ship in Phase 3. Activate it in the final migration PR per
+[`button-primitives-migration.md`](button-primitives-migration.md) §"Migration
+PRs — PR 4". Unit tests live at `scripts/check-raw-buttons.test.mjs` and run
+via `node scripts/check-raw-buttons.test.mjs`.
+
+---
+
 ## 2. ts-rs Rust to TypeScript IPC types
 
 Rust IPC types in `crates/forge-core` are the source of truth for the

--- a/scripts/check-raw-buttons.mjs
+++ b/scripts/check-raw-buttons.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Raw-`<button>` drift check — DRAFTED, DISABLED (F-398).
+//
+// Purpose: once `@forge/design` ships `Button` / `IconButton` / `Tab+Tabs` /
+// `MenuItem` primitives (Phase 3), forbid raw `<button>` inside
+// `web/packages/app/src/` outside the allowlisted row/card-as-button sites.
+//
+// State today: DRAFTED and NOT WIRED into CI. The primitives don't exist yet,
+// so activating this rule would fail the build against the existing 44 raw
+// sites. This file exists so the lint is committed and reviewable alongside
+// the migration plan; Phase-3 migration PR 4 (cleanup) flips the switch.
+//
+// To activate in Phase 3:
+//   1. Delete or shrink the `ALLOWLIST` below to only true row/card-as-button
+//      files (rows 1, 14, 18, 19, 27 from the F-398 catalog).
+//   2. Add `node scripts/check-raw-buttons.mjs` to `justfile`'s `check-web`
+//      recipe, after `pnpm check-tokens`.
+//   3. Add a `pnpm check-raw-buttons` script to `web/package.json`.
+//
+// Migration plan: `docs/frontend/button-primitives-migration.md`.
+// Tests:         `scripts/check-raw-buttons.test.mjs` (unit-tested on fixtures).
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+
+// Allowlist of files that legitimately render a raw `<button>` because the
+// content shape (row, card, tree item) isn't cleanly expressible through a
+// primitive. Sourced from the F-398 catalog's row/card-as-button callout.
+//
+// Paths are relative to the repo root, using forward slashes.
+export const ALLOWLIST = [
+  'web/packages/app/src/shell/StatusBar.tsx',               // row 1 — bg-agent badge
+  'web/packages/app/src/components/BranchMetadataPopover.tsx', // row 14 — variant rows
+  'web/packages/app/src/routes/AgentMonitor.tsx',           // rows 18, 19 — agent row, trace step
+  'web/packages/app/src/routes/Dashboard/SessionsPanel.tsx', // row 27 — session card
+];
+
+/** Recursively yield absolute paths of `.tsx` files under `dir`. */
+function* walkTsx(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkTsx(full);
+    } else if (entry.isFile() && entry.name.endsWith('.tsx')) {
+      yield full;
+    }
+  }
+}
+
+/**
+ * Match opening JSX `<button` tags. The trailing boundary is a whitespace
+ * char or `>` so we don't false-positive on identifiers like `Button`,
+ * `ButtonGroup`, etc. (JSX tag names are case-sensitive; capital `B`
+ * components are primitives by convention.)
+ */
+const rawButton = /<button(?=[\s>])/g;
+
+/**
+ * Scan every `.tsx` file under `root`, returning `{ file, line }` for each
+ * raw `<button` opening tag in a file not covered by `allowlist`.
+ *
+ * Exported so `check-raw-buttons.test.mjs` can drive it with tmpdir
+ * fixtures without hitting the real repo tree.
+ *
+ * @param {{ root: string, allowlist?: string[] }} opts
+ * @returns {Array<{ file: string, line: number }>}
+ */
+export function scanTsxSources({ root, allowlist = [] }) {
+  const suppressed = new Set(allowlist);
+  const findings = [];
+  for (const file of walkTsx(root)) {
+    const rel = relative(root, file).split('\\').join('/');
+    if (suppressed.has(rel)) continue;
+    const source = readFileSync(file, 'utf-8');
+    rawButton.lastIndex = 0;
+    let m;
+    while ((m = rawButton.exec(source)) !== null) {
+      const upto = source.slice(0, m.index);
+      const line = upto.split('\n').length;
+      findings.push({ file: rel, line });
+    }
+  }
+  return findings;
+}
+
+/** CLI entry point — invoked only when this file is run directly. */
+function main() {
+  const repoRoot = resolve(new URL('..', import.meta.url).pathname);
+  const scanRoot = resolve(repoRoot, 'web/packages/app/src');
+  const findings = scanTsxSources({ root: scanRoot, allowlist: ALLOWLIST.map((p) => relative('web/packages/app/src', p).split('\\').join('/')) });
+  if (findings.length > 0) {
+    console.error(`Raw <button> detected at ${findings.length} site(s):`);
+    for (const f of findings) console.error(`  - ${f.file}:${f.line}`);
+    console.error('\nUse a @forge/design primitive (Button / IconButton / Tab / MenuItem)');
+    console.error('or add the file to ALLOWLIST in scripts/check-raw-buttons.mjs if it');
+    console.error('is a row/card-as-button site.');
+    process.exit(1);
+  }
+  console.log('ok: no raw <button> outside allowlisted sites');
+}
+
+// Only run the CLI when this file is invoked directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/check-raw-buttons.test.mjs
+++ b/scripts/check-raw-buttons.test.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Tests for check-raw-buttons.mjs.
+//
+// The rule is drafted DISABLED (F-398): it is not wired into `just check-web`
+// and CI does not call it. These tests prove the rule catches raw `<button>`
+// on a TSX fixture and honors the allowlist of row/card-as-button sites.
+// They run only when explicitly invoked: `node scripts/check-raw-buttons.test.mjs`.
+
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const rulePath = resolve(here, 'check-raw-buttons.mjs');
+
+/** Run a fixture through the rule's exported `scanTsxSources` and return findings. */
+async function runRule({ files, allowlist }) {
+  const { scanTsxSources } = await import(pathToFileURL(rulePath).href);
+  const root = mkdtempSync(resolve(tmpdir(), 'forge-raw-button-'));
+  try {
+    for (const [relPath, body] of Object.entries(files)) {
+      const abs = resolve(root, relPath);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, body, 'utf-8');
+    }
+    return scanTsxSources({ root, allowlist: allowlist ?? [] });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+const cases = [];
+function test(name, fn) { cases.push({ name, fn }); }
+
+test('flags a raw <button> in a TSX file', async () => {
+  const findings = await runRule({
+    files: {
+      'web/packages/app/src/components/Foo.tsx':
+        'export const Foo = () => <button type="button">CLICK</button>;\n',
+    },
+  });
+  if (findings.length !== 1) throw new Error(`expected 1 finding, got ${findings.length}: ${JSON.stringify(findings)}`);
+  if (!findings[0].file.endsWith('Foo.tsx')) throw new Error(`wrong file: ${findings[0].file}`);
+  if (findings[0].line !== 1) throw new Error(`wrong line: ${findings[0].line}`);
+});
+
+test('ignores a Button primitive import from @forge/design', async () => {
+  const findings = await runRule({
+    files: {
+      'web/packages/app/src/components/Foo.tsx':
+        "import { Button } from '@forge/design';\nexport const Foo = () => <Button variant=\"primary\">CLICK</Button>;\n",
+    },
+  });
+  if (findings.length !== 0) throw new Error(`expected 0 findings, got ${findings.length}: ${JSON.stringify(findings)}`);
+});
+
+test('skips files on the allowlist (row/card-as-button sites)', async () => {
+  const findings = await runRule({
+    files: {
+      'web/packages/app/src/routes/AgentMonitor.tsx':
+        'export const Row = () => <button type="button" class="row">...</button>;\n',
+    },
+    allowlist: ['web/packages/app/src/routes/AgentMonitor.tsx'],
+  });
+  if (findings.length !== 0) throw new Error(`expected allowlist to suppress, got ${findings.length}: ${JSON.stringify(findings)}`);
+});
+
+test('flags multi-line <button> blocks with attrs spanning lines', async () => {
+  const findings = await runRule({
+    files: {
+      'web/packages/app/src/components/Multi.tsx':
+        'export const Multi = () => (\n  <button\n    type="button"\n    class="x"\n  >GO</button>\n);\n',
+    },
+  });
+  if (findings.length !== 1) throw new Error(`expected 1 finding, got ${findings.length}`);
+  if (findings[0].line !== 2) throw new Error(`expected line 2 (opening <button), got ${findings[0].line}`);
+});
+
+test('does not false-positive on a string containing the word button', async () => {
+  const findings = await runRule({
+    files: {
+      'web/packages/app/src/components/Label.tsx':
+        'export const Label = () => <span title="this is a button label">x</span>;\n',
+    },
+  });
+  if (findings.length !== 0) throw new Error(`expected 0 findings, got ${findings.length}: ${JSON.stringify(findings)}`);
+});
+
+let failed = 0;
+for (const { name, fn } of cases) {
+  try {
+    await fn();
+    console.log(`ok: ${name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL: ${name}`);
+    console.error(`  ${err.message}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} test(s) failed`);
+  process.exit(1);
+}
+console.log(`\n${cases.length} tests passed`);


### PR DESCRIPTION
Closes forge-ide/forge#399

## Summary
- Committed a Phase-3 migration plan at `docs/frontend/button-primitives-migration.md` detailing the four primitives (`Button`, `IconButton`, `Tab+Tabs`, `MenuItem`), per-primitive API sketches, a11y requirements, site-by-site mapping for all 44 catalogued raw `<button>` locations, and the 4-PR migration sequence grouped by archetype.
- Created the Phase-3 tracking issue forge-ide/forge#526 (F-450) — `@forge/design Button/IconButton/Tab/MenuItem primitives + migration sweep` — with DoD covering the four primitives plus the full migration and lint activation.
- Drafted `scripts/check-raw-buttons.mjs` as a disabled sibling of `check-tokens.mjs` that forbids raw `<button>` in `web/packages/app/src/` outside the allowlist of five row/card-as-button files. Unit-tested at `scripts/check-raw-buttons.test.mjs` (5 cases, green). Wiring into `just check-web` is deferred to the Phase-3 cleanup PR per the migration doc.
- Pointer added in `docs/frontend/generation-pipelines.md` so the drafted rule is discoverable alongside the active token-drift rule.
- No `.tsx` files touched; no `crates/` changes; no conflict with PR #525.

## Test plan
- `node scripts/check-raw-buttons.test.mjs` passes (5/5)
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` all pass
- `pnpm check-tokens` passes (58 tokens match)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)