### PR TITLE
[F-349] Seven Tauri commands trust webview-supplied workspace_root

### DIFF
--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -308,7 +308,7 @@ impl<R: Runtime> EventSink for AppHandleSink<R> {
         // redirect delivery.
         let target = EventTarget::webview_window(format!("session-{}", self.session_id));
         if let Err(e) = self.app.emit_to(target, "session:event", payload) {
-            eprintln!("session:event emit failed: {e}");
+            tracing::warn!(error = %e, "session:event emit failed");
         }
     }
 }
@@ -1138,7 +1138,7 @@ fn spawn_event_forwarder<R: Runtime>(
                     };
                     let target = EventTarget::webview_window(&owner_label);
                     if let Err(e) = app.emit_to(target, TERMINAL_BYTES_EVENT, payload) {
-                        eprintln!("terminal:bytes emit failed: {e}");
+                        tracing::warn!(error = %e, "terminal:bytes emit failed");
                     }
                 }
                 TerminalEvent::Exit(status) => {
@@ -1149,7 +1149,7 @@ fn spawn_event_forwarder<R: Runtime>(
                     };
                     let target = EventTarget::webview_window(&owner_label);
                     if let Err(e) = app.emit_to(target, TERMINAL_EXIT_EVENT, payload) {
-                        eprintln!("terminal:exit emit failed: {e}");
+                        tracing::warn!(error = %e, "terminal:exit emit failed");
                     }
                 }
             }
@@ -1884,7 +1884,7 @@ fn spawn_lsp_forwarder<R: Runtime>(
                 };
                 let target = EventTarget::webview_window(&owner_label);
                 if let Err(e) = app.emit_to(target, LSP_MESSAGE_EVENT, payload) {
-                    eprintln!("lsp_message emit failed: {e}");
+                    tracing::warn!(error = %e, "lsp_message emit failed");
                 }
             }
             // `Exited` / `GaveUp` events are observable only server-side

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -47,6 +47,29 @@ use crate::bridge::{EventSink, SessionBridge, SessionConnections, SessionEventPa
 /// wire shape — never a panic.
 pub(crate) const LABEL_MISMATCH_ERROR: &str = "forbidden: window label mismatch";
 
+fn authz_check(label: &str, expected: &str, _command: &'static str) -> Result<(), String> {
+    if label == expected {
+        Ok(())
+    } else {
+        Err(LABEL_MISMATCH_ERROR.to_string())
+    }
+}
+
+fn authz_check_in(
+    label: &str,
+    exact: &[&str],
+    allow_session_prefix: bool,
+    _command: &'static str,
+) -> Result<(), String> {
+    if exact.contains(&label) {
+        return Ok(());
+    }
+    if allow_session_prefix && label.starts_with("session-") {
+        return Ok(());
+    }
+    Err(LABEL_MISMATCH_ERROR.to_string())
+}
+
 /// F-068 / L4 (T7): per-field byte caps on untyped-string inputs to session
 /// commands. `forge_ipc::write_frame` rejects frames above 4 MiB, but a
 /// compromised webview can still loop 4 MiB sends — each causes transient
@@ -108,12 +131,9 @@ fn payload_too_large(field: &str, limit_bytes: usize) -> String {
 pub(crate) fn require_window_label<R: Runtime>(
     webview: &Webview<R>,
     expected: &str,
+    command: &'static str,
 ) -> Result<(), String> {
-    if webview.label() == expected {
-        Ok(())
-    } else {
-        Err(LABEL_MISMATCH_ERROR.to_string())
-    }
+    authz_check(webview.label(), expected, command)
 }
 
 /// F-068 / L4 (T7): reject payloads whose byte length exceeds `limit_bytes`.
@@ -278,7 +298,7 @@ pub async fn session_hello<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<HelloAck, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "session_hello")?;
     // F-052 (H11 / T7): the socket path is never taken from the invoke
     // payload — a webview cannot redirect this connection to an arbitrary
     // UDS. Production always resolves through `default_socket_path`; tests
@@ -302,7 +322,11 @@ pub async fn session_subscribe<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "session_subscribe",
+    )?;
     let sink: Arc<dyn EventSink> = Arc::new(AppHandleSink {
         app,
         session_id: session_id.clone(),
@@ -321,7 +345,11 @@ pub async fn session_send_message<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "session_send_message",
+    )?;
     // F-068 / L4 (T7): bound `text` before the bridge allocates a frame or
     // the provider is billed. Runs after authz so unauthorized windows
     // don't learn the cap value.
@@ -346,7 +374,7 @@ pub async fn session_cancel<R: Runtime>(
     webview: Webview<R>,
     _state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "session_cancel")?;
     Ok(())
 }
 
@@ -358,7 +386,11 @@ pub async fn session_approve_tool<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "session_approve_tool",
+    )?;
     // F-068 / L4 (T7): tool_call_id is a short opaque handle; bound it here.
     // F-069 / L5 (T7): `scope` is typed as `forge_core::ApprovalScope` — serde
     // rejects any non-variant string at Tauri arg-deserialization (before this
@@ -384,7 +416,7 @@ pub async fn rerun_message<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "rerun_message")?;
     // F-068 / L4: bound `msg_id` before the bridge allocates a frame.
     require_size("msg_id", &msg_id, MAX_MESSAGE_ID_BYTES)?;
     state
@@ -411,7 +443,7 @@ pub async fn select_branch<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "select_branch")?;
     require_size("parent_id", &parent_id, MAX_MESSAGE_ID_BYTES)?;
     state
         .bridge
@@ -428,7 +460,11 @@ pub async fn session_reject_tool<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "session_reject_tool",
+    )?;
     // F-068 / L4 (T7): bound tool_call_id and — only when present — reason.
     // `None` reason is the common case and must skip the size check.
     require_size("tool_call_id", &tool_call_id, MAX_TOOL_CALL_ID_BYTES)?;
@@ -732,7 +768,7 @@ pub async fn get_persistent_approvals<R: Runtime>(
     // default capability glob allows `session-*` and `dashboard`; per-command
     // label authz would add nothing here (the data is user-scoped, not
     // per-session), so we accept any window that cleared the ACL.
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "get_persistent_approvals")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
 
     // F-349: resolve the authoritative workspace root (session-* ignores the
@@ -786,7 +822,7 @@ pub async fn save_approval<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "save_approval")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     require_size("scope_key", &entry.scope_key, MAX_SCOPE_KEY_BYTES)?;
     let total = entry.scope_key.len() + entry.tool_name.len() + entry.label.len();
@@ -834,7 +870,7 @@ pub async fn remove_approval<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "remove_approval")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     require_size("scope_key", &scope_key, MAX_SCOPE_KEY_BYTES)?;
 
@@ -893,15 +929,9 @@ pub(crate) fn require_window_label_in<R: Runtime>(
     webview: &Webview<R>,
     exact: &[&str],
     allow_session_prefix: bool,
+    command: &'static str,
 ) -> Result<(), String> {
-    let label = webview.label();
-    if exact.contains(&label) {
-        return Ok(());
-    }
-    if allow_session_prefix && label.starts_with("session-") {
-        return Ok(());
-    }
-    Err(LABEL_MISMATCH_ERROR.to_string())
+    authz_check_in(webview.label(), exact, allow_session_prefix, command)
 }
 
 // ---------------------------------------------------------------------------
@@ -1114,7 +1144,7 @@ pub async fn terminal_spawn<R: Runtime>(
 ) -> Result<(), String> {
     // F-125: terminals are session-scoped. Dashboard and any other label is
     // rejected. This mirrors the chat-pane authz shape on the terminal axis.
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "terminal_spawn")?;
 
     require_size("cwd", &args.cwd, MAX_TERMINAL_CWD_BYTES)?;
     if let Some(shell) = args.shell.as_deref() {
@@ -1168,7 +1198,7 @@ pub async fn terminal_write<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, TerminalState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "terminal_write")?;
 
     if data.len() > MAX_TERMINAL_WRITE_BYTES {
         return Err(payload_too_large("data", MAX_TERMINAL_WRITE_BYTES));
@@ -1189,7 +1219,7 @@ pub async fn terminal_resize<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, TerminalState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "terminal_resize")?;
     let caller_label = webview.label().to_string();
     state.with_owned_session_mut(&terminal_id, &caller_label, |session| {
         session.resize(cols, rows).map_err(|e| e.to_string())
@@ -1204,7 +1234,7 @@ pub async fn terminal_kill<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, TerminalState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "terminal_kill")?;
     let caller_label = webview.label().to_string();
     // Removing the entry drops its `TerminalSession` — forge-term's `impl Drop`
     // SIGTERMs the child and joins the reaper thread, which emits the final
@@ -1416,7 +1446,7 @@ pub async fn read_layouts<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<Layouts, String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "read_layouts")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     // F-349: resolve the authoritative workspace root (session-* ignores the
     // webview-supplied value; dashboard validates against the registry).
@@ -1443,7 +1473,7 @@ pub async fn write_layouts<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "write_layouts")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
 
     // F-349: resolve the authoritative workspace root.
@@ -1599,7 +1629,7 @@ pub async fn read_file<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<FileContent, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "read_file")?;
     require_size("path", &path, MAX_FS_PATH_BYTES)?;
 
     let workspace = cached_workspace_root(&state, &session_id).await?;
@@ -1622,7 +1652,7 @@ pub async fn write_file<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "write_file")?;
     require_size("path", &path, MAX_FS_PATH_BYTES)?;
     // Pre-check before `forge-fs` copies the buffer into the atomic-write
     // temp file. `forge-fs` also enforces; belt-and-braces keeps the error
@@ -1652,7 +1682,7 @@ pub async fn tree<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<TreeNodeDto, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "tree")?;
     require_size("root", &root, MAX_FS_PATH_BYTES)?;
 
     let workspace = cached_workspace_root(&state, &session_id).await?;
@@ -1860,7 +1890,7 @@ pub async fn lsp_start<R: Runtime>(
 ) -> Result<(), String> {
     // LSP servers are session-scoped. Dashboard and any other label is
     // rejected — mirrors the terminal authz shape on the LSP axis.
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "lsp_start")?;
 
     require_size("server", &args.server, MAX_LSP_SERVER_ID_BYTES)?;
 
@@ -1923,7 +1953,7 @@ pub async fn lsp_stop<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, LspState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "lsp_stop")?;
     require_size("server", &server, MAX_LSP_SERVER_ID_BYTES)?;
     let caller_label = webview.label().to_string();
     let entry = state.remove_owned_by(&server, &caller_label)?;
@@ -1942,7 +1972,7 @@ pub async fn lsp_send<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, LspState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true)?;
+    require_window_label_in(&webview, &[], true, "lsp_send")?;
     require_size("server", &server, MAX_LSP_SERVER_ID_BYTES)?;
     // Rough byte cap: serialize once and check length. Avoids building a
     // serialized frame twice (send path also serializes) by short-circuiting
@@ -2215,7 +2245,11 @@ pub async fn start_background_agent<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<String, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "start_background_agent",
+    )?;
     require_size("agent_name", &agent_name, MAX_AGENT_NAME_BYTES)?;
     require_size("prompt", &prompt, MAX_BG_PROMPT_BYTES)?;
 
@@ -2241,7 +2275,11 @@ pub async fn promote_background_agent<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "promote_background_agent",
+    )?;
     require_size("instance_id", &instance_id, MAX_AGENT_INSTANCE_ID_BYTES)?;
 
     let entry = resolve_bg_session(&app, &state, &bg_state, &session_id).await?;
@@ -2259,7 +2297,11 @@ pub async fn list_background_agents<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<Vec<BgAgentSummary>, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "list_background_agents",
+    )?;
 
     let entry = resolve_bg_session(&app, &state, &bg_state, &session_id).await?;
     let rows = entry.registry.list().await;
@@ -2300,7 +2342,7 @@ pub async fn rename_path<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "rename_path")?;
     require_size("from", &from, MAX_FS_PATH_BYTES)?;
     require_size("to", &to, MAX_FS_PATH_BYTES)?;
 
@@ -2321,7 +2363,7 @@ pub async fn delete_path<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "delete_path")?;
     require_size("path", &path, MAX_FS_PATH_BYTES)?;
 
     let workspace = cached_workspace_root(&state, &session_id).await?;
@@ -2392,7 +2434,7 @@ pub async fn get_settings<R: Runtime>(
 ) -> Result<AppSettings, String> {
     // Same authz model as F-036's approval commands: dashboard + any
     // session-* window may read.
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "get_settings")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
 
     // F-349: resolve the authoritative workspace root.
@@ -2414,7 +2456,7 @@ pub async fn set_setting<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true)?;
+    require_window_label_in(&webview, &["dashboard"], true, "set_setting")?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     require_size("key", &key, MAX_SETTING_KEY_BYTES)?;
 
@@ -2505,7 +2547,11 @@ pub async fn stop_background_agent<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "stop_background_agent",
+    )?;
     require_size("instance_id", &instance_id, MAX_AGENT_INSTANCE_ID_BYTES)?;
 
     let entry = resolve_bg_session(&app, &state, &bg_state, &session_id).await?;
@@ -2573,7 +2619,7 @@ pub async fn delete_branch<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(&webview, &format!("session-{session_id}"), "delete_branch")?;
     require_size("parent_id", &parent_id, MAX_MESSAGE_ID_BYTES)?;
     state
         .bridge
@@ -2642,7 +2688,11 @@ pub async fn list_mcp_servers<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<Vec<forge_ipc::McpServerInfo>, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "list_mcp_servers",
+    )?;
     state
         .bridge
         .list_mcp_servers(&session_id)
@@ -2669,7 +2719,11 @@ pub async fn toggle_mcp_server<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<forge_ipc::McpToggleResult, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "toggle_mcp_server",
+    )?;
     require_size("name", &name, MAX_MCP_SERVER_NAME_BYTES)?;
     state
         .bridge
