### PR TITLE
feat(app): ToolCallCard Phase 3 — expanded body + parallel-reads grouping (F-447)

### DIFF
--- a/web/packages/app/src/ipc/events.test.ts
+++ b/web/packages/app/src/ipc/events.test.ts
@@ -143,6 +143,10 @@ describe('fromRustEvent — tool_call_completed', () => {
       kind: 'ToolCallCompleted',
       tool_call_id: 'tc-7',
       result_summary: '{"ok":true,"bytes":42}',
+      // F-447: ok/duration forwarded verbatim so the expanded card can
+      // distinguish success from failure without re-parsing the summary.
+      result_ok: true,
+      duration_ms: 12,
     });
   });
 
@@ -159,6 +163,40 @@ describe('fromRustEvent — tool_call_completed', () => {
     const out = fromRustEvent(rust);
     expect(out).toMatchObject({ kind: 'ToolCallCompleted', tool_call_id: 'tc-8' });
     expect((out as { result_summary: string }).result_summary.length).toBe(200);
+  });
+
+  // F-447: the expanded body renders `result.preview` as the up-to-800-char
+  // result preview, independent of the 200-char result_summary truncation.
+  it('forwards result.preview and result.error as structured fields', () => {
+    const rust = {
+      type: 'tool_call_completed',
+      id: 'tc-p',
+      result: { ok: true, preview: 'hello from forge' },
+      duration_ms: 42,
+      at: '2026-04-18T10:00:05Z',
+    };
+    expect(fromRustEvent(rust)).toMatchObject({
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-p',
+      result_ok: true,
+      result_preview: 'hello from forge',
+      duration_ms: 42,
+    });
+
+    const errored = {
+      type: 'tool_call_completed',
+      id: 'tc-e',
+      result: { ok: false, error: 'ENOENT' },
+      duration_ms: 7,
+      at: '2026-04-18T10:00:05Z',
+    };
+    expect(fromRustEvent(errored)).toMatchObject({
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-e',
+      result_ok: false,
+      result_error: 'ENOENT',
+      duration_ms: 7,
+    });
   });
 });
 

--- a/web/packages/app/src/ipc/events.ts
+++ b/web/packages/app/src/ipc/events.ts
@@ -88,11 +88,31 @@ export function fromRustEvent(rustEvent: unknown): SessionEvent | null {
       warnDrop('tool_call_completed', 'id missing or not a string');
       return null;
     }
-    return {
+    const result = ev['result'];
+    // F-447: the Rust wire `result` is `{ ok: bool, preview?: string, error?: string }`.
+    // Phase 2 collapsed result into a single `result_summary` stringified blob;
+    // Phase 3 needs the structured pieces for the expanded body's "preview",
+    // status glyph, and duration readout. Keep `result_summary` for backwards
+    // compatibility with existing consumers — the store carries both.
+    const out: SessionEvent = {
       kind: 'ToolCallCompleted',
       tool_call_id: id,
-      result_summary: JSON.stringify(ev['result'] ?? null).slice(0, 200),
+      result_summary: JSON.stringify(result ?? null).slice(0, 200),
     };
+    if (isObjectWith(result, 'ok') && typeof result.ok === 'boolean') {
+      out.result_ok = result.ok;
+    }
+    if (isObjectWith(result, 'preview') && isString(result.preview)) {
+      out.result_preview = result.preview;
+    }
+    if (isObjectWith(result, 'error') && isString(result.error)) {
+      out.result_error = result.error;
+    }
+    const durationMs = ev['duration_ms'];
+    if (typeof durationMs === 'number' && Number.isFinite(durationMs)) {
+      out.duration_ms = durationMs;
+    }
+    return out;
   }
 
   if (type === 'tool_call_approval_requested') {

--- a/web/packages/app/src/routes/Session/ChatPane.css
+++ b/web/packages/app/src/routes/Session/ChatPane.css
@@ -150,10 +150,16 @@
 }
 
 /* -------------------------------------------------------------------------
-   Tool call placeholder (F-026 will replace this)
+   Tool call card (F-026 / F-447)
+   ----------------------------------------------------------------------
+   Phase 3 supersedes the `.tool-placeholder` Phase-2 surface. The class
+   name change is deliberate: the surface is no longer a placeholder; it
+   is the authoritative tool-call card. Icon tint is driven by the
+   `data-tool-kind` attribute (read / agent / general) so the spec §5
+   bullet-1 color rules live in CSS, not JSX.
    ---------------------------------------------------------------------- */
 
