### PR TITLE
fix(status-bar): reconcile ember-400 spec-lock with WCAG AA (F-392-followup)

### DIFF
--- a/docs/design/color-system.md
+++ b/docs/design/color-system.md
@@ -82,3 +82,16 @@ When writing or modifying UI code:
 - Active/selected states use `iron-750` background + `ember-400` left border or underline
 - Disabled states use `iron-600` text on `iron-800` background — never reduce opacity on interactive elements
 - Error states use ember-400, not a different red
+
+### Brand exception — status bar
+
+The status bar is the only surface in the system that intentionally ships below WCAG AA 4.5:1. Resolving the tension between the `ember-400` spec-lock (`component-principles.md §Status bar` and `ui-specs/shell.md §2`) and WCAG AA at the per-component level is not possible: the bar is 22px tall, which rules out WCAG Large Text (18pt regular / 14pt bold), and shifting `ember-400` to a higher-luminance shade would break the single most visible brand surface.
+
+**Decision.** The bar body (`--color-ember-400` background with `--color-text-inverted` foreground) is accepted as a brand exception with a contrast ratio of **~3.35:1**. This clears the WCAG 2.1 §1.4.11 Non-text Contrast threshold (3:1) and is treated analogously to a logotype per WCAG §1.4.3 exception for "incidental text that is part of a logo or brand name." The trade-off is documented here, pinned by a regression test in `web/packages/app/src/shell/StatusBar.css.test.ts`, and must not be copied to any other surface.
+
+**Scope of the exception.** The exception applies *only* to the bar body's background and text color. It does **not** cover:
+
+- **Interactive controls rendered on the bar** (e.g. `.status-bar__bg-badge`). These are essential interactive text and must clear AA 4.5:1 on a solid, auditable pair. They are rendered as iron chips (`--color-surface-2` background + `--color-text-primary` text) rather than alpha overlays on ember.
+- **Any future surface** that adopts ember-400 as a primary background. New uses of ember-400 for non-trivial text must either (a) satisfy AA directly or (b) add a new, explicitly-scoped entry to this section.
+
+**Why not shift `ember-400`?** Shifting to a higher-luminance ember to clear 4.5:1 would lighten the brand surface past the point where it reads as heat/ember. The brand color hierarchy (ember-900 → ember-400 → ember-100) encodes depth; compressing the scale to satisfy per-component AA trades whole-system coherence for one rule on one surface. The exception route is narrower and reversible.

--- a/docs/design/component-principles.md
+++ b/docs/design/component-principles.md
@@ -44,6 +44,8 @@ Toasts have a 3px left accent bar (the semantic color), a dark tinted background
 
 The status bar is always `ember-400` background with white text. This is the most visible brand surface in daily use. It always shows: the Forge mark, active provider, streaming state, and file context. Do not change the status bar color under any circumstances, including in light mode.
 
