### PR TITLE
[F-448] SubAgentBanner Phase 3: model/tool-count chips + state-chip popover

### DIFF
--- a/crates/forge-core/src/event.rs
+++ b/crates/forge-core/src/event.rs
@@ -125,10 +125,22 @@ pub enum Event {
         duration_ms: u64,
         at: DateTime<Utc>,
     },
+    /// F-136 / F-448: orchestrator spawned a sub-agent.
+    ///
+    /// Phase-3 additions (F-448): optional `model` and `tool_count` feed the
+    /// banner's header chips on the webview side. Both are `Option<_>` +
+    /// `skip_serializing_if = "Option::is_none"` so absent values roundtrip
+    /// as the Phase-2 wire shape (no new keys) and the UI hides the chip.
+    /// When `Some`, they serialize as `model: "..."` / `tool_count: <int>`
+    /// alongside the existing `parent`/`child`/`from_msg` triple.
     SubAgentSpawned {
         parent: AgentInstanceId,
         child: AgentInstanceId,
         from_msg: MessageId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_count: Option<u32>,
     },
     BackgroundAgentStarted {
         id: AgentInstanceId,

--- a/crates/forge-core/tests/event_wire_shape.rs
+++ b/crates/forge-core/tests/event_wire_shape.rs
@@ -479,17 +479,46 @@ fn tool_call_approved_auto_wire_shape() {
 #[test]
 fn sub_agent_spawned_wire_shape() {
     // F-137: sub-agent spawn edge drawn in the AgentMonitor graph.
+    // F-448 Phase 3: adds optional `model` + `tool_count` — absent here so
+    // the wire shape is byte-identical to the Phase-2 emission. A separate
+    // assertion below pins the `Some(_)` path.
     assert_wire_eq(
         Event::SubAgentSpawned {
             parent: instance_id("inst-parent"),
             child: instance_id("inst-child"),
             from_msg: msg_id("mid-spawn"),
+            model: None,
+            tool_count: None,
         },
         json!({
             "type": "sub_agent_spawned",
             "parent": "inst-parent",
             "child": "inst-child",
             "from_msg": "mid-spawn",
+        }),
+    );
+}
+
+#[test]
+fn sub_agent_spawned_wire_shape_carries_model_and_tool_count() {
+    // F-448 Phase 3: when the orchestrator knows the child's model / tool
+    // surface at spawn time, the two optional header-chip fields serialize
+    // on the wire. The Phase-2 triple (parent/child/from_msg) is unchanged.
+    assert_wire_eq(
+        Event::SubAgentSpawned {
+            parent: instance_id("inst-parent"),
+            child: instance_id("inst-child"),
+            from_msg: msg_id("mid-spawn"),
+            model: Some("sonnet-4.5".to_string()),
+            tool_count: Some(4),
+        },
+        json!({
+            "type": "sub_agent_spawned",
+            "parent": "inst-parent",
+            "child": "inst-child",
+            "from_msg": "mid-spawn",
+            "model": "sonnet-4.5",
+            "tool_count": 4,
         }),
     );
 }

--- a/crates/forge-session/src/tools/agent_spawn.rs
+++ b/crates/forge-session/src/tools/agent_spawn.rs
@@ -19,11 +19,14 @@
 //! only. The follow-up that wires an actual step-executor reads the stored
 //! prompt to materialise the child's first user turn.
 //!
-//! The event wire shape matches the existing `forge_core::Event::SubAgentSpawned
-//! { parent, child, from_msg }` variant — the DoD in issue #248 names a
-//! hypothetical `{ parent_id, child_id, agent_name }` shape that does not
-//! exist in the tree. Adjusting the event variant would ripple through the
-//! `event_wire_shape` regression tests and is deliberately out of scope here.
+//! The event wire shape matches `forge_core::Event::SubAgentSpawned
+//! { parent, child, from_msg, model?, tool_count? }`. The optional
+//! `model`/`tool_count` chip fields were added in F-448 Phase 3 with
+//! `skip_serializing_if = "Option::is_none"` so absent values roundtrip as
+//! the Phase-2 wire shape. The tool emits `None` for both today — `AgentDef`
+//! carries no model field and the dispatcher's tool surface is session-
+//! scoped rather than per-child; the pipe is wired so a follow-up can
+//! populate them without a wire change.
 
 use std::sync::Arc;
 
@@ -131,15 +134,22 @@ impl Tool for AgentSpawnTool {
         };
 
         // Emit the session-level event so replay / UI banners pick up the
-        // spawn. We use the existing `SubAgentSpawned { parent, child,
-        // from_msg }` variant — see module docs for why `agent_name` is
-        // not carried on the event itself.
+        // spawn. F-448 Phase 3 added optional `model` + `tool_count` to the
+        // variant; see module docs for why both are `None` today.
         if let Err(e) = agent_ctx
             .session
             .emit(Event::SubAgentSpawned {
                 parent: agent_ctx.parent_instance_id.clone(),
                 child: instance.id.clone(),
                 from_msg: agent_ctx.current_msg_id.clone(),
+                // F-448 Phase 3: `model` and `tool_count` are wired through
+                // the event variant but `AgentDef` does not carry a model
+                // today and the dispatcher's tool surface is session-wide,
+                // not per-child. Emit `None` until a follow-up teaches
+                // `AgentDef` a `model` field and scopes the tool registry
+                // per instance. The webview hides absent chips cleanly.
+                model: None,
+                tool_count: None,
             })
             .await
         {
@@ -420,6 +430,7 @@ mod tests {
                 parent,
                 child,
                 from_msg: emitted_from,
+                ..
             } = event
             {
                 found = Some((parent, child, emitted_from));

--- a/crates/forge-session/tests/agent_spawn.rs
+++ b/crates/forge-session/tests/agent_spawn.rs
@@ -113,6 +113,7 @@ async fn parent_process_spawning_container_child_does_not_escalate_or_demote_pri
             parent,
             child,
             from_msg: _,
+            ..
         } = event
         {
             assert_eq!(

--- a/crates/forge-session/tests/agent_spawn_live.rs
+++ b/crates/forge-session/tests/agent_spawn_live.rs
@@ -110,6 +110,7 @@ async fn agent_spawn_from_live_turn_registers_child_and_emits_sub_agent_spawned(
             parent,
             child,
             from_msg,
+            ..
         } = event
         {
             spawned = Some((parent, child, from_msg));

--- a/docs/ui-specs/sub-agent-banner.md
+++ b/docs/ui-specs/sub-agent-banner.md
@@ -10,23 +10,20 @@
 
 **Size.** Full width, content-driven.
 
-**Phase 2 scope.** The banner ships with glyph, agent name, delegated-at timestamp, state chip, and chevron. Model and tool-count chips, plus the state-chip details popover, are **deferred to Phase 3** (tracked in F-448) — they require wire fields the orchestrator does not forward today (`SubAgentBannerTurn` carries no `model` or `tool_count`) and a popover surface that Phase 2 does not host.
-
-**Visual anatomy (Phase 2 — shipped).**
+**Visual anatomy.**
 ```
-┌───────────────────────────────────────────────────┐
-│[↳] ↳ spawned · test-writer   delegated at 14:37   [running]  [>]
-├───────────────────────────────────────────────────┤
-│  sub-agent body: message thread, indented,       │
-│  with its own tool calls nested inside           │
-└───────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────────┐
+│[↳] ↳ spawned · test-writer   delegated at 14:37   [sonnet-4.5]  [4 tools]  [running]  [>]
+├───────────────────────────────────────────────────────────────────────────┤
+│  sub-agent body: message thread, indented,                                │
+│  with its own tool calls nested inside                                    │
+└───────────────────────────────────────────────────────────────────────────┘
 ```
 - Container: `--color-surface-1` bg, 1px `--color-border-1`, **2px left border `--color-ember-400`**, radius `--r-sm`
-- Header (left → right): `↳ spawned · <n>` in Fira Code 11px text-primary, then `delegated at HH:MM` in text-tertiary 10px, then the state chip pushed right, then the chevron
+- Header (left → right): `↳ spawned · <n>` in Fira Code 11px text-primary, then `delegated at HH:MM` in text-tertiary 10px, then the optional `[model]` and `[N tools]` chips, then the state chip pushed right, then the chevron
+- `[model]` and `[N tools]` chips appear only when the orchestrator forwards the corresponding fields on `SubAgentBannerTurn`. Each hides independently when absent
 - State chip values: `running` / `done` / `queued` / `error` / `killed`
 - State chip uses semantic color: running=warn, done=ok, queued=text-secondary, error=err, killed=text-tertiary
-
-**Visual anatomy (Phase 3 — deferred).** Once the orchestrator forwards `model` and `tool_count` on `SubAgentBannerTurn`, the header adds `[model]` and `[N tools]` chips between the timestamp and the state chip, and the state chip becomes an interactive `<button>` that opens the status-details popover (see Interaction). Header shape becomes `[↳] ↳ spawned · <n>  delegated at HH:MM  [sonnet-4.5] [4 tools] [running]  [>]`.
 
 **Collapsed state.**
 - Just the header row. Chevron on far right opens.
@@ -38,8 +35,8 @@
 
 **Interaction.**
 - Click header: toggle collapse
-- Double-click header: focus the agent in the Agent Monitor (§9) *(Phase 2)*
-- Click state chip: show sub-agent status details popover *(Phase 3 — deferred; state chip is a passive label in Phase 2)*
+- Double-click header: focus the agent in the Agent Monitor (§9)
+- Click state chip: open the sub-agent status details popover. The chip is a `<button>` whose click does **not** toggle the header collapse (event is stopped at the chip). The popover surfaces child instance id, status, started-at, last-step summary, and an "Open in Agent Monitor" affordance. It dismisses on outside click or Escape
 
 **Doesn't do.**
 - Does not let the user inject messages directly into a sub-agent's thread from here. To steer a sub-agent, use Agent Monitor's "interrupt + refine".

--- a/web/packages/app/src/components/SubAgentBanner.css
+++ b/web/packages/app/src/components/SubAgentBanner.css
@@ -63,8 +63,11 @@
   flex: 0 0 auto;
 }
 
-.sub-agent-banner__state-chip {
-  margin-left: auto;
+/*
+ * F-448 Phase 3 — generic header chip (model + tool_count). Shares the
+ * visual language with the state chip but no semantic data-state.
+ */
+.sub-agent-banner__chip {
   padding: 0 var(--sp-2);
   border-radius: var(--r-sm);
   border: 1px solid var(--color-border-1);
@@ -74,6 +77,43 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   flex: 0 0 auto;
+}
+
+/*
+ * F-448 Phase 3 — state chip is now the first right-pushed element via its
+ * wrapper slot, which owns `margin-left: auto` so both the model/tool chips
+ * and the state chip+popover cluster align cleanly on the right.
+ */
+.sub-agent-banner__state-chip-slot {
+  position: relative;
+  margin-left: auto;
+  flex: 0 0 auto;
+  display: inline-flex;
+}
+
+.sub-agent-banner__state-chip {
+  padding: 0 var(--sp-2);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--color-border-1);
+  background: var(--color-surface-3);
+  color: var(--color-text-secondary);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  flex: 0 0 auto;
+  /* F-448: button reset — keeps the span-era visuals while exposing
+     keyboard activation + stopPropagation click behavior. */
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.sub-agent-banner__state-chip:hover {
+  border-color: var(--color-ember-400);
+}
+
+.sub-agent-banner__state-chip:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
 }
 
 /*

--- a/web/packages/app/src/components/SubAgentBanner.test.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.test.tsx
@@ -3,6 +3,11 @@ import { render, fireEvent } from '@solidjs/testing-library';
 import { SubAgentBanner } from './SubAgentBanner';
 import type { ChatTurn } from '../stores/messages';
 
+// F-448 Phase 3 — header chip completion (`model`, `N tools`) + state-chip
+// popover. Tests cover: chip rendering with/without fields, popover open /
+// close, stopPropagation preventing the header toggle on chip click,
+// Escape + outside-click dismissal.
+
 // F-136 component tests — the DoD pins expand/collapse, nested rendering for
 // sub-of-sub banners, and completion state. Tests pass a `turn` fixture +
 // optional `children`/`onOpenInMonitor` overrides; no store wiring required.
@@ -241,6 +246,134 @@ describe('SubAgentBanner — double-click to Agent Monitor (F-140)', () => {
     expect(openBtn).toHaveTextContent('OPEN MONITOR');
     expect(openBtn.textContent).not.toMatch(/Open in new window/);
     fireEvent.click(openBtn);
+    expect(open).toHaveBeenCalledWith('child-1');
+  });
+});
+
+describe('SubAgentBanner — header chips (F-448 Phase 3)', () => {
+  it('renders the model chip when the turn carries a model', () => {
+    const { getByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn({ model: 'sonnet-4.5' })} />
+    ));
+    const chip = getByTestId('sub-agent-banner-model-child-1');
+    expect(chip).toHaveTextContent('sonnet-4.5');
+  });
+
+  it('renders the tool-count chip when the turn carries a tool_count', () => {
+    const { getByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn({ tool_count: 4 })} />
+    ));
+    const chip = getByTestId('sub-agent-banner-tools-child-1');
+    // Chip reads "N tools" in plural; singular form is accepted for 1.
+    expect(chip).toHaveTextContent('4 tools');
+  });
+
+  it('singular tool-count label for tool_count === 1', () => {
+    const { getByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn({ tool_count: 1 })} />
+    ));
+    expect(getByTestId('sub-agent-banner-tools-child-1')).toHaveTextContent('1 tool');
+  });
+
+  it('hides the model chip when model is undefined', () => {
+    const { queryByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    expect(queryByTestId('sub-agent-banner-model-child-1')).not.toBeInTheDocument();
+  });
+
+  it('hides the tool-count chip when tool_count is undefined', () => {
+    const { queryByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    expect(queryByTestId('sub-agent-banner-tools-child-1')).not.toBeInTheDocument();
+  });
+
+  it('chips render independently — model without tool_count is fine', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn({ model: 'haiku-3.5' })} />
+    ));
+    expect(getByTestId('sub-agent-banner-model-child-1')).toHaveTextContent('haiku-3.5');
+    expect(queryByTestId('sub-agent-banner-tools-child-1')).not.toBeInTheDocument();
+  });
+});
+
+describe('SubAgentBanner — state-chip popover (F-448 Phase 3)', () => {
+  it('state chip is a <button> — not a passive <span>', () => {
+    const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    const chip = getByTestId('sub-agent-banner-state-child-1');
+    expect(chip.tagName).toBe('BUTTON');
+    // Button must be reachable by keyboard — Tab order.
+    expect(chip.getAttribute('type')).toBe('button');
+  });
+
+  it('clicking the state chip opens the details popover', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn()} />
+    ));
+    expect(queryByTestId('sub-agent-banner-popover-child-1')).not.toBeInTheDocument();
+    fireEvent.click(getByTestId('sub-agent-banner-state-child-1'));
+    expect(getByTestId('sub-agent-banner-popover-child-1')).toBeInTheDocument();
+  });
+
+  it('state-chip click does not also toggle the header collapse (stopPropagation)', () => {
+    const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    const section = getByTestId('sub-agent-banner-child-1');
+    // Starts collapsed.
+    expect(section).toHaveAttribute('data-expanded', 'false');
+    fireEvent.click(getByTestId('sub-agent-banner-state-child-1'));
+    // Still collapsed — the chip's click must not bubble to the header.
+    expect(section).toHaveAttribute('data-expanded', 'false');
+  });
+
+  it('popover renders child instance id, status, started-at, last-step summary', () => {
+    const at = new Date();
+    at.setHours(9, 5, 0, 0);
+    const { getByTestId } = render(() => (
+      <SubAgentBanner
+        turn={makeTurn({
+          child_instance_id: 'child-abc',
+          status: 'running',
+          started_at: at.getTime(),
+          step_count: 2,
+          last_step_summary: 'wrote foo.ts',
+        })}
+      />
+    ));
+    fireEvent.click(getByTestId('sub-agent-banner-state-child-abc'));
+    const pop = getByTestId('sub-agent-banner-popover-child-abc');
+    expect(pop).toHaveTextContent('child-abc');
+    expect(pop).toHaveTextContent('running');
+    expect(pop.textContent).toMatch(/\d{2}:\d{2}/);
+    expect(pop).toHaveTextContent('wrote foo.ts');
+  });
+
+  it('popover dismisses on Escape', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn()} />
+    ));
+    fireEvent.click(getByTestId('sub-agent-banner-state-child-1'));
+    expect(getByTestId('sub-agent-banner-popover-child-1')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(queryByTestId('sub-agent-banner-popover-child-1')).not.toBeInTheDocument();
+  });
+
+  it('popover dismisses on outside mousedown', () => {
+    const { getByTestId, queryByTestId } = render(() => (
+      <>
+        <div data-testid="outside" />
+        <SubAgentBanner turn={makeTurn()} />
+      </>
+    ));
+    fireEvent.click(getByTestId('sub-agent-banner-state-child-1'));
+    expect(getByTestId('sub-agent-banner-popover-child-1')).toBeInTheDocument();
+    fireEvent.mouseDown(getByTestId('outside'));
+    expect(queryByTestId('sub-agent-banner-popover-child-1')).not.toBeInTheDocument();
+  });
+
+  it('"Open in Agent Monitor" link inside the popover calls onOpenInMonitor', () => {
+    const open = vi.fn();
+    const { getByTestId } = render(() => (
+      <SubAgentBanner turn={makeTurn()} onOpenInMonitor={open} />
+    ));
+    fireEvent.click(getByTestId('sub-agent-banner-state-child-1'));
+    fireEvent.click(getByTestId('sub-agent-banner-popover-monitor-child-1'));
     expect(open).toHaveBeenCalledWith('child-1');
   });
 });

--- a/web/packages/app/src/components/SubAgentBanner.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.tsx
@@ -1,19 +1,21 @@
 import { type Component, createSignal, For, Show } from 'solid-js';
 import type { ChatTurn, SubAgentStatus } from '../stores/messages';
+import { SubAgentDetailsPopover } from './SubAgentDetailsPopover';
 import './SubAgentBanner.css';
 
 // ---------------------------------------------------------------------------
 // SubAgentBanner — inline representation of a spawned sub-agent in the
-// parent's ChatPane (F-136). Matches `docs/ui-specs/sub-agent-banner.md` §6
-// Phase-2 anatomy: 2px ember left-border accent, header row
-// (`↳ spawned · <name>  delegated at HH:MM  [state]  [chevron]`), click
-// header to toggle collapse. Double-click navigates to the Agent Monitor
-// (F-140) with the child instance pre-selected — the route 404s until F-140
-// lands.
+// parent's ChatPane (F-136 + F-448). Matches `docs/ui-specs/sub-agent-banner.md`
+// §6. Header row: `↳ spawned · <name>  delegated at HH:MM  [model]  [N tools]
+// [state]  [chevron]`. Click header to toggle collapse. Double-click navigates
+// to the Agent Monitor (F-140) with the child instance pre-selected — the
+// route 404s until F-140 lands.
 //
-// Phase-3 deferred (per spec §6): model + tool-count chips require wire
-// fields (`model`, `tool_count`) the orchestrator does not forward today;
-// the state chip becomes an interactive popover trigger at the same time.
+// Phase-3 additions (F-448):
+//   * Optional `model` + `tool_count` chips between timestamp and state chip,
+//     hidden individually when the field is undefined.
+//   * State chip is a `<button>` that toggles the status details popover;
+//     its click stopPropagation()s so the header collapse is not toggled.
 //
 // Backend gap (flagged in the PR body): today no step events ride the
 // child's `instance_id` so live step streaming is wired through props but
@@ -67,6 +69,7 @@ function statusLabel(status: SubAgentStatus): string {
 export const SubAgentBanner: Component<SubAgentBannerProps> = (props) => {
   // Spec §6 "Collapsed state" — default collapsed; user expands to inspect.
   const [expanded, setExpanded] = createSignal(false);
+  const [popoverOpen, setPopoverOpen] = createSignal(false);
 
   const depth = (): number => props.depth ?? 0;
   const beyondMaxDepth = (): boolean => depth() >= MAX_INLINE_DEPTH;
@@ -98,6 +101,17 @@ export const SubAgentBanner: Component<SubAgentBannerProps> = (props) => {
     }
     // Pre-step-executor phase — nothing to summarise yet.
     return 'waiting for first step';
+  };
+
+  const toolChipLabel = (n: number): string => `${n} ${n === 1 ? 'tool' : 'tools'}`;
+
+  // F-448: clicking the state chip opens the popover without toggling the
+  // header's expand/collapse. stopPropagation is required because the chip
+  // is a descendant of the header, whose own click handler would otherwise
+  // fire.
+  const onStateChipClick = (e: MouseEvent): void => {
+    e.stopPropagation();
+    setPopoverOpen((v) => !v);
   };
 
   return (
@@ -133,12 +147,47 @@ export const SubAgentBanner: Component<SubAgentBannerProps> = (props) => {
         >
           delegated at {formatStartedAt(props.turn.started_at)}
         </span>
-        <span
-          class="sub-agent-banner__state-chip"
-          data-testid={`sub-agent-banner-state-${props.turn.child_instance_id}`}
-          data-state={props.turn.status}
-        >
-          {statusLabel(props.turn.status)}
+        <Show when={props.turn.model}>
+          <span
+            class="sub-agent-banner__chip sub-agent-banner__model"
+            data-testid={`sub-agent-banner-model-${props.turn.child_instance_id}`}
+          >
+            {props.turn.model}
+          </span>
+        </Show>
+        <Show when={props.turn.tool_count !== undefined}>
+          <span
+            class="sub-agent-banner__chip sub-agent-banner__tools"
+            data-testid={`sub-agent-banner-tools-${props.turn.child_instance_id}`}
+          >
+            {toolChipLabel(props.turn.tool_count!)}
+          </span>
+        </Show>
+        <span class="sub-agent-banner__state-chip-slot">
+          <button
+            type="button"
+            class="sub-agent-banner__state-chip"
+            data-testid={`sub-agent-banner-state-${props.turn.child_instance_id}`}
+            data-state={props.turn.status}
+            aria-haspopup="menu"
+            aria-expanded={popoverOpen() ? 'true' : 'false'}
+            onClick={onStateChipClick}
+          >
+            {statusLabel(props.turn.status)}
+          </button>
+          <Show when={popoverOpen()}>
+            <SubAgentDetailsPopover
+              childInstanceId={props.turn.child_instance_id}
+              status={props.turn.status}
+              startedAt={props.turn.started_at}
+              lastStepSummary={props.turn.last_step_summary}
+              onOpenInMonitor={() => {
+                setPopoverOpen(false);
+                openInMonitor();
+              }}
+              onDismiss={() => setPopoverOpen(false)}
+            />
+          </Show>
         </span>
         <span
           class="sub-agent-banner__chevron"

--- a/web/packages/app/src/components/SubAgentDetailsPopover.css
+++ b/web/packages/app/src/components/SubAgentDetailsPopover.css
@@ -1,0 +1,97 @@
+/*
+ * F-448 Phase 3 — SubAgent status details popover.
+ *
+ * Positioned by the parent via an absolutely-anchored wrapper on the banner
+ * header. Tokens mirror BranchMetadataPopover so the two surfaces read as
+ * siblings. No opacity tweaks per component-principles.md.
+ */
+
+.sub-agent-popover {
+  position: absolute;
+  top: calc(100% + var(--sp-1));
+  right: 0;
+  z-index: 20;
+  min-width: 260px;
+  max-width: 360px;
+  background: var(--color-surface-2);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-1);
+  border-radius: var(--r-sm);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+  padding: var(--sp-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.sub-agent-popover__grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: var(--sp-2);
+  row-gap: var(--sp-1);
+  margin: 0;
+}
+
+.sub-agent-popover__grid dt {
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
+
+.sub-agent-popover__grid dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  word-break: break-all;
+}
+
+.sub-agent-popover__status[data-state='running'] {
+  color: var(--color-warning);
+}
+
+.sub-agent-popover__status[data-state='done'] {
+  color: var(--color-ok, #33d17a);
+}
+
+.sub-agent-popover__status[data-state='error'] {
+  color: var(--color-error);
+}
+
+.sub-agent-popover__status[data-state='queued'] {
+  color: var(--color-text-secondary);
+}
+
+.sub-agent-popover__status[data-state='killed'] {
+  color: var(--color-text-tertiary);
+}
+
+.sub-agent-popover__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--sp-1);
+  border-top: 1px solid var(--color-border-1);
+}
+
+.sub-agent-popover__monitor {
+  background: transparent;
+  border: 1px solid var(--color-border-2);
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: 10px;
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+.sub-agent-popover__monitor:hover {
+  border-color: var(--color-ember-400);
+  color: var(--color-ember-400);
+}
+
+.sub-agent-popover__monitor:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}

--- a/web/packages/app/src/components/SubAgentDetailsPopover.tsx
+++ b/web/packages/app/src/components/SubAgentDetailsPopover.tsx
@@ -1,0 +1,94 @@
+import { type Component, Show } from 'solid-js';
+import { useFocusTrap } from '../lib/useFocusTrap';
+import type { SubAgentStatus } from '../stores/messages';
+import './SubAgentDetailsPopover.css';
+
+/**
+ * F-448 Phase 3 — status details popover anchored to the SubAgentBanner's
+ * state chip. Spec `docs/ui-specs/sub-agent-banner.md` §6 Interaction.
+ *
+ * Surfaces the child's instance id, status, started-at timestamp, last-step
+ * summary, and a jump into the Agent Monitor (§9). Dismisses on outside
+ * click and Escape via the menu-mode `useFocusTrap` hook.
+ */
+
+export interface SubAgentDetailsPopoverProps {
+  childInstanceId: string;
+  status: SubAgentStatus;
+  /** ms epoch of the spawn — rendered as `HH:MM:SS`. */
+  startedAt: number;
+  /** Optional last-step summary line; hidden when undefined. */
+  lastStepSummary?: string | undefined;
+  /** Fires when the "Open in Agent Monitor" affordance is activated. */
+  onOpenInMonitor: () => void;
+  /** Fires on Escape or outside click. Host owns open/closed state. */
+  onDismiss: () => void;
+}
+
+function formatStartedAt(ms: number): string {
+  const d = new Date(ms);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+export const SubAgentDetailsPopover: Component<SubAgentDetailsPopoverProps> = (props) => {
+  // Menu-mode focus trap: Escape + outside-click dismissal without moving
+  // focus into the popover (the state-chip button retains focus so Tab flow
+  // stays predictable).
+  let rootRef: HTMLDivElement | undefined;
+  useFocusTrap(() => rootRef, { trap: false, onDismiss: () => props.onDismiss() });
+
+  return (
+    <div
+      ref={rootRef}
+      class="sub-agent-popover"
+      data-testid={`sub-agent-banner-popover-${props.childInstanceId}`}
+      role="menu"
+      aria-label={`Sub-agent ${props.childInstanceId} details`}
+    >
+      <dl class="sub-agent-popover__grid">
+        <dt>instance</dt>
+        <dd
+          class="sub-agent-popover__instance"
+          data-testid={`sub-agent-banner-popover-instance-${props.childInstanceId}`}
+        >
+          {props.childInstanceId}
+        </dd>
+        <dt>status</dt>
+        <dd
+          class="sub-agent-popover__status"
+          data-state={props.status}
+          data-testid={`sub-agent-banner-popover-status-${props.childInstanceId}`}
+        >
+          {props.status}
+        </dd>
+        <dt>started</dt>
+        <dd
+          class="sub-agent-popover__started"
+          data-testid={`sub-agent-banner-popover-started-${props.childInstanceId}`}
+        >
+          {formatStartedAt(props.startedAt)}
+        </dd>
+        <Show when={props.lastStepSummary}>
+          <dt>last step</dt>
+          <dd
+            class="sub-agent-popover__last-step"
+            data-testid={`sub-agent-banner-popover-last-step-${props.childInstanceId}`}
+          >
+            {props.lastStepSummary}
+          </dd>
+        </Show>
+      </dl>
+      <footer class="sub-agent-popover__footer">
+        <button
+          type="button"
+          class="sub-agent-popover__monitor"
+          data-testid={`sub-agent-banner-popover-monitor-${props.childInstanceId}`}
+          onClick={() => props.onOpenInMonitor()}
+        >
+          OPEN IN AGENT MONITOR
+        </button>
+      </footer>
+    </div>
+  );
+};

--- a/web/packages/app/src/ipc/events.test.ts
+++ b/web/packages/app/src/ipc/events.test.ts
@@ -518,6 +518,58 @@ describe('fromRustEvent — sub_agent_spawned (F-136)', () => {
       fromRustEvent({ type: 'sub_agent_spawned', parent: 'p', child: 'c' }),
     ).toBeNull();
   });
+
+  // F-448 Phase 3: optional header-chip wire fields.
+  it('forwards optional model + tool_count when the Rust event carries them', () => {
+    const rust = {
+      type: 'sub_agent_spawned',
+      parent: 'p',
+      child: 'c',
+      from_msg: 'm',
+      model: 'sonnet-4.5',
+      tool_count: 4,
+    };
+    expect(fromRustEvent(rust)).toEqual({
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'p',
+      child_instance_id: 'c',
+      from_msg: 'm',
+      model: 'sonnet-4.5',
+      tool_count: 4,
+    });
+  });
+
+  it('omits model when payload carries a non-string model', () => {
+    const rust = {
+      type: 'sub_agent_spawned',
+      parent: 'p',
+      child: 'c',
+      from_msg: 'm',
+      model: 123,
+    };
+    expect(fromRustEvent(rust)).toEqual({
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'p',
+      child_instance_id: 'c',
+      from_msg: 'm',
+    });
+  });
+
+  it('omits tool_count when payload carries a non-number tool_count', () => {
+    const rust = {
+      type: 'sub_agent_spawned',
+      parent: 'p',
+      child: 'c',
+      from_msg: 'm',
+      tool_count: 'four',
+    };
+    expect(fromRustEvent(rust)).toEqual({
+      kind: 'SubAgentSpawned',
+      parent_instance_id: 'p',
+      child_instance_id: 'c',
+      from_msg: 'm',
+    });
+  });
 });
 
 describe('fromRustEvent — background_agent_completed (F-136)', () => {

--- a/web/packages/app/src/ipc/events.ts
+++ b/web/packages/app/src/ipc/events.ts
@@ -176,6 +176,12 @@ export function fromRustEvent(rustEvent: unknown): SessionEvent | null {
       return null;
     }
     const agentName = ev['agent_name'];
+    // F-448 Phase 3: optional header-chip fields. Non-string model / non-
+    // number tool_count is a daemon wire skew — drop the field silently
+    // (the banner hides absent chips cleanly) rather than failing the whole
+    // event and losing the spawn itself.
+    const model = ev['model'];
+    const toolCount = ev['tool_count'];
     const out: SessionEvent = {
       kind: 'SubAgentSpawned',
       parent_instance_id: parent,
@@ -183,6 +189,10 @@ export function fromRustEvent(rustEvent: unknown): SessionEvent | null {
       from_msg: fromMsg,
     };
     if (isString(agentName)) out.agent_name = agentName;
+    if (isString(model)) out.model = model;
+    if (typeof toolCount === 'number' && Number.isFinite(toolCount)) {
+      out.tool_count = toolCount;
+    }
     return out;
   }
 

--- a/web/packages/app/src/stores/messages.test.ts
+++ b/web/packages/app/src/stores/messages.test.ts
@@ -556,5 +556,36 @@ describe('messages store', () => {
       pushEvent(SID, { kind: 'BackgroundAgentCompleted', instance_id: 'nobody' });
       expect(getMessagesState(SID).turns).toHaveLength(0);
     });
+
+    // F-448 Phase 3: optional model / tool_count fields flow from the wire
+    // event onto the banner turn. Omitted fields leave the turn fields
+    // `undefined` so the component can hide chips cleanly.
+    it('carries model + tool_count onto the banner turn when the event provides them', () => {
+      pushEvent(SID, {
+        kind: 'SubAgentSpawned',
+        parent_instance_id: 'p',
+        child_instance_id: 'c-enriched',
+        from_msg: 'm',
+        model: 'sonnet-4.5',
+        tool_count: 4,
+      });
+      const turn = getMessagesState(SID).turns[0]!;
+      if (turn.type !== 'sub_agent_banner') throw new Error('expected banner');
+      expect(turn.model).toBe('sonnet-4.5');
+      expect(turn.tool_count).toBe(4);
+    });
+
+    it('leaves model / tool_count undefined when the event omits them', () => {
+      pushEvent(SID, {
+        kind: 'SubAgentSpawned',
+        parent_instance_id: 'p',
+        child_instance_id: 'c-bare',
+        from_msg: 'm',
+      });
+      const turn = getMessagesState(SID).turns[0]!;
+      if (turn.type !== 'sub_agent_banner') throw new Error('expected banner');
+      expect(turn.model).toBeUndefined();
+      expect(turn.tool_count).toBeUndefined();
+    });
   });
 });

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -56,6 +56,12 @@ export type SessionEvent =
       child_instance_id: string;
       from_msg: string;
       agent_name?: string;
