### PR TITLE
chore(deps): bump rustls-webpki past RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4110,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Bump `rustls-webpki` from `0.103.12` to `0.103.13` via `cargo update -p rustls-webpki` (lockfile-only, no manifest changes).
- Picks up the fix for [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) — reachable panic in CRL parsing. Bumped version satisfies the advisory's patched range `>=0.103.13, <0.104.0-alpha.1`.
- Unblocks `cargo deny check advisories` on `main`, which was failing against the newly-published advisory.

## Test plan

- [x] `cargo update -p rustls-webpki` → `0.103.12 -> 0.103.13`
- [x] `cargo deny check advisories` → `advisories ok`
- [x] `cargo check --workspace` → clean

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>