### PR TITLE
[F-368] MCP manager error paths log at debug silencing crash signals

### DIFF
--- a/crates/forge-mcp/src/manager.rs
+++ b/crates/forge-mcp/src/manager.rs
@@ -616,6 +616,13 @@ async fn run_lifecycle(
                 return;
             }
             Err(reason) => {
+                tracing::warn!(
+                    target: "forge_mcp::manager",
+                    server = %name,
+                    %reason,
+                    attempt,
+                    "MCP server session failed; will retry",
+                );
                 shared
                     .publish(ServerState::Degraded {
                         reason: reason.clone(),
@@ -796,7 +803,7 @@ async fn run_pump(
                         }
                     }
                     TransportEvent::Closed(reason) => {
-                        tracing::debug!(
+                        tracing::warn!(
                             target: "forge_mcp::manager",
                             server = %server_name,
                             %reason,
@@ -816,7 +823,7 @@ async fn run_pump(
                             pending.insert(id, slot);
                         }
                         if let Err(err) = transport.send(frame).await {
-                            tracing::debug!(
+                            tracing::warn!(
                                 target: "forge_mcp::manager",
                                 server = %server_name,
                                 error = %err,
@@ -827,7 +834,7 @@ async fn run_pump(
                         }
                     }
                     None => {
-                        tracing::debug!(
+                        tracing::warn!(
                             target: "forge_mcp::manager",
                             server = %server_name,
                             "pump exiting: command channel closed",


### PR DESCRIPTION
## Summary

- Adds `tracing::warn!` to the `run_lifecycle` `Err` arm — previously no log existed when a server session failed before retry
- Promotes `tracing::debug!` → `warn!` on three `run_pump` error paths: transport closed, transport send failure, command channel closed
- Leaves `unmatched response` and `unhandled notification` at `debug!` — routine, non-crash signals

Fixes #369 (F-368).

## Test plan

- [ ] Existing 52 unit tests in `forge-mcp` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)