### PR TITLE
[F-394] EditorPane reimplements header instead of using PaneHeader primitive

### DIFF
--- a/docs/ui-specs/pane-header.md
+++ b/docs/ui-specs/pane-header.md
@@ -67,6 +67,20 @@ Behavior: clicking invokes the parent's `onClose` callback. For chat panes in th
 
 Accessibility: the rendered text is the convention; `aria-label="Close session window"` carries the screen-reader copy and stays in plain sentence case.
 
+### PH.6a Trailing slot (badges)
+
+An optional per-pane badge slot sits between the subject and the cost meter. Pane types plug it with pane-specific state indicators — today the editor's dirty-dot (6px circle, `--color-accent-warn`) for unsaved buffers; terminals and the chat pane leave it empty.
+
+- **Placement.** Between subject and the `margin-left: auto` cost meter. Document order is `type → subject → trailing → provider → cost → close`, so screen readers traverse pane identity before pane state.
+- **Contents.** Caller-supplied JSX. The primitive does not style the badge itself — pane consumers own the visual so each pane's state language (dirty, error, muted, etc.) stays pane-scoped.
+- **Narrow-width collapse.** The slot is non-essential chrome: removed from the tree entirely at `icon-only` (<240px) alongside the provider pill and cost meter. It remains at `compact` so the dirty-dot stays visible when only the label collapses.
+- **Accessibility.** Badges with meaning carry their own accessible name (`aria-label="unsaved changes"` on the dirty-dot). The trailing `<span>` wrapper has no role so the badge's own semantics surface directly.
+- **Not.** Not a drop target for arbitrary actions — action buttons belong in the overflow `⋯` menu (§PH.5). Not a chat-only surface — any pane type can pass a badge.
+
+### PH.6b Landmark role
+
+The pane header's `<header>` element is **sub-structural** (nested inside the pane's `<section>`) and therefore must not carry `role="banner"`. ARIA reserves the banner landmark for the single top-level page banner; a per-pane banner creates duplicate landmarks that confuse AT users. Consumers that need a drag handle on the header pass `onHeaderPointerDown`; the primitive forwards it to the `<header>` element so consumers don't wrap the primitive in an extra `<div>`.
+
 ### PH.7 Cross-spec references
 
 - `layout-panes.md §3.3` — defines the 28px slot; this spec details the contents.

--- a/web/packages/app/src/panes/EditorPane.css
+++ b/web/packages/app/src/panes/EditorPane.css
@@ -1,7 +1,7 @@
-/* F-122: EditorPane styles. The header mirrors `docs/ui-specs/pane-header.md`
- * §PH.1 but with the EDITOR type label + file-path breadcrumb (PH.2 subject
- * slot adapted) + dirty-dot (PH-derived — not in the spec verbatim; see PR
- * body for the F-122 spec-gap note). */
+/* F-122 / F-394: EditorPane styles. Header chrome is owned by the shared
+ * `PaneHeader` primitive (`pane-header.md`); only the pane-specific surfaces
+ * — the dirty-dot badge rendered in the primitive's `trailing` slot, the
+ * inline error banner, and the iframe host — live here. */
 
 .editor-pane {
   display: flex;
@@ -12,48 +12,6 @@
   background: var(--color-surface-1);
 }
 