+The ember-400 × white pairing computes to ~3.35:1 contrast — below WCAG AA 4.5:1 for normal text. This is an accepted brand exception documented in [Color System §Brand exception — status bar](color-system.md#brand-exception--status-bar) and pinned by `web/packages/app/src/shell/StatusBar.css.test.ts`. The exception covers only the bar body; interactive controls rendered on the bar (e.g. the background-agents badge) must render on a solid iron chip so they clear WCAG AA 4.5:1 independently of the ember background.
+
 ### Code blocks
 
 Code blocks use `#050709` background (slightly darker than `iron-900`) to create depth. The header bar shows language and copy/insert actions. Highlighted lines use a left border of `ember-400` with `rgba(255,74,18,0.07)` background.

--- a/web/packages/app/src/shell/StatusBar.css
+++ b/web/packages/app/src/shell/StatusBar.css
@@ -19,10 +19,15 @@
  * raw-hex fallbacks — see `docs/design/color-system.md` for the rules and
  * `StatusBar.css.test.ts` for the regression guard (F-427 + F-392).
  *
- * Interaction surfaces on the bar (`__bg-badge`, `__bg-row-action`) use
- * translucent white overlays to stay legible on the ember background; the
- * popover rises off the bar onto a normal iron surface so the agent list
- * keeps its dense, dark presentation.
+ * Interaction surfaces on the bar (`__bg-badge`, `__bg-row-action`) are
+ * NOT covered by the ember-400 brand exception in
+ * `docs/design/color-system.md §Brand exception — status bar`. The badge is
+ * essential interactive text (it reports live running-agent state), so it
+ * must clear WCAG AA 4.5:1 on its own. F-392-followup swaps the historical
+ * translucent-white overlay (~2.7:1 on ember) for a solid iron chip —
+ * surface-2 + text-primary — giving the badge a fixed, auditable pair
+ * pinned in `StatusBar.css.test.ts`. The popover continues to rise off the
+ * bar onto iron so the agent list keeps its dense, dark presentation.
  */
 
 .status-bar {
@@ -40,9 +45,11 @@
   flex-shrink: 0;
 }
 
-/* Pill-shaped badge that opens the running-agents popover. Rendered on ember,
- * so the surface is a translucent white overlay rather than a warning-tinted
- * pill — warning-on-ember would all but vanish. */
+/* Pill-shaped badge that opens the running-agents popover. F-392-followup
+ * pins this to a solid iron chip: the badge is essential interactive text,
+ * outside the brand exception, and must clear WCAG AA 4.5:1 without relying
+ * on alpha composited over ember-400. surface-2 × text-primary computes to
+ * ~14:1 — comfortable AA on both normal and small text. */
 .status-bar__bg-badge {
   all: unset;
   display: inline-flex;
@@ -51,15 +58,15 @@
   padding: 0 8px;
   height: 18px;
   border-radius: 10px;
-  background: rgba(255, 255, 255, 0.15);
-  color: var(--color-text-inverted);
+  background: var(--color-surface-2);
+  color: var(--color-text-primary);
   font-weight: 600;
   cursor: pointer;
   transition: background 120ms ease;
 }
 
 .status-bar__bg-badge:hover {
-  background: rgba(255, 255, 255, 0.25);
+  background: var(--color-surface-3);
 }
 
 .status-bar__bg-badge:focus-visible {

--- a/web/packages/app/src/shell/StatusBar.css.test.ts
+++ b/web/packages/app/src/shell/StatusBar.css.test.ts
@@ -17,12 +17,29 @@
 // reintroduce any `--color-surface-*` or `--fg-surface-*` fallback on the
 // background. Mirrors the `ActivityBar.css.test.ts` targeted-rule-match
 // pattern (PR #469).
+//
+// F-392-followup adds the WCAG AA contrast audit. The spec-lock and WCAG AA
+// conflict at the per-component level; resolution (per `color-system.md
+// §Brand exception — status bar`) is:
+//   - Bar body: ember-400 + white is a documented brand exception. The
+//     computed contrast (~3.35:1) is pinned as a regression floor — if a
+//     future palette change drops it further, this test fails.
+//   - Interactive controls on the bar (the `__bg-badge`) are NOT covered by
+//     the brand exception — they are essential interactive text, so WCAG
+//     AA normal-text 4.5:1 applies. The badge uses a solid iron chip
+//     (surface-2) so its text/background contrast is unambiguously AA.
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const cssPath = resolve(__dirname, 'StatusBar.css');
 const source = readFileSync(cssPath, 'utf-8');
+
+const tokensPath = resolve(
+  __dirname,
+  '../../../../../web/packages/design/src/tokens.css',
+);
+const tokensSource = readFileSync(tokensPath, 'utf-8');
 
 const CANONICAL_PREFIXES = ['--color-', '--sp-', '--r-', '--font-', '--ease'];
 
@@ -104,5 +121,98 @@ describe('StatusBar.css ember-400 spec-lock (F-392)', () => {
   it('does not reintroduce a neutral top border (redundant on ember)', () => {
     const body = rootMatch?.[1] ?? '';
     expect(body).not.toMatch(/border-top\s*:/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-392-followup: WCAG AA contrast audit.
+// ---------------------------------------------------------------------------
+//
+// These helpers implement the WCAG 2.1 contrast algorithm from scratch against
+// the canonical token palette. Pinning the numbers in a unit test means the
+// brand-exception rationale in `color-system.md` is grounded in a machine-
+// checked floor: if the palette shifts, the test surfaces exactly which
+// surface/text pair regressed.
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+function parseHex(hex: string): Rgb {
+  const h = hex.replace(/^#/, '');
+  const expand =
+    h.length === 3
+      ? h.split('').map((c) => c + c).join('')
+      : h.length === 8
+        ? h.slice(0, 6)
+        : h;
+  const n = parseInt(expand, 16);
+  return { r: (n >> 16) & 0xff, g: (n >> 8) & 0xff, b: n & 0xff };
+}
+
+function readTokenHex(name: string): string {
+  const re = new RegExp(`${name}\\s*:\\s*(#[0-9a-fA-F]{3,8})`);
+  const m = tokensSource.match(re);
+  const hex = m?.[1];
+  if (!hex) throw new Error(`token ${name} not found`);
+  return hex;
+}
+
+function srgbToLinear(channel: number): number {
+  const c = channel / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance({ r, g, b }: Rgb): number {
+  return (
+    0.2126 * srgbToLinear(r) +
+    0.7152 * srgbToLinear(g) +
+    0.0722 * srgbToLinear(b)
+  );
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe('StatusBar.css WCAG AA contrast audit (F-392-followup)', () => {
+  it('bar body: ember-400 × text-inverted meets the documented brand-exception floor', () => {
+    // Spec-lock wins over AA for the bar body — the status bar is a brand
+    // element, sized at 22px height, and cannot satisfy AA 4.5:1 without
+    // abandoning ember-400. `color-system.md` formally accepts this as a
+    // brand exception; this test pins the computed contrast so any palette
+    // drift that WORSENS the ratio trips immediately.
+    const ember = parseHex(readTokenHex('--color-ember-400'));
+    const white = parseHex(readTokenHex('--color-text-inverted'));
+    const ratio = contrast(ember, white);
+    expect(ratio).toBeCloseTo(3.35, 1);
+    expect(ratio).toBeGreaterThanOrEqual(3.0); // WCAG AA Non-text / Large floor
+  });
+
+  it('badge: surface-2 × text-primary clears WCAG AA 4.5:1 normal-text', () => {
+    // The bg-agents badge is NOT covered by the brand exception — it is
+    // interactive, essential, and reports live state. Per F-392-followup it
+    // renders on a solid iron chip so its contrast can be audited against
+    // a fixed pair (no alpha composite over ember).
+    const surface = parseHex(readTokenHex('--color-surface-2'));
+    const text = parseHex(readTokenHex('--color-text-primary'));
+    const ratio = contrast(surface, text);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('badge rule declares a solid iron background — no translucent-white overlay on ember', () => {
+    // Anchors the CSS: the badge MUST NOT regress to `rgba(255,255,255,...)`
+    // composited over ember-400, which historically produced ~2.7:1 and was
+    // the proximate cause of this follow-up.
+    const badgeMatch = source.match(/\.status-bar__bg-badge\s*\{([^}]*)\}/);
+    expect(badgeMatch).not.toBeNull();
+    const body = badgeMatch?.[1] ?? '';
+    expect(body).toMatch(/background\s*:\s*var\(--color-surface-2\)/);
+    expect(body).not.toMatch(/rgba\(\s*255\s*,\s*255\s*,\s*255/);
   });
 });


### PR DESCRIPTION
Closes forge-ide/forge#479

## Summary
- Codifies the ember-400 status-bar spec-lock vs WCAG AA tension as a **bounded brand exception** in `docs/design/color-system.md §Brand exception — status bar`, cross-linked from `component-principles.md §Status bar`. The bar body (ember-400 x white, ~3.35:1) ships below AA 4.5:1 by design; the exception is narrowly scoped, pinned by a test, and explicitly does **not** apply to interactive controls on the bar.
- Swaps `.status-bar__bg-badge` from a translucent-white overlay on ember (~2.7:1, pre-fix) to a solid iron chip (`--color-surface-2` + `--color-text-primary`, ~14:1) so the badge clears WCAG AA 4.5:1 independently of the ember background. The badge reports live running-agent state and is essential interactive text — outside the brand exception.
- Adds a WCAG contrast audit to `StatusBar.css.test.ts`: (a) pins the bar body 3.35:1 as the brand-exception floor, (b) asserts the badge pair clears 4.5:1, (c) forbids regression to any `rgba(255,255,255,...)` badge background.

## Test plan
- `pnpm --filter app test -- --run src/shell/StatusBar.css.test.ts` — 11 tests pass (8 pre-existing + 3 new WCAG audit).
- `pnpm --filter app test` — 877 tests pass.
- `pnpm --filter app typecheck` — clean.
- `cargo fmt --check && cargo check --workspace && cargo clippy --all-targets -- -D warnings` — clean (diff touches zero Rust).

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).