### PR TITLE
fix(editor-pane): first-class --color-accent-danger so error copy stays legible (F-417-followup)

### DIFF
--- a/docs/design/token-reference.md
+++ b/docs/design/token-reference.md
@@ -47,8 +47,12 @@ These tokens should be defined at `:root` and used throughout. Never use raw val
 
   /* Accent aliases — stable names for warn/danger signals used across panes.
    * `--color-accent-warn` pins dirty/unsaved-buffer indicators to ember-100
-   * so the signal stays visually distinctive on `--color-surface-1`. */
+   * so the signal stays visually distinctive on `--color-surface-1`.
+   * `--color-accent-danger` aliases --color-error so error copy on elevated
+   * surfaces (e.g. `.editor-pane__error` on `--color-surface-3`) reads as the
+   * error accent rather than collapsing to text-primary via a var() fallback. */
   --color-accent-warn: var(--color-ember-100);
+  --color-accent-danger: var(--color-error);
 
   /* Semantic backgrounds */
   --color-success-bg: rgba(61,220,132,0.07);

--- a/web/packages/app/src/panes/EditorPane.css
+++ b/web/packages/app/src/panes/EditorPane.css
@@ -89,7 +89,7 @@
 .editor-pane__error {
   padding: var(--sp-2) var(--sp-4);
   background: var(--color-surface-3);
-  color: var(--color-accent-danger, var(--color-text-primary));
+  color: var(--color-accent-danger);
   border-bottom: 1px solid var(--color-border-1);
   font-family: var(--font-mono);
   font-size: 11px;

--- a/web/packages/app/src/panes/EditorPane.css.test.ts
+++ b/web/packages/app/src/panes/EditorPane.css.test.ts
@@ -11,6 +11,13 @@ import { resolve } from 'node:path';
 // tokens.css + token-reference.md; the fallback is removed so the dot
 // always paints the ember accent.
 //
+// F-417-followup: the same camouflage shape was live on `.editor-pane__error`
+// via `color: var(--color-accent-danger, var(--color-text-primary))` with
+// `--color-accent-danger` undefined — error text resolved to near-white on
+// `--color-surface-3`. `--color-accent-danger` is now a first-class alias
+// for `--color-error` in tokens.css + token-reference.md; the fallback is
+// removed so error copy always paints the error accent.
+//
 // Source-string assertions mirror the F-090 / F-084 pattern
 // (ProviderPanel.css.test.ts) — JSDOM cannot reliably resolve var()
 // chains at the source level.
@@ -55,5 +62,22 @@ describe('EditorPane dirty-dot — F-417 fallback no longer defeats the signal',
 
   it('docs/design/token-reference.md declares --color-accent-warn alongside tokens.css', () => {
     expect(tokenRef).toMatch(/--color-accent-warn:\s*var\(--color-ember-100\);/);
+  });
+});
+
+describe('EditorPane error — F-417-followup fallback no longer defeats the signal', () => {
+  it('.editor-pane__error uses --color-accent-danger with no text-primary fallback', () => {
+    const body = ruleBody('.editor-pane__error');
+    const normalised = body.replace(/\s+/g, ' ');
+    expect(normalised).toContain('color: var(--color-accent-danger);');
+    expect(normalised).not.toMatch(/var\(--color-accent-danger,\s*var\(--color-text-primary\)\)/);
+  });
+
+  it('tokens.css defines --color-accent-danger as a --color-error alias', () => {
+    expect(tokensCss).toMatch(/--color-accent-danger:\s*var\(--color-error\);/);
+  });
+
+  it('docs/design/token-reference.md declares --color-accent-danger alongside tokens.css', () => {
+    expect(tokenRef).toMatch(/--color-accent-danger:\s*var\(--color-error\);/);
   });
 });

--- a/web/packages/design/src/tokens.css
+++ b/web/packages/design/src/tokens.css
@@ -35,8 +35,12 @@
 
   /* Accent aliases — stable names for warn/danger signals used across panes.
    * `--color-accent-warn` pins dirty/unsaved-buffer indicators to ember-100
-   * so the signal stays visually distinctive on `--color-surface-1`. */
+   * so the signal stays visually distinctive on `--color-surface-1`.
+   * `--color-accent-danger` aliases --color-error so error copy on elevated
+   * surfaces (e.g. `.editor-pane__error` on `--color-surface-3`) reads as the
+   * error accent rather than collapsing to text-primary via a var() fallback. */
   --color-accent-warn: var(--color-ember-100);
+  --color-accent-danger: var(--color-error);
 
   /* Semantic backgrounds */
   --color-success-bg: rgba(61,220,132,0.07);


### PR DESCRIPTION
Closes forge-ide/forge#486

## Summary
- Define `--color-accent-danger` as a first-class `var(--color-error)` alias in `web/packages/design/src/tokens.css` (parallel to F-417's `--color-accent-warn`)
- Mirror the addition in `docs/design/token-reference.md` so `scripts/check-tokens.mjs` stays authoritative
- Strip the `var(--color-text-primary)` fallback from `.editor-pane__error` at `web/packages/app/src/panes/EditorPane.css:92` so drift fails loudly
- Extend `web/packages/app/src/panes/EditorPane.css.test.ts` with a parallel regression block asserting `.editor-pane__error` uses `var(--color-accent-danger)` with no fallback and that the token is pinned in `tokens.css` + `token-reference.md`

## Test plan
- `pnpm --filter app test` passes (887 tests; 3 new, 3 existing accent-warn unchanged)
- `node scripts/check-tokens.mjs` reports ok (59 tokens match reference, no drift)
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` all pass

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with Claude Code