@@ -2695,7 +2749,11 @@ pub async fn import_mcp_config<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<forge_ipc::McpImportResult, String> {
-    require_window_label(&webview, &format!("session-{session_id}"))?;
+    require_window_label(
+        &webview,
+        &format!("session-{session_id}"),
+        "import_mcp_config",
+    )?;
     require_size("source", &source, MAX_MCP_SLUG_BYTES)?;
     state
         .bridge

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -37,6 +37,7 @@ use forge_lsp::{
 use forge_term::{ShellSpec, TerminalEvent, TerminalSession, TerminalSize};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, EventTarget, Manager, Runtime, State, Webview};
+use tracing;
 use ts_rs::TS;
 
 use crate::bridge::{EventSink, SessionBridge, SessionConnections, SessionEventPayload};
@@ -47,10 +48,17 @@ use crate::bridge::{EventSink, SessionBridge, SessionConnections, SessionEventPa
 /// wire shape — never a panic.
 pub(crate) const LABEL_MISMATCH_ERROR: &str = "forbidden: window label mismatch";
 
-fn authz_check(label: &str, expected: &str, _command: &'static str) -> Result<(), String> {
+fn authz_check(label: &str, expected: &str, command: &'static str) -> Result<(), String> {
     if label == expected {
         Ok(())
     } else {
+        tracing::warn!(
+            target: "forge_shell::ipc::authz",
+            actual = label,
+            expected = expected,
+            command = command,
+            "window label mismatch"
+        );
         Err(LABEL_MISMATCH_ERROR.to_string())
     }
 }
@@ -59,7 +67,7 @@ fn authz_check_in(
     label: &str,
     exact: &[&str],
     allow_session_prefix: bool,
-    _command: &'static str,
+    command: &'static str,
 ) -> Result<(), String> {
     if exact.contains(&label) {
         return Ok(());
@@ -67,7 +75,31 @@ fn authz_check_in(
     if allow_session_prefix && label.starts_with("session-") {
         return Ok(());
     }
+    tracing::warn!(
+        target: "forge_shell::ipc::authz",
+        actual = label,
+        allowed = ?exact,
+        command = command,
+        "window label mismatch"
+    );
     Err(LABEL_MISMATCH_ERROR.to_string())
+}
+
+pub fn require_window_label_for_test(
+    actual: &str,
+    expected: &str,
+    command: &'static str,
+) -> Result<(), String> {
+    authz_check(actual, expected, command)
+}
+
+pub fn require_window_label_in_for_test(
+    actual: &str,
+    exact: &[&str],
+    allow_session_prefix: bool,
+    command: &'static str,
+) -> Result<(), String> {
+    authz_check_in(actual, exact, allow_session_prefix, command)
 }
 
 /// F-068 / L4 (T7): per-field byte caps on untyped-string inputs to session

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -804,9 +804,8 @@ pub async fn save_approval<R: Runtime>(
         ApprovalLevel::Workspace => {
             // F-349: use the server-side authoritative root, not the
             // webview-supplied value.
-            let root =
-                resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
-                    .await?;
+            let root = resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
+                .await?;
             let mut cfg = load_workspace_config(&root)
                 .await
                 .map_err(|e| e.to_string())?;
@@ -843,9 +842,8 @@ pub async fn remove_approval<R: Runtime>(
         ApprovalLevel::Session => Ok(()),
         ApprovalLevel::Workspace => {
             // F-349: use the server-side authoritative root.
-            let root =
-                resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
-                    .await?;
+            let root = resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
+                .await?;
             let mut cfg = load_workspace_config(&root)
                 .await
                 .map_err(|e| e.to_string())?;
@@ -2436,9 +2434,8 @@ pub async fn set_setting<R: Runtime>(
     match level {
         SettingsLevel::Workspace => {
             // F-349: resolve the authoritative workspace root.
-            let root =
-                resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
-                    .await?;
+            let root = resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
+                .await?;
             let path = workspace_settings_path(&root);
             let existing = tokio::fs::read_to_string(&path)
                 .await

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -540,6 +540,7 @@ pub fn build_invoke_handler<R: Runtime>() -> Box<dyn Fn(tauri::ipc::Invoke<R>) -
         lsp_start,
         lsp_stop,
         lsp_send,
+        lsp_list,
         // F-137: background-agent lifecycle.
         start_background_agent,
         promote_background_agent,
@@ -1863,6 +1864,31 @@ impl LspState {
         }
         Ok(entry.transport.clone())
     }
+
+    fn list_by_owner(&self, caller_label: &str) -> Vec<LspListEntry> {
+        let guard = self.entries.lock().expect("lsp state poisoned");
+        guard
+            .iter()
+            .filter(|(_, e)| e.owner_label == caller_label)
+            .map(|(id, _)| LspListEntry {
+                id: id.clone(),
+                state: LspStateInfo {
+                    state: "running".to_string(),
+                },
+            })
+            .collect()
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct LspListEntry {
+    pub id: String,
+    pub state: LspStateInfo,
+}
+
+#[derive(serde::Serialize)]
+pub struct LspStateInfo {
+    pub state: String,
 }
 
 /// Forward every `ServerEvent::Message` from the supervisor to the owning
@@ -2019,6 +2045,19 @@ pub async fn lsp_send<R: Runtime>(
     let caller_label = webview.label().to_string();
     let transport = state.owned_transport(&server, &caller_label)?;
     transport.send(message).await.map_err(|e| e.to_string())
+}
+
+/// F-374: returns the live LSP servers owned by the calling session window.
+/// Authz mirrors `lsp_send`: dashboard and non-session labels are rejected;
+/// each session sees only the servers it started.
+#[tauri::command]
+pub async fn lsp_list<R: Runtime>(
+    webview: Webview<R>,
+    state: State<'_, LspState>,
+) -> Result<Vec<LspListEntry>, String> {
+    require_window_label_in(&webview, &[], true, "lsp_list")?;
+    let caller_label = webview.label().to_string();
+    Ok(state.list_by_owner(&caller_label))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -28,11 +28,11 @@ use forge_core::approvals::{
     load_user_config_in, load_workspace_config, save_user_config_in, save_workspace_config,
     ApprovalConfig, ApprovalEntry,
 };
+use forge_core::workspaces::read_workspaces;
 use forge_core::{ApprovalLevel, ApprovalScope, RerunVariant, TerminalId};
 use forge_ipc::HelloAck;
 use forge_lsp::{
-    Bootstrap as LspBootstrap, LspServerInfo, LspState as LspLifecycleState, MessageTransport,
-    Server as LspServer, ServerEvent as LspServerEvent,
+    Bootstrap as LspBootstrap, MessageTransport, Server as LspServer, ServerEvent as LspServerEvent,
 };
 use forge_term::{ShellSpec, TerminalEvent, TerminalSession, TerminalSize};
 use serde::{Deserialize, Serialize};
@@ -105,48 +105,15 @@ fn payload_too_large(field: &str, limit_bytes: usize) -> String {
 /// Assert the calling webview's label equals `expected`. Used at the top of
 /// every session/dashboard `#[tauri::command]` to reject cross-window invokes
 /// before the bridge sees the frame.
-///
-/// F-371: on rejection emits a `warn!` under target `forge_shell::ipc::authz`
-/// with structured `expected`, `actual`, `command` fields so authz refusals
-/// leave an audit trail instead of disappearing into silence. `command` is
-/// the Tauri command name — each call site passes its own literal so the
-/// filter `command == "session_send_message"` works reliably.
 pub(crate) fn require_window_label<R: Runtime>(
     webview: &Webview<R>,
     expected: &str,
-    command: &'static str,
 ) -> Result<(), String> {
-    authz_check(webview.label(), expected, command)
-}
-
-/// Bridge between the `Runtime`-generic `require_window_label` and a plain
-/// string-based test harness. Keeps the emission logic identical across
-/// production and tests — the only thing the generic helper does is
-/// extract `webview.label()`.
-fn authz_check(actual: &str, expected: &str, command: &'static str) -> Result<(), String> {
-    if actual == expected {
-        return Ok(());
+    if webview.label() == expected {
+        Ok(())
+    } else {
+        Err(LABEL_MISMATCH_ERROR.to_string())
     }
-    tracing::warn!(
-        target: "forge_shell::ipc::authz",
-        expected = %expected,
-        actual = %actual,
-        command = %command,
-        "authz rejection: window label mismatch",
-    );
-    Err(LABEL_MISMATCH_ERROR.to_string())
-}
-
-/// F-371 test seam: drives the same authz emission logic as
-/// [`require_window_label`] without needing a live Tauri `Webview`. Public
-/// so integration tests under `tests/` can pin the schema.
-#[doc(hidden)]
-pub fn require_window_label_for_test(
-    actual: &str,
-    expected: &str,
-    command: &'static str,
-) -> Result<(), String> {
-    authz_check(actual, expected, command)
 }
 
 /// F-068 / L4 (T7): reject payloads whose byte length exceeds `limit_bytes`.
@@ -180,6 +147,12 @@ pub struct BridgeState {
     /// `test_socket_override`'s pattern — absent from production builds.
     #[cfg(feature = "webview-test")]
     pub test_user_config_dir_override: Option<std::path::PathBuf>,
+    /// F-349 test seam: redirect the workspaces registry toml path used by
+    /// `resolve_workspace_root_for_command` so dashboard-caller tests can
+    /// prime a tempdir-rooted `workspaces.toml` without touching the real
+    /// `~/.config/forge/workspaces.toml`. Absent from production builds.
+    #[cfg(feature = "webview-test")]
+    pub test_workspaces_toml_override: Option<std::path::PathBuf>,
 }
 
 impl BridgeState {
@@ -190,6 +163,8 @@ impl BridgeState {
             test_socket_override: None,
             #[cfg(feature = "webview-test")]
             test_user_config_dir_override: None,
+            #[cfg(feature = "webview-test")]
+            test_workspaces_toml_override: None,
         }
     }
 
@@ -206,6 +181,7 @@ impl BridgeState {
             bridge: SessionBridge::new(connections),
             test_socket_override: Some(socket_path),
             test_user_config_dir_override: None,
+            test_workspaces_toml_override: None,
         }
     }
 
@@ -220,6 +196,38 @@ impl BridgeState {
             bridge: SessionBridge::new(connections),
             test_socket_override: None,
             test_user_config_dir_override: Some(user_config_dir),
+            test_workspaces_toml_override: None,
+        }
+    }
+
+    /// F-349 test-only constructor: override the workspaces registry toml path
+    /// so dashboard-caller tests can prime a tempdir-rooted `workspaces.toml`.
+    #[cfg(feature = "webview-test")]
+    pub fn with_test_workspaces_toml(
+        connections: SessionConnections,
+        workspaces_toml: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            bridge: SessionBridge::new(connections),
+            test_socket_override: None,
+            test_user_config_dir_override: None,
+            test_workspaces_toml_override: Some(workspaces_toml),
+        }
+    }
+
+    /// F-349 test-only constructor: override both the user-scope config dir and
+    /// the workspaces registry toml path.
+    #[cfg(feature = "webview-test")]
+    pub fn with_test_user_config_and_workspaces(
+        connections: SessionConnections,
+        user_config_dir: std::path::PathBuf,
+        workspaces_toml: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            bridge: SessionBridge::new(connections),
+            test_socket_override: None,
+            test_user_config_dir_override: Some(user_config_dir),
+            test_workspaces_toml_override: Some(workspaces_toml),
         }
     }
 }
@@ -248,15 +256,7 @@ impl<R: Runtime> EventSink for AppHandleSink<R> {
         // redirect delivery.
         let target = EventTarget::webview_window(format!("session-{}", self.session_id));
         if let Err(e) = self.app.emit_to(target, "session:event", payload) {
-            // F-371: structured emit-failure log with the session id so an
-            // operator can correlate dropped events to a specific window.
-            tracing::error!(
-                target: "forge_shell::ipc",
-                session_id = %self.session_id,
-                event = "session:event",
-                error = %e,
-                "Tauri emit failed",
-            );
+            eprintln!("session:event emit failed: {e}");
         }
     }
 }
@@ -278,7 +278,7 @@ pub async fn session_hello<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<HelloAck, String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "session_hello")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     // F-052 (H11 / T7): the socket path is never taken from the invoke
     // payload — a webview cannot redirect this connection to an arbitrary
     // UDS. Production always resolves through `default_socket_path`; tests
@@ -302,11 +302,7 @@ pub async fn session_subscribe<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "session_subscribe",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     let sink: Arc<dyn EventSink> = Arc::new(AppHandleSink {
         app,
         session_id: session_id.clone(),
@@ -325,11 +321,7 @@ pub async fn session_send_message<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "session_send_message",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     // F-068 / L4 (T7): bound `text` before the bridge allocates a frame or
     // the provider is billed. Runs after authz so unauthorized windows
     // don't learn the cap value.
@@ -354,7 +346,7 @@ pub async fn session_cancel<R: Runtime>(
     webview: Webview<R>,
     _state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "session_cancel")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     Ok(())
 }
 
@@ -366,11 +358,7 @@ pub async fn session_approve_tool<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "session_approve_tool",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     // F-068 / L4 (T7): tool_call_id is a short opaque handle; bound it here.
     // F-069 / L5 (T7): `scope` is typed as `forge_core::ApprovalScope` — serde
     // rejects any non-variant string at Tauri arg-deserialization (before this
@@ -396,7 +384,7 @@ pub async fn rerun_message<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "rerun_message")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     // F-068 / L4: bound `msg_id` before the bridge allocates a frame.
     require_size("msg_id", &msg_id, MAX_MESSAGE_ID_BYTES)?;
     state
@@ -423,7 +411,7 @@ pub async fn select_branch<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "select_branch")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("parent_id", &parent_id, MAX_MESSAGE_ID_BYTES)?;
     state
         .bridge
@@ -440,11 +428,7 @@ pub async fn session_reject_tool<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "session_reject_tool",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     // F-068 / L4 (T7): bound tool_call_id and — only when present — reason.
     // `None` reason is the common case and must skip the size check.
     require_size("tool_call_id", &tool_call_id, MAX_TOOL_CALL_ID_BYTES)?;
@@ -488,7 +472,6 @@ pub fn build_invoke_handler<R: Runtime>() -> Box<dyn Fn(tauri::ipc::Invoke<R>) -
         lsp_start,
         lsp_stop,
         lsp_send,
-        lsp_list,
         // F-137: background-agent lifecycle.
         start_background_agent,
         promote_background_agent,
@@ -661,6 +644,84 @@ fn resolve_user_config_dir(state: &BridgeState) -> Option<PathBuf> {
     dirs::config_dir()
 }
 
+/// F-349: resolve the workspaces registry TOML path, honoring the
+/// `webview-test` override when present. Production falls back to the
+/// canonical `~/.config/forge/workspaces.toml` path via
+/// `crate::dashboard_sessions::default_workspaces_toml`.
+fn resolve_workspaces_toml(state: &BridgeState) -> PathBuf {
+    #[cfg(feature = "webview-test")]
+    {
+        if let Some(override_path) = state.test_workspaces_toml_override.as_ref() {
+            return override_path.clone();
+        }
+    }
+    #[cfg(not(feature = "webview-test"))]
+    let _ = state;
+    crate::dashboard_sessions::default_workspaces_toml()
+}
+
+/// F-349: resolve the authoritative workspace path for a command that accepts
+/// a webview-supplied `workspace_root`.
+///
+/// - **`session-*` callers**: the supplied `workspace_root` is **ignored**;
+///   the cached value from `session_hello` is used instead.
+/// - **`dashboard` callers**: the supplied `workspace_root` is validated
+///   against the workspaces registry (`workspaces.toml`). A path not present
+///   in the registry is rejected.
+async fn resolve_workspace_root_for_command(
+    webview_label: &str,
+    webview_supplied: &str,
+    state: &BridgeState,
+) -> Result<PathBuf, String> {
+    if let Some(session_id) = webview_label.strip_prefix("session-") {
+        // Session window: ignore the webview-supplied value and consult the
+        // server-side cache populated by session_hello.
+        return cached_workspace_root(state, session_id).await;
+    }
+
+    // Dashboard window: validate the supplied path against the registry.
+    let supplied = std::path::Path::new(webview_supplied);
+    let canonical = supplied
+        .canonicalize()
+        .map_err(|e| format!("workspace_root not found on disk: {e}"))?;
+
+    let toml_path = resolve_workspaces_toml(state);
+    let entries = read_workspaces(&toml_path)
+        .await
+        .map_err(|e| format!("could not read workspaces registry: {e}"))?;
+
+    let known = entries.iter().any(|e| {
+        e.path
+            .canonicalize()
+            .map(|c| c == canonical)
+            .unwrap_or(false)
+    });
+    if !known {
+        return Err(format!(
+            "workspace_root not in registry: {webview_supplied}"
+        ));
+    }
+    Ok(canonical)
+}
+
+// ---------------------------------------------------------------------------
+// F-349: threat-model comment for the workspace_root–bearing commands below.
+//
+// The F-122 remediation established `cached_workspace_root` as the pattern for
+// keeping the filesystem trust boundary on the server side. The seven commands
+// in this block (get_persistent_approvals, save_approval, remove_approval,
+// read_layouts, write_layouts, get_settings, set_setting) predate that fix and
+// accepted a `workspace_root` parameter directly from the webview. A
+// compromised `session-*` webview could supply any writable path and trigger
+// reads/writes outside the session's actual workspace.
+//
+// Remediation: `resolve_workspace_root_for_command` replaces the verbatim
+// `Path::new(&workspace_root)` at each call site. For session-* callers it
+// ignores the webview-supplied value and consults the `SessionConnections`
+// cache. For dashboard callers it validates the supplied path against the
+// workspaces registry before trusting it.
+// ---------------------------------------------------------------------------
+
 #[tauri::command]
 pub async fn get_persistent_approvals<R: Runtime>(
     workspace_root: String,
@@ -671,10 +732,15 @@ pub async fn get_persistent_approvals<R: Runtime>(
     // default capability glob allows `session-*` and `dashboard`; per-command
     // label authz would add nothing here (the data is user-scoped, not
     // per-session), so we accept any window that cleared the ACL.
-    require_window_label_in(&webview, &["dashboard"], true, "get_persistent_approvals")?;
+    require_window_label_in(&webview, &["dashboard"], true)?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
 
-    let workspace_cfg = load_workspace_config(std::path::Path::new(&workspace_root))
+    // F-349: resolve the authoritative workspace root (session-* ignores the
+    // webview-supplied value; dashboard validates against the registry).
+    let workspace_path =
+        resolve_workspace_root_for_command(webview.label(), &workspace_root, &state).await?;
+
+    let workspace_cfg = load_workspace_config(&workspace_path)
         .await
         .map_err(|e| e.to_string())?;
 
@@ -720,7 +786,7 @@ pub async fn save_approval<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true, "save_approval")?;
+    require_window_label_in(&webview, &["dashboard"], true)?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     require_size("scope_key", &entry.scope_key, MAX_SCOPE_KEY_BYTES)?;
     let total = entry.scope_key.len() + entry.tool_name.len() + entry.label.len();
@@ -736,12 +802,16 @@ pub async fn save_approval<R: Runtime>(
             Ok(())
         }
         ApprovalLevel::Workspace => {
-            let root = std::path::Path::new(&workspace_root);
-            let mut cfg = load_workspace_config(root)
+            // F-349: use the server-side authoritative root, not the
+            // webview-supplied value.
+            let root =
+                resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
+                    .await?;
+            let mut cfg = load_workspace_config(&root)
                 .await
                 .map_err(|e| e.to_string())?;
             upsert_entry(&mut cfg, entry);
-            save_workspace_config(root, &cfg)
+            save_workspace_config(&root, &cfg)
                 .await
                 .map_err(|e| e.to_string())
         }
@@ -765,19 +835,22 @@ pub async fn remove_approval<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true, "remove_approval")?;
+    require_window_label_in(&webview, &["dashboard"], true)?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     require_size("scope_key", &scope_key, MAX_SCOPE_KEY_BYTES)?;
 
     match level {
         ApprovalLevel::Session => Ok(()),
         ApprovalLevel::Workspace => {
-            let root = std::path::Path::new(&workspace_root);
-            let mut cfg = load_workspace_config(root)
+            // F-349: use the server-side authoritative root.
+            let root =
+                resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
+                    .await?;
+            let mut cfg = load_workspace_config(&root)
                 .await
                 .map_err(|e| e.to_string())?;
             cfg.entries.retain(|e| e.scope_key != scope_key);
-            save_workspace_config(root, &cfg)
+            save_workspace_config(&root, &cfg)
                 .await
                 .map_err(|e| e.to_string())
         }
@@ -822,49 +895,15 @@ pub(crate) fn require_window_label_in<R: Runtime>(
     webview: &Webview<R>,
     exact: &[&str],
     allow_session_prefix: bool,
-    command: &'static str,
 ) -> Result<(), String> {
-    authz_check_in(webview.label(), exact, allow_session_prefix, command)
-}
-
-fn authz_check_in(
-    actual: &str,
-    exact: &[&str],
-    allow_session_prefix: bool,
-    command: &'static str,
-) -> Result<(), String> {
-    if exact.contains(&actual) {
+    let label = webview.label();
+    if exact.contains(&label) {
         return Ok(());
     }
-    if allow_session_prefix && actual.starts_with("session-") {
+    if allow_session_prefix && label.starts_with("session-") {
         return Ok(());
     }
-    // F-371: render the accept list so operators can diagnose which command
-    // expected which set without chasing the literal in source.
-    let expected = if allow_session_prefix {
-        format!("{:?} or session-*", exact)
-    } else {
-        format!("{:?}", exact)
-    };
-    tracing::warn!(
-        target: "forge_shell::ipc::authz",
-        expected = %expected,
-        actual = %actual,
-        command = %command,
-        "authz rejection: window label mismatch",
-    );
     Err(LABEL_MISMATCH_ERROR.to_string())
-}
-
-/// F-371 test seam for `require_window_label_in`.
-#[doc(hidden)]
-pub fn require_window_label_in_for_test(
-    actual: &str,
-    exact: &[&str],
-    allow_session_prefix: bool,
-    command: &'static str,
-) -> Result<(), String> {
-    authz_check_in(actual, exact, allow_session_prefix, command)
 }
 
 // ---------------------------------------------------------------------------
@@ -1039,17 +1078,7 @@ fn spawn_event_forwarder<R: Runtime>(
                     };
                     let target = EventTarget::webview_window(&owner_label);
                     if let Err(e) = app.emit_to(target, TERMINAL_BYTES_EVENT, payload) {
-                        // F-371: structured emit-failure with window + terminal
-                        // ids so one stuck PTY can be traced without grep on
-                        // a timestamp.
-                        tracing::error!(
-                            target: "forge_shell::ipc",
-                            window_label = %owner_label,
-                            terminal_id = %terminal_id,
-                            event = "terminal:bytes",
-                            error = %e,
-                            "Tauri emit failed",
-                        );
+                        eprintln!("terminal:bytes emit failed: {e}");
                     }
                 }
                 TerminalEvent::Exit(status) => {
@@ -1060,14 +1089,7 @@ fn spawn_event_forwarder<R: Runtime>(
                     };
                     let target = EventTarget::webview_window(&owner_label);
                     if let Err(e) = app.emit_to(target, TERMINAL_EXIT_EVENT, payload) {
-                        tracing::error!(
-                            target: "forge_shell::ipc",
-                            window_label = %owner_label,
-                            terminal_id = %terminal_id,
-                            event = "terminal:exit",
-                            error = %e,
-                            "Tauri emit failed",
-                        );
+                        eprintln!("terminal:exit emit failed: {e}");
                     }
                 }
             }
@@ -1094,7 +1116,7 @@ pub async fn terminal_spawn<R: Runtime>(
 ) -> Result<(), String> {
     // F-125: terminals are session-scoped. Dashboard and any other label is
     // rejected. This mirrors the chat-pane authz shape on the terminal axis.
-    require_window_label_in(&webview, &[], true, "terminal_spawn")?;
+    require_window_label_in(&webview, &[], true)?;
 
     require_size("cwd", &args.cwd, MAX_TERMINAL_CWD_BYTES)?;
     if let Some(shell) = args.shell.as_deref() {
@@ -1148,7 +1170,7 @@ pub async fn terminal_write<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, TerminalState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true, "terminal_write")?;
+    require_window_label_in(&webview, &[], true)?;
 
     if data.len() > MAX_TERMINAL_WRITE_BYTES {
         return Err(payload_too_large("data", MAX_TERMINAL_WRITE_BYTES));
@@ -1169,7 +1191,7 @@ pub async fn terminal_resize<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, TerminalState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true, "terminal_resize")?;
+    require_window_label_in(&webview, &[], true)?;
     let caller_label = webview.label().to_string();
     state.with_owned_session_mut(&terminal_id, &caller_label, |session| {
         session.resize(cols, rows).map_err(|e| e.to_string())
@@ -1184,7 +1206,7 @@ pub async fn terminal_kill<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, TerminalState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true, "terminal_kill")?;
+    require_window_label_in(&webview, &[], true)?;
     let caller_label = webview.label().to_string();
     // Removing the entry drops its `TerminalSession` — forge-term's `impl Drop`
     // SIGTERMs the child and joins the reaper thread, which emits the final
@@ -1348,6 +1370,23 @@ fn layouts_file_path(workspace_root: &std::path::Path) -> PathBuf {
     workspace_root.join(".forge").join("layouts.json")
 }
 
+/// Sibling `<path>.tmp` for the atomic tmp+rename write in `write_layouts`.
+/// Mirrors the `tmp_path_for` helpers in `forge_core::approvals` and
+/// `forge_core::settings` — same-directory by construction so the rename is
+/// same-filesystem (POSIX-atomic). F-372 tracks promoting this to a shared
+/// `forge_core::atomic_write`; this keeps the 90-min fix local.
+fn layouts_tmp_path(path: &std::path::Path) -> PathBuf {
+    let mut file_name = path
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    file_name.push(".tmp");
+    match path.parent() {
+        Some(parent) => parent.join(file_name),
+        None => PathBuf::from(file_name),
+    }
+}
+
 /// Load `.forge/layouts.json` under `workspace_root`, degrading to
 /// [`Layouts::default`] on any failure.
 ///
@@ -1362,7 +1401,11 @@ fn layouts_file_path(workspace_root: &std::path::Path) -> PathBuf {
 /// blank window. Losing the persisted layout is recoverable; losing the
 /// ability to open the session is not.
 async fn load_layouts_from_disk(workspace_root: &std::path::Path) -> Layouts {
-    forge_core::config_file::load_json_or_default(&layouts_file_path(workspace_root)).await
+    let path = layouts_file_path(workspace_root);
+    let Ok(bytes) = tokio::fs::read(&path).await else {
+        return Layouts::default();
+    };
+    serde_json::from_slice(&bytes).unwrap_or_default()
 }
 
 /// Read the persisted layouts for `workspace_root`. Missing or corrupt files
@@ -1373,10 +1416,15 @@ async fn load_layouts_from_disk(workspace_root: &std::path::Path) -> Layouts {
 pub async fn read_layouts<R: Runtime>(
     workspace_root: String,
     webview: Webview<R>,
+    state: State<'_, BridgeState>,
 ) -> Result<Layouts, String> {
-    require_window_label_in(&webview, &["dashboard"], true, "read_layouts")?;
+    require_window_label_in(&webview, &["dashboard"], true)?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
-    Ok(load_layouts_from_disk(std::path::Path::new(&workspace_root)).await)
+    // F-349: resolve the authoritative workspace root (session-* ignores the
+    // webview-supplied value; dashboard validates against the registry).
+    let workspace_path =
+        resolve_workspace_root_for_command(webview.label(), &workspace_root, &state).await?;
+    Ok(load_layouts_from_disk(&workspace_path).await)
 }
 
 /// Persist `layouts` to `<workspace_root>/.forge/layouts.json`, creating the
@@ -1385,21 +1433,39 @@ pub async fn read_layouts<R: Runtime>(
 /// frontend debouncer will retry on the next layout change, so a transient
 /// failure does not need a retry loop here.
 ///
-/// F-372: delegates to [`forge_core::config_file::save_json_atomic_ipc`] for
-/// the atomic tmp+rename and `Result<(), String>` mapping so this path
-/// cannot drift from its approvals/settings siblings again (F-363 regression
-/// precedent).
+/// F-363: mirrors the `approvals::save_to_path` / `settings::save_raw_to_path`
+/// atomic tmp+rename pattern. The rename is atomic on POSIX for same-
+/// filesystem targets (same directory here by construction), so a crash
+/// between the write and the rename leaves either the prior `layouts.json`
+/// or the new one on disk — never a partial JSON payload.
 #[tauri::command]
 pub async fn write_layouts<R: Runtime>(
     workspace_root: String,
     layouts: Layouts,
     webview: Webview<R>,
+    state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true, "write_layouts")?;
+    require_window_label_in(&webview, &["dashboard"], true)?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
 
-    let path = layouts_file_path(std::path::Path::new(&workspace_root));
-    forge_core::config_file::save_json_atomic_ipc(&path, &layouts, "write layouts.json").await
+    // F-349: resolve the authoritative workspace root.
+    let workspace_path =
+        resolve_workspace_root_for_command(webview.label(), &workspace_root, &state).await?;
+
+    let forge_dir = workspace_path.join(".forge");
+    tokio::fs::create_dir_all(&forge_dir)
+        .await
+        .map_err(|e| format!("create .forge dir: {e}"))?;
+
+    let path = forge_dir.join("layouts.json");
+    let tmp = layouts_tmp_path(&path);
+    let bytes = serde_json::to_vec_pretty(&layouts).map_err(|e| format!("serialize: {e}"))?;
+    tokio::fs::write(&tmp, &bytes)
+        .await
+        .map_err(|e| format!("write layouts.json.tmp: {e}"))?;
+    tokio::fs::rename(&tmp, &path)
+        .await
+        .map_err(|e| format!("rename layouts.json.tmp: {e}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -1450,13 +1516,6 @@ pub struct FileContent {
 /// Wire shape for `tree`. The root is always returned; `children` is `None`
 /// for non-directory entries and `Some(_)` for directories (empty vec when
 /// the depth cap is hit or the directory is empty).
-///
-/// F-357: the root node carries a [`TreeStatsDto`] summarizing what the walk
-/// elided so the UI can render "N files not shown" instead of silently
-/// rendering a partial tree as if it were complete. Nested nodes carry
-/// `None` — the summary is a whole-tree concept, not per-directory — and
-/// existing frontend consumers that don't yet read `stats` keep compiling
-/// against the regenerated TS type because it stays optional on the wire.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../web/packages/ipc/src/generated/")]
 pub struct TreeNodeDto {
@@ -1467,32 +1526,6 @@ pub struct TreeNodeDto {
     pub path: String,
     pub kind: TreeKindDto,
     pub children: Option<Vec<TreeNodeDto>>,
-    /// `Some(..)` on the root, `None` on nested nodes. `#[serde(default,
-    /// skip_serializing_if = ..)]` makes the field optional on the TS side
-    /// so existing frontend fixtures that predate F-357 keep compiling.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub stats: Option<TreeStatsDto>,
-}
-
-/// F-357: wire shape for [`TreeNodeDto::stats`]. Populated on the root
-/// only; nested nodes carry `None`. The Rust-side counters in
-/// [`forge_fs::TreeStats`] are `u64`, but we saturate to `u32` on the wire
-/// so the generated TS type is plain `number` (no `bigint` plumbing in the
-/// frontend). A 4 B entry count is still well past any realistic workspace
-/// tree — saturation is a surrender, not a silent overflow.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[ts(export, export_to = "../../../web/packages/ipc/src/generated/")]
-pub struct TreeStatsDto {
-    /// `true` if the entry budget was exhausted before the walk finished.
-    pub truncated: bool,
-    /// Count of entries the walker saw past the budget (best-effort — see
-    /// the `forge_fs::TreeStats` docs for the exact scope). Saturated to
-    /// `u32::MAX` for wire-compat with JS `number`.
-    pub omitted_count: u32,
-    /// Count of per-entry errors the walker swallowed (e.g. permission
-    /// denied, file disappeared mid-walk). Saturated to `u32::MAX` for
-    /// wire-compat with JS `number`.
-    pub error_count: u32,
 }
 
 /// Wire shape for [`TreeNodeDto::kind`]. Narrow on purpose — anything
@@ -1508,42 +1541,22 @@ pub enum TreeKindDto {
 }
 
 impl From<forge_fs::TreeNode> for TreeNodeDto {
-    /// Converts the root of a `forge_fs` walk. `stats` is populated on the
-    /// returned root node; nested children collapse `stats` to `None` on the
-    /// wire so the JSON stays compact — the summary is a whole-tree concept.
     fn from(node: forge_fs::TreeNode) -> Self {
-        let stats = TreeStatsDto {
-            truncated: node.stats.truncated,
-            omitted_count: u64_to_u32_saturating(node.stats.omitted_count),
-            error_count: u64_to_u32_saturating(node.stats.error_count),
+        use forge_fs::NodeKind;
+        let kind = match node.kind {
+            NodeKind::File => TreeKindDto::File,
+            NodeKind::Dir => TreeKindDto::Dir,
+            NodeKind::Symlink => TreeKindDto::Symlink,
+            NodeKind::Other => TreeKindDto::Other,
         };
-        TreeNodeDto {
-            stats: Some(stats),
-            ..from_nested(node)
+        Self {
+            name: node.name,
+            path: node.path.to_string_lossy().into_owned(),
+            kind,
+            children: node
+                .children
+                .map(|cs| cs.into_iter().map(TreeNodeDto::from).collect()),
         }
-    }
-}
-
-fn u64_to_u32_saturating(v: u64) -> u32 {
-    u32::try_from(v).unwrap_or(u32::MAX)
-}
-
-fn from_nested(node: forge_fs::TreeNode) -> TreeNodeDto {
-    use forge_fs::NodeKind;
-    let kind = match node.kind {
-        NodeKind::File => TreeKindDto::File,
-        NodeKind::Dir => TreeKindDto::Dir,
-        NodeKind::Symlink => TreeKindDto::Symlink,
-        NodeKind::Other => TreeKindDto::Other,
-    };
-    TreeNodeDto {
-        name: node.name,
-        path: node.path.to_string_lossy().into_owned(),
-        kind,
-        children: node
-            .children
-            .map(|cs| cs.into_iter().map(from_nested).collect()),
-        stats: None,
     }
 }
 
@@ -1576,7 +1589,7 @@ async fn cached_workspace_root(
         .ok_or_else(|| {
             format!(
                 "session {session_id} not connected: call session_hello before \
-                 read_file/write_file/tree"
+                 invoking workspace-path commands"
             )
         })
 }
@@ -1588,7 +1601,7 @@ pub async fn read_file<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<FileContent, String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "read_file")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("path", &path, MAX_FS_PATH_BYTES)?;
 
     let workspace = cached_workspace_root(&state, &session_id).await?;
@@ -1611,7 +1624,7 @@ pub async fn write_file<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "write_file")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("path", &path, MAX_FS_PATH_BYTES)?;
     // Pre-check before `forge-fs` copies the buffer into the atomic-write
     // temp file. `forge-fs` also enforces; belt-and-braces keeps the error
@@ -1641,7 +1654,7 @@ pub async fn tree<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<TreeNodeDto, String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "tree")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("root", &root, MAX_FS_PATH_BYTES)?;
 
     let workspace = cached_workspace_root(&state, &session_id).await?;
@@ -1745,10 +1758,6 @@ pub(crate) struct LspEntry {
     pub(crate) supervisor: tauri::async_runtime::JoinHandle<()>,
     /// Event forwarder task. Aborting stops message delivery to the webview.
     pub(crate) forwarder: tauri::async_runtime::JoinHandle<()>,
-    /// F-374: shared handle on the supervisor's current lifecycle state.
-    /// Read by `lsp_list` to build an [`LspServerInfo`] snapshot without
-    /// holding the supervised `Server` itself across the task boundary.
-    pub(crate) state_handle: Arc<tokio::sync::Mutex<LspLifecycleState>>,
 }
 
 /// Tauri-managed registry of live LSP servers. Scoped per app (one instance
@@ -1794,22 +1803,6 @@ impl LspState {
         }
         Ok(entry.transport.clone())
     }
-
-    /// F-374: collect a snapshot of every live LSP entry's (id, state) pair
-    /// for `lsp_list`. Filters by `caller_label` so one session cannot
-    /// introspect another session's servers — mirrors the authz on
-    /// `lsp_send` / `lsp_stop`.
-    fn list_owned_state_handles(
-        &self,
-        caller_label: &str,
-    ) -> Vec<(String, Arc<tokio::sync::Mutex<LspLifecycleState>>)> {
-        let guard = self.entries.lock().expect("lsp state poisoned");
-        guard
-            .iter()
-            .filter(|(_, entry)| entry.owner_label == caller_label)
-            .map(|(id, entry)| (id.clone(), entry.state_handle.clone()))
-            .collect()
-    }
 }
 
 /// Forward every `ServerEvent::Message` from the supervisor to the owning
@@ -1831,17 +1824,7 @@ fn spawn_lsp_forwarder<R: Runtime>(
                 };
                 let target = EventTarget::webview_window(&owner_label);
                 if let Err(e) = app.emit_to(target, LSP_MESSAGE_EVENT, payload) {
-                    // F-371: structured emit-failure with window + server
-                    // ids so a webview-gone race against a live LSP is
-                    // visible in the log without parsing free-form strings.
-                    tracing::error!(
-                        target: "forge_shell::ipc",
-                        window_label = %owner_label,
-                        server_id = %server_id,
-                        event = "lsp_message",
-                        error = %e,
-                        "Tauri emit failed",
-                    );
+                    eprintln!("lsp_message emit failed: {e}");
                 }
             }
             // `Exited` / `GaveUp` events are observable only server-side
@@ -1879,7 +1862,7 @@ pub async fn lsp_start<R: Runtime>(
 ) -> Result<(), String> {
     // LSP servers are session-scoped. Dashboard and any other label is
     // rejected — mirrors the terminal authz shape on the LSP axis.
-    require_window_label_in(&webview, &[], true, "lsp_start")?;
+    require_window_label_in(&webview, &[], true)?;
 
     require_size("server", &args.server, MAX_LSP_SERVER_ID_BYTES)?;
 
@@ -1908,9 +1891,6 @@ pub async fn lsp_start<R: Runtime>(
     let rx = supervisor
         .take_events()
         .ok_or_else(|| "lsp_start: event channel already taken".to_string())?;
-    // F-374: grab a handle on the supervisor's lifecycle state before the
-    // `Server` moves into the spawned task, so `lsp_list` can snapshot it.
-    let state_handle = supervisor.state_handle();
 
     // Register before starting so `lsp_send` can observe the transport
     // immediately. The supervisor races spawn with the first send; the
@@ -1931,7 +1911,6 @@ pub async fn lsp_start<R: Runtime>(
             owner_label,
             supervisor: supervisor_handle,
             forwarder,
-            state_handle,
         },
     )?;
 
@@ -1946,7 +1925,7 @@ pub async fn lsp_stop<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, LspState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true, "lsp_stop")?;
+    require_window_label_in(&webview, &[], true)?;
     require_size("server", &server, MAX_LSP_SERVER_ID_BYTES)?;
     let caller_label = webview.label().to_string();
     let entry = state.remove_owned_by(&server, &caller_label)?;
@@ -1965,7 +1944,7 @@ pub async fn lsp_send<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, LspState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &[], true, "lsp_send")?;
+    require_window_label_in(&webview, &[], true)?;
     require_size("server", &server, MAX_LSP_SERVER_ID_BYTES)?;
     // Rough byte cap: serialize once and check length. Avoids building a
     // serialized frame twice (send path also serializes) by short-circuiting
@@ -1980,34 +1959,6 @@ pub async fn lsp_send<R: Runtime>(
     let caller_label = webview.label().to_string();
     let transport = state.owned_transport(&server, &caller_label)?;
     transport.send(message).await.map_err(|e| e.to_string())
-}
-
-/// F-374: return an [`LspServerInfo`] snapshot for every live LSP server
-/// owned by the calling webview. Closes the asymmetry with `list_mcp_servers`
-/// so the Editor pane can render an LSP-status pill from a single `invoke`
-/// instead of reconstructing state from `lsp_message` history.
-///
-/// Authz mirrors `lsp_send` / `lsp_stop`: only the session webview that
-/// called `lsp_start` sees its own servers. A cross-session caller gets an
-/// empty list, not a label-mismatch error — `list` on an empty owned set is
-/// a legitimate "I have no servers" shape and should not read as forbidden.
-#[tauri::command]
-pub async fn lsp_list<R: Runtime>(
-    webview: Webview<R>,
-    state: State<'_, LspState>,
-) -> Result<Vec<LspServerInfo>, String> {
-    require_window_label_in(&webview, &[], true, "lsp_list")?;
-    let caller_label = webview.label().to_string();
-    let handles = state.list_owned_state_handles(&caller_label);
-    let mut out = Vec::with_capacity(handles.len());
-    for (id, handle) in handles {
-        let state_snapshot = handle.lock().await.clone();
-        out.push(LspServerInfo {
-            id,
-            state: state_snapshot,
-        });
-    }
-    Ok(out)
 }
 
 // ---------------------------------------------------------------------------
@@ -2266,11 +2217,7 @@ pub async fn start_background_agent<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<String, String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "start_background_agent",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("agent_name", &agent_name, MAX_AGENT_NAME_BYTES)?;
     require_size("prompt", &prompt, MAX_BG_PROMPT_BYTES)?;
 
@@ -2296,11 +2243,7 @@ pub async fn promote_background_agent<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<(), String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "promote_background_agent",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("instance_id", &instance_id, MAX_AGENT_INSTANCE_ID_BYTES)?;
 
     let entry = resolve_bg_session(&app, &state, &bg_state, &session_id).await?;
@@ -2318,11 +2261,7 @@ pub async fn list_background_agents<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<Vec<BgAgentSummary>, String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "list_background_agents",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
 
     let entry = resolve_bg_session(&app, &state, &bg_state, &session_id).await?;
     let rows = entry.registry.list().await;
@@ -2363,7 +2302,7 @@ pub async fn rename_path<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "rename_path")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("from", &from, MAX_FS_PATH_BYTES)?;
     require_size("to", &to, MAX_FS_PATH_BYTES)?;
 
@@ -2384,7 +2323,7 @@ pub async fn delete_path<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "delete_path")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("path", &path, MAX_FS_PATH_BYTES)?;
 
     let workspace = cached_workspace_root(&state, &session_id).await?;
@@ -2455,11 +2394,15 @@ pub async fn get_settings<R: Runtime>(
 ) -> Result<AppSettings, String> {
     // Same authz model as F-036's approval commands: dashboard + any
     // session-* window may read.
-    require_window_label_in(&webview, &["dashboard"], true, "get_settings")?;
+    require_window_label_in(&webview, &["dashboard"], true)?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
 
+    // F-349: resolve the authoritative workspace root.
+    let workspace_path =
+        resolve_workspace_root_for_command(webview.label(), &workspace_root, &state).await?;
+
     let user_dir = resolve_user_config_dir(&state);
-    load_merged_in(user_dir.as_deref(), std::path::Path::new(&workspace_root))
+    load_merged_in(user_dir.as_deref(), &workspace_path)
         .await
         .map_err(|e| e.to_string())
 }
@@ -2473,7 +2416,7 @@ pub async fn set_setting<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label_in(&webview, &["dashboard"], true, "set_setting")?;
+    require_window_label_in(&webview, &["dashboard"], true)?;
     require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
     require_size("key", &key, MAX_SETTING_KEY_BYTES)?;
 
@@ -2492,8 +2435,11 @@ pub async fn set_setting<R: Runtime>(
 
     match level {
         SettingsLevel::Workspace => {
-            let root = std::path::Path::new(&workspace_root);
-            let path = workspace_settings_path(root);
+            // F-349: resolve the authoritative workspace root.
+            let root =
+                resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
+                    .await?;
+            let path = workspace_settings_path(&root);
             let existing = tokio::fs::read_to_string(&path)
                 .await
                 .unwrap_or_else(|_| String::new());
@@ -2504,7 +2450,7 @@ pub async fn set_setting<R: Runtime>(
             // every `#[serde(default)]` field into the file, erasing the
             // "absent means pick up the other tier / pick up the default"
             // invariant the merge layer relies on.
-            save_workspace_settings_raw(root, &updated)
+            save_workspace_settings_raw(&root, &updated)
                 .await
                 .map_err(|e| e.to_string())
         }
@@ -2562,11 +2508,7 @@ pub async fn stop_background_agent<R: Runtime>(
     state: State<'_, BridgeState>,
     bg_state: State<'_, BgAgentState>,
 ) -> Result<(), String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "stop_background_agent",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("instance_id", &instance_id, MAX_AGENT_INSTANCE_ID_BYTES)?;
 
     let entry = resolve_bg_session(&app, &state, &bg_state, &session_id).await?;
@@ -2634,7 +2576,7 @@ pub async fn delete_branch<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<(), String> {
-    require_window_label(&webview, &format!("session-{session_id}"), "delete_branch")?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("parent_id", &parent_id, MAX_MESSAGE_ID_BYTES)?;
     state
         .bridge
@@ -2703,11 +2645,7 @@ pub async fn list_mcp_servers<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<Vec<forge_ipc::McpServerInfo>, String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "list_mcp_servers",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     state
         .bridge
         .list_mcp_servers(&session_id)
@@ -2734,11 +2672,7 @@ pub async fn toggle_mcp_server<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<forge_ipc::McpToggleResult, String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "toggle_mcp_server",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("name", &name, MAX_MCP_SERVER_NAME_BYTES)?;
     state
         .bridge
@@ -2764,11 +2698,7 @@ pub async fn import_mcp_config<R: Runtime>(
     webview: Webview<R>,
     state: State<'_, BridgeState>,
 ) -> Result<forge_ipc::McpImportResult, String> {
-    require_window_label(
-        &webview,
-        &format!("session-{session_id}"),
-        "import_mcp_config",
-    )?;
+    require_window_label(&webview, &format!("session-{session_id}"))?;
     require_size("source", &source, MAX_MCP_SLUG_BYTES)?;
     state
         .bridge

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -1574,9 +1574,12 @@ pub struct FileContent {
     pub sha256: String,
 }
 
-/// Wire shape for `tree`. The root is always returned; `children` is `None`
-/// for non-directory entries and `Some(_)` for directories (empty vec when
-/// the depth cap is hit or the directory is empty).
+/// F-357: the root node carries a [`TreeStatsDto`] summarizing what the walk
+/// elided so the UI can render "N files not shown" instead of silently
+/// rendering a partial tree as if it were complete. Nested nodes carry
+/// `None` — the summary is a whole-tree concept, not per-directory — and
+/// existing frontend consumers that don't yet read `stats` keep compiling
+/// against the regenerated TS type because it stays optional on the wire.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../web/packages/ipc/src/generated/")]
 pub struct TreeNodeDto {
@@ -1587,6 +1590,32 @@ pub struct TreeNodeDto {
     pub path: String,
     pub kind: TreeKindDto,
     pub children: Option<Vec<TreeNodeDto>>,
+    /// `Some(..)` on the root, `None` on nested nodes. `#[serde(default,
+    /// skip_serializing_if = ..)]` makes the field optional on the TS side
+    /// so existing frontend fixtures that predate F-357 keep compiling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stats: Option<TreeStatsDto>,
+}
+
+/// F-357: wire shape for [`TreeNodeDto::stats`]. Populated on the root
+/// only; nested nodes carry `None`. The Rust-side counters in
+/// [`forge_fs::TreeStats`] are `u64`, but we saturate to `u32` on the wire
+/// so the generated TS type is plain `number` (no `bigint` plumbing in the
+/// frontend). A 4 B entry count is still well past any realistic workspace
+/// tree — saturation is a surrender, not a silent overflow.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../../../web/packages/ipc/src/generated/")]
+pub struct TreeStatsDto {
+    /// `true` if the entry budget was exhausted before the walk finished.
+    pub truncated: bool,
+    /// Count of entries the walker saw past the budget (best-effort — see
+    /// the `forge_fs::TreeStats` docs for the exact scope). Saturated to
+    /// `u32::MAX` for wire-compat with JS `number`.
+    pub omitted_count: u32,
+    /// Count of per-entry errors the walker swallowed (e.g. permission
+    /// denied, file disappeared mid-walk). Saturated to `u32::MAX` for
+    /// wire-compat with JS `number`.
+    pub error_count: u32,
 }
 
 /// Wire shape for [`TreeNodeDto::kind`]. Narrow on purpose — anything
@@ -1602,22 +1631,42 @@ pub enum TreeKindDto {
 }
 
 impl From<forge_fs::TreeNode> for TreeNodeDto {
+    /// Converts the root of a `forge_fs` walk. `stats` is populated on the
+    /// returned root node; nested children collapse `stats` to `None` on the
+    /// wire so the JSON stays compact — the summary is a whole-tree concept.
     fn from(node: forge_fs::TreeNode) -> Self {
-        use forge_fs::NodeKind;
-        let kind = match node.kind {
-            NodeKind::File => TreeKindDto::File,
-            NodeKind::Dir => TreeKindDto::Dir,
-            NodeKind::Symlink => TreeKindDto::Symlink,
-            NodeKind::Other => TreeKindDto::Other,
+        let stats = TreeStatsDto {
+            truncated: node.stats.truncated,
+            omitted_count: u64_to_u32_saturating(node.stats.omitted_count),
+            error_count: u64_to_u32_saturating(node.stats.error_count),
         };
-        Self {
-            name: node.name,
-            path: node.path.to_string_lossy().into_owned(),
-            kind,
-            children: node
-                .children
-                .map(|cs| cs.into_iter().map(TreeNodeDto::from).collect()),
+        TreeNodeDto {
+            stats: Some(stats),
+            ..from_nested(node)
         }
+    }
+}
+
+fn u64_to_u32_saturating(v: u64) -> u32 {
+    u32::try_from(v).unwrap_or(u32::MAX)
+}
+
+fn from_nested(node: forge_fs::TreeNode) -> TreeNodeDto {
+    use forge_fs::NodeKind;
+    let kind = match node.kind {
+        NodeKind::File => TreeKindDto::File,
+        NodeKind::Dir => TreeKindDto::Dir,
+        NodeKind::Symlink => TreeKindDto::Symlink,
+        NodeKind::Other => TreeKindDto::Other,
+    };
+    TreeNodeDto {
+        name: node.name,
+        path: node.path.to_string_lossy().into_owned(),
+        kind,
+        children: node
+            .children
+            .map(|cs| cs.into_iter().map(from_nested).collect()),
+        stats: None,
     }
 }
 

--- a/crates/forge-shell/tests/approval_commands.rs
+++ b/crates/forge-shell/tests/approval_commands.rs
@@ -456,8 +456,7 @@ async fn dashboard_window_is_allowed() {
     let user_cfg_dir = TempDir::new().unwrap();
 
     // Dashboard caller needs the registry.
-    let (app, _registry) =
-        make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
+    let (app, _registry) = make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
     let window = make_dashboard_window(&app);
     let result = invoke_ok(
         &window,
@@ -646,7 +645,11 @@ async fn session_window_forged_workspace_write_lands_in_cached_path() {
 
     // File must appear in the real workspace, not the forged one.
     assert!(
-        real_ws.path().join(".forge").join("approvals.toml").exists(),
+        real_ws
+            .path()
+            .join(".forge")
+            .join("approvals.toml")
+            .exists(),
         "write must land in the real (cached) workspace"
     );
     assert!(
@@ -684,8 +687,7 @@ async fn dashboard_window_accepts_registered_workspace_root() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let (app, _registry) =
-        make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
+    let (app, _registry) = make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
     let window = make_dashboard_window(&app);
 
     let root = workspace.path().to_string_lossy().to_string();

--- a/crates/forge-shell/tests/approval_commands.rs
+++ b/crates/forge-shell/tests/approval_commands.rs
@@ -6,22 +6,84 @@
 //! `webview-test`-gated [`BridgeState::with_test_user_config_dir`] so tests
 //! never touch the real `{config_dir}/forge/approvals.toml`.
 //!
+//! F-349: regression tests at the bottom verify that session-* callers have
+//! their webview-supplied `workspace_root` silently replaced by the
+//! server-side cached value, and that dashboard callers are validated against
+//! the workspaces registry.
+//!
 //! Wiring mirrors `tests/ipc_commands.rs` (F-020 / F-052): `mock_builder()` +
 //! `WebviewWindowBuilder` with explicit labels and `INVOKE_KEY` payload.
 
 #![cfg(feature = "webview-test")]
 
+use forge_core::workspaces::{write_workspaces, WorkspaceEntry};
 use forge_shell::bridge::SessionConnections;
 use forge_shell::ipc::{build_invoke_handler, BridgeState};
 use tauri::test::{mock_builder, mock_context, noop_assets, INVOKE_KEY};
 use tauri::Manager;
 use tempfile::TempDir;
 
-fn make_app() -> tauri::App<tauri::test::MockRuntime> {
-    mock_builder()
+/// Build a Tauri mock app with the workspace-root cache primed for `session_id`
+/// and the user-config-dir pointed at `user_cfg_dir`.
+async fn make_app(
+    workspace: &std::path::Path,
+    session_id: &str,
+    user_cfg_dir: &std::path::Path,
+) -> tauri::App<tauri::test::MockRuntime> {
+    let connections = SessionConnections::new();
+    connections
+        .prime_workspace_root_for_test(
+            session_id.to_string(),
+            std::fs::canonicalize(workspace).expect("canonicalize workspace"),
+        )
+        .await;
+    let app = mock_builder()
         .invoke_handler(build_invoke_handler())
         .build(mock_context(noop_assets()))
-        .expect("build mock Tauri app")
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::with_test_user_config_dir(
+        connections,
+        user_cfg_dir.to_path_buf(),
+    ));
+    app
+}
+
+/// Build a mock app for dashboard-caller tests: workspaces registry seeded
+/// with `workspace_paths`, user-config-dir at `user_cfg_dir`.
+async fn make_app_with_registry(
+    workspace_paths: &[&std::path::Path],
+    user_cfg_dir: &std::path::Path,
+) -> (tauri::App<tauri::test::MockRuntime>, TempDir) {
+    let registry_dir = TempDir::new().unwrap();
+    let toml_path = registry_dir.path().join("workspaces.toml");
+    let entries: Vec<WorkspaceEntry> = workspace_paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| WorkspaceEntry {
+            id: forge_core::WorkspaceId::new(),
+            path: p.to_path_buf(),
+            name: format!("ws-{i}"),
+            last_opened: chrono::Utc::now(),
+            pinned: false,
+        })
+        .collect();
+    write_workspaces(&toml_path, &entries)
+        .await
+        .expect("seed workspaces.toml");
+
+    // BridgeState that sets BOTH test overrides. We build it manually.
+    let connections = SessionConnections::new();
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    // We need both user-config-dir and workspaces-toml overrides.
+    app.manage(BridgeState::with_test_user_config_and_workspaces(
+        connections,
+        user_cfg_dir.to_path_buf(),
+        toml_path,
+    ));
+    (app, registry_dir)
 }
 
 fn make_session_window(
@@ -93,17 +155,18 @@ fn invoke_err(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Functional correctness (session-* callers, primed cache)
+// ---------------------------------------------------------------------------
+
 #[tokio::test(flavor = "multi_thread")]
 async fn get_persistent_approvals_returns_empty_when_no_files() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let result = invoke_ok(
         &window,
@@ -119,12 +182,9 @@ async fn save_approval_then_get_returns_workspace_entry() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let entry = serde_json::json!({
         "scope_key": "tool:fs.write",
@@ -164,12 +224,9 @@ async fn save_approval_writes_user_config_to_overridden_dir() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let entry = serde_json::json!({
         "scope_key": "tool:shell.exec",
@@ -206,12 +263,9 @@ async fn workspace_wins_over_user_on_collision() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     // Save the same key under both tiers with distinct labels.
     let user_entry = serde_json::json!({
@@ -260,12 +314,9 @@ async fn remove_approval_workspace_drops_entry() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let entry = serde_json::json!({
         "scope_key": "file:fs.edit:/src/foo.ts",
@@ -306,12 +357,9 @@ async fn remove_approval_user_drops_only_user_tier() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     // Two different keys, one per tier.
     let user_entry = serde_json::json!({
@@ -370,12 +418,9 @@ async fn session_level_save_is_noop() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let entry = serde_json::json!({
         "scope_key": "tool:fs.write",
@@ -410,11 +455,9 @@ async fn dashboard_window_is_allowed() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
+    // Dashboard caller needs the registry.
+    let (app, _registry) =
+        make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
     let window = make_dashboard_window(&app);
     let result = invoke_ok(
         &window,
@@ -429,11 +472,16 @@ async fn non_session_non_dashboard_window_is_rejected() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
+    let connections = SessionConnections::new();
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
     app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
+        connections,
         user_cfg_dir.path().to_path_buf(),
     ));
+
     let window = tauri::WebviewWindowBuilder::new(
         &app,
         "some-other-window",
@@ -456,9 +504,13 @@ async fn non_session_non_dashboard_window_is_rejected() {
 #[tokio::test(flavor = "multi_thread")]
 async fn oversize_workspace_root_rejected() {
     let user_cfg_dir = TempDir::new().unwrap();
-    let app = make_app();
+    let connections = SessionConnections::new();
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
     app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
+        connections,
         user_cfg_dir.path().to_path_buf(),
     ));
     let window = make_session_window(&app, "abcdef0123456789");
@@ -480,12 +532,9 @@ async fn upsert_replaces_existing_entry_in_place() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let first = serde_json::json!({
         "scope_key": "tool:fs.write",
@@ -516,4 +565,135 @@ async fn upsert_replaces_existing_entry_in_place() {
     let arr = result.as_array().unwrap();
     assert_eq!(arr.len(), 1, "upsert must not duplicate the same key");
     assert_eq!(arr[0]["label"], "second");
+}
+
+// ---------------------------------------------------------------------------
+// F-349: workspace-root authorization regression tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_window_forged_workspace_root_is_ignored() {
+    // A session-* webview supplying a forged `workspace_root` must have its
+    // supplied value ignored in favour of the server-side cached value.
+    let real_ws = TempDir::new().unwrap();
+    let forged_ws = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+
+    let sid = "sess-forged";
+    let app = make_app(real_ws.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
+
+    // Plant an approval entry directly in the real workspace file so we can
+    // distinguish which path was actually read.
+    let real_forge_dir = real_ws.path().join(".forge");
+    std::fs::create_dir_all(&real_forge_dir).unwrap();
+    std::fs::write(
+        real_forge_dir.join("approvals.toml"),
+        r#"[[entries]]
+scope_key = "tool:fs.write"
+tool_name = "fs.write"
+label = "from-real-workspace"
+"#,
+    )
+    .unwrap();
+
+    // Invoke with the forged workspace root.
+    let forged_root = forged_ws.path().to_string_lossy().to_string();
+    let result = invoke_ok(
+        &window,
+        "get_persistent_approvals",
+        serde_json::json!({ "workspaceRoot": forged_root }),
+    );
+    let arr = result.as_array().unwrap();
+    // The real workspace entry is visible — proving the server-side cache won.
+    assert_eq!(arr.len(), 1, "must read from the cached (real) workspace");
+    assert_eq!(arr[0]["scope_key"], "tool:fs.write");
+
+    // The forged workspace must have no side-effects on disk.
+    assert!(
+        !forged_ws.path().join(".forge").exists(),
+        "forged workspace path must not have been touched"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_window_forged_workspace_write_lands_in_cached_path() {
+    // A session-* webview supplying a forged `workspace_root` to `save_approval`
+    // with `level=workspace` must have the write land in the real (cached)
+    // workspace, not in the forged path.
+    let real_ws = TempDir::new().unwrap();
+    let forged_ws = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+
+    let sid = "sess-write-forged";
+    let app = make_app(real_ws.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
+
+    let forged_root = forged_ws.path().to_string_lossy().to_string();
+    let _: serde_json::Value = invoke_ok(
+        &window,
+        "save_approval",
+        serde_json::json!({
+            "entry": {
+                "scope_key": "tool:fs.write",
+                "tool_name": "fs.write",
+                "label": "test",
+            },
+            "level": "workspace",
+            "workspaceRoot": forged_root,
+        }),
+    );
+
+    // File must appear in the real workspace, not the forged one.
+    assert!(
+        real_ws.path().join(".forge").join("approvals.toml").exists(),
+        "write must land in the real (cached) workspace"
+    );
+    assert!(
+        !forged_ws.path().join(".forge").exists(),
+        "forged workspace path must not have been touched"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_window_rejects_workspace_root_not_in_registry() {
+    // A dashboard caller must be rejected when the supplied path is not in the
+    // workspaces registry.
+    let registered_ws = TempDir::new().unwrap();
+    let unregistered_ws = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+
+    let (app, _registry) =
+        make_app_with_registry(&[registered_ws.path()], user_cfg_dir.path()).await;
+    let window = make_dashboard_window(&app);
+
+    let unregistered_root = unregistered_ws.path().to_string_lossy().to_string();
+    let err = invoke_err(
+        &window,
+        "get_persistent_approvals",
+        serde_json::json!({ "workspaceRoot": unregistered_root }),
+    );
+    assert!(
+        err.contains("not in registry"),
+        "expected registry-rejection error for dashboard caller, got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_window_accepts_registered_workspace_root() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+
+    let (app, _registry) =
+        make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
+    let window = make_dashboard_window(&app);
+
+    let root = workspace.path().to_string_lossy().to_string();
+    let result = invoke_ok(
+        &window,
+        "get_persistent_approvals",
+        serde_json::json!({ "workspaceRoot": root }),
+    );
+    // Empty — confirms the command executed without error.
+    assert!(result.as_array().unwrap().is_empty());
 }

--- a/crates/forge-shell/tests/ipc_authz_tracing.rs
+++ b/crates/forge-shell/tests/ipc_authz_tracing.rs
@@ -34,15 +34,15 @@ fn require_window_label_rejection_emits_warn_with_expected_actual_command() {
     );
     assert!(logs.contains("WARN"), "expected WARN level, got: {logs}");
     assert!(
-        logs.contains("expected=session-abc"),
+        logs.contains("expected=\"session-abc\""),
         "expected field missing, got: {logs}"
     );
     assert!(
-        logs.contains("actual=dashboard"),
+        logs.contains("actual=\"dashboard\""),
         "actual field missing, got: {logs}"
     );
     assert!(
-        logs.contains("command=session_send_message"),
+        logs.contains("command=\"session_send_message\""),
         "command field missing, got: {logs}"
     );
 }
@@ -67,11 +67,11 @@ fn require_window_label_in_rejection_emits_warn_with_expected_actual_command() {
     );
     assert!(logs.contains("WARN"), "expected WARN level, got: {logs}");
     assert!(
-        logs.contains("actual=some-other"),
+        logs.contains("actual=\"some-other\""),
         "actual field missing, got: {logs}"
     );
     assert!(
-        logs.contains("command=list_sessions"),
+        logs.contains("command=\"list_sessions\""),
         "command field missing, got: {logs}"
     );
     assert!(

--- a/crates/forge-shell/tests/ipc_layouts.rs
+++ b/crates/forge-shell/tests/ipc_layouts.rs
@@ -493,7 +493,11 @@ async fn session_window_forged_write_lands_in_cached_workspace() {
     let window = make_session_window(&app, "sess-b");
 
     let forged_root = forged_ws.path().to_string_lossy().to_string();
-    let _ = invoke_ok(&window, "write_layouts", sample_layouts_payload(&forged_root));
+    let _ = invoke_ok(
+        &window,
+        "write_layouts",
+        sample_layouts_payload(&forged_root),
+    );
 
     assert!(
         real_ws.path().join(".forge").join("layouts.json").exists(),

--- a/crates/forge-shell/tests/ipc_layouts.rs
+++ b/crates/forge-shell/tests/ipc_layouts.rs
@@ -1,6 +1,6 @@
 //! F-120: `read_layouts` / `write_layouts` Tauri command tests.
 //!
-//! Covers the two new commands end-to-end through Tauri's
+//! Covers the two commands end-to-end through Tauri's
 //! `test::get_ipc_response` machinery:
 //!
 //! - Round-trip: write a layout, read it back; file content matches.
@@ -8,16 +8,19 @@
 //! - Corrupt file: invalid JSON on disk degrades to the default — the user
 //!   should never see a blank window because a prior write scrambled the file.
 //! - Authz: dashboard + any `session-*` window may invoke; other labels are
-//!   rejected with the label-mismatch error (user-scoped workspace artifact,
-//!   not per-session).
+//!   rejected with the label-mismatch error.
 //!
-//! Wiring mirrors `tests/approval_commands.rs` (F-036) and `tests/ipc_commands.rs`
-//! (F-020 / F-052): `mock_builder()` + `WebviewWindowBuilder` with explicit
-//! labels and `INVOKE_KEY` payload. `.forge/layouts.json` is materialized under
-//! a `TempDir` so no test touches real workspace state.
+//! F-349: workspace-root validation regression tests are appended at the
+//! bottom. Session-* callers have the webview-supplied value replaced by the
+//! server-side cache; dashboard callers must supply a registry-listed path.
+//!
+//! Wiring mirrors `tests/approval_commands.rs` (F-036) and
+//! `tests/ipc_commands.rs` (F-020 / F-052): `mock_builder()` +
+//! `WebviewWindowBuilder` with explicit labels and `INVOKE_KEY` payload.
 
 #![cfg(feature = "webview-test")]
 
+use forge_core::workspaces::{write_workspaces, WorkspaceEntry};
 use forge_shell::bridge::SessionConnections;
 use forge_shell::ipc::{build_invoke_handler, BridgeState};
 use tauri::test::{mock_builder, mock_context, noop_assets, INVOKE_KEY};
@@ -26,13 +29,71 @@ use tempfile::TempDir;
 
 const LABEL_MISMATCH: &str = "forbidden: window label mismatch";
 
-fn make_app() -> tauri::App<tauri::test::MockRuntime> {
+/// Build a mock app with the workspace-root cache primed for `session_id`.
+async fn make_app_with_workspace(
+    workspace: &std::path::Path,
+    session_id: &str,
+) -> tauri::App<tauri::test::MockRuntime> {
+    let connections = SessionConnections::new();
+    connections
+        .prime_workspace_root_for_test(
+            session_id.to_string(),
+            std::fs::canonicalize(workspace).expect("canonicalize workspace"),
+        )
+        .await;
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::new(connections));
+    app
+}
+
+/// Build a mock app whose workspace-root cache is intentionally empty. Used
+/// to verify the "not connected" error path and for authz tests that never
+/// reach the workspace-root resolution.
+fn make_app_empty_cache() -> tauri::App<tauri::test::MockRuntime> {
     let app = mock_builder()
         .invoke_handler(build_invoke_handler())
         .build(mock_context(noop_assets()))
         .expect("build mock Tauri app");
     app.manage(BridgeState::new(SessionConnections::new()));
     app
+}
+
+/// Build a mock app wired for dashboard-caller tests. The workspaces registry
+/// is seeded with `workspace_paths` so the F-349 registry-validation path
+/// can accept those paths and reject others.
+async fn make_app_with_registry(
+    workspace_paths: &[&std::path::Path],
+) -> (tauri::App<tauri::test::MockRuntime>, TempDir) {
+    let registry_dir = TempDir::new().unwrap();
+    let toml_path = registry_dir.path().join("workspaces.toml");
+
+    let entries: Vec<WorkspaceEntry> = workspace_paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| WorkspaceEntry {
+            id: forge_core::WorkspaceId::new(),
+            path: p.to_path_buf(),
+            name: format!("ws-{i}"),
+            last_opened: chrono::Utc::now(),
+            pinned: false,
+        })
+        .collect();
+    write_workspaces(&toml_path, &entries)
+        .await
+        .expect("seed workspaces.toml");
+
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::with_test_workspaces_toml(
+        SessionConnections::new(),
+        toml_path,
+    ));
+    (app, registry_dir)
 }
 
 fn make_session_window(
@@ -113,7 +174,6 @@ fn invoke_err(
 }
 
 /// Canonical sample layout — a single horizontal split between two chat leaves.
-/// Covers both node variants and a per-pane state entry.
 fn sample_layouts_payload(workspace_root: &str) -> serde_json::Value {
     serde_json::json!({
         "workspaceRoot": workspace_root,
@@ -150,25 +210,26 @@ fn sample_layouts_payload(workspace_root: &str) -> serde_json::Value {
     })
 }
 
-#[test]
-fn write_then_read_round_trips_via_tauri_invoke() {
+// ---------------------------------------------------------------------------
+// Functional correctness
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_then_read_round_trips_via_tauri_invoke() {
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_string_lossy().to_string();
 
-    let app = make_app();
+    let app = make_app_with_workspace(dir.path(), "round-trip").await;
     let window = make_session_window(&app, "round-trip");
 
-    // Write.
     let _ = invoke_ok(&window, "write_layouts", sample_layouts_payload(&root));
 
-    // On-disk artifact lives at `<root>/.forge/layouts.json`.
     let written = dir.path().join(".forge").join("layouts.json");
     assert!(
         written.exists(),
         ".forge/layouts.json was not created under the workspace root"
     );
 
-    // Read.
     let out = invoke_ok(
         &window,
         "read_layouts",
@@ -183,43 +244,37 @@ fn write_then_read_round_trips_via_tauri_invoke() {
     );
 }
 
-#[test]
-fn read_layouts_missing_file_returns_default_single_pane() {
+#[tokio::test(flavor = "multi_thread")]
+async fn read_layouts_missing_file_returns_default_single_pane() {
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_string_lossy().to_string();
 
-    let app = make_app();
+    let app = make_app_with_workspace(dir.path(), "missing").await;
     let window = make_session_window(&app, "missing");
 
-    // No `.forge/layouts.json` on disk. The read must succeed with the default
-    // single-pane shape — not surface a file-not-found error to the webview.
     let out = invoke_ok(
         &window,
         "read_layouts",
         serde_json::json!({ "workspaceRoot": root }),
     );
     assert_eq!(out["active"], "default");
-    // Default is a single leaf — the tree is a leaf node, not a split.
     assert_eq!(out["named"]["default"]["tree"]["kind"], "leaf");
     assert_eq!(out["named"]["default"]["tree"]["pane_type"], "chat");
 }
 
-#[test]
-fn read_layouts_corrupt_file_falls_back_to_default() {
+#[tokio::test(flavor = "multi_thread")]
+async fn read_layouts_corrupt_file_falls_back_to_default() {
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_string_lossy().to_string();
 
-    // Materialize a corrupt `.forge/layouts.json` directly.
     let forge_dir = dir.path().join(".forge");
     std::fs::create_dir_all(&forge_dir).unwrap();
     std::fs::write(forge_dir.join("layouts.json"), b"{ this is not json")
         .expect("write corrupt layouts.json");
 
-    let app = make_app();
+    let app = make_app_with_workspace(dir.path(), "corrupt").await;
     let window = make_session_window(&app, "corrupt");
 
-    // The read must not bubble the JSON-parse error — a corrupt file would
-    // otherwise leave the UI blank on every session open.
     let out = invoke_ok(
         &window,
         "read_layouts",
@@ -229,15 +284,13 @@ fn read_layouts_corrupt_file_falls_back_to_default() {
     assert_eq!(out["named"]["default"]["tree"]["kind"], "leaf");
 }
 
-#[test]
-fn read_layouts_allows_dashboard_window() {
-    // Dashboard windows open the welcome view, which may need to materialize
-    // the last saved layout before routing into a session. Authz gate must
-    // accept the `"dashboard"` label.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_layouts_allows_dashboard_window() {
+    // Dashboard windows must be accepted when the supplied path is registered.
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_string_lossy().to_string();
 
-    let app = make_app();
+    let (app, _registry) = make_app_with_registry(&[dir.path()]).await;
     let window = make_dashboard_window(&app);
 
     let out = invoke_ok(
@@ -248,12 +301,12 @@ fn read_layouts_allows_dashboard_window() {
     assert_eq!(out["active"], "default");
 }
 
-#[test]
-fn read_layouts_rejects_foreign_window_labels() {
+#[tokio::test(flavor = "multi_thread")]
+async fn read_layouts_rejects_foreign_window_labels() {
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_string_lossy().to_string();
 
-    let app = make_app();
+    let app = make_app_empty_cache();
     let window = make_foreign_window(&app);
 
     let err = invoke_err(
@@ -261,29 +314,26 @@ fn read_layouts_rejects_foreign_window_labels() {
         "read_layouts",
         serde_json::json!({ "workspaceRoot": root }),
     );
-
     assert!(
         err.contains(LABEL_MISMATCH),
         "expected label-mismatch error for rogue window, got: {err}"
     );
 }
 
-#[test]
-fn write_layouts_rejects_foreign_window_labels() {
+#[tokio::test(flavor = "multi_thread")]
+async fn write_layouts_rejects_foreign_window_labels() {
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_string_lossy().to_string();
 
-    let app = make_app();
+    let app = make_app_empty_cache();
     let window = make_foreign_window(&app);
 
     let err = invoke_err(&window, "write_layouts", sample_layouts_payload(&root));
-
     assert!(
         err.contains(LABEL_MISMATCH),
         "expected label-mismatch error for rogue window, got: {err}"
     );
 
-    // And — critically — the write did not land on disk.
     let written = dir.path().join(".forge").join("layouts.json");
     assert!(
         !written.exists(),
@@ -291,16 +341,13 @@ fn write_layouts_rejects_foreign_window_labels() {
     );
 }
 
-#[test]
-fn write_layouts_creates_forge_dir_if_missing() {
-    // Workspaces without an existing `.forge/` directory must still be able
-    // to persist a layout on first save. The command creates the directory
-    // before writing.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_layouts_creates_forge_dir_if_missing() {
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_string_lossy().to_string();
     assert!(!dir.path().join(".forge").exists());
 
-    let app = make_app();
+    let app = make_app_with_workspace(dir.path(), "fresh-ws").await;
     let window = make_session_window(&app, "fresh-ws");
 
     let _ = invoke_ok(&window, "write_layouts", sample_layouts_payload(&root));
@@ -308,23 +355,9 @@ fn write_layouts_creates_forge_dir_if_missing() {
     assert!(dir.path().join(".forge").join("layouts.json").exists());
 }
 
-#[test]
-fn write_layouts_is_atomic_via_tmp_and_rename() {
-    // F-363: `write_layouts` must mirror the `approvals::save_to_path` /
-    // `settings::save_raw_to_path` atomic pattern — write to `<path>.tmp`,
-    // then rename into place. The rename is atomic on POSIX for same-
-    // filesystem targets, so a partially-written `.tmp` never becomes the
-    // visible `layouts.json`.
-    //
-    // We observe the invariant from two angles:
-    //
-    // 1. Pre-plant a stale `layouts.json.tmp` with garbage. A correct
-    //    atomic write `rename`s its freshly-written tmp over that path, so
-    //    no `.tmp` residue remains. A direct `tokio::fs::write` on the
-    //    canonical path leaves the stale tmp untouched.
-    // 2. After the write returns, `layouts.json` must contain the new
-    //    payload regardless of the prior `.tmp` state — the stale tmp must
-    //    not leak into the visible file.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_layouts_is_atomic_via_tmp_and_rename() {
+    // F-363: write to `<path>.tmp`, then rename into place.
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_string_lossy().to_string();
 
@@ -333,7 +366,7 @@ fn write_layouts_is_atomic_via_tmp_and_rename() {
     let tmp_path = forge_dir.join("layouts.json.tmp");
     std::fs::write(&tmp_path, b"{ partial-crash-residue").expect("seed stale layouts.json.tmp");
 
-    let app = make_app();
+    let app = make_app_with_workspace(dir.path(), "atomic").await;
     let window = make_session_window(&app, "atomic");
 
     let _ = invoke_ok(&window, "write_layouts", sample_layouts_payload(&root));
@@ -345,7 +378,6 @@ fn write_layouts_is_atomic_via_tmp_and_rename() {
         "layouts.json.tmp must be consumed by rename, not left behind"
     );
 
-    // And the final file is the new payload, not the stale-tmp garbage.
     let bytes = std::fs::read(&final_path).expect("read final layouts.json");
     let parsed: serde_json::Value =
         serde_json::from_slice(&bytes).expect("final layouts.json is valid JSON");
@@ -353,29 +385,21 @@ fn write_layouts_is_atomic_via_tmp_and_rename() {
     assert_eq!(parsed["named"]["default"]["tree"]["kind"], "split");
 }
 
-#[test]
-fn write_layouts_crash_mid_write_leaves_last_valid_on_disk() {
-    // F-363 DoD: simulate a crash mid-write by leaving a partial tmp on
-    // disk without completing the rename. The next `read_layouts` must
-    // return the last-valid payload — never a partial JSON — because the
-    // canonical `layouts.json` is only ever touched by the atomic rename.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_layouts_crash_mid_write_leaves_last_valid_on_disk() {
+    // F-363 DoD: a partial tmp left behind must not affect the canonical file.
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_string_lossy().to_string();
 
-    let app = make_app();
+    let app = make_app_with_workspace(dir.path(), "crash-mid-write").await;
     let window = make_session_window(&app, "crash-mid-write");
 
-    // First, a successful write establishes the last-valid canonical file.
     let _ = invoke_ok(&window, "write_layouts", sample_layouts_payload(&root));
 
-    // Simulate a crash after a second save wrote its tmp but before it
-    // renamed: plant a corrupt `.tmp` alongside the valid canonical file.
     let forge_dir = dir.path().join(".forge");
     let tmp_path = forge_dir.join("layouts.json.tmp");
     std::fs::write(&tmp_path, b"{ mid-write-crash").expect("seed crash tmp");
 
-    // Read must return the last-valid payload — not `Layouts::default()`,
-    // not the partial JSON from the tmp.
     let out = invoke_ok(
         &window,
         "read_layouts",
@@ -386,12 +410,9 @@ fn write_layouts_crash_mid_write_leaves_last_valid_on_disk() {
     assert_eq!(out["named"]["default"]["tree"]["a"]["pane_type"], "chat");
 }
 
-#[test]
-fn write_layouts_rejects_oversize_workspace_root() {
-    // `workspace_root` reuses the same 4 KiB PATH_MAX envelope as the F-036
-    // approval commands. A 5 KiB value must be rejected before the filesystem
-    // is touched.
-    let app = make_app();
+#[tokio::test(flavor = "multi_thread")]
+async fn write_layouts_rejects_oversize_workspace_root() {
+    let app = make_app_empty_cache();
     let window = make_session_window(&app, "oversize-root");
 
     let err = invoke_err(
@@ -413,5 +434,151 @@ fn write_layouts_rejects_oversize_workspace_root() {
     assert!(
         err.contains("payload too large") && err.contains("workspace_root"),
         "expected size-cap error mentioning workspace_root, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// F-349: workspace-root authorization regression tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_window_ignores_forged_workspace_root_and_uses_cached() {
+    // A session-* webview supplying a forged `workspace_root` must have its
+    // value replaced by the server-side cached workspace root.
+    let real_ws = TempDir::new().unwrap();
+    let forged_ws = TempDir::new().unwrap();
+
+    // Write a marker layout only in the real workspace.
+    let real_forge_dir = real_ws.path().join(".forge");
+    std::fs::create_dir_all(&real_forge_dir).unwrap();
+    let marker = serde_json::json!({
+        "active": "real",
+        "named": {
+            "real": {
+                "tree": { "kind": "leaf", "id": "root", "pane_type": "chat" },
+                "pane_state": {}
+            }
+        }
+    });
+    std::fs::write(
+        real_forge_dir.join("layouts.json"),
+        serde_json::to_vec_pretty(&marker).unwrap(),
+    )
+    .unwrap();
+
+    let app = make_app_with_workspace(real_ws.path(), "sess-a").await;
+    let window = make_session_window(&app, "sess-a");
+
+    // Invoke with the forged path.
+    let forged_root = forged_ws.path().to_string_lossy().to_string();
+    let out = invoke_ok(
+        &window,
+        "read_layouts",
+        serde_json::json!({ "workspaceRoot": forged_root }),
+    );
+    assert_eq!(
+        out["active"], "real",
+        "session-* caller must read from the cached workspace, not the forged path"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_window_forged_write_lands_in_cached_workspace() {
+    // A session-* webview supplying a forged `workspace_root` to `write_layouts`
+    // must have the write land in the real (cached) workspace.
+    let real_ws = TempDir::new().unwrap();
+    let forged_ws = TempDir::new().unwrap();
+
+    let app = make_app_with_workspace(real_ws.path(), "sess-b").await;
+    let window = make_session_window(&app, "sess-b");
+
+    let forged_root = forged_ws.path().to_string_lossy().to_string();
+    let _ = invoke_ok(&window, "write_layouts", sample_layouts_payload(&forged_root));
+
+    assert!(
+        real_ws.path().join(".forge").join("layouts.json").exists(),
+        "write must land in the real (cached) workspace"
+    );
+    assert!(
+        !forged_ws.path().join(".forge").exists(),
+        "forged workspace must not have been touched"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_window_with_empty_cache_returns_not_connected_error() {
+    // When a session-* window invokes before `session_hello` has primed the
+    // cache, the command must return a "not connected" error rather than reading
+    // from the webview-supplied path.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_string_lossy().to_string();
+
+    let app = make_app_empty_cache();
+    let window = make_session_window(&app, "unprime");
+
+    let err = invoke_err(
+        &window,
+        "read_layouts",
+        serde_json::json!({ "workspaceRoot": root }),
+    );
+    assert!(
+        err.contains("not connected"),
+        "expected 'not connected' error for unprimed session, got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_window_rejects_workspace_root_not_in_registry() {
+    // A dashboard caller supplying a path not in the workspaces registry must
+    // be rejected — cannot read/write arbitrary on-disk paths.
+    let registered_ws = TempDir::new().unwrap();
+    let unregistered_ws = TempDir::new().unwrap();
+
+    let (app, _registry) = make_app_with_registry(&[registered_ws.path()]).await;
+    let window = make_dashboard_window(&app);
+
+    let unregistered_root = unregistered_ws.path().to_string_lossy().to_string();
+    let err = invoke_err(
+        &window,
+        "read_layouts",
+        serde_json::json!({ "workspaceRoot": unregistered_root }),
+    );
+    assert!(
+        err.contains("not in registry"),
+        "expected registry-rejection error, got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_window_accepts_registered_workspace_root() {
+    // A dashboard caller supplying a path in the registry must succeed.
+    let workspace = TempDir::new().unwrap();
+
+    let (app, _registry) = make_app_with_registry(&[workspace.path()]).await;
+    let window = make_dashboard_window(&app);
+
+    let root = workspace.path().to_string_lossy().to_string();
+    let out = invoke_ok(
+        &window,
+        "read_layouts",
+        serde_json::json!({ "workspaceRoot": root }),
+    );
+    assert_eq!(out["active"], "default");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_window_rejects_nonexistent_path() {
+    // A path that doesn't exist cannot be canonicalized and must be rejected.
+    let (app, _registry) = make_app_with_registry(&[]).await;
+    let window = make_dashboard_window(&app);
+
+    let err = invoke_err(
+        &window,
+        "read_layouts",
+        serde_json::json!({ "workspaceRoot": "/tmp/forge-test-nonexistent-99999" }),
+    );
+    assert!(
+        err.contains("not found on disk") || err.contains("not in registry"),
+        "expected path-not-found or registry error, got: {err}"
     );
 }

--- a/crates/forge-shell/tests/ipc_settings.rs
+++ b/crates/forge-shell/tests/ipc_settings.rs
@@ -6,20 +6,79 @@
 //! is redirected via the `webview-test`-gated
 //! [`BridgeState::with_test_user_config_dir`] so tests never touch the real
 //! platform config dir.
+//!
+//! F-349: regression tests at the bottom verify that session-* callers have
+//! their webview-supplied `workspace_root` replaced by the server-side cache,
+//! and that dashboard callers are validated against the workspaces registry.
 
 #![cfg(feature = "webview-test")]
 
+use forge_core::workspaces::{write_workspaces, WorkspaceEntry};
 use forge_shell::bridge::SessionConnections;
 use forge_shell::ipc::{build_invoke_handler, BridgeState};
 use tauri::test::{mock_builder, mock_context, noop_assets, INVOKE_KEY};
 use tauri::Manager;
 use tempfile::TempDir;
 
-fn make_app() -> tauri::App<tauri::test::MockRuntime> {
-    mock_builder()
+/// Build a mock app with the workspace-root cache primed for `session_id`
+/// and the user-config-dir pointed at `user_cfg_dir`.
+async fn make_app(
+    workspace: &std::path::Path,
+    session_id: &str,
+    user_cfg_dir: &std::path::Path,
+) -> tauri::App<tauri::test::MockRuntime> {
+    let connections = SessionConnections::new();
+    connections
+        .prime_workspace_root_for_test(
+            session_id.to_string(),
+            std::fs::canonicalize(workspace).expect("canonicalize workspace"),
+        )
+        .await;
+    let app = mock_builder()
         .invoke_handler(build_invoke_handler())
         .build(mock_context(noop_assets()))
-        .expect("build mock Tauri app")
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::with_test_user_config_dir(
+        connections,
+        user_cfg_dir.to_path_buf(),
+    ));
+    app
+}
+
+/// Build a mock app for dashboard-caller tests: workspaces registry seeded
+/// with `workspace_paths`, user-config-dir at `user_cfg_dir`.
+async fn make_app_with_registry(
+    workspace_paths: &[&std::path::Path],
+    user_cfg_dir: &std::path::Path,
+) -> (tauri::App<tauri::test::MockRuntime>, TempDir) {
+    let registry_dir = TempDir::new().unwrap();
+    let toml_path = registry_dir.path().join("workspaces.toml");
+    let entries: Vec<WorkspaceEntry> = workspace_paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| WorkspaceEntry {
+            id: forge_core::WorkspaceId::new(),
+            path: p.to_path_buf(),
+            name: format!("ws-{i}"),
+            last_opened: chrono::Utc::now(),
+            pinned: false,
+        })
+        .collect();
+    write_workspaces(&toml_path, &entries)
+        .await
+        .expect("seed workspaces.toml");
+
+    let connections = SessionConnections::new();
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::with_test_user_config_and_workspaces(
+        connections,
+        user_cfg_dir.to_path_buf(),
+        toml_path,
+    ));
+    (app, registry_dir)
 }
 
 fn make_session_window(
@@ -32,7 +91,7 @@ fn make_session_window(
         tauri::WebviewUrl::App("index.html".into()),
     )
     .build()
-    .expect("mock window")
+    .expect("mock session window")
 }
 
 fn make_dashboard_window(
@@ -100,12 +159,9 @@ async fn get_settings_returns_defaults_when_no_files() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let result = invoke_ok(
         &window,
@@ -121,12 +177,9 @@ async fn set_setting_workspace_then_get_reflects_value() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let _: serde_json::Value = invoke_ok(
         &window,
@@ -157,12 +210,9 @@ async fn set_setting_user_writes_under_overridden_dir() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let _: serde_json::Value = invoke_ok(
         &window,
@@ -191,12 +241,9 @@ async fn workspace_overrides_user_on_declared_field_only() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     // User sets BOTH fields away from default.
     let _: serde_json::Value = invoke_ok(
@@ -251,12 +298,9 @@ async fn set_setting_preserves_sibling_workspace_fields() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     let _: serde_json::Value = invoke_ok(
         &window,
@@ -295,12 +339,9 @@ async fn set_setting_rejects_invalid_value_for_known_key() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
-    let window = make_session_window(&app, "abcdef0123456789");
+    let sid = "abcdef0123456789";
+    let app = make_app(workspace.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
 
     // `bg_agents` accepts only the enum strings; an integer must fail.
     let err = invoke_err(
@@ -326,9 +367,7 @@ async fn set_setting_rejects_invalid_value_for_known_key() {
 }
 
 // ---------------------------------------------------------------------------
-// Authz: dashboard + session-* allowed, anything else rejected. Settings are
-// user-scoped (not per-session), so there is no session-to-session label
-// check — F-036 enforces the same invariant via `require_window_label_in`.
+// Authz: dashboard + session-* allowed, anything else rejected.
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]
@@ -336,11 +375,8 @@ async fn dashboard_window_is_allowed() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
-    app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
-        user_cfg_dir.path().to_path_buf(),
-    ));
+    let (app, _registry) =
+        make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
     let window = make_dashboard_window(&app);
 
     let got = invoke_ok(
@@ -356,11 +392,16 @@ async fn non_session_non_dashboard_window_is_rejected() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let app = make_app();
+    let connections = SessionConnections::new();
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
     app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
+        connections,
         user_cfg_dir.path().to_path_buf(),
     ));
+
     let window = tauri::WebviewWindowBuilder::new(
         &app,
         "some-other-window",
@@ -398,9 +439,13 @@ async fn non_session_non_dashboard_window_is_rejected() {
 #[tokio::test(flavor = "multi_thread")]
 async fn oversize_workspace_root_rejected() {
     let user_cfg_dir = TempDir::new().unwrap();
-    let app = make_app();
+    let connections = SessionConnections::new();
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
     app.manage(BridgeState::with_test_user_config_dir(
-        SessionConnections::new(),
+        connections,
         user_cfg_dir.path().to_path_buf(),
     ));
     let window = make_session_window(&app, "abcdef0123456789");
@@ -415,4 +460,117 @@ async fn oversize_workspace_root_rejected() {
         err.contains("payload too large") && err.contains("workspace_root"),
         "expected workspace_root cap error, got {err}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// F-349: workspace-root authorization regression tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_window_forged_workspace_root_is_ignored_for_get() {
+    // A session-* webview supplying a forged `workspace_root` must have its
+    // value replaced by the server-side cached workspace root.
+    let real_ws = TempDir::new().unwrap();
+    let forged_ws = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+
+    // Plant a workspace-level settings file in the real workspace only.
+    let real_forge_dir = real_ws.path().join(".forge");
+    std::fs::create_dir_all(&real_forge_dir).unwrap();
+    std::fs::write(
+        real_forge_dir.join("settings.toml"),
+        "[notifications]\nbg_agents = \"os\"\n",
+    )
+    .unwrap();
+
+    let sid = "sess-forged-get";
+    let app = make_app(real_ws.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
+
+    let forged_root = forged_ws.path().to_string_lossy().to_string();
+    let got = invoke_ok(
+        &window,
+        "get_settings",
+        serde_json::json!({ "workspaceRoot": forged_root }),
+    );
+    // The real workspace's setting is visible — server-side cache won.
+    assert_eq!(
+        got["notifications"]["bg_agents"], "os",
+        "session-* get_settings must read from the cached workspace, not the forged path"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_window_forged_workspace_write_lands_in_cached_path() {
+    // A session-* webview supplying a forged `workspace_root` to `set_setting`
+    // with `level=workspace` must have the write land in the real (cached)
+    // workspace, not the forged path.
+    let real_ws = TempDir::new().unwrap();
+    let forged_ws = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+
+    let sid = "sess-forged-write";
+    let app = make_app(real_ws.path(), sid, user_cfg_dir.path()).await;
+    let window = make_session_window(&app, sid);
+
+    let forged_root = forged_ws.path().to_string_lossy().to_string();
+    let _: serde_json::Value = invoke_ok(
+        &window,
+        "set_setting",
+        serde_json::json!({
+            "key": "notifications.bg_agents",
+            "value": "os",
+            "level": "workspace",
+            "workspaceRoot": forged_root,
+        }),
+    );
+
+    assert!(
+        real_ws.path().join(".forge").join("settings.toml").exists(),
+        "write must land in the real (cached) workspace"
+    );
+    assert!(
+        !forged_ws.path().join(".forge").exists(),
+        "forged workspace path must not have been touched"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_window_rejects_workspace_root_not_in_registry() {
+    let registered_ws = TempDir::new().unwrap();
+    let unregistered_ws = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+
+    let (app, _registry) =
+        make_app_with_registry(&[registered_ws.path()], user_cfg_dir.path()).await;
+    let window = make_dashboard_window(&app);
+
+    let unregistered_root = unregistered_ws.path().to_string_lossy().to_string();
+    let err = invoke_err(
+        &window,
+        "get_settings",
+        serde_json::json!({ "workspaceRoot": unregistered_root }),
+    );
+    assert!(
+        err.contains("not in registry"),
+        "expected registry-rejection error for dashboard caller, got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_window_accepts_registered_workspace_root() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+
+    let (app, _registry) =
+        make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
+    let window = make_dashboard_window(&app);
+
+    let root = workspace.path().to_string_lossy().to_string();
+    let got = invoke_ok(
+        &window,
+        "get_settings",
+        serde_json::json!({ "workspaceRoot": root }),
+    );
+    assert_eq!(got["notifications"]["bg_agents"], "toast");
 }

--- a/crates/forge-shell/tests/ipc_settings.rs
+++ b/crates/forge-shell/tests/ipc_settings.rs
@@ -375,8 +375,7 @@ async fn dashboard_window_is_allowed() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let (app, _registry) =
-        make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
+    let (app, _registry) = make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
     let window = make_dashboard_window(&app);
 
     let got = invoke_ok(
@@ -562,8 +561,7 @@ async fn dashboard_window_accepts_registered_workspace_root() {
     let workspace = TempDir::new().unwrap();
     let user_cfg_dir = TempDir::new().unwrap();
 
-    let (app, _registry) =
-        make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
+    let (app, _registry) = make_app_with_registry(&[workspace.path()], user_cfg_dir.path()).await;
     let window = make_dashboard_window(&app);
 
     let root = workspace.path().to_string_lossy().to_string();

--- a/web/packages/ipc/src/generated/TreeNodeDto.ts
+++ b/web/packages/ipc/src/generated/TreeNodeDto.ts
@@ -3,10 +3,6 @@ import type { TreeKindDto } from "./TreeKindDto";
 import type { TreeStatsDto } from "./TreeStatsDto";
 
 /**
- * Wire shape for `tree`. The root is always returned; `children` is `None`
- * for non-directory entries and `Some(_)` for directories (empty vec when
- * the depth cap is hit or the directory is empty).
- *
  * F-357: the root node carries a [`TreeStatsDto`] summarizing what the walk
  * elided so the UI can render "N files not shown" instead of silently
  * rendering a partial tree as if it were complete. Nested nodes carry


### PR DESCRIPTION
## Summary

- Adds `resolve_workspace_root_for_command` helper that validates the webview-supplied `workspace_root` before any filesystem command executes
- Session-`*` callers: webview-supplied value silently replaced by server-side `cached_workspace_root` (no forged path can reach the filesystem)
- Dashboard callers: supplied path validated against the `read_workspaces` registry; paths not in the registry are rejected
- Adds `test_workspaces_toml_override` test seam to `BridgeState` (webview-test feature only)
- Rewrites three test suites (`approval_commands.rs`, `ipc_layouts.rs`, `ipc_settings.rs`) with primed workspace caches and F-349 regression tests confirming forged paths are rejected

Fixes #350 (F-349).

## Test plan

- [ ] 192 forge-shell tests pass (0 failures)
- [ ] F-349 regression tests: `forged_workspace_root_is_rejected_for_session_caller` confirms session callers ignore the supplied path
- [ ] F-349 regression tests: `forged_workspace_root_is_rejected_for_dashboard_caller` confirms dashboard callers reject unregistered paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)