-.editor-pane__header {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-3);
-  height: 28px;
-  padding: 0 var(--sp-4);
-  background: var(--color-surface-2);
-  border-bottom: 1px solid var(--color-border-1);
-  font-family: var(--font-body);
-  flex: 0 0 auto;
-}
-
-.editor-pane__type-label {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-text-tertiary);
-}
-
-.editor-pane__breadcrumb {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-1);
-  font-size: 13px;
-  color: var(--color-text-primary);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.editor-pane__breadcrumb-prefix {
-  color: var(--color-text-tertiary);
-  font-family: var(--font-mono);
-  font-size: 11px;
-}
-
-.editor-pane__breadcrumb-leaf {
-  color: var(--color-text-primary);
-}
-
 .editor-pane__dirty-dot {
   width: 6px;
   height: 6px;
@@ -62,28 +20,8 @@
    * A fallback here previously masked drift with a near-white text color
    * that defeated the dirty-dot signal against --color-surface-1. */
   background: var(--color-accent-warn);
-  margin-left: var(--sp-1);
   flex: 0 0 auto;
-}
-
-.editor-pane__close {
-  margin-left: auto;
-  background: transparent;
-  border: 1px solid transparent;
-  padding: 0 var(--sp-2);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  transition: color var(--ease), border-color var(--ease);
-}
-
-.editor-pane__close:hover {
-  color: var(--color-text-primary);
-  border-color: var(--color-border-2);
-  border-radius: var(--r-sm);
+  display: inline-block;
 }
 
 .editor-pane__error {

--- a/web/packages/app/src/panes/EditorPane.test.tsx
+++ b/web/packages/app/src/panes/EditorPane.test.tsx
@@ -49,8 +49,8 @@ describe('breadcrumb helpers', () => {
 });
 
 describe('EditorPane render', () => {
-  it('renders EDITOR type label, breadcrumb leaf, and close button', () => {
-    const { getByTestId, getByText, getByRole } = render(() => (
+  it('renders EDITOR type label, subject leaf, and close button via PaneHeader', () => {
+    const { getByTestId, getByRole } = render(() => (
       <EditorPane
         path={FILE}
         src="about:blank"
@@ -64,10 +64,13 @@ describe('EditorPane render', () => {
         onClose={vi.fn()}
       />
     ));
-    expect(getByText('EDITOR')).toBeInTheDocument();
-    expect(getByText('main.ts')).toBeInTheDocument();
+    // F-394: chrome comes from PaneHeader, not an inline header block.
+    expect(getByTestId('pane-header-type-label').textContent).toBe('EDITOR');
+    expect(getByTestId('pane-header-subject').textContent).toBe('main.ts');
     expect(getByTestId('editor-pane-iframe')).toBeInTheDocument();
-    expect(getByRole('button', { name: /close editor pane/i })).toBeInTheDocument();
+    // EditorPane uses "Close pane" aria-label (matches the primitive's
+    // closeAriaLabel contract).
+    expect(getByRole('button', { name: /close pane/i })).toBeInTheDocument();
   });
 
   it('does not render the dirty dot initially', () => {
@@ -486,6 +489,87 @@ describe('message origin isolation', () => {
     for (const [, targetOrigin] of calls) {
       expect(targetOrigin).not.toBe('*');
     }
+  });
+});
+
+// F-394: EditorPane uses the PaneHeader primitive — no inline header markup.
+// The dirty-dot ships through the PaneHeader `trailing` slot. The sub-
+// structural <header> no longer stamps `role="banner"`.
+describe('EditorPane PaneHeader adoption (F-394)', () => {
+  it('routes the dirty indicator through the PaneHeader trailing slot', async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      path: FILE,
+      content: 'v1',
+      bytes: 2,
+      sha256: 'sha',
+    });
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+    const posted: unknown[] = [];
+    const { getByTestId } = render(() => (
+      <EditorPane
+        path={FILE}
+        src="about:blank"
+        readFile={readFile}
+        writeFile={writeFile}
+        postToIframe={(m) => posted.push(m)}
+        onClose={vi.fn()}
+      />
+    ));
+    const iframe = getByTestId('editor-pane-iframe') as HTMLIFrameElement;
+    fireFromIframe(iframe, { kind: 'ready' });
+    await Promise.resolve();
+    await Promise.resolve();
+    fireFromIframe(iframe, {
+      kind: 'change',
+      uri: `file://${FILE}`,
+      value: 'v2',
+    });
+    const dirty = getByTestId('editor-pane-dirty');
+    // Dirty dot lives inside the primitive — not under `.editor-pane__header`.
+    expect(dirty.closest('.pane-header')).not.toBeNull();
+    expect(dirty.closest('.editor-pane__header')).toBeNull();
+  });
+
+  it('emits no role="banner" landmark from the editor pane', () => {
+    const readFile = vi.fn().mockResolvedValue({
+      path: FILE,
+      content: '',
+      bytes: 0,
+      sha256: '',
+    });
+    const { container } = render(() => (
+      <EditorPane
+        path={FILE}
+        src="about:blank"
+        readFile={readFile}
+        writeFile={vi.fn().mockResolvedValue(undefined)}
+        onClose={vi.fn()}
+      />
+    ));
+    expect(container.querySelectorAll('[role="banner"]').length).toBe(0);
+  });
+
+  it('forwards onHeaderPointerDown through the PaneHeader for drag-to-dock', () => {
+    const readFile = vi.fn().mockResolvedValue({
+      path: FILE,
+      content: '',
+      bytes: 0,
+      sha256: '',
+    });
+    const onHeaderPointerDown = vi.fn();
+    const { getByTestId } = render(() => (
+      <EditorPane
+        path={FILE}
+        src="about:blank"
+        readFile={readFile}
+        writeFile={vi.fn().mockResolvedValue(undefined)}
+        onHeaderPointerDown={onHeaderPointerDown}
+        onClose={vi.fn()}
+      />
+    ));
+    const header = getByTestId('pane-header-subject').parentElement!;
+    fireEvent.pointerDown(header);
+    expect(onHeaderPointerDown).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/web/packages/app/src/panes/EditorPane.tsx
+++ b/web/packages/app/src/panes/EditorPane.tsx
@@ -5,10 +5,11 @@
 // `window.postMessage`, mirroring the protocol documented in
 // `web/packages/monaco-host/src/protocol.ts`.
 //
-// Header (breadcrumb, dirty-dot, CLOSE button) follows
-// `docs/ui-specs/pane-header.md` §PH.1–PH.6 adapted for the EDITOR pane
-// type label. The spec's narrow-width / overflow-menu slots are placeholders
-// for now — this PR is focused on the IPC bridge + dirty-state signal.
+// F-394: chrome (type label, subject, dirty badge, close button) is driven
+// through the shared `PaneHeader` primitive (`pane-header.md` §PH.1–PH.6
+// + trailing-slot section). The dirty dot rides the primitive's `trailing`
+// slot; the inline header block that previously duplicated the primitive's
+// markup is gone.
 //
 // The component is intentionally test-friendly: every side-channel (iframe
 // URL, postMessage dispatch, IPC invoke) is injectable through
@@ -30,6 +31,7 @@ import {
   writeFile as defaultWriteFile,
 } from '../ipc/fs';
 import { activeSessionId } from '../stores/session';
+import { PaneHeader } from '../routes/Session/PaneHeader';
 import './EditorPane.css';
 
 /** Default URL the iframe loads. Relative so it resolves under both the
@@ -284,8 +286,7 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
     postToIframe({ kind: 'close', uri: currentUri() });
   });
 
-  const { prefix, leaf } = trimmedBreadcrumb(props.path);
-  const breadcrumbTitle = (): string => props.path;
+  const breadcrumb = createMemo(() => trimmedBreadcrumb(props.path));
 
   return (
     <section
@@ -293,37 +294,25 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
       data-testid="editor-pane"
       onKeyDown={handleKeyDown}
     >
-      <header
-        class="editor-pane__header"
-        role="banner"
-        onPointerDown={props.onHeaderPointerDown}
-      >
-        <span class="editor-pane__type-label">EDITOR</span>
-        <span
-          class="editor-pane__breadcrumb"
-          data-testid="editor-pane-breadcrumb"
-          title={breadcrumbTitle()}
-        >
-          {prefix && <span class="editor-pane__breadcrumb-prefix">{prefix}/</span>}
-          <span class="editor-pane__breadcrumb-leaf">{leaf}</span>
-          {isDirty() && (
+      <PaneHeader
+        typeLabel="EDITOR"
+        subject={breadcrumb().leaf}
+        costLabel={breadcrumb().prefix || undefined}
+        closeLabel="CLOSE PANE"
+        closeAriaLabel="Close pane"
+        onHeaderPointerDown={props.onHeaderPointerDown}
+        onClose={props.onClose}
+        trailing={
+          isDirty() ? (
             <span
               class="editor-pane__dirty-dot"
               data-testid="editor-pane-dirty"
               aria-label="unsaved changes"
               role="status"
             />
-          )}
-        </span>
-        <button
-          type="button"
-          class="editor-pane__close"
-          aria-label="Close editor pane"
-          onClick={props.onClose}
-        >
-          CLOSE PANE
-        </button>
-      </header>
+          ) : undefined
+        }
+      />
       {errorMessage() !== null && (
         <div
           class="editor-pane__error"

--- a/web/packages/app/src/panes/paneLandmarks.test.tsx
+++ b/web/packages/app/src/panes/paneLandmarks.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@solidjs/testing-library';
+import type { SessionId } from '@forge/ipc';
+import { EditorPane } from './EditorPane';
+import { TerminalPane } from './TerminalPane';
+import { setActiveSessionId } from '../stores/session';
+import { setInvokeForTesting } from '../lib/tauri';
+
+// F-394 regression: rendering both panes in the same window must produce a
+// single banner landmark for the document (ideally zero sub-structural
+// banners — the real top-level banner, if any, is owned by the window
+// shell, not by individual panes). Prior to F-394 both EditorPane and
+// PaneHeader stamped role="banner" on their sub-structural <header>, so
+// this assertion would have failed with two `[role="banner"]` elements.
+
+// xterm + matchMedia / IntersectionObserver polyfills — copied from
+// TerminalPane.test.tsx so this suite can mount TerminalPane without the
+// xterm boot path blowing up in jsdom.
+(globalThis as { matchMedia?: unknown }).matchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+});
+if (typeof window !== 'undefined') {
+  (window as unknown as { matchMedia: unknown }).matchMedia =
+    (globalThis as { matchMedia: unknown }).matchMedia;
+}
+(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver = class {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+};
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+const SID = 'session-landmark-test' as SessionId;
+
+beforeEach(() => {
+  setActiveSessionId(SID);
+  setInvokeForTesting(vi.fn().mockResolvedValue(undefined) as never);
+  (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  setActiveSessionId(null);
+  setInvokeForTesting(null);
+});
+
+describe('F-394 — single banner landmark across coexisting panes', () => {
+  it('produces at most one role="banner" when editor + terminal panes co-render', () => {
+    const { container } = render(() => (
+      <div>
+        <EditorPane
+          path="/ws/file.ts"
+          src="about:blank"
+          readFile={vi.fn().mockResolvedValue({
+            path: '/ws/file.ts',
+            content: '',
+            bytes: 0,
+            sha256: '',
+          })}
+          writeFile={vi.fn().mockResolvedValue(undefined)}
+          onClose={vi.fn()}
+        />
+        <TerminalPane cwd="/ws" shell="/bin/zsh" onClose={vi.fn()} />
+      </div>
+    ));
+    // Post-F-394: both panes drop their sub-structural banner. The test
+    // tolerates a single shell-level banner the surrounding window might
+    // add, but never two banners from the panes themselves.
+    const banners = container.querySelectorAll('[role="banner"]');
+    expect(banners.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/web/packages/app/src/routes/Session/PaneHeader.test.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render } from '@solidjs/testing-library';
+import { fireEvent, render } from '@solidjs/testing-library';
 import type { ProviderId } from '@forge/ipc';
 import { PaneHeader } from './PaneHeader';
 
@@ -175,5 +175,90 @@ describe('PaneHeader compactness (F-119)', () => {
       expect(getByRole('button', { name: 'Close session window' })).not.toBeNull();
       unmount();
     }
+  });
+});
+
+// F-394: the pane-header <header> is sub-structural (nested inside a pane
+// <section>). ARIA treats a sub-structural <header> as a generic landmark
+// only when it's a top-level descendant of <body>; inside a <section> it
+// becomes a `banner` landmark only if explicitly tagged with role="banner".
+// Previously both PaneHeader and EditorPane stamped role="banner" on their
+// header, producing multiple banner landmarks per document. Drop it here
+// so only the actual top-level banner (if any) counts.
+describe('PaneHeader landmark (F-394)', () => {
+  it('does not set role="banner" on the <header>', () => {
+    const { getByTestId } = render(() => (
+      <PaneHeader subject="example" onClose={vi.fn()} />
+    ));
+    const header = getByTestId('pane-header-subject').parentElement;
+    expect(header?.tagName.toLowerCase()).toBe('header');
+    expect(header?.getAttribute('role')).not.toBe('banner');
+  });
+});
+
+// F-394: PaneHeader needs a slot for pane-specific badges (e.g. the editor's
+// dirty-dot indicator) so consumers stop re-implementing the header markup.
+// The slot sits between the subject and the cost meter, caller-owned JSX,
+// removed from the tree at `icon-only` alongside the other badges.
+describe('PaneHeader trailing slot (F-394)', () => {
+  it('renders arbitrary trailing JSX after the subject', () => {
+    const { getByTestId } = render(() => (
+      <PaneHeader
+        subject="file.ts"
+        trailing={<span data-testid="ph-trailing-node">!</span>}
+        onClose={vi.fn()}
+      />
+    ));
+    const trailing = getByTestId('ph-trailing-node');
+    expect(trailing).toBeInTheDocument();
+    // Placement: trailing must sit after the subject in document order so
+    // screen-reader traversal reads subject → badge.
+    const subject = getByTestId('pane-header-subject');
+    expect(subject.compareDocumentPosition(trailing) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
+  });
+
+  it('omits the trailing slot from the tree at `icon-only`', () => {
+    const { queryByTestId } = render(() => (
+      <PaneHeader
+        subject="file.ts"
+        compactness="icon-only"
+        trailing={<span data-testid="ph-trailing-node">!</span>}
+        onClose={vi.fn()}
+      />
+    ));
+    // At icon-only, provider + cost disappear; the trailing badge is
+    // non-essential chrome with the same disposition.
+    expect(queryByTestId('ph-trailing-node')).toBeNull();
+  });
+
+  it('renders no trailing wrapper when `trailing` is undefined', () => {
+    // Default call shape must produce no extra DOM — consumers that don't
+    // pass a trailing node see the same layout they had before.
+    const { container } = render(() => (
+      <PaneHeader subject="file.ts" onClose={vi.fn()} />
+    ));
+    expect(
+      container.querySelector('[data-testid="pane-header-trailing"]'),
+    ).toBeNull();
+  });
+});
+
+// F-394: EditorPane needs to thread the F-150 drag-to-dock pointerdown into
+// the header element. Accepting the handler on the primitive avoids wrapping
+// the header in an extra <div> at every consumer site.
+describe('PaneHeader onHeaderPointerDown (F-394)', () => {
+  it('forwards pointerdown on the <header> to the supplied handler', () => {
+    const onHeaderPointerDown = vi.fn();
+    const { getByTestId } = render(() => (
+      <PaneHeader
+        subject="file.ts"
+        onHeaderPointerDown={onHeaderPointerDown}
+        onClose={vi.fn()}
+      />
+    ));
+    const header = getByTestId('pane-header-subject').parentElement!;
+    fireEvent.pointerDown(header);
+    expect(onHeaderPointerDown).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/packages/app/src/routes/Session/PaneHeader.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.tsx
@@ -33,6 +33,21 @@ const TYPE_ICON: Record<PaneHeaderType, string> = {
 export interface PaneHeaderProps {
   subject: string;
   /**
+   * F-394 trailing slot. Caller-owned JSX rendered between the subject and
+   * the cost-meter slot — the natural home for pane-specific badges like
+   * EditorPane's dirty indicator. Non-essential chrome: removed from the
+   * tree at `icon-only` alongside the provider pill and cost meter so
+   * screen readers don't announce vestigial content.
+   */
+  trailing?: JSX.Element | undefined;
+  /**
+   * F-394 drag-source handler. Forwarded as `onPointerDown` on the
+   * `<header>`. Consumers threaded through F-118's drag-to-dock gesture
+   * (e.g. `dockApi.startDrag(leafId)`) pass it here; the header is the
+   * only non-content surface on a pane and the canonical drag handle.
+   */
+  onHeaderPointerDown?: ((e: PointerEvent) => void) | undefined;
+  /**
    * Active provider id (F-091). Drives the pill accent color via the
    * `--pane-header-provider-accent` custom property; the display text remains
    * the caller-supplied `providerLabel`.
@@ -47,7 +62,7 @@ export interface PaneHeaderProps {
    * pane types pass a short status string (e.g. a terminal's `cwd`) or
    * `undefined` to suppress the slot entirely.
    */
-  costLabel?: string;
+  costLabel?: string | undefined;
   /**
    * Close-button label copy (`pane-header.md §PH.6`). Chat panes use
    * `CLOSE SESSION`; terminal/editor panes pass `CLOSE PANE`/`CLOSE TAB`.
@@ -90,6 +105,12 @@ export interface PaneHeaderProps {
  * cost meter are removed from the tree entirely at `icon-only` (<240px) —
  * removed rather than hidden so screen readers don't announce vestigial
  * content. The close button stays at every compactness level per §PH.6.
+ *
+ * F-394: exposes a `trailing` slot for pane-specific badges (e.g. the
+ * editor's dirty-dot) and forwards `onHeaderPointerDown` so consumers keep
+ * a single header surface rather than wrapping the primitive. The sub-
+ * structural `<header>` no longer claims `role="banner"` — ARIA reserves
+ * the banner landmark for the one top-level banner per document.
  */
 export const PaneHeader: Component<PaneHeaderProps> = (props) => {
   // Inline custom property keeps `.pane-header__provider` rule generic; the
@@ -105,7 +126,11 @@ export const PaneHeader: Component<PaneHeaderProps> = (props) => {
   const isIconLabel = (): boolean => compactness() !== 'full';
   const showBadges = (): boolean => compactness() !== 'icon-only';
   return (
-    <header class="pane-header" role="banner" data-compactness={compactness()}>
+    <header
+      class="pane-header"
+      data-compactness={compactness()}
+      onPointerDown={props.onHeaderPointerDown}
+    >
       <span
         class="pane-header__type-label"
         data-testid="pane-header-type-label"
@@ -117,6 +142,11 @@ export const PaneHeader: Component<PaneHeaderProps> = (props) => {
       <span class="pane-header__subject" data-testid="pane-header-subject">
         {props.subject}
       </span>
+      <Show when={showBadges() && props.trailing !== undefined}>
+        <span class="pane-header__trailing" data-testid="pane-header-trailing">
+          {props.trailing}
+        </span>
+      </Show>
       <Show
         when={
           showBadges() &&

--- a/web/packages/app/src/routes/Session/SessionWindow.test.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.test.tsx
@@ -544,8 +544,14 @@ describe('SessionWindow', () => {
     expect(store.__openFileCalls).toContain('/ws/README.md');
     // F-150: chat pane stays — the split mounts editor beside it.
     expect(queryByTestId('chat-pane')).not.toBeNull();
-    const breadcrumb = await findByTestId('editor-pane-breadcrumb');
-    expect(breadcrumb.textContent).toContain('README.md');
+    // F-394: breadcrumb leaf is the PaneHeader subject; prefix lands in
+    // the detail/cost slot. Scope the lookup to the editor section —
+    // multiple pane-headers render in parallel (chat + editor).
+    const editorSection = editor;
+    const subject = editorSection.querySelector(
+      '[data-testid="pane-header-subject"]',
+    );
+    expect(subject?.textContent).toBe('README.md');
     // Tree is now a v-split with one editor leaf (F-150 DoD: split-when-none).
     const rootTree = store.layouts.named[store.layouts.active]?.tree;
     expect(rootTree?.kind).toBe('split');
@@ -629,7 +635,10 @@ describe('SessionWindow', () => {
     // Both panes render in parallel before the close.
     await findByTestId('chat-pane');
 
-    const close = await findByRole('button', { name: /close editor pane/i });
+    // F-394: EditorPane uses the PaneHeader primitive; close aria-label is
+    // "Close pane". The chat leaf's close button says "Close session window",
+    // so the `/close pane/i` regex uniquely matches the editor leaf.
+    const close = await findByRole('button', { name: /close pane/i });
     close.click();
 
     // Editor leaf removed; chat leaf promoted to the whole grid.
@@ -737,12 +746,16 @@ describe('SessionWindow', () => {
     };
 
     try {
-      // EditorPane's own header is where onHeaderPointerDown is wired —
-      // that's the drag source for the editor leaf. Fire pointerdown on
-      // it, then move + up over the chat leaf's left edge to dock the
-      // editor on the far left.
-      const editorHeader = document.querySelector(
-        '.editor-pane__header',
+      // EditorPane's PaneHeader (F-394) is the drag source for the editor
+      // leaf — it forwards `onHeaderPointerDown` to `onHeaderPointerDown`
+      // on the primitive's <header>. Fire pointerdown on the PaneHeader
+      // inside the editor section, then move + up over the chat leaf's
+      // left edge to dock the editor on the far left.
+      const editorSection = document.querySelector(
+        '[data-testid="editor-pane"]',
+      ) as HTMLElement | null;
+      const editorHeader = editorSection?.querySelector(
+        '.pane-header',
       ) as HTMLElement | null;
       expect(editorHeader).not.toBeNull();
       const pd = new MouseEvent('pointerdown', {


### PR DESCRIPTION
Closes forge-ide/forge#395

## Summary
- EditorPane now consumes the shared `PaneHeader` primitive (TerminalPane already did); the inline header markup + CSS that drifted from the primitive are deleted.
- `PaneHeader` gains a `trailing` slot (pane-specific badges) and `onHeaderPointerDown` (drag-source forwarding) so consumers avoid wrapping the primitive. The editor's dirty-dot rides the trailing slot.
- `role="banner"` is removed from the sub-structural pane `<header>` — ARIA reserves the banner landmark for the single top-level page banner. Rendering both panes in one window now produces at most one banner landmark.
- `docs/ui-specs/pane-header.md` picks up §PH.6a (trailing/badge slot) and §PH.6b (landmark-role constraint).

## Test plan
- `pnpm -r test` (893 tests, including a new `paneLandmarks.test.tsx` regression that co-renders EditorPane + TerminalPane and asserts `[role="banner"].length <= 1`) passes
- `pnpm -r typecheck` passes
- `pnpm check-tokens` passes
- F-394-targeted RED tests in `PaneHeader.test.tsx` + `EditorPane.test.tsx` assert the trailing slot, absence of `role="banner"`, and pointerdown forwarding

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)