-.tool-placeholder {
+.tool-call-card {
   display: flex;
   flex-direction: column;
   padding: var(--sp-2) var(--sp-3);
@@ -165,32 +171,72 @@
   color: var(--color-text-secondary);
 }
 
-.tool-placeholder--awaiting {
+.tool-call-card--awaiting {
   border-color: var(--color-warning-border);
   background: var(--color-surface-2);
 }
 
-.tool-placeholder--awaiting:focus {
+.tool-call-card--awaiting:focus {
   outline: none;
   border-color: var(--color-ember-400);
 }
 
-.tool-placeholder--completed {
+.tool-call-card--completed {
   color: var(--color-text-tertiary);
 }
 
-.tool-placeholder__header {
+.tool-call-card--errored {
+  border-color: var(--color-error-border);
+}
+
+/* F-447: expanded-state chrome per spec §5. Tinted ember background, ember
+   hairline border, sharp 3px radius. `rgba(255,209,102,…)` matches the
+   spec verbatim — the ember-100 hex is #ffd166, and the spec pins the two
+   alpha channels used here. Kept as raw rgba (not a token alias) because
+   these are one-off surface tints the spec anchors to this component. */
+.tool-call-card--expanded {
+  background: rgba(255, 209, 102, 0.04);
+  border-color: rgba(255, 209, 102, 0.15);
+}
+
+/* F-447 §5.1 nested child in a parallel-reads group. Drops the border so
+   the group body reads as one card, flattens the padding, and leaves
+   expansion off — nested rows stay compact. */
+.tool-call-card--nested {
+  padding: var(--sp-1) 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+}
+
+.tool-call-card__row {
   display: flex;
   align-items: center;
   gap: var(--sp-2);
 }
 
-.tool-placeholder__icon {
-  color: var(--color-text-tertiary);
+.tool-call-card__row[role='button'] {
+  cursor: pointer;
+}
+
+/* F-447: per-tool icon color. The spec assigns ember-100 (gold) to general
+   tools, info (steel) to pure reads, and ember-400 to agent spawns. The
+   data attribute keeps the kind→color map in one place and keeps the
+   component code free of inline styles. */
+.tool-call-card__icon {
+  color: var(--color-ember-100);
   flex: 0 0 auto;
 }
 
-.tool-placeholder__name {
+.tool-call-card[data-tool-kind='read'] .tool-call-card__icon {
+  color: var(--color-info);
+}
+
+.tool-call-card[data-tool-kind='agent'] .tool-call-card__icon {
+  color: var(--color-ember-400);
+}
+
+.tool-call-card__name {
   flex: 0 0 auto;
   color: var(--color-text-primary);
 }
@@ -198,7 +244,7 @@
 /* F-041: one-line arg summary sits between the tool name and the status,
    takes the remaining space, and truncates with an ellipsis when narrower
    than the content. Muted so the tool name stays the primary read. */
-.tool-placeholder__args {
+.tool-call-card__args {
   flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
@@ -208,9 +254,160 @@
   font-variant-numeric: tabular-nums;
 }
 
-.tool-placeholder__status {
-  color: var(--color-text-tertiary);
+/* F-447: duration readout — text-tertiary mono 11px per spec §5 bullet 3,
+   right-aligned by sitting to the right of the flex-grow args span with
+   no grow of its own. Tabular-nums keeps the column stable when several
+   cards stack. */
+.tool-call-card__duration {
   flex: 0 0 auto;
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+  margin-left: auto;
+}
+
+/* F-447: status glyph. Colors match the spec's intent: ✓ steel info, ! warn
+   amber, ✗ error ember. Non-grow so it anchors between duration and
+   chevron. */
+.tool-call-card__status {
+  flex: 0 0 auto;
+  color: var(--color-text-tertiary);
+}
+
+.tool-call-card__status[data-status='completed'] {
+  color: var(--color-info);
+}
+
+.tool-call-card__status[data-status='awaiting-approval'] {
+  color: var(--color-warning);
+}
+
+.tool-call-card__status[data-status='errored'] {
+  color: var(--color-error);
+}
+
+/* F-447: chevron affordance. Rotates 90° when the card is expanded so the
+   `›` reads as `v`. `transform-origin: center` keeps the pivot centred
+   under the glyph's visual baseline. */
+.tool-call-card__chevron {
+  flex: 0 0 auto;
+  color: var(--color-text-tertiary);
+  transition: transform var(--ease);
+  transform-origin: center;
+}
+
+.tool-call-card--expanded > .tool-call-card__row > .tool-call-card__chevron {
+  transform: rotate(90deg);
+}
+
+/* F-447: expanded body. Sits inside the tinted card surface, holds the
+   args/result/diff blocks. Vertical stack with generous breathing room. */
+.tool-call-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  margin-top: var(--sp-2);
+  padding-top: var(--sp-2);
+  border-top: 1px solid var(--color-border-1);
+}
+
+.tool-call-card__block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.tool-call-card__block-label {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.tool-call-card__args-json,
+.tool-call-card__result,
+.tool-call-card__diff,
+.tool-call-card__error {
+  margin: 0;
+  padding: var(--sp-2);
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-1);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--color-text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+.tool-call-card__error {
+  color: var(--color-error);
+  border-color: var(--color-error-border);
+  background: var(--color-error-bg);
+}
+
+.tool-call-card__show-more {
+  align-self: flex-start;
+  padding: var(--sp-1) var(--sp-2);
+  background: transparent;
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.tool-call-card__show-more:hover {
+  border-color: var(--color-ember-400);
+  color: var(--color-ember-400);
+}
+
+/* -------------------------------------------------------------------------
+   Parallel-reads group (F-447 §5.1)
+   ----------------------------------------------------------------------
+   `.tool-call-group` shares most of its collapsed-row styling with
+   `.tool-call-card` by re-using the same child class names inside the
+   row. The group body indents children per spec: `--sp-5` with a 2px
+   `--color-border-1` left edge.
+   ---------------------------------------------------------------------- */
+
+.tool-call-group {
+  display: flex;
+  flex-direction: column;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-1);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.tool-call-group[data-expanded='true'] {
+  background: rgba(255, 209, 102, 0.04);
+  border-color: rgba(255, 209, 102, 0.15);
+}
+
+.tool-call-group__row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  cursor: pointer;
+}
+
+.tool-call-group[data-expanded='true'] .tool-call-card__chevron {
+  transform: rotate(90deg);
+}
+
+.tool-call-group__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  margin-top: var(--sp-2);
+  padding: var(--sp-1) 0 var(--sp-1) var(--sp-5);
+  border-left: 2px solid var(--color-border-1);
 }
 
 /* -------------------------------------------------------------------------

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -1875,6 +1875,61 @@ describe('ToolCallCard Phase 3 — expand/collapse (F-447)', () => {
       'false',
     );
   });
+
+  // F-447 follow-up (PR #547 review): the row's Enter/Space handler must be a
+  // no-op when the card is awaiting approval — otherwise it collapses the diff
+  // the user just read AND the keydown bubbles to ApprovalPrompt's native
+  // listener, which interprets Enter as "approve once."
+  it('ignores Enter on the row while awaiting-approval (does not collapse the open body)', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-aa-kb',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/foo.ts' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-aa-kb',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/foo.ts' }),
+      preview: { description: '--- a\n+++ b\n@@ -1 +1 @@\n-x\n+y' },
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    const card = getByTestId('tool-call-card-tc-aa-kb');
+    // awaiting-approval cards open by default
+    expect(card).toHaveAttribute('data-expanded', 'true');
+
+    const row = getByTestId('tool-call-row-tc-aa-kb');
+    // Row must not be in the tab order while the outer card owns activation.
+    expect(row).not.toHaveAttribute('tabindex', '0');
+
+    fireEvent.keyDown(row, { key: 'Enter' });
+    // Row handler was a no-op — body is still expanded.
+    expect(card).toHaveAttribute('data-expanded', 'true');
+  });
+
+  it('ignores Space on the row while awaiting-approval (duplicate-activate guard)', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-aa-sp',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/bar.ts' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-aa-sp',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/bar.ts' }),
+      preview: { description: 'Edit' },
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    const card = getByTestId('tool-call-card-tc-aa-sp');
+    expect(card).toHaveAttribute('data-expanded', 'true');
+
+    const row = getByTestId('tool-call-row-tc-aa-sp');
+    fireEvent.keyDown(row, { key: ' ' });
+    expect(card).toHaveAttribute('data-expanded', 'true');
+  });
 });
 
 describe('ToolCallCard Phase 3 — expanded body (F-447)', () => {

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -158,11 +158,13 @@ describe('ChatPane rendering', () => {
       args_json: JSON.stringify(bigArgs),
     });
     const { getByTestId } = render(() => <ChatPane />);
-    const card = getByTestId('tool-call-card-tc-nopath');
+    const summary = getByTestId('tool-call-args-tc-nopath');
     // Contains the leading tokens of the stringified JSON…
-    expect(card).toHaveTextContent('"query"');
+    expect(summary).toHaveTextContent('"query"');
     // …but is bounded by the ~60-char cap, not the full 100+ char payload.
-    expect(card.textContent ?? '').not.toContain('x'.repeat(80));
+    // F-447: the expanded body renders the full pretty-printed args — so
+    // the truncation assertion must scope to the collapsed summary span.
+    expect(summary.textContent ?? '').not.toContain('x'.repeat(80));
   });
 
   // F-080 item 6: the prior "unparseable args_json" test was deleted because
@@ -1675,5 +1677,440 @@ describe('Composer Send button (F-391)', () => {
     );
 
     expect(viaClick).toEqual(viaEnter);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-447 — ToolCallCard Phase 3: expanded body + parallel-reads grouping
+// ---------------------------------------------------------------------------
+
+describe('ToolCallCard Phase 3 — icon kind (F-447)', () => {
+  it('tags pure-read tools with data-tool-kind="read"', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-kind-read',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'a.txt' }),
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-card-tc-kind-read')).toHaveAttribute(
+      'data-tool-kind',
+      'read',
+    );
+  });
+
+  it('tags agent-spawn tools with data-tool-kind="agent"', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-kind-agent',
+      tool_name: 'agent.spawn',
+      args_json: '{}',
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-card-tc-kind-agent')).toHaveAttribute(
+      'data-tool-kind',
+      'agent',
+    );
+  });
+
+  it('tags everything else with data-tool-kind="general"', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-kind-general',
+      tool_name: 'fs.write',
+      args_json: JSON.stringify({ path: '/tmp/x' }),
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-card-tc-kind-general')).toHaveAttribute(
+      'data-tool-kind',
+      'general',
+    );
+  });
+});
+
+describe('ToolCallCard Phase 3 — status glyph (F-447)', () => {
+  it('renders ✓ for completed calls', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-glyph-ok',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'a.txt' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-glyph-ok',
+      result_summary: '{"ok":true}',
+      result_ok: true,
+      duration_ms: 12,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-status-tc-glyph-ok')).toHaveTextContent('✓');
+  });
+
+  it('renders ✗ for errored calls', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-glyph-err',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'a.txt' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallFailed',
+      tool_call_id: 'tc-glyph-err',
+      error: 'ENOENT',
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-status-tc-glyph-err')).toHaveTextContent('✗');
+  });
+
+  it('renders ! for awaiting-approval calls', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-glyph-wait',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/foo.ts' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-glyph-wait',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/foo.ts' }),
+      preview: { description: 'Edit' },
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-status-tc-glyph-wait')).toHaveTextContent('!');
+  });
+});
+
+describe('ToolCallCard Phase 3 — duration readout (F-447)', () => {
+  it('renders the wire-reported duration in the collapsed row', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-dur',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'a.txt' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-dur',
+      result_summary: '{"ok":true}',
+      result_ok: true,
+      duration_ms: 42,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-duration-tc-dur')).toHaveTextContent('42ms');
+  });
+
+  it('collapses to "awaiting approval" while approval is pending', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-aa',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/x' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-aa',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/x' }),
+      preview: { description: 'Edit' },
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-duration-tc-aa')).toHaveTextContent(
+      'awaiting approval',
+    );
+  });
+});
+
+describe('ToolCallCard Phase 3 — expand/collapse (F-447)', () => {
+  it('collapses a completed card by default and expands on click', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-xp',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'a.txt' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-xp',
+      result_summary: '{"ok":true,"preview":"hello"}',
+      result_ok: true,
+      result_preview: 'hello',
+      duration_ms: 10,
+    });
+    const { getByTestId, queryByTestId } = render(() => <ChatPane />);
+    const card = getByTestId('tool-call-card-tc-xp');
+    expect(card).toHaveAttribute('data-expanded', 'false');
+    expect(queryByTestId('tool-call-body-tc-xp')).not.toBeInTheDocument();
+
+    fireEvent.click(getByTestId('tool-call-row-tc-xp'));
+    expect(card).toHaveAttribute('data-expanded', 'true');
+    expect(getByTestId('tool-call-body-tc-xp')).toBeInTheDocument();
+  });
+
+  it('toggles expanded on keyboard activation (Enter)', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-kb',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'a.txt' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-kb',
+      result_summary: '{}',
+      result_ok: true,
+      duration_ms: 3,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    const row = getByTestId('tool-call-row-tc-kb');
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(getByTestId('tool-call-card-tc-kb')).toHaveAttribute(
+      'data-expanded',
+      'true',
+    );
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(getByTestId('tool-call-card-tc-kb')).toHaveAttribute(
+      'data-expanded',
+      'false',
+    );
+  });
+});
+
+describe('ToolCallCard Phase 3 — expanded body (F-447)', () => {
+  it('pretty-prints args JSON in the expanded body', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-args',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'a.txt', lines: [1, 2, 3] }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-args',
+      result_summary: '{}',
+      result_ok: true,
+      duration_ms: 3,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('tool-call-row-tc-args'));
+    const argsBlock = getByTestId('tool-call-args-json-tc-args');
+    // Pretty-printing produces a multi-line indented body.
+    expect(argsBlock.textContent).toContain('\n');
+    expect(argsBlock.textContent).toContain('"path": "a.txt"');
+  });
+
+  it('renders the result preview and caps it at 800 chars with "show more"', () => {
+    const big = 'y'.repeat(2000);
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-big',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'a.txt' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-big',
+      result_summary: '{}',
+      result_ok: true,
+      result_preview: big,
+      duration_ms: 5,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('tool-call-row-tc-big'));
+    const pre = getByTestId('tool-call-result-tc-big');
+    expect((pre.textContent ?? '').length).toBe(800);
+    const showMore = getByTestId('tool-call-show-more-tc-big');
+    fireEvent.click(showMore);
+    const pre2 = getByTestId('tool-call-result-tc-big');
+    expect((pre2.textContent ?? '').length).toBe(2000);
+  });
+
+  it('renders a diff/command preview block for destructive tools', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-edit',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/foo.ts' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallApprovalRequested',
+      tool_call_id: 'tc-edit',
+      tool_name: 'fs.edit',
+      args_json: JSON.stringify({ path: '/src/foo.ts' }),
+      preview: { description: '--- a\n+++ b\n@@ -1 +1 @@\n-x\n+y' },
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    // awaiting-approval expands by default
+    const diff = getByTestId('tool-call-diff-tc-edit');
+    expect(diff).toBeInTheDocument();
+    expect(diff.textContent).toContain('+++ b');
+  });
+
+  it('surfaces the error payload in a dedicated block when errored', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-badfail',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'missing.txt' }),
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallFailed',
+      tool_call_id: 'tc-badfail',
+      error: 'ENOENT: no such file',
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('tool-call-row-tc-badfail'));
+    expect(getByTestId('tool-call-error-tc-badfail')).toHaveTextContent('ENOENT');
+  });
+});
+
+describe('ToolCallCard Phase 3 — parallel-reads grouping (F-447 §5.1)', () => {
+  it('collapses consecutive reads with shared batch_id into one aggregate card', () => {
+    for (const id of ['tc-pr-1', 'tc-pr-2', 'tc-pr-3']) {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: id,
+        tool_name: 'fs.read',
+        args_json: JSON.stringify({ path: `${id}.txt` }),
+        batch_id: '7',
+      });
+    }
+    const { getByTestId, queryByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-group-7')).toBeInTheDocument();
+    expect(getByTestId('tool-call-group-count-7')).toHaveTextContent('3 calls');
+    // Individual cards are NOT rendered at the top level — they're nested
+    // inside the group body (hidden while collapsed).
+    expect(queryByTestId('tool-call-body-tc-pr-1')).not.toBeInTheDocument();
+  });
+
+  it('reports the max duration across children as the aggregate duration', () => {
+    for (const id of ['tc-dur-1', 'tc-dur-2']) {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: id,
+        tool_name: 'fs.read',
+        args_json: JSON.stringify({ path: `${id}.txt` }),
+        batch_id: '9',
+      });
+    }
+    pushEvent(SID, {
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-dur-1',
+      result_summary: '{}',
+      result_ok: true,
+      duration_ms: 10,
+    });
+    pushEvent(SID, {
+      kind: 'ToolCallCompleted',
+      tool_call_id: 'tc-dur-2',
+      result_summary: '{}',
+      result_ok: true,
+      duration_ms: 25,
+    });
+    const { getByTestId } = render(() => <ChatPane />);
+    expect(getByTestId('tool-call-group-duration-9')).toHaveTextContent('25ms');
+  });
+
+  it('expands the group to show each child card', () => {
+    for (const id of ['tc-xp-1', 'tc-xp-2']) {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: id,
+        tool_name: 'fs.read',
+        args_json: JSON.stringify({ path: `${id}.txt` }),
+        batch_id: '11',
+      });
+    }
+    const { getByTestId, queryByTestId } = render(() => <ChatPane />);
+    expect(queryByTestId('tool-call-group-body-11')).not.toBeInTheDocument();
+    fireEvent.click(getByTestId('tool-call-group-row-11'));
+    expect(getByTestId('tool-call-group-body-11')).toBeInTheDocument();
+    expect(getByTestId('tool-call-card-tc-xp-1')).toBeInTheDocument();
+    expect(getByTestId('tool-call-card-tc-xp-2')).toBeInTheDocument();
+  });
+
+  it('renders a single call with batch_id as a standalone card (no group chrome)', () => {
+    pushEvent(SID, {
+      kind: 'ToolCallStarted',
+      tool_call_id: 'tc-solo',
+      tool_name: 'fs.read',
+      args_json: JSON.stringify({ path: 'a.txt' }),
+      batch_id: '42',
+    });
+    const { getByTestId, queryByTestId } = render(() => <ChatPane />);
+    expect(queryByTestId('tool-call-group-42')).not.toBeInTheDocument();
+    expect(getByTestId('tool-call-card-tc-solo')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F-447 — CSS drift fixture
+// ---------------------------------------------------------------------------
+//
+// Visual regression for the Phase 3 surfaces. The gate asserts the CSS
+// source pins spec §5's load-bearing values: the tinted expanded-state
+// background (`rgba(255,209,102,0.04)` + `0.15` border), the `--r-sm`
+// radius, the nested group's `--sp-5` indent with a 2px `--color-border-1`
+// left edge, and the `.tool-call-card` class name (Phase 3 supersedes the
+// `.tool-placeholder` name per the DoD). Driven off the source file the
+// same way `ChatPane.css` drift was pinned in F-086 — jsdom doesn't
+// resolve external stylesheets, so the CSS source is the contract.
+
+describe('ToolCallCard Phase 3 — CSS drift fixture (F-447)', () => {
+  const cssSource = readFileSync(
+    resolve(__dirname, 'ChatPane.css'),
+    'utf-8',
+  );
+
+  it('declares the .tool-call-card class (replacing .tool-placeholder)', () => {
+    expect(cssSource).toMatch(/\.tool-call-card\s*\{/);
+    // `.tool-placeholder` must not appear as a live selector — only
+    // referenced inside comments (the migration note).
+    const liveSelectorMatch = cssSource.match(/^\s*\.tool-placeholder/m);
+    expect(liveSelectorMatch).toBeNull();
+  });
+
+  it('pins the expanded-state tinted background and border per spec §5', () => {
+    const expandedRule = cssSource.match(
+      /\.tool-call-card--expanded\s*\{([^}]*)\}/,
+    );
+    expect(expandedRule).not.toBeNull();
+    const body = expandedRule?.[1] ?? '';
+    expect(body).toMatch(/rgba\(\s*255\s*,\s*209\s*,\s*102\s*,\s*0\.04\s*\)/);
+    expect(body).toMatch(/rgba\(\s*255\s*,\s*209\s*,\s*102\s*,\s*0\.15\s*\)/);
+  });
+
+  it('uses --r-sm for the card radius', () => {
+    const cardRule = cssSource.match(/\.tool-call-card\s*\{([^}]*)\}/);
+    expect(cardRule?.[1] ?? '').toMatch(/border-radius\s*:\s*var\(--r-sm\)/);
+  });
+
+  it('indents nested children --sp-5 with a 2px --color-border-1 left edge', () => {
+    const bodyRule = cssSource.match(
+      /\.tool-call-group__body\s*\{([^}]*)\}/,
+    );
+    expect(bodyRule).not.toBeNull();
+    const body = bodyRule?.[1] ?? '';
+    expect(body).toMatch(/var\(--sp-5\)/);
+    expect(body).toMatch(/border-left\s*:\s*2px\s+solid\s+var\(--color-border-1\)/);
+  });
+
+  it('maps tool-kind attribute to its spec §5 icon color token', () => {
+    expect(cssSource).toMatch(
+      /\.tool-call-card\[data-tool-kind='read'\]\s+\.tool-call-card__icon\s*\{[^}]*var\(--color-info\)/,
+    );
+    expect(cssSource).toMatch(
+      /\.tool-call-card\[data-tool-kind='agent'\]\s+\.tool-call-card__icon\s*\{[^}]*var\(--color-ember-400\)/,
+    );
+    // General default — lives on the base .tool-call-card__icon rule.
+    const iconRule = cssSource.match(/\.tool-call-card__icon\s*\{([^}]*)\}/);
+    expect(iconRule?.[1] ?? '').toMatch(/var\(--color-ember-100\)/);
+  });
+
+  it('rotates the chevron 90deg when the card is expanded', () => {
+    expect(cssSource).toMatch(
+      /\.tool-call-card--expanded\s*>\s*\.tool-call-card__row\s*>\s*\.tool-call-card__chevron\s*\{[^}]*transform\s*:\s*rotate\(90deg\)/,
+    );
   });
 });

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -342,9 +342,13 @@ const ToolCallCard: Component<{
   // pressing Enter / Space anywhere on the header toggles expanded.
   const handleHeaderKeyDown = (e: KeyboardEvent): void => {
     if (e.key !== 'Enter' && e.key !== ' ') return;
-    // Let the existing tabIndex=0 awaiting-approval focus-ring path own
-    // activation when the card is the approval target — otherwise we'd
-    // swallow the keyboard approve-confirm in the prompt below.
+    // While awaiting approval, the outer card owns activation and
+    // ApprovalPrompt attaches a native `keydown` listener that treats Enter as
+    // "approve once." Running the row handler would (a) collapse the diff the
+    // user just read and (b) bubble to the approval listener, producing both a
+    // collapse AND an approve on a single key press. No-op here so the prompt
+    // stays in sole control of keyboard activation.
+    if (props.turn.status === 'awaiting-approval') return;
     if (!canExpand()) return;
     e.preventDefault();
     toggleExpanded();
@@ -401,7 +405,13 @@ const ToolCallCard: Component<{
         class="tool-call-card__row"
         data-testid={`tool-call-row-${props.turn.tool_call_id}`}
         role={canExpand() ? 'button' : undefined}
-        tabIndex={canExpand() ? 0 : undefined}
+        tabIndex={
+          canExpand()
+            ? props.turn.status === 'awaiting-approval'
+              ? -1
+              : 0
+            : undefined
+        }
         aria-expanded={canExpand() ? expanded() : undefined}
         aria-controls={
           canExpand() ? `tool-call-body-${props.turn.tool_call_id}` : undefined

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -18,6 +18,7 @@ import {
   neighbourVariantId,
   type ChatTurn,
   type BranchGroup,
+  type ToolCallStatus,
 } from '../../stores/messages';
 import { BranchSelectorStrip } from '../../components/BranchSelectorStrip';
 import { BranchGutter } from '../../components/BranchGutter';
@@ -75,7 +76,8 @@ function reportInvokeError(sessionId: SessionId, command: string, err: unknown):
 }
 
 // ---------------------------------------------------------------------------
-// ToolCallCard — inline tool call card with optional approval prompt (F-026/F-027)
+// ToolCallCard — inline tool call card with optional approval prompt
+// (F-026 / F-027 / F-447)
 // ---------------------------------------------------------------------------
 
 /**
@@ -122,11 +124,88 @@ function extractPath(argsJson: string): string {
   return '';
 }
 
-const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholder' }> }> = (
-  props,
-) => {
+// F-447: the Phase 3 spec splits tools into three icon-tinted kinds. Pure
+// read-only tools take the steel/info hue; agent spawns take ember-400;
+// everything else (writes, shell.exec, network calls) inherits the warm
+// ember-100 general-tool hue. The classification lives next to the
+// component because the spec ties it to the visual treatment.
+type ToolKind = 'read' | 'agent' | 'general';
+
+const READ_ONLY_TOOLS = new Set(['fs.read', 'fs.list', 'fs.stat', 'fs.glob']);
+
+function toolKind(toolName: string): ToolKind {
+  if (READ_ONLY_TOOLS.has(toolName)) return 'read';
+  if (toolName.startsWith('agent.') || toolName.startsWith('subagent.')) {
+    return 'agent';
+  }
+  return 'general';
+}
+
+// F-447: writes, shell.exec, and any future destructive kind must surface a
+// diff / command preview in the expanded body. Reads and queries do not.
+function isDestructiveTool(toolName: string): boolean {
+  return (
+    toolName === 'fs.write' ||
+    toolName === 'fs.edit' ||
+    toolName === 'shell.exec' ||
+    toolName.startsWith('process.')
+  );
+}
+
+// F-447: the collapsed-row status glyph. Awaiting-approval renders with the
+// warn `!` — the expanded body surfaces the approval prompt and the pending
+// explanation, so the glyph alone is enough in the row.
+function statusGlyph(status: ToolCallStatus): '✓' | '!' | '✗' {
+  if (status === 'completed') return '✓';
+  if (status === 'errored') return '✗';
+  return '!';
+}
+
+function formatDuration(ms: number | undefined): string | null {
+  if (ms === undefined) return null;
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const mins = Math.floor(ms / 60_000);
+  const rem = Math.round((ms - mins * 60_000) / 1000);
+  return `${mins}m ${rem}s`;
+}
+
+const RESULT_PREVIEW_CAP = 800;
+
+/**
+ * F-447: pretty-print a Rust-side args blob (arrives as valid JSON text).
+ * Indents two spaces; handles the `"null"` edge case (no args) by returning
+ * the literal so the expanded body still has readable text.
+ */
+function prettyPrintArgs(argsJson: string): string {
+  try {
+    return JSON.stringify(JSON.parse(argsJson), null, 2);
+  } catch {
+    return argsJson;
+  }
+}
+
+const ToolCallCard: Component<{
+  turn: Extract<ChatTurn, { type: 'tool_placeholder' }>;
+  /**
+   * F-447 §5.1: when the card is a child inside a parallel-reads group,
+   * the aggregate header owns the expand affordance and the child renders
+   * in a compact "row" mode — no border, no tinted expanded body, no
+   * standalone chevron. Defaults to false.
+   */
+  nested?: boolean;
+}> = (props) => {
   let cardRef: HTMLDivElement | undefined;
   const sessionId = () => activeSessionId();
+  // F-447: expanded state is local to this card. Spec §5 defaults the
+  // currently-streaming (in-progress) and awaiting-approval cards to
+  // expanded; completed / errored collapse by default. The signal tracks
+  // user overrides so a later click can flip either way.
+  const [expanded, setExpanded] = createSignal(
+    props.turn.status === 'awaiting-approval' || props.turn.status === 'in-progress',
+  );
+  // F-447: the "show more" toggle for the 800-char result-preview cap.
+  const [showFullPreview, setShowFullPreview] = createSignal(false);
 
   // Check whitelist on each render
   const whitelistKey = createMemo(() => {
@@ -247,29 +326,104 @@ const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholde
     }
   };
 
+  const kind = createMemo<ToolKind>(() => toolKind(props.turn.tool_name));
+  const durationText = (): string | null => {
+    if (props.turn.status === 'awaiting-approval' && whitelistKey() === null) {
+      return 'awaiting approval';
+    }
+    return formatDuration(props.turn.duration_ms);
+  };
+  const canExpand = (): boolean => !props.nested;
+  const toggleExpanded = (): void => {
+    if (!canExpand()) return;
+    setExpanded((v) => !v);
+  };
+  // F-447: the collapsed row doubles as a button. Clicking the chevron or
+  // pressing Enter / Space anywhere on the header toggles expanded.
+  const handleHeaderKeyDown = (e: KeyboardEvent): void => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    // Let the existing tabIndex=0 awaiting-approval focus-ring path own
+    // activation when the card is the approval target — otherwise we'd
+    // swallow the keyboard approve-confirm in the prompt below.
+    if (!canExpand()) return;
+    e.preventDefault();
+    toggleExpanded();
+  };
+
+  // F-447: the destructive preview is whatever the daemon handed us. For
+  // completed writes/execs, this is populated by `result_preview`; for
+  // awaiting approval it comes from `preview.description`. Either way,
+  // renders in a dedicated block separated from the generic result block.
+  const destructivePreview = (): string | null => {
+    if (!isDestructiveTool(props.turn.tool_name)) return null;
+    if (props.turn.status === 'awaiting-approval' && props.turn.preview) {
+      return props.turn.preview.description;
+    }
+    return props.turn.result_preview ?? null;
+  };
+
+  const genericPreview = (): string | null => {
+    if (isDestructiveTool(props.turn.tool_name)) return null;
+    return props.turn.result_preview ?? null;
+  };
+
+  const truncatedPreview = (): { text: string; truncated: boolean } => {
+    const raw = genericPreview() ?? '';
+    if (raw.length <= RESULT_PREVIEW_CAP || showFullPreview()) {
+      return { text: raw, truncated: false };
+    }
+    return {
+      text: raw.slice(0, RESULT_PREVIEW_CAP),
+      truncated: true,
+    };
+  };
+
   return (
     <div
-      class="tool-placeholder"
+      class="tool-call-card"
       data-testid={`tool-call-card-${props.turn.tool_call_id}`}
+      data-tool-kind={kind()}
+      data-status={props.turn.status}
+      data-expanded={expanded() ? 'true' : 'false'}
       classList={{
-        'tool-placeholder--completed': props.turn.status === 'completed',
-        'tool-placeholder--awaiting': props.turn.status === 'awaiting-approval',
+        'tool-call-card--nested': props.nested === true,
+        'tool-call-card--completed': props.turn.status === 'completed',
+        'tool-call-card--errored': props.turn.status === 'errored',
+        'tool-call-card--awaiting': props.turn.status === 'awaiting-approval',
+        'tool-call-card--expanded': expanded(),
       }}
       tabIndex={props.turn.status === 'awaiting-approval' ? 0 : undefined}
       ref={cardRef}
     >
-      <div class="tool-placeholder__header">
-        <span class="tool-placeholder__icon" aria-hidden="true">
+      {/* Collapsed row. Acts as the expand/collapse affordance; keyboard
+          activation via Enter/Space on the role="button" element. */}
+      <div
+        class="tool-call-card__row"
+        data-testid={`tool-call-row-${props.turn.tool_call_id}`}
+        role={canExpand() ? 'button' : undefined}
+        tabIndex={canExpand() ? 0 : undefined}
+        aria-expanded={canExpand() ? expanded() : undefined}
+        aria-controls={
+          canExpand() ? `tool-call-body-${props.turn.tool_call_id}` : undefined
+        }
+        onClick={() => toggleExpanded()}
+        onKeyDown={handleHeaderKeyDown}
+      >
+        <span
+          class="tool-call-card__icon"
+          data-testid={`tool-call-icon-${props.turn.tool_call_id}`}
+          aria-hidden="true"
+        >
           ⚙
         </span>
-        <span class="tool-placeholder__name">{props.turn.tool_name}</span>
+        <span class="tool-call-card__name">{props.turn.tool_name}</span>
 
         {/* One-line arg summary — path for path-taking tools, otherwise a
             short stringified JSON. Skipped when args_json is unparseable. */}
         <Show when={summarizeArgs(props.turn.args_json)}>
           {(summary) => (
             <span
-              class="tool-placeholder__args"
+              class="tool-call-card__args"
               data-testid={`tool-call-args-${props.turn.tool_call_id}`}
             >
               {summary()}
@@ -286,11 +440,113 @@ const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholde
           />
         </Show>
 
-        {/* Status label (hidden when awaiting — prompt fills that role) */}
-        <Show when={props.turn.status !== 'awaiting-approval' || whitelistKey() !== null}>
-          <span class="tool-placeholder__status">{props.turn.status}</span>
+        {/* F-447: duration readout — right-aligned. Spec §5 collapses to
+            `awaiting approval` when approval is pending so the user knows
+            the call is parked on them rather than still running. */}
+        <Show when={durationText()}>
+          {(text) => (
+            <span
+              class="tool-call-card__duration"
+              data-testid={`tool-call-duration-${props.turn.tool_call_id}`}
+            >
+              {text()}
+            </span>
+          )}
+        </Show>
+
+        {/* F-447: status glyph. Replaces the Phase 2 raw-text status. */}
+        <span
+          class="tool-call-card__status"
+          data-testid={`tool-call-status-${props.turn.tool_call_id}`}
+          data-status={props.turn.status}
+        >
+          {statusGlyph(props.turn.status)}
+        </span>
+
+        {/* F-447: chevron affordance; rotates 90° via CSS when expanded. */}
+        <Show when={canExpand()}>
+          <span
+            class="tool-call-card__chevron"
+            data-testid={`tool-call-chevron-${props.turn.tool_call_id}`}
+            aria-hidden="true"
+          >
+            ›
+          </span>
         </Show>
       </div>
+
+      {/* F-447 expanded body — tinted background, pretty-printed args,
+          result preview with show-more, metadata, destructive preview. */}
+      <Show when={expanded() && canExpand()}>
+        <div
+          class="tool-call-card__body"
+          id={`tool-call-body-${props.turn.tool_call_id}`}
+          data-testid={`tool-call-body-${props.turn.tool_call_id}`}
+        >
+          <section class="tool-call-card__block">
+            <header class="tool-call-card__block-label">args</header>
+            <pre
+              class="tool-call-card__args-json"
+              data-testid={`tool-call-args-json-${props.turn.tool_call_id}`}
+            >
+              {prettyPrintArgs(props.turn.args_json)}
+            </pre>
+          </section>
+
+          <Show when={destructivePreview()}>
+            {(text) => (
+              <section class="tool-call-card__block">
+                <header class="tool-call-card__block-label">
+                  {props.turn.tool_name === 'shell.exec' ? 'command' : 'diff'}
+                </header>
+                <pre
+                  class="tool-call-card__diff"
+                  data-testid={`tool-call-diff-${props.turn.tool_call_id}`}
+                >
+                  {text()}
+                </pre>
+              </section>
+            )}
+          </Show>
+
+          <Show when={genericPreview()}>
+            <section class="tool-call-card__block">
+              <header class="tool-call-card__block-label">result</header>
+              <pre
+                class="tool-call-card__result"
+                data-testid={`tool-call-result-${props.turn.tool_call_id}`}
+              >
+                {truncatedPreview().text}
+              </pre>
+              <Show when={truncatedPreview().truncated}>
+                <button
+                  type="button"
+                  class="tool-call-card__show-more"
+                  data-testid={`tool-call-show-more-${props.turn.tool_call_id}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setShowFullPreview(true);
+                  }}
+                >
+                  show more
+                </button>
+              </Show>
+            </section>
+          </Show>
+
+          <Show when={props.turn.error !== undefined}>
+            <section class="tool-call-card__block tool-call-card__block--error">
+              <header class="tool-call-card__block-label">error</header>
+              <pre
+                class="tool-call-card__error"
+                data-testid={`tool-call-error-${props.turn.tool_call_id}`}
+              >
+                {props.turn.error}
+              </pre>
+            </section>
+          </Show>
+        </div>
+      </Show>
 
       {/* Inline approval prompt */}
       <Show
@@ -309,6 +565,106 @@ const ToolCallCard: Component<{ turn: Extract<ChatTurn, { type: 'tool_placeholde
           onApprove={handleApprove}
           onReject={handleReject}
         />
+      </Show>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// ParallelReadsGroup — F-447 §5.1
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate card for a run of read-only tool calls that share a `batch_id`.
+ * Collapsed: `parallel reads · N calls   48ms ✓ ›`. Expanded: each child
+ * renders as a nested compact row. Aggregate duration is the max across
+ * children (spec §5.1). Writes never enter here — the store tags only reads
+ * with a batch_id via the orchestrator's `parallel_group` field.
+ */
+const ParallelReadsGroup: Component<{
+  batchId: string;
+  calls: Array<Extract<ChatTurn, { type: 'tool_placeholder' }>>;
+}> = (props) => {
+  const [expanded, setExpanded] = createSignal(false);
+
+  const aggregateDuration = createMemo<number | undefined>(() => {
+    let max: number | undefined;
+    for (const c of props.calls) {
+      if (c.duration_ms === undefined) continue;
+      if (max === undefined || c.duration_ms > max) max = c.duration_ms;
+    }
+    return max;
+  });
+
+  const aggregateStatus = createMemo<ToolCallStatus>(() => {
+    if (props.calls.some((c) => c.status === 'errored')) return 'errored';
+    if (props.calls.some((c) => c.status === 'in-progress')) return 'in-progress';
+    if (props.calls.some((c) => c.status === 'awaiting-approval')) {
+      return 'awaiting-approval';
+    }
+    return 'completed';
+  });
+
+  const handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    e.preventDefault();
+    setExpanded((v) => !v);
+  };
+
+  return (
+    <div
+      class="tool-call-group"
+      data-testid={`tool-call-group-${props.batchId}`}
+      data-expanded={expanded() ? 'true' : 'false'}
+      data-status={aggregateStatus()}
+    >
+      <div
+        class="tool-call-group__row"
+        data-testid={`tool-call-group-row-${props.batchId}`}
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded()}
+        aria-controls={`tool-call-group-body-${props.batchId}`}
+        onClick={() => setExpanded((v) => !v)}
+        onKeyDown={handleKeyDown}
+      >
+        <span class="tool-call-card__icon" aria-hidden="true">⚙</span>
+        <span class="tool-call-card__name">parallel reads</span>
+        <span
+          class="tool-call-card__args"
+          data-testid={`tool-call-group-count-${props.batchId}`}
+        >
+          · {props.calls.length} calls
+        </span>
+        <Show when={formatDuration(aggregateDuration())}>
+          {(text) => (
+            <span
+              class="tool-call-card__duration"
+              data-testid={`tool-call-group-duration-${props.batchId}`}
+            >
+              {text()}
+            </span>
+          )}
+        </Show>
+        <span
+          class="tool-call-card__status"
+          data-status={aggregateStatus()}
+          data-testid={`tool-call-group-status-${props.batchId}`}
+        >
+          {statusGlyph(aggregateStatus())}
+        </span>
+        <span class="tool-call-card__chevron" aria-hidden="true">›</span>
+      </div>
+      <Show when={expanded()}>
+        <div
+          class="tool-call-group__body"
+          id={`tool-call-group-body-${props.batchId}`}
+          data-testid={`tool-call-group-body-${props.batchId}`}
+        >
+          <For each={props.calls}>
+            {(call) => <ToolCallCard turn={call} nested />}
+          </For>
+        </div>
       </Show>
     </div>
   );
@@ -987,6 +1343,48 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
     });
   });
 
+  // F-447 §5.1: parallel-reads grouping. Bucket consecutive tool_placeholder
+  // turns that share a `batch_id` into a single synthetic group item so
+  // `ParallelReadsGroup` can render the aggregate header + nested children.
+  // Non-placeholder turns break the run; a batch_id mismatch also breaks it.
+  // Runs of length 1 degrade to the standalone card — no group chrome — so
+  // a solo read doesn't awkwardly render as "parallel reads · 1 call".
+  type DisplayItem =
+    | { kind: 'turn'; turn: ChatTurn }
+    | {
+        kind: 'tool_group';
+        batchId: string;
+        calls: Array<Extract<ChatTurn, { type: 'tool_placeholder' }>>;
+      };
+
+  const displayItems = createMemo<DisplayItem[]>(() => {
+    const out: DisplayItem[] = [];
+    const turns = visibleTurns();
+    let i = 0;
+    while (i < turns.length) {
+      const t = turns[i]!;
+      if (t.type === 'tool_placeholder' && t.batch_id !== undefined) {
+        const bid = t.batch_id;
+        const run: Array<Extract<ChatTurn, { type: 'tool_placeholder' }>> = [];
+        while (i < turns.length) {
+          const n = turns[i]!;
+          if (n.type !== 'tool_placeholder' || n.batch_id !== bid) break;
+          run.push(n);
+          i += 1;
+        }
+        if (run.length > 1) {
+          out.push({ kind: 'tool_group', batchId: bid, calls: run });
+        } else {
+          out.push({ kind: 'turn', turn: run[0]! });
+        }
+        continue;
+      }
+      out.push({ kind: 'turn', turn: t });
+      i += 1;
+    }
+    return out;
+  });
+
   let listRef: HTMLDivElement | undefined;
   // Track whether the user has scrolled up (released auto-pin)
   const [userScrolledUp, setUserScrolledUp] = createSignal(false);
@@ -1093,8 +1491,12 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
             // composer ready
           </p>
         </Show>
-        <For each={visibleTurns()}>
-          {(turn) => {
+        <For each={displayItems()}>
+          {(item) => {
+            if (item.kind === 'tool_group') {
+              return <ParallelReadsGroup batchId={item.batchId} calls={item.calls} />;
+            }
+            const turn = item.turn;
             switch (turn.type) {
               case 'user':
                 return <UserBubble turn={turn} />;

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -35,7 +35,33 @@ export type SessionEvent =
   // transitions an existing placeholder. They remain for the fallback branch
   // (placeholder missing) used by the pre-wire unit tests.
   | { kind: 'ToolCallApprovalRequested'; tool_call_id: string; tool_name?: string; args_json?: string; preview: ApprovalPreview }
-  | { kind: 'ToolCallCompleted'; tool_call_id: string; result_summary: string }
+  | {
+      kind: 'ToolCallCompleted';
+      tool_call_id: string;
+      result_summary: string;
+      /**
+       * F-447: structured carry-through from the Rust wire `result` object.
+       * `result_summary` is retained for existing consumers (truncated JSON
+       * blob); the fields below are what the expanded card body reads so it
+       * doesn't have to re-parse the summary.
+       */
+      result_ok?: boolean;
+      result_preview?: string;
+      /**
+       * F-447: preserved for parity with the wire shape. The store routes
+       * `result.ok === false` through the `ToolCallFailed` code path so the
+       * expanded card can render the error verbatim instead of a truncated
+       * JSON blob.
+       */
+      result_error?: string;
+      /**
+       * F-447: authoritative duration from the daemon's `tool_call_completed`
+       * wire event. Phase 2 recomputed duration as `Date.now() - started_at`,
+       * which drifts whenever the daemon and client clocks disagree or the
+       * completion arrives out-of-order. Prefer the wire value when present.
+       */
+      duration_ms?: number;
+    }
   | { kind: 'ToolCallFailed'; tool_call_id: string; error: string }
   // F-144 / F-145: branch-tree mutations. `BranchSelected` flips the active
   // variant for a given branch point; `BranchDeleted` tombstones a variant.
@@ -103,6 +129,9 @@ export type ChatTurn =
       started_at: number;
       duration_ms?: number;
       result_summary?: string;
+      /** F-447: structured pieces of the completed-call `result` object. */
+      result_ok?: boolean;
+      result_preview?: string;
       error?: string;
       /** Populated when status is 'awaiting-approval'. */
       preview?: ApprovalPreview;
@@ -502,9 +531,25 @@ export function pushEvent(sessionId: SessionId, event: SessionEvent): void {
           );
           if (idx >= 0) {
             const turn = state.turns[idx] as Extract<ChatTurn, { type: 'tool_placeholder' }>;
-            turn.status = 'completed';
+            // F-447: prefer the wire-reported `result.ok === false` as the
+            // errored signal so the status glyph reflects the daemon's own
+            // verdict rather than assuming any completion is a success.
+            turn.status = event.result_ok === false ? 'errored' : 'completed';
             turn.result_summary = event.result_summary;
-            turn.duration_ms = Date.now() - turn.started_at;
+            if (event.result_ok !== undefined) turn.result_ok = event.result_ok;
+            if (event.result_preview !== undefined) {
+              turn.result_preview = event.result_preview;
+            }
+            // F-447: a completed-but-failed call (ok=false) carries the
+            // error string; route it into `turn.error` so the collapsed
+            // row's ✗ glyph has message text to pair with.
+            if (event.result_ok === false && event.result_error !== undefined) {
+              turn.error = event.result_error;
+            }
+            // F-447: prefer the wire value; fall back to local elapsed time
+            // when the daemon didn't carry a duration (older wire shapes or
+            // orphaned completions in tests).
+            turn.duration_ms = event.duration_ms ?? (Date.now() - turn.started_at);
           }
         }),
       );

--- a/web/packages/app/tests/phase1/uat-06-tool-call-card.spec.ts
+++ b/web/packages/app/tests/phase1/uat-06-tool-call-card.spec.ts
@@ -1,8 +1,17 @@
-// UAT-06 — Tool call card rendering (F-026).
+// UAT-06 — Tool call card rendering (F-026 / F-447).
 // Plan: docs/testing/phase1-uat.md §UAT-06
+//
+// F-447 re-enables the Phase 2 skipped interactions:
+//   • expand/collapse toggle on completed cards
+//   • parallel-reads group header for read-only calls sharing a batch_id
+//   • errored-state rendering
+//   • fs.edit diff preview in the expanded body
+//
+// All selectors below are authoritative — the component uses them too.
 
 import { test, expect, type TauriMockHandle } from './fixtures/tauri-mock';
 import {
+  toolCallApprovalRequested,
   toolCallCompleted,
   toolCallStarted,
   userMessage,
@@ -38,34 +47,76 @@ test.describe('UAT-06 — tool call card', () => {
 
     await expect(page.getByTestId('tool-call-card-tc-1')).toBeVisible();
     await expect(page.getByTestId('tool-call-card-tc-1')).toContainText('fs.read');
-    // F-041: the collapsed card header also shows a one-line path summary
-    // next to the tool name.
     await expect(page.getByTestId('tool-call-card-tc-1')).toContainText('readable.txt');
   });
 
-  test('expand/collapse toggle persists while window is open', async () => {
-    test.skip(true, 'interaction selector pending — see phase1-uat.md §UAT-06 step 2-3');
+  test('expand/collapse toggle persists while window is open', async ({ tauri, page }) => {
+    await mountSession(page, tauri);
+    await tauri.emit('session:event', userMessage(SESSION_ID, 'open it'));
+    await tauri.emit(
+      'session:event',
+      toolCallStarted(SESSION_ID, 'tc-xp', 'fs.read', { path: 'a.txt' }),
+    );
+    await tauri.emit(
+      'session:event',
+      toolCallCompleted(SESSION_ID, 'tc-xp', { ok: true, preview: 'payload' }),
+    );
+
+    const card = page.getByTestId('tool-call-card-tc-xp');
+    await expect(card).toHaveAttribute('data-expanded', 'false');
+    await page.getByTestId('tool-call-row-tc-xp').click();
+    await expect(card).toHaveAttribute('data-expanded', 'true');
+    await expect(page.getByTestId('tool-call-body-tc-xp')).toBeVisible();
+    await page.getByTestId('tool-call-row-tc-xp').click();
+    await expect(card).toHaveAttribute('data-expanded', 'false');
   });
 
   test('three read-only calls with shared batch_id render as a group', async ({ tauri, page }) => {
     await mountSession(page, tauri);
-    // Rust's parallel_group is u32; fixture takes a number and the adapter
-    // stringifies it for the store's batch_id field.
+    // Rust's parallel_group is u32; the adapter stringifies it into the
+    // store's batch_id field (see ipc/events.ts).
     for (const id of ['tc-1', 'tc-2', 'tc-3']) {
       await tauri.emit(
         'session:event',
         toolCallStarted(SESSION_ID, id, 'fs.read', { path: `${id}.txt` }, 7),
       );
     }
-    // TODO: assert the group header. Selector not yet established.
-    test.skip(true, 'group header selector pending — see phase1-uat.md §UAT-06 step 4');
+    await expect(page.getByTestId('tool-call-group-7')).toBeVisible();
+    await expect(page.getByTestId('tool-call-group-count-7')).toContainText('3 calls');
   });
 
-  test('errored status renders with error color token', async () => {
-    test.skip(true, 'selector pending — see phase1-uat.md §UAT-06 step 5');
+  test('errored status renders with the ✗ glyph', async ({ tauri, page }) => {
+    await mountSession(page, tauri);
+    await tauri.emit(
+      'session:event',
+      toolCallStarted(SESSION_ID, 'tc-err', 'fs.read', { path: 'missing.txt' }),
+    );
+    await tauri.emit(
+      'session:event',
+      toolCallCompleted(SESSION_ID, 'tc-err', { ok: false, error: 'ENOENT' }),
+    );
+    await expect(page.getByTestId('tool-call-status-tc-err')).toHaveText('✗');
+    await expect(page.getByTestId('tool-call-card-tc-err')).toHaveAttribute(
+      'data-status',
+      'errored',
+    );
   });
 
-  test('fs.edit completion shows unified-diff preview in expanded card', async () => {
-    test.skip(true, 'selector pending — see phase1-uat.md §UAT-06 step 6');
+  test('fs.edit approval surfaces a diff preview in the expanded body', async ({ tauri, page }) => {
+    await mountSession(page, tauri);
+    await tauri.emit(
+      'session:event',
+      toolCallStarted(SESSION_ID, 'tc-edit', 'fs.edit', {
+        path: '/src/foo.ts',
+        patch: '...',
+      }),
+    );
+    await tauri.emit(
+      'session:event',
+      toolCallApprovalRequested(SESSION_ID, 'tc-edit', {
+        description: '--- a\n+++ b\n@@ -1 +1 @@\n-x\n+y',
+      }),
+    );
+    await expect(page.getByTestId('tool-call-diff-tc-edit')).toContainText('+++ b');
   });
 });


### PR DESCRIPTION
Closes forge-ide/forge#448

## Summary

Upgrades the Phase-2 tool-call placeholder to the authoritative Phase-3
surface per `docs/ui-specs/tool-call-card.md` §5 / §5.1:

- Per-tool icon color via `data-tool-kind` (read → info, agent → ember-400, general → ember-100)
- Status glyph (✓ / ! / ✗) replaces the raw status string
- Duration readout (`42ms` / `1.2s` / awaiting approval) right-aligned
- Chevron affordance — click + keyboard activation expand the card
- Expanded body: tinted ember background, pretty-printed args JSON, 800-char-capped result preview with "show more", diff/command preview for destructive tools, error block
- §5.1 parallel-reads grouping: consecutive reads sharing a `batch_id` render under a single aggregate card; expanded view shows each child card nested `--sp-5` with a 2px left edge
- `tool_call_completed` adapter forwards `result.ok/preview/error` and `duration_ms` through the store — no more stringified-JSON re-parsing in the UI
- CSS class tree renamed `.tool-placeholder*` → `.tool-call-card*`
- UAT-06 skipped tests (expand/collapse, group header, errored glyph, fs.edit diff) re-enabled with authoritative selectors

## Test plan

- `pnpm typecheck` passes (`tsc --noEmit` clean)
- `pnpm test` — 912 tests pass (27 new for F-447 behavior + CSS drift fixture)
- `pnpm check-tokens` passes (no raw hex/px drift)
- `cargo fmt --check && cargo check && cargo test && cargo clippy -- -D warnings` pass
- Playwright UAT-06 suite re-enabled; selectors match component

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)