### PR TITLE
[F-370] ResourceMonitor samples daemon PID not per-instance

### DIFF
--- a/crates/forge-session/src/bg_agents.rs
+++ b/crates/forge-session/src/bg_agents.rs
@@ -262,12 +262,15 @@ impl BackgroundAgentRegistry {
             "started",
         );
 
-        // F-152: start per-instance resource sampling. No per-agent
-        // sidecar process exists yet, so we sample the daemon's own PID
-        // — this gives the AgentMonitor inspector a *live* pill stream
-        // today and lets a future step executor swap in the real PID by
-        // calling `monitor().track(id, child_pid)` at spawn time without
-        // reshaping the event wiring.
+        // F-152 / F-370: no per-agent sidecar process exists yet. Passing
+        // the daemon's own PID hits the `ResourceMonitor::track` daemon-PID
+        // guard, which makes the call a deliberate no-op — no task is
+        // registered and no `ResourceSample` is emitted, so the UI
+        // AgentMonitor pills render the `—` placeholder instead of
+        // session-wide numbers that look per-instance. When a future step
+        // executor forks a provider sidecar per instance, it calls
+        // `registry.monitor().track(id, child_pid)` with the real PID and
+        // the event wiring below begins forwarding samples unchanged.
         self.monitor.track(id.clone(), std::process::id()).await;
 
         // `broadcast::Sender::send` errors only when no subscribers are
@@ -397,11 +400,13 @@ impl BackgroundAgentRegistry {
         &self.orchestrator
     }
 
-    /// F-152: accessor for the resource monitor. A future step executor
-    /// that forks a provider sidecar per instance can call
-    /// `registry.monitor().track(id, child_pid)` to swap the degenerate
-    /// daemon-PID sampling set up in `start()` for real per-child
-    /// sampling.
+    /// F-152 / F-370: accessor for the resource monitor. A future step
+    /// executor that forks a provider sidecar per instance calls
+    /// `registry.monitor().track(id, child_pid)` with the real child PID
+    /// to start emitting `ResourceSample` events. Today `start()` only
+    /// invokes `track` with the daemon's own PID, which hits the
+    /// monitor's daemon-PID no-op guard, so no misleading per-instance
+    /// sample reaches the webview until a real child PID is supplied.
     pub fn monitor(&self) -> &Arc<ResourceMonitor> {
         &self.monitor
     }
@@ -594,15 +599,64 @@ mod tests {
         );
     }
 
-    // F-152: end-to-end wiring — spawning a background agent must produce
-    // `Event::ResourceSample` on the registry's event bus. This pins the
-    // integration that connects the sampler to the webview-facing stream.
+    // F-152 / F-370: end-to-end wiring for the resource monitor. Today
+    // `start()` has no per-child PID to attach, so it does NOT emit
+    // `ResourceSample` (the daemon-PID guard in `ResourceMonitor::track`
+    // makes that call a deliberate no-op). The forwarder wiring that
+    // carries samples from the monitor's broadcast onto the registry's
+    // event bus is still covered here — we just drive it by calling
+    // `monitor().track(id, real_pid)` directly, mirroring what a future
+    // step executor will do once per-child PIDs exist.
+
+    /// Simulate a future step executor by handing the monitor a PID other
+    /// than the daemon's — that's the real-world path the guard exists to
+    /// protect, and the only case in which `ResourceSample` should fire.
+    fn non_daemon_pid() -> u32 {
+        std::process::id().wrapping_add(1)
+    }
 
     #[tokio::test]
