### PR TITLE
[F-367] Parallel transport-resolution logic in forge-mcp lib.rs and import.rs

### DIFF
--- a/crates/forge-mcp/src/import.rs
+++ b/crates/forge-mcp/src/import.rs
@@ -27,7 +27,7 @@
 //! `envFile`, `auth`, `supports_parallel_tool_calls`, ...) that have no
 //! universal-schema analogue.
 
-use crate::{McpServerSpec, ServerKind};
+use crate::{build_server_kind, McpServerSpec, StrictFields};
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 use std::{
@@ -180,46 +180,16 @@ struct JsonServer {
 
 impl JsonServer {
     fn into_spec(self) -> Result<McpServerSpec> {
-        let kind_str = self.kind.as_deref().map(normalize_kind);
-        let transport = match kind_str {
-            Some("stdio") => Transport::Stdio,
-            Some("http") => Transport::Http,
-            Some(other) => {
-                return Err(anyhow!(
-                    "unknown MCP server type {other:?}; expected \"stdio\" or \"http\""
-                ))
-            }
-            None => match (self.command.is_some(), self.url.is_some()) {
-                (true, false) => Transport::Stdio,
-                (false, true) => Transport::Http,
-                (true, true) => {
-                    return Err(anyhow!(
-                        "MCP server declares both `command` and `url`; set `type` explicitly"
-                    ))
-                }
-                (false, false) => {
-                    return Err(anyhow!(
-                    "MCP server missing transport fields: need `command` (stdio) or `url` (http)"
-                ))
-                }
-            },
-        };
-
-        let kind = match transport {
-            Transport::Stdio => ServerKind::Stdio {
-                command: self
-                    .command
-                    .ok_or_else(|| anyhow!("stdio MCP server missing `command`"))?,
-                args: self.args,
-                env: self.env,
-            },
-            Transport::Http => ServerKind::Http {
-                url: self
-                    .url
-                    .ok_or_else(|| anyhow!("http MCP server missing `url`"))?,
-                headers: self.headers,
-            },
-        };
+        let normalized = self.kind.as_deref().map(normalize_kind);
+        let kind = build_server_kind(
+            normalized,
+            self.command,
+            self.args,
+            self.env,
+            self.url,
+            self.headers,
+            StrictFields::Drop,
+        )?;
         Ok(McpServerSpec { kind })
     }
 }
@@ -234,11 +204,6 @@ fn normalize_kind(raw: &str) -> &str {
         "http" | "sse" | "streamable-http" | "streamable_http" => "http",
         other => other,
     }
-}
-
-enum Transport {
-    Stdio,
-    Http,
 }
 
 fn parse_json_map(raw: &str, key: &str) -> Result<BTreeMap<String, McpServerSpec>> {
@@ -410,6 +375,7 @@ pub mod codex {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ServerKind;
 
     fn assert_stdio<'a>(
         servers: &'a BTreeMap<String, McpServerSpec>,

--- a/crates/forge-mcp/src/lib.rs
+++ b/crates/forge-mcp/src/lib.rs
@@ -79,39 +79,65 @@ impl TryFrom<RawServer> for McpServerSpec {
     type Error = anyhow::Error;
 
     fn try_from(raw: RawServer) -> Result<Self> {
-        let resolved = resolve_transport(raw.kind.as_deref(), &raw)?;
-
-        let kind = match resolved {
-            Transport::Stdio => {
-                if raw.url.is_some() || !raw.headers.is_empty() {
-                    return Err(anyhow!("stdio MCP server must not set `url` or `headers`"));
-                }
-                let command = raw
-                    .command
-                    .ok_or_else(|| anyhow!("stdio MCP server missing `command`"))?;
-                ServerKind::Stdio {
-                    command,
-                    args: raw.args,
-                    env: raw.env,
-                }
-            }
-            Transport::Http => {
-                if raw.command.is_some() || !raw.args.is_empty() || !raw.env.is_empty() {
-                    return Err(anyhow!(
-                        "http MCP server must not set `command`, `args`, or `env`"
-                    ));
-                }
-                let url = raw
-                    .url
-                    .ok_or_else(|| anyhow!("http MCP server missing `url`"))?;
-                ServerKind::Http {
-                    url,
-                    headers: raw.headers,
-                }
-            }
-        };
-
+        let kind = build_server_kind(
+            raw.kind.as_deref(),
+            raw.command,
+            raw.args,
+            raw.env,
+            raw.url,
+            raw.headers,
+            StrictFields::Reject,
+        )?;
         Ok(McpServerSpec { kind })
+    }
+}
+
+/// How [`build_server_kind`] treats fields that don't belong to the resolved
+/// transport. `Reject` fails the parse (universal schema loader). `Drop`
+/// silently discards them (import-source converters, which routinely carry
+/// tool-specific extras on the opposite transport's keys).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StrictFields {
+    Reject,
+    Drop,
+}
+
+/// Shared transport-resolution path for both the universal-schema loader and
+/// the source-format importers. Resolves the transport from an explicit
+/// `"type"` hint or, absent a hint, from which of `command` / `url` is set,
+/// then extracts the matching [`ServerKind`] variant. `strict` controls
+/// whether fields that belong to the other transport are rejected or
+/// dropped.
+pub(crate) fn build_server_kind(
+    type_hint: Option<&str>,
+    command: Option<String>,
+    args: Vec<String>,
+    env: BTreeMap<String, String>,
+    url: Option<String>,
+    headers: BTreeMap<String, String>,
+    strict: StrictFields,
+) -> Result<ServerKind> {
+    let transport = resolve_transport(type_hint, command.is_some(), url.is_some())?;
+
+    match transport {
+        Transport::Stdio => {
+            if strict == StrictFields::Reject && (url.is_some() || !headers.is_empty()) {
+                return Err(anyhow!("stdio MCP server must not set `url` or `headers`"));
+            }
+            let command = command.ok_or_else(|| anyhow!("stdio MCP server missing `command`"))?;
+            Ok(ServerKind::Stdio { command, args, env })
+        }
+        Transport::Http => {
+            if strict == StrictFields::Reject
+                && (command.is_some() || !args.is_empty() || !env.is_empty())
+            {
+                return Err(anyhow!(
+                    "http MCP server must not set `command`, `args`, or `env`"
+                ));
+            }
+            let url = url.ok_or_else(|| anyhow!("http MCP server missing `url`"))?;
+            Ok(ServerKind::Http { url, headers })
+        }
     }
 }
 
@@ -120,14 +146,18 @@ enum Transport {
     Http,
 }
 
-fn resolve_transport(declared: Option<&str>, raw: &RawServer) -> Result<Transport> {
+fn resolve_transport(
+    declared: Option<&str>,
+    has_command: bool,
+    has_url: bool,
+) -> Result<Transport> {
     match declared {
         Some("stdio") => Ok(Transport::Stdio),
         Some("http") => Ok(Transport::Http),
         Some(other) => Err(anyhow!(
             "unknown MCP server type {other:?}; expected \"stdio\" or \"http\""
         )),
-        None => match (raw.command.is_some(), raw.url.is_some()) {
+        None => match (has_command, has_url) {
             (true, false) => Ok(Transport::Stdio),
             (false, true) => Ok(Transport::Http),
             (true, true) => Err(anyhow!(
@@ -479,6 +509,69 @@ mod tests {
         write(&tmp.path().join(".mcp.json"), &rendered);
         let parsed = config::load_workspace(tmp.path()).unwrap();
         assert_eq!(parsed, servers);
+    }
+
+    #[test]
+    fn build_server_kind_infers_stdio_from_command() {
+        let kind = build_server_kind(
+            None,
+            Some("npx".into()),
+            vec!["-y".into()],
+            BTreeMap::new(),
+            None,
+            BTreeMap::new(),
+            StrictFields::Reject,
+        )
+        .unwrap();
+        assert!(matches!(kind, ServerKind::Stdio { .. }));
+    }
+
+    #[test]
+    fn build_server_kind_strict_rejects_cross_transport_fields() {
+        let err = build_server_kind(
+            Some("stdio"),
+            Some("npx".into()),
+            vec![],
+            BTreeMap::new(),
+            Some("https://x".into()),
+            BTreeMap::new(),
+            StrictFields::Reject,
+        )
+        .expect_err("stdio + url must reject under Reject");
+        assert!(format!("{err:#}").contains("stdio"));
+    }
+
+    #[test]
+    fn build_server_kind_lenient_drops_cross_transport_fields() {
+        let kind = build_server_kind(
+            Some("stdio"),
+            Some("npx".into()),
+            vec![],
+            BTreeMap::new(),
+            Some("https://x".into()),
+            BTreeMap::new(),
+            StrictFields::Drop,
+        )
+        .expect("lenient must accept and drop extras");
+        match kind {
+            ServerKind::Stdio { command, .. } => assert_eq!(command, "npx"),
+            other => panic!("expected Stdio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_server_kind_rejects_ambiguous_transport() {
+        let err = build_server_kind(
+            None,
+            Some("npx".into()),
+            vec![],
+            BTreeMap::new(),
+            Some("https://x".into()),
+            BTreeMap::new(),
+            StrictFields::Drop,
+        )
+        .expect_err("both set with no hint must reject");
+        assert!(format!("{err:#}").contains("both"));
     }
 
     #[test]


### PR DESCRIPTION
Closes forge-ide/forge#368

## Summary
- Single `build_server_kind` helper in `forge-mcp::lib` used by both the universal-schema `TryFrom<RawServer>` and the import path's `JsonServer::into_spec`.
- Error strings for unknown type, ambiguous transport, missing transport fields, and missing `command`/`url` now live in one place.
- `StrictFields` flag (`Reject` for lib, `Drop` for import) preserves the two behavioral axes that genuinely differ between the call sites; `normalize_kind` stays on the import side and runs before the helper.
- Existing unit tests pass unchanged; four new tests lock the helper's contract.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)