### PR TITLE
[F-348] MCP HTTP transport leaks URL credentials into errors/logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "ts-rs",
+ "url",
  "wiremock",
 ]
 

--- a/crates/forge-mcp/Cargo.toml
+++ b/crates/forge-mcp/Cargo.toml
@@ -36,6 +36,11 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 # Codex source format (F-131) stores MCP servers in `~/.codex/config.toml`.
 toml = "0.8"
 tracing = "0.1"
+# F-348: URL parsing for redacting query strings, fragments, and userinfo
+# out of error messages and tracing fields before they reach log sinks or
+# the `Degraded { reason }` broadcast. Already pulled in transitively by
+# reqwest; declared directly so the transport can call `url::Url::parse`.
+url = "2"
 # F-132: `McpServerInfo`, `ServerState`, and `McpStateEvent` cross the Tauri
 # boundary as return types / emitted events; ts-rs emits their TypeScript
 # shapes into `web/packages/ipc/src/generated/` alongside forge-core's types.

--- a/crates/forge-mcp/src/transport/http.rs
+++ b/crates/forge-mcp/src/transport/http.rs
@@ -108,8 +108,11 @@ impl Drop for Http {
 
 impl std::fmt::Debug for Http {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Route through `redacted` (F-348) so `{:?}`-style logging — e.g. a
+        // `tracing` field carrying the handle — cannot leak a query-string
+        // token or `user:pass@` userinfo.
         f.debug_struct("Http")
-            .field("url", &self.url)
+            .field("url", &redacted(&self.url))
             .finish_non_exhaustive()
     }
 }
