### PR TITLE
[F-366] Fix listener lifecycle mount-race in AgentMonitor and TerminalPane

### DIFF
--- a/web/packages/app/src/ipc/useEventListener.test.ts
+++ b/web/packages/app/src/ipc/useEventListener.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We test the mounted-flag logic by exercising createMountedSubscription with
+// manually-controlled onMount/onCleanup stubs so we can simulate fast unmount
+// without a full Solid render environment.
+
+let mountCbs: Array<() => void> = [];
+let cleanupCbs: Array<() => void> = [];
+
+vi.mock('solid-js', () => ({
+  onMount: (cb: () => void) => {
+    mountCbs.push(cb);
+  },
+  onCleanup: (cb: () => void) => {
+    cleanupCbs.push(cb);
+  },
+}));
+
+// Import after mock so the module picks up the stubbed solid-js.
+const { createMountedSubscription } = await import('./useEventListener');
+
+beforeEach(() => {
+  mountCbs = [];
+  cleanupCbs = [];
+});
+
+describe('createMountedSubscription', () => {
+  it('stores the unlisten function when component stays mounted', async () => {
+    const unlisten = vi.fn();
+    let resolveSetup!: (fn: () => void) => void;
+    const setup = () =>
+      new Promise<() => void>((res) => {
+        resolveSetup = res;
+      });
+
+    createMountedSubscription(setup);
+
+    // Simulate mount
+    mountCbs.forEach((cb) => cb());
+    // Resolve after mount
+    resolveSetup(unlisten);
+    await Promise.resolve(); // flush microtask
+
+    // Cleanup
+    cleanupCbs.forEach((cb) => cb());
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it('calls unlisten immediately on fast unmount (before setup resolves)', async () => {
+    const unlisten = vi.fn();
+    let resolveSetup!: (fn: () => void) => void;
+    const setup = () =>
+      new Promise<() => void>((res) => {
+        resolveSetup = res;
+      });
+
+    createMountedSubscription(setup);
+
+    // Simulate mount then immediate cleanup before setup resolves
+    mountCbs.forEach((cb) => cb());
+    cleanupCbs.forEach((cb) => cb());
+
+    // Now setup resolves — the listener should be detached immediately
+    resolveSetup(unlisten);
+    await Promise.resolve();
+
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it('does not call unlisten twice when cleanup fires after normal detach', async () => {
+    const unlisten = vi.fn();
+    const setup = () => Promise.resolve(unlisten);
+
+    createMountedSubscription(setup);
+    mountCbs.forEach((cb) => cb());
+    await Promise.resolve();
+
+    // Normal cleanup
+    cleanupCbs.forEach((cb) => cb());
+    cleanupCbs.forEach((cb) => cb()); // second cleanup shouldn't double-call
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+});

--- a/web/packages/app/src/ipc/useEventListener.ts
+++ b/web/packages/app/src/ipc/useEventListener.ts
@@ -1,0 +1,34 @@
+import { onCleanup, onMount } from 'solid-js';
+import type { UnlistenFn } from '@tauri-apps/api/event';
+
+/**
+ * Safely registers an async subscription inside a Solid component.
+ *
+ * Accepts a `setup` thunk returning Promise<UnlistenFn>. Handles the
+ * fast-unmount race: if the component unmounts before the promise resolves,
+ * the unlisten function is called immediately rather than leaking.
+ *
+ * Call during component setup (not inside onMount) — it installs its own
+ * onMount/onCleanup guards.
+ */
+export function createMountedSubscription(setup: () => Promise<UnlistenFn>): void {
+  let mounted = true;
+  let unlisten: UnlistenFn | null = null;
+
+  onMount(() => {
+    void (async () => {
+      const fn = await setup();
+      if (mounted) {
+        unlisten = fn;
+      } else {
+        fn();
+      }
+    })();
+  });
+
+  onCleanup(() => {
+    mounted = false;
+    unlisten?.();
+    unlisten = null;
+  });
+}

--- a/web/packages/app/src/panes/TerminalPane.tsx
+++ b/web/packages/app/src/panes/TerminalPane.tsx
@@ -96,6 +96,7 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
   let unlistenBytes: UnlistenFn | null = null;
   let unlistenExit: UnlistenFn | null = null;
   let resizeObserver: ResizeObserver | null = null;
+  let termMounted = true;
   // Tracks whether spawn succeeded so cleanup doesn't attempt to kill a
   // terminal that was never registered on the Rust side.
   let spawnCompleted = false;
@@ -152,7 +153,7 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
     void (async () => {
       // Subscribe before spawning so we cannot miss bytes emitted between
       // spawn return and subscription set-up.
-      unlistenBytes = await listen<TerminalBytesEvent>(
+      const bytesOff = await listen<TerminalBytesEvent>(
         TERMINAL_BYTES_EVENT,
         (event) => {
           if (event.payload.terminal_id !== id) return;
@@ -160,7 +161,10 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
           term.write(new Uint8Array(event.payload.data));
         },
       );
-      unlistenExit = await listen<TerminalExitEvent>(
+      if (!termMounted) { bytesOff(); return; }
+      unlistenBytes = bytesOff;
+
+      const exitOff = await listen<TerminalExitEvent>(
         TERMINAL_EXIT_EVENT,
         (event) => {
           if (event.payload.terminal_id !== id) return;
@@ -183,6 +187,8 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
           spawnCompleted = false;
         },
       );
+      if (!termMounted) { exitOff(); return; }
+      unlistenExit = exitOff;
 
       const args: TerminalSpawnArgs = {
         terminal_id: id,
@@ -235,6 +241,7 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
   });
 
   onCleanup(() => {
+    termMounted = false;
     tearingDown = true;
     const id = terminalId();
     if (resizeObserver) {

--- a/web/packages/app/src/routes/AgentMonitor.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.tsx
@@ -18,11 +18,11 @@ import {
   For,
   on,
   onCleanup,
-  onMount,
   Show,
   type Component,
   type JSX,
 } from 'solid-js';
+import { createMountedSubscription } from '../ipc/useEventListener';
 import { useParams, useSearchParams } from '@solidjs/router';
 import { invoke } from '../lib/tauri';
 import { useFocusTrap } from '../lib/useFocusTrap';
@@ -919,11 +919,7 @@ export const AgentMonitor: Component = () => {
     return { kind: 'ready' };
   });
 
-  onMount(async () => {
-    // Subscribe to session events to update sub-agents + step timelines.
-    const unlisten = await onSessionEvent((payload) => applyEvent(payload));
-    onCleanup(() => unlisten());
-  });
+  createMountedSubscription(() => onSessionEvent((payload) => applyEvent(payload)));
 
   function applyEvent(payload: SessionEventPayload) {
     const ev = payload.event as Record<string, unknown> | null;


### PR DESCRIPTION
## Summary

- Introduces `createMountedSubscription()` helper (`web/packages/app/src/ipc/useEventListener.ts`) that safely handles the SolidJS fast-unmount race: if a component unmounts before a `listen()` promise resolves, the unlisten function is called immediately rather than leaking
- Migrates `AgentMonitor.tsx` from broken `onMount(async () => { ... onCleanup(...) })` to `createMountedSubscription`
- Adds `termMounted` flag guards around `TerminalPane.tsx`'s two `listen()` calls so both `unlistenBytes` and `unlistenExit` are cancelled on fast unmount

## Test plan

- [x] 3 new unit tests in `useEventListener.test.ts` covering: normal mount, fast-unmount before resolve, and no double-call on repeated cleanup
- [x] All 890 existing tests pass
- [ ] CI green

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)