-    async fn start_drives_resource_samples_onto_the_registry_event_bus() {
+    async fn start_does_not_emit_resource_sample_for_background_agents() {
+        // F-370 DoD invariant: a plain `start` (no real child PID) must
+        // NOT stream `ResourceSample` on the registry bus — the daemon's
+        // own process metrics are not a meaningful per-instance pill.
+        // The UI falls back to the `—` placeholder because no event ever
+        // arrives for this id.
         let reg = fresh_with_fast_monitor().await;
         let mut rx = reg.events();
         let id = reg.start("writer", Arc::from("p")).await.unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(250);
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await {
+                Ok(Ok(Event::ResourceSample { instance_id, .. })) if instance_id == id => {
+                    panic!(
+                        "start() must not emit ResourceSample for bg agents \
+                         until real per-child PIDs are available (F-370)"
+                    );
+                }
+                _ => continue,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn monitor_track_with_real_pid_reaches_registry_event_bus() {
+        // Forwarder wiring check: when a (future) caller hands the monitor
+        // a real per-instance PID, the resulting `ResourceSample` reaches
+        // the registry's subscribers on the same bus that carries
+        // `BackgroundAgent*` events.
+        let reg = fresh_with_fast_monitor().await;
+        let mut rx = reg.events();
+        let id = reg.start("writer", Arc::from("p")).await.unwrap();
+
+        // Drain the Started event so the next ResourceSample stands out.
+        match rx.recv().await.unwrap() {
+            Event::BackgroundAgentStarted { .. } => {}
+            other => panic!("expected Started, got {other:?}"),
+        }
+
+        reg.monitor().track(id.clone(), non_daemon_pid()).await;
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         let mut saw_sample = false;
@@ -620,7 +674,8 @@ mod tests {
         }
         assert!(
             saw_sample,
-            "registry event bus must surface ResourceSample after start"
+            "registry event bus must surface ResourceSample when monitor is \
+             tracking a real per-instance PID"
         );
     }
 
@@ -633,6 +688,9 @@ mod tests {
         let reg = fresh_with_fast_monitor().await;
         let mut rx = reg.events();
         let id = reg.start("writer", Arc::from("p")).await.unwrap();
+        // Stand in for a future step executor: wire the monitor to a real
+        // PID so the forwarder has actual samples to propagate.
+        reg.monitor().track(id.clone(), non_daemon_pid()).await;
 
         // Wait for at least one resource sample so we know the sampler is live.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);

--- a/crates/forge-session/src/resource_monitor.rs
+++ b/crates/forge-session/src/resource_monitor.rs
@@ -136,7 +136,30 @@ impl ResourceMonitor {
     /// identified by `id`. Idempotent on `id` — a repeated `track` with
     /// the same id replaces the previous task (used when a restarted
     /// instance reuses its id).
+    ///
+    /// # Daemon-PID guard (F-370)
+    ///
+    /// If `pid` equals the daemon's own PID this call is a deliberate
+    /// no-op: it registers no task, emits no `ResourceSample`, and leaves
+    /// the id **un-tracked**. The `Event::ResourceSample` wire shape is
+    /// per-instance, but the daemon-wide numbers would be shifted by
+    /// unrelated cross-agent work — rendered in the AgentMonitor pills
+    /// as if they were per-instance, the values mislead the user. Until
+    /// a real per-child PID is available (e.g. a future step executor
+    /// that forks a provider sidecar), skipping emission lets the UI
+    /// fall back to the `—` placeholder the pre-F-152 stub already
+    /// rendered. Callers with a real child PID get full sampling.
     pub async fn track(&self, id: AgentInstanceId, pid: u32) {
+        if pid == std::process::id() {
+            // Drop any stale task already registered under this id so a
+            // previous real-PID track doesn't keep sampling after a
+            // "downgrade" to the daemon PID.
+            let mut tasks = self.tasks.lock().await;
+            if let Some(prev) = tasks.remove(&id) {
+                prev.abort();
+            }
+            return;
+        }
         let mut tasks = self.tasks.lock().await;
         if let Some(prev) = tasks.remove(&id) {
             prev.abort();
@@ -1031,6 +1054,62 @@ mod tests {
             mon.tracked_count().await,
             1,
             "re-tracking the same id must replace, not duplicate"
+        );
+    }
+
+    #[tokio::test]
+    async fn track_is_a_noop_when_pid_equals_daemon_pid() {
+        // F-370: sampling the daemon's own PID yields session-wide numbers
+        // shifted by unrelated cross-agent work, rendered by the UI as if
+        // they were per-instance. Until a real per-child PID is available
+        // (e.g. a future step executor that forks a provider sidecar),
+        // `track(id, daemon_pid)` is a deliberate no-op — it registers no
+        // task and emits no `ResourceSample`, so the AgentMonitor pills
+        // stay at the `—` placeholder rather than streaming misleading
+        // values.
+        let fake = Arc::new(FakeSampler::new(sample(0.1 * TICK_SCALE, 4096, 7)));
+        let mon = ResourceMonitor::new(Arc::clone(&fake) as Arc<dyn Sampler>, TEST_TICK);
+        let mut rx = mon.events();
+        let id = inst();
+
+        mon.track(id.clone(), std::process::id()).await;
+
+        assert_eq!(
+            mon.tracked_count().await,
+            0,
+            "tracking the daemon PID must not register a task"
+        );
+
+        // Wait well past a tick to be certain no sample emits.
+        let waited = tokio::time::timeout(TEST_TICK * 5, rx.recv()).await;
+        assert!(
+            waited.is_err(),
+            "no ResourceSample should fire for a daemon-PID track, got {waited:?}"
+        );
+        assert_eq!(
+            fake.calls(),
+            0,
+            "sampler must never be invoked for the daemon PID"
+        );
+    }
+
+    #[tokio::test]
+    async fn track_with_real_pid_after_daemon_pid_still_works() {
+        // Regression guard: the daemon-PID no-op must not poison the
+        // monitor for subsequent real-PID calls on the same id.
+        let fake = Arc::new(FakeSampler::new(sample(0.1 * TICK_SCALE, 4096, 7)));
+        let mon = ResourceMonitor::new(Arc::clone(&fake) as Arc<dyn Sampler>, TEST_TICK);
+        let mut rx = mon.events();
+        let id = inst();
+
+        mon.track(id.clone(), std::process::id()).await;
+        mon.track(id.clone(), std::process::id().wrapping_add(1))
+            .await;
+
+        let ev = recv_one(&mut rx).await;
+        assert!(
+            matches!(ev, Event::ResourceSample { instance_id, .. } if instance_id == id),
+            "a subsequent real-PID track must start emitting samples"
         );
     }
 

--- a/crates/forge-shell/tests/ipc_bg_agents.rs
+++ b/crates/forge-shell/tests/ipc_bg_agents.rs
@@ -652,9 +652,16 @@ async fn stop_background_agent_transitions_instance_to_terminal_and_stops_sampli
         .unwrap()
         .to_string();
 
-    // Wait until the monitor has actually begun tracking — `start` registers
-    // on the tracking set synchronously but the monitor hand-off runs on a
-    // spawned task, so we observe it eventually.
+    // F-370: `start` itself does not register a sampler task — the
+    // daemon-PID guard in `ResourceMonitor::track` prevents misleading
+    // per-instance pills while no real child PID exists. Stand in for
+    // the future step executor by handing the monitor a non-daemon PID
+    // directly so the `untrack(id) on terminal` invariant still has a
+    // live task to abort.
+    let instance_id_parsed = forge_core::AgentInstanceId::from_string(instance_id.clone());
+    monitor
+        .track(instance_id_parsed, std::process::id().wrapping_add(1))
+        .await;
     let deadline = Instant::now() + Duration::from_secs(2);
     while monitor.tracked_count().await == 0 && Instant::now() < deadline {
         tokio::time::sleep(Duration::from_millis(5)).await;
@@ -662,7 +669,7 @@ async fn stop_background_agent_transitions_instance_to_terminal_and_stops_sampli
     assert_eq!(
         monitor.tracked_count().await,
         1,
-        "monitor must track the instance while it is running"
+        "monitor must track the instance once a real PID is supplied"
     );
 
     invoke(


### PR DESCRIPTION
Closes forge-ide/forge#371

## Summary
- Guard `ResourceMonitor::track` so a call with `pid == std::process::id()` is a deliberate no-op — no task registered, no `ResourceSample` emitted.
- `BackgroundAgentRegistry::start` still calls `track(id, std::process::id())`; with the guard it now leaves the id untracked and the AgentMonitor UI falls back to the existing `—` placeholder instead of streaming misleading daemon-wide values.
- Follow-up F-451 (#542) tracks wiring real per-child PIDs once a step executor forks sidecars.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (new RED→GREEN coverage: `track_is_a_noop_when_pid_equals_daemon_pid`, `track_with_real_pid_after_daemon_pid_still_works`, `start_does_not_emit_resource_sample_for_background_agents`, `monitor_track_with_real_pid_reaches_registry_event_bus`)
- `cargo test -p forge-shell --features webview-test` passes (14 ipc_bg_agents cases)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)