@@ -177,14 +180,14 @@ impl Http {
             .json(&message)
             .send()
             .await
-            .with_context(|| format!("POST {} failed", self.url))?;
+            .with_context(|| format!("POST {} failed", redacted(&self.url)))?;
 
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
             return Err(anyhow!(
                 "POST {} returned HTTP {}: {}",
-                self.url,
+                redacted(&self.url),
                 status,
                 super::truncate(&body, 512),
             ));
@@ -196,7 +199,7 @@ impl Http {
         let body = resp
             .bytes()
             .await
-            .with_context(|| format!("reading POST {} response body", self.url))?;
+            .with_context(|| format!("reading POST {} response body", redacted(&self.url)))?;
         if body.is_empty() {
             return Ok(());
         }
@@ -204,7 +207,7 @@ impl Http {
         let value: serde_json::Value = serde_json::from_slice(&body).with_context(|| {
             format!(
                 "parsing POST {} response as JSON: {}",
-                self.url,
+                redacted(&self.url),
                 super::truncate(&String::from_utf8_lossy(&body), 512),
             )
         })?;
@@ -227,6 +230,30 @@ impl Http {
     /// is being torn down — see note on [`HttpEvent`]).
     pub async fn recv(&mut self) -> Option<HttpEvent> {
         self.rx.recv().await
+    }
+}
+
+/// Return a log-safe rendering of `url`: scheme + host + path only. Query
+/// strings, fragments, and `user:pass@` userinfo are stripped so signed
+/// one-time URLs (`?X-Amz-Signature=...`), personal-proxy tokens
+/// (`?token=...`), and HTTP basic-auth credentials cannot bleed into
+/// tracing sinks or the `Degraded { reason }` broadcast (F-348).
+///
+/// Every user-facing emission of `url` in this module — error contexts,
+/// `tracing` fields, and any text that ends up in `HttpEvent::Closed` —
+/// must route through this helper. The real URL stays inside reqwest,
+/// where the query string and userinfo are actually needed for the
+/// request.
+fn redacted(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(mut u) => {
+            u.set_query(None);
+            u.set_fragment(None);
+            let _ = u.set_username("");
+            let _ = u.set_password(None);
+            u.into()
+        }
+        Err(_) => "<invalid-url>".to_string(),
     }
 }
 
@@ -265,9 +292,12 @@ async fn sse_reader_loop(
 ) {
     let mut delay = INITIAL_RECONNECT_DELAY;
     let mut consecutive_failures: usize = 0;
+    // Compute the redaction once: `url` is immutable for the reader's
+    // lifetime, so we avoid re-parsing on every retry / log line.
+    let log_url = redacted(&url);
 
     loop {
-        match open_and_read_sse(&client, &url, &headers, &tx).await {
+        match open_and_read_sse(&client, &url, &log_url, &headers, &tx).await {
             Ok(ReaderExit::ConsumerDropped) => {
                 // Nothing left to feed — quit cleanly.
                 return;
@@ -279,7 +309,7 @@ async fn sse_reader_loop(
                 consecutive_failures = 0;
                 tracing::debug!(
                     target: "forge_mcp::transport::http",
-                    url = %url,
+                    url = %log_url,
                     "SSE stream ended cleanly; reconnecting",
                 );
             }
@@ -288,7 +318,7 @@ async fn sse_reader_loop(
                 let reason = format!("{err:#}");
                 tracing::warn!(
                     target: "forge_mcp::transport::http",
-                    url = %url,
+                    url = %log_url,
                     error = %err,
                     attempts = consecutive_failures,
                     "SSE read failed; backing off before reconnect",
@@ -301,7 +331,7 @@ async fn sse_reader_loop(
                     );
                     tracing::warn!(
                         target: "forge_mcp::transport::http",
-                        url = %url,
+                        url = %log_url,
                         %detail,
                         "SSE reader terminating; surfacing Closed to consumer",
                     );
@@ -332,6 +362,7 @@ enum ReaderExit {
 async fn open_and_read_sse(
     client: &reqwest::Client,
     url: &str,
+    log_url: &str,
     headers: &HeaderMap,
     tx: &mpsc::Sender<HttpEvent>,
 ) -> Result<ReaderExit> {
@@ -341,11 +372,11 @@ async fn open_and_read_sse(
         .header(ACCEPT, "text/event-stream")
         .send()
         .await
-        .with_context(|| format!("GET {url} for SSE stream"))?;
+        .with_context(|| format!("GET {log_url} for SSE stream"))?;
 
     let status = resp.status();
     if !status.is_success() {
-        return Err(anyhow!("GET {url} returned HTTP {status}"));
+        return Err(anyhow!("GET {log_url} returned HTTP {status}"));
     }
 
     let mut stream = resp.bytes_stream();
@@ -354,7 +385,7 @@ async fn open_and_read_sse(
     let mut buf: Vec<u8> = Vec::with_capacity(1024);
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.with_context(|| format!("reading SSE chunk from {url}"))?;
+        let chunk = chunk.with_context(|| format!("reading SSE chunk from {log_url}"))?;
         buf.extend_from_slice(&chunk);
 
         while let Some(end) = find_event_boundary(&buf) {
@@ -522,6 +553,51 @@ mod tests {
     fn parse_event_data_returns_none_without_data_field() {
         let frame = b"event: heartbeat\nid: 7";
         assert!(parse_event_data(frame).is_none());
+    }
+
+    #[test]
+    fn redacted_strips_query_string_token() {
+        let input = "https://mcp.example.com/v1?access_token=shhh";
+        let out = redacted(input);
+        assert!(!out.contains("shhh"), "token must not appear: {out}");
+        assert!(
+            !out.contains("access_token"),
+            "query key must be gone: {out}"
+        );
+        assert!(out.contains("mcp.example.com"), "host must survive: {out}");
+        assert!(out.contains("/v1"), "path must survive: {out}");
+    }
+
+    #[test]
+    fn redacted_strips_fragment() {
+        let input = "https://mcp.example.com/v1#tok=shhh";
+        let out = redacted(input);
+        assert!(!out.contains("shhh"), "fragment must be gone: {out}");
+        assert!(!out.contains('#'), "fragment delimiter must be gone: {out}");
+    }
+
+    #[test]
+    fn redacted_strips_userinfo() {
+        let input = "https://alice:s3cret@mcp.example.com/v1";
+        let out = redacted(input);
+        assert!(!out.contains("alice"), "username must be gone: {out}");
+        assert!(!out.contains("s3cret"), "password must be gone: {out}");
+        assert!(out.contains("mcp.example.com"));
+    }
+
+    #[test]
+    fn redacted_falls_back_on_invalid_url() {
+        let out = redacted("not a url at all");
+        assert_eq!(out, "<invalid-url>");
+    }
+
+    #[test]
+    fn redacted_preserves_clean_url_shape() {
+        let input = "https://mcp.example.com/v1";
+        let out = redacted(input);
+        assert!(out.contains("https://"));
+        assert!(out.contains("mcp.example.com"));
+        assert!(out.contains("/v1"));
     }
 
     #[test]

--- a/crates/forge-mcp/tests/http_roundtrip.rs
+++ b/crates/forge-mcp/tests/http_roundtrip.rs
@@ -277,3 +277,95 @@ async fn manager_degrades_http_server_on_sustained_reconnect_failure() {
 
     mgr.stop("remote").await.expect("stop remote");
 }
+
+/// F-348: URL credentials (query-string tokens, `user:pass@` userinfo) must
+/// never appear in the error returned by `Http::send`. The MCP server URL is
+/// needed inside reqwest but every user-facing emission routes through the
+/// `redacted()` helper, which strips query, fragment, and userinfo.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn post_error_redacts_query_string_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(""),
+        )
+        .mount(&server)
+        .await;
+
+    // Append a secret as a query-string token, mirroring signed-URL /
+    // personal-dev-proxy patterns called out in the threat model.
+    let url_with_token = format!("{}/?access_token=shhh-no-logging", server.uri());
+    let t = Http::connect(&http_spec(&url_with_token, "Bearer token"))
+        .await
+        .expect("connect");
+
+    let err = t
+        .send(serde_json::json!({"jsonrpc":"2.0","id":1}))
+        .await
+        .expect_err("500 must surface");
+    let msg = format!("{err:#}");
+    assert!(
+        !msg.contains("shhh-no-logging"),
+        "query-string token must not appear in error: {msg}"
+    );
+    assert!(
+        !msg.contains("access_token"),
+        "query key must not appear in error: {msg}"
+    );
+    assert!(
+        msg.contains("500"),
+        "error should still name the HTTP status: {msg}"
+    );
+}
+
+/// F-348: sustained SSE failure emits `HttpEvent::Closed(reason)`. That
+/// reason string is broadcast by the manager as `Degraded { reason }`, so
+/// it absolutely must not carry URL credentials.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sse_closed_reason_redacts_query_string_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("down"))
+        .mount(&server)
+        .await;
+
+    let url_with_token = format!("{}/?access_token=shhh-no-broadcast", server.uri());
+    let mut t = Http::connect(&http_spec(&url_with_token, "Bearer token"))
+        .await
+        .expect("connect");
+
+    let ev = tokio::time::timeout(Duration::from_secs(10), t.recv())
+        .await
+        .expect("timed out waiting for HttpEvent::Closed")
+        .expect("channel closed before Closed event surfaced");
+
+    match ev {
+        HttpEvent::Closed(reason) => {
+            assert!(
+                !reason.contains("shhh-no-broadcast"),
+                "Closed reason must not carry the token: {reason}"
+            );
+            assert!(
+                !reason.contains("access_token"),
+                "Closed reason must not carry the query key: {reason}"
+            );
+        }
+        HttpEvent::Message(v) => {
+            panic!("expected HttpEvent::Closed after sustained failure, got Message({v})")
+        }
+    }
+}


### PR DESCRIPTION
Closes forge-ide/forge#349

## Summary
- Add `redacted()` helper (scheme + host + path only — strips query, fragment, userinfo) and apply it to every user-facing URL emission in `crates/forge-mcp/src/transport/http.rs`: POST error contexts, SSE GET contexts, reader tracing fields, and the `Debug` impl on `Http`.
- Regression tests: unit-level coverage for query-string, fragment, and userinfo stripping plus the invalid-URL fallback; two integration tests in `http_roundtrip.rs` that attach `?access_token=shhh` to the server URL and assert the token is absent from the POST error and from `HttpEvent::Closed(reason)` (which the manager rebroadcasts as `Degraded { reason }`).
- Closes the error-message-disclosure threat (CWE-532 / CWE-598): tokens no longer reach tracing sinks or the UI/IPC state stream.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` clean
- New tests: `redacted_strips_query_string_token`, `redacted_strips_fragment`, `redacted_strips_userinfo`, `redacted_falls_back_on_invalid_url`, `redacted_preserves_clean_url_shape`, `post_error_redacts_query_string_token`, `sse_closed_reason_redacts_query_string_token`

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)