+      // F-448 Phase 3: header chips. Optional because the orchestrator does
+      // not always know the child's model / tool surface at spawn time —
+      // omission is the norm today, and the banner hides each chip cleanly
+      // when the corresponding field is undefined.
+      model?: string;
+      tool_count?: number;
     }
   // F-136: sub-agent background lifecycle reached a terminal state. Flips any
   // banner whose child id matches from `running` → `done`. Emitted by
@@ -123,6 +129,10 @@ export type ChatTurn =
       last_step_summary?: string;
       /** Count of steps seen so far — reserved for future step-routing work. */
       step_count?: number;
+      /** F-448 Phase 3: child agent's active model label (e.g. "sonnet-4.5"). */
+      model?: string;
+      /** F-448 Phase 3: number of tools exposed to the child agent. */
+      tool_count?: number;
     }
   | { type: 'error'; message: string };
 
@@ -564,6 +574,12 @@ export function pushEvent(sessionId: SessionId, event: SessionEvent): void {
           };
           if (event.agent_name !== undefined) {
             banner.agent_name = event.agent_name;
+          }
+          if (event.model !== undefined) {
+            banner.model = event.model;
+          }
+          if (event.tool_count !== undefined) {
+            banner.tool_count = event.tool_count;
           }
           state.turns.push(banner);
         }),


### PR DESCRIPTION
Closes forge-ide/forge#475

## Summary
- Extends `Event::SubAgentSpawned` with optional `model` and `tool_count` fields (`skip_serializing_if = "Option::is_none"` so absent values roundtrip as the Phase-2 wire shape). Threads them through the IPC mapper and the messages store onto `SubAgentBannerTurn`.
- Renders `[model]` and `[N tools]` chips in the banner header between the `delegated at HH:MM` timestamp and the state chip. Each chip hides independently when its field is `undefined`.
- Promotes the state chip from a passive `<span>` to a `<button>` whose click opens a status-details popover and `stopPropagation()`s the header collapse.
- New `SubAgentDetailsPopover` surfaces child instance id, status, started-at (`HH:MM:SS`), last-step summary, and an "Open in Agent Monitor" affordance. Dismisses on outside click + Escape via the menu-mode `useFocusTrap`.
- `docs/ui-specs/sub-agent-banner.md` §6 updated: Phase-3 anatomy promoted to current, Phase-2 carve-out removed.

`agent.spawn` emits `model: None` / `tool_count: None` today — `AgentDef` has no model field and the dispatcher's tool surface is session-scoped, not per-child. The pipe is wired so a follow-up can populate them without a wire change.

## Test plan
- `cargo test -p forge-core --test event_wire_shape` — both `sub_agent_spawned_wire_shape` (absent fields → Phase-2 wire shape unchanged) and new `sub_agent_spawned_wire_shape_carries_model_and_tool_count` (present fields serialize) pass.
- `cargo test -p forge-session --test agent_spawn` / `--test agent_spawn_live` — pattern matches updated to use `..`; existing assertions still pass.
- `cargo test --workspace` passes.
- `cargo clippy --workspace --all-targets -- -D warnings` passes.
- `pnpm --filter app test` — 67 files, 905 tests all pass (29 now in `SubAgentBanner.test.tsx` covering chips, popover, `stopPropagation`, Escape + outside-click dismissal, and Open-in-Agent-Monitor).
- `pnpm -r typecheck` passes.
- `pnpm check-tokens` passes.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)