### PR TITLE
[F-400] Add loading/empty/error states to EditorPane, TerminalPane, FilesSidebar

### DIFF
--- a/web/packages/app/src/panes/EditorPane.css
+++ b/web/packages/app/src/panes/EditorPane.css
@@ -24,6 +24,17 @@
   display: inline-block;
 }
 
+.editor-pane__loading {
+  padding: var(--sp-2) var(--sp-4);
+  background: var(--color-surface-2);
+  color: var(--color-text-tertiary);
+  border-bottom: 1px solid var(--color-border-1);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  flex: 0 0 auto;
+}
+
 .editor-pane__error {
   padding: var(--sp-2) var(--sp-4);
   background: var(--color-surface-3);

--- a/web/packages/app/src/panes/EditorPane.test.tsx
+++ b/web/packages/app/src/panes/EditorPane.test.tsx
@@ -573,6 +573,109 @@ describe('EditorPane PaneHeader adoption (F-394)', () => {
   });
 });
 
+describe('loading states (F-400)', () => {
+  it('shows LOADING EDITOR placeholder before the iframe emits ready', () => {
+    const { getByTestId } = render(() => (
+      <EditorPane
+        path={FILE}
+        src="about:blank"
+        readFile={vi.fn().mockResolvedValue({ path: FILE, content: '', bytes: 0, sha256: '' })}
+        writeFile={vi.fn().mockResolvedValue(undefined)}
+        onClose={vi.fn()}
+      />
+    ));
+    const loading = getByTestId('editor-pane-loading');
+    expect(loading).toBeInTheDocument();
+    expect(loading.getAttribute('role')).toBe('status');
+    expect(loading.textContent).toContain('LOADING EDITOR');
+  });
+
+  it('removes the LOADING EDITOR placeholder once the iframe emits ready', async () => {
+    const readFile = vi.fn().mockResolvedValue({ path: FILE, content: 'x', bytes: 1, sha256: '' });
+    const { getByTestId, queryByTestId } = render(() => (
+      <EditorPane
+        path={FILE}
+        src="about:blank"
+        readFile={readFile}
+        writeFile={vi.fn().mockResolvedValue(undefined)}
+        postToIframe={vi.fn()}
+        onClose={vi.fn()}
+      />
+    ));
+    expect(queryByTestId('editor-pane-loading')).toBeInTheDocument();
+
+    const iframe = getByTestId('editor-pane-iframe') as HTMLIFrameElement;
+    const event = new MessageEvent('message', {
+      data: { kind: 'ready' },
+      source: iframe.contentWindow as MessageEventSource,
+    });
+    window.dispatchEvent(event);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(queryByTestId('editor-pane-loading')).not.toBeInTheDocument();
+  });
+
+  it('shows LOADING FILE while readFile is in-flight (after ready)', async () => {
+    let resolveRead!: (v: { path: string; content: string; bytes: number; sha256: string }) => void;
+    const readFile = vi.fn().mockReturnValue(
+      new Promise<{ path: string; content: string; bytes: number; sha256: string }>((res) => {
+        resolveRead = res;
+      }),
+    );
+    const { getByTestId, queryByTestId } = render(() => (
+      <EditorPane
+        path={FILE}
+        src="about:blank"
+        readFile={readFile}
+        writeFile={vi.fn().mockResolvedValue(undefined)}
+        postToIframe={vi.fn()}
+        onClose={vi.fn()}
+      />
+    ));
+
+    const iframe = getByTestId('editor-pane-iframe') as HTMLIFrameElement;
+    const event = new MessageEvent('message', {
+      data: { kind: 'ready' },
+      source: iframe.contentWindow as MessageEventSource,
+    });
+    window.dispatchEvent(event);
+    await Promise.resolve();
+
+    expect(getByTestId('editor-pane-file-loading')).toBeInTheDocument();
+
+    resolveRead({ path: FILE, content: 'done', bytes: 4, sha256: '' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(queryByTestId('editor-pane-file-loading')).not.toBeInTheDocument();
+  });
+
+  it('hides the loading placeholder when an error is shown instead', async () => {
+    const readFile = vi.fn().mockRejectedValue(new Error('denied'));
+    const { getByTestId, queryByTestId } = render(() => (
+      <EditorPane
+        path={FILE}
+        src="about:blank"
+        readFile={readFile}
+        writeFile={vi.fn().mockResolvedValue(undefined)}
+        onClose={vi.fn()}
+      />
+    ));
+    const iframe = getByTestId('editor-pane-iframe') as HTMLIFrameElement;
+    const event = new MessageEvent('message', {
+      data: { kind: 'ready' },
+      source: iframe.contentWindow as MessageEventSource,
+    });
+    window.dispatchEvent(event);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(queryByTestId('editor-pane-loading')).not.toBeInTheDocument();
+    expect(getByTestId('editor-pane-error')).toBeInTheDocument();
+  });
+});
+
 beforeEach(() => {
   // F-385: EditorPane reads the session id from the global `activeSessionId`
   // signal. Tests mount outside of SessionWindow, so we seed the signal

--- a/web/packages/app/src/panes/EditorPane.tsx
+++ b/web/packages/app/src/panes/EditorPane.tsx
@@ -136,7 +136,8 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
 
   const [isDirty, setIsDirty] = createSignal(false);
   const [errorMessage, setErrorMessage] = createSignal<string | null>(null);
-  const [, setIsReady] = createSignal(false);
+  const [isReady, setIsReady] = createSignal(false);
+  const [isFileLoading, setIsFileLoading] = createSignal(false);
   // Track last-saved contents separately from current to decide dirty.
   let lastSavedValue: string | null = null;
   let currentValue: string | null = null;
@@ -187,6 +188,7 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
   const sendOpen = async (): Promise<void> => {
     const sid = activeSessionId();
     if (sid === null) return;
+    setIsFileLoading(true);
     try {
       const file = await readFile(sid, props.path);
       lastSavedValue = file.content;
@@ -201,6 +203,8 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
       });
     } catch (err) {
       setErrorMessage(errorToString(err));
+    } finally {
+      setIsFileLoading(false);
     }
   };
 
@@ -313,6 +317,24 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
           ) : undefined
         }
       />
+      {!isReady() && errorMessage() === null && (
+        <div
+          class="editor-pane__loading"
+          role="status"
+          data-testid="editor-pane-loading"
+        >
+          LOADING EDITOR…
+        </div>
+      )}
+      {isReady() && isFileLoading() && errorMessage() === null && (
+        <div
+          class="editor-pane__loading"
+          role="status"
+          data-testid="editor-pane-file-loading"
+        >
+          LOADING FILE…
+        </div>
+      )}
       {errorMessage() !== null && (
         <div
           class="editor-pane__error"

--- a/web/packages/app/src/panes/TerminalPane.css
+++ b/web/packages/app/src/panes/TerminalPane.css
@@ -32,6 +32,20 @@
   background: transparent;
 }
 
+.terminal-pane__loading {
+  position: absolute;
+  top: var(--sp-3);
+  left: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--color-border-1);
+  border-radius: var(--r-sm);
+  background: var(--color-surface-2);
+  color: var(--color-text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
 .terminal-pane__error {
   position: absolute;
   top: var(--sp-3);

--- a/web/packages/app/src/panes/TerminalPane.test.tsx
+++ b/web/packages/app/src/panes/TerminalPane.test.tsx
@@ -264,4 +264,54 @@ describe('TerminalPane', () => {
     btn.click();
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  describe('loading states (F-400)', () => {
+    it('shows SPAWNING SHELL loading overlay immediately on mount', () => {
+      const { getByTestId } = render(() => (
+        <TerminalPane cwd="/tmp" onClose={vi.fn()} />
+      ));
+      const loading = getByTestId('terminal-pane-loading');
+      expect(loading).toBeInTheDocument();
+      expect(loading.getAttribute('role')).toBe('status');
+      expect(loading.textContent).toContain('SPAWNING SHELL');
+    });
+
+    it('removes the loading overlay once spawn resolves', async () => {
+      const { queryByTestId } = render(() => (
+        <TerminalPane cwd="/tmp" onClose={vi.fn()} />
+      ));
+      // Let the spawn async chain finish (listen x2 + spawn resolve).
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(queryByTestId('terminal-pane-loading')).not.toBeInTheDocument();
+    });
+
+    it('hides loading overlay and shows error when spawn fails', async () => {
+      invokeMock.mockImplementation((command: string) => {
+        if (command === 'terminal_spawn') {
+          return Promise.reject(new Error('label mismatch'));
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const { queryByTestId, findByRole } = render(() => (
+        <TerminalPane cwd="/tmp" onClose={vi.fn()} />
+      ));
+
+      const alert = await findByRole('alert');
+      expect(alert.textContent).toMatch(/terminal_spawn failed/);
+      expect(queryByTestId('terminal-pane-loading')).not.toBeInTheDocument();
+    });
+
+    it('does not show error before spawn resolves', () => {
+      const { queryByTestId, queryByRole } = render(() => (
+        <TerminalPane cwd="/tmp" onClose={vi.fn()} />
+      ));
+      // Before spawn: loading shown, no error.
+      expect(queryByTestId('terminal-pane-loading')).toBeInTheDocument();
+      expect(queryByRole('alert')).toBeNull();
+    });
+  });
 });

--- a/web/packages/app/src/panes/TerminalPane.tsx
+++ b/web/packages/app/src/panes/TerminalPane.tsx
@@ -89,6 +89,7 @@ export function shellDisplayName(shell: string | undefined): string {
 export const TerminalPane: Component<TerminalPaneProps> = (props) => {
   const [terminalId] = createSignal<TerminalId>(newTerminalId());
   const [spawnError, setSpawnError] = createSignal<string | null>(null);
+  const [spawning, setSpawning] = createSignal(true);
 
   let hostRef: HTMLDivElement | undefined;
   let term: Terminal | undefined;
@@ -203,6 +204,8 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
       } catch (err) {
         setSpawnError(`terminal_spawn failed: ${String(err)}`);
         return;
+      } finally {
+        setSpawning(false);
       }
     })();
 
@@ -283,6 +286,15 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
         onClose={props.onClose}
       />
       <div class="terminal-pane__body">
+        <Show when={spawning() && !spawnError()}>
+          <div
+            class="terminal-pane__loading"
+            role="status"
+            data-testid="terminal-pane-loading"
+          >
+            SPAWNING SHELL…
+          </div>
+        </Show>
         <Show when={spawnError()}>
           <div class="terminal-pane__error" role="alert">
             {spawnError()}

--- a/web/packages/app/src/shell/FilesSidebar.css
+++ b/web/packages/app/src/shell/FilesSidebar.css
@@ -40,6 +40,21 @@
   background: var(--color-surface-1, #161616);
 }
 
+.files-sidebar__loading {
+  padding: 6px 10px;
+  color: var(--color-text-tertiary, #888);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  border-bottom: 1px solid var(--color-border-1, #1f1f1f);
+}
+
+.files-sidebar__empty {
+  padding: 6px 10px;
+  color: var(--color-text-tertiary, #888);
+  font-size: 11px;
+  font-style: italic;
+}
+
 .files-sidebar__error {
   padding: 6px 10px;
   color: var(--color-accent-ember, #ff4a12);

--- a/web/packages/app/src/shell/FilesSidebar.test.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.test.tsx
@@ -440,7 +440,6 @@ describe('FilesSidebar loading and empty states (F-400)', () => {
     );
     const { getByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -460,7 +459,6 @@ describe('FilesSidebar loading and empty states (F-400)', () => {
     const loadTree = vi.fn().mockResolvedValue(demoTree());
     const { findByText, queryByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -481,7 +479,6 @@ describe('FilesSidebar loading and empty states (F-400)', () => {
     const loadTree = vi.fn().mockResolvedValue(emptyRoot);
     const { findByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -502,7 +499,6 @@ describe('FilesSidebar loading and empty states (F-400)', () => {
     );
     const { queryByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}
@@ -521,7 +517,6 @@ describe('FilesSidebar loading and empty states (F-400)', () => {
     const loadTree = vi.fn().mockRejectedValue(new Error('permission denied'));
     const { findByTestId, queryByTestId } = render(() => (
       <FilesSidebar
-        sessionId={SID}
         workspaceRoot={WS}
         onOpen={vi.fn()}
         loadTree={loadTree}

--- a/web/packages/app/src/shell/FilesSidebar.test.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.test.tsx
@@ -429,3 +429,105 @@ describe('FilesSidebar stats notice (F-536)', () => {
     expect(queryByTestId('files-sidebar-stats-notice')).toBeNull();
   });
 });
+
+describe('FilesSidebar loading and empty states (F-400)', () => {
+  it('shows LOADING TREE while the first loadTree call is pending', async () => {
+    let resolve!: (v: TreeNodeDto) => void;
+    const loadTree = vi.fn().mockReturnValue(
+      new Promise<TreeNodeDto>((res) => {
+        resolve = res;
+      }),
+    );
+    const { getByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    const loading = getByTestId('files-sidebar-loading');
+    expect(loading).toBeInTheDocument();
+    expect(loading.getAttribute('role')).toBe('status');
+    expect(loading.textContent).toContain('LOADING TREE');
+
+    resolve(demoTree());
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it('removes LOADING TREE after loadTree resolves', async () => {
+    const loadTree = vi.fn().mockResolvedValue(demoTree());
+    const { findByText, queryByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    await findByText('README.md');
+    expect(queryByTestId('files-sidebar-loading')).toBeNull();
+  });
+
+  it('shows NO FILES when the workspace is empty (loaded, no error)', async () => {
+    const emptyRoot: TreeNodeDto = {
+      name: 'empty',
+      path: WS,
+      kind: 'Dir',
+      children: [],
+      stats: null,
+    } as unknown as TreeNodeDto;
+    const loadTree = vi.fn().mockResolvedValue(emptyRoot);
+    const { findByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    const empty = await findByTestId('files-sidebar-empty');
+    expect(empty).toBeInTheDocument();
+    expect(empty.getAttribute('role')).toBe('status');
+    expect(empty.textContent).toContain('NO FILES');
+  });
+
+  it('does not show NO FILES while still loading', async () => {
+    let resolve!: (v: TreeNodeDto) => void;
+    const loadTree = vi.fn().mockReturnValue(
+      new Promise<TreeNodeDto>((res) => {
+        resolve = res;
+      }),
+    );
+    const { queryByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    // Still loading — empty placeholder must not appear
+    expect(queryByTestId('files-sidebar-empty')).toBeNull();
+    expect(queryByTestId('files-sidebar-loading')).toBeInTheDocument();
+
+    resolve(demoTree());
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it('does not show NO FILES when there is a load error', async () => {
+    const loadTree = vi.fn().mockRejectedValue(new Error('permission denied'));
+    const { findByTestId, queryByTestId } = render(() => (
+      <FilesSidebar
+        sessionId={SID}
+        workspaceRoot={WS}
+        onOpen={vi.fn()}
+        loadTree={loadTree}
+      />
+    ));
+    await findByTestId('files-sidebar-error');
+    expect(queryByTestId('files-sidebar-empty')).toBeNull();
+  });
+});

--- a/web/packages/app/src/shell/FilesSidebar.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.tsx
@@ -71,12 +71,14 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
 
   const [rootNode, setRootNode] = createSignal<TreeNodeDto | null>(null);
   const [error, setError] = createSignal<string | null>(null);
+  const [isLoading, setIsLoading] = createSignal(false);
   const [expanded, setExpanded] = createSignal<Set<string>>(new Set());
   const [menu, setMenu] = createSignal<ContextMenuTarget | null>(null);
 
   const refresh = async (): Promise<void> => {
     const sid = activeSessionId();
     if (sid === null) return;
+    setIsLoading(true);
     try {
       const next = await load()(sid, props.workspaceRoot);
       setRootNode(next);
@@ -90,6 +92,8 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
       setError(null);
     } catch (err) {
       setError(errorToString(err));
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -233,6 +237,11 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
           </svg>
         </button>
       </header>
+      <Show when={isLoading()}>
+        <div class="files-sidebar__loading" role="status" data-testid="files-sidebar-loading">
+          LOADING TREE
+        </div>
+      </Show>
       <Show when={error() !== null}>
         <div class="files-sidebar__error" role="alert" data-testid="files-sidebar-error">
           {error()}
@@ -244,6 +253,11 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
         </div>
       </Show>
       <div class="files-sidebar__tree" role="tree">
+        <Show when={!isLoading() && rootChildren().length === 0 && error() === null}>
+          <div class="files-sidebar__empty" role="status" data-testid="files-sidebar-empty">
+            NO FILES
+          </div>
+        </Show>
         <For each={rootChildren()}>
           {(child) => (
             <TreeRow


### PR DESCRIPTION
## Summary

Closes #401. Extends the interaction-state pattern from F-399 to the three pane/shell surfaces that were missing loading placeholders.

- **EditorPane**: restores the discarded `isReady` signal getter; renders `LOADING EDITOR…` (`role="status"`) between mount and the iframe `ready` message; renders `LOADING FILE…` (`role="status"`) while `readFile` is in-flight after ready
- **TerminalPane**: adds `spawning` signal (starts `true`, cleared in the `finally` block after `terminal_spawn` resolves or rejects); renders `SPAWNING SHELL…` (`role="status"`) overlay while `spawning && !spawnError` — the existing error branch is unchanged
- **FilesSidebar**: tracks `isLoading` explicitly in `refresh` (`finally` clears it); renders `LOADING TREE` (`role="status"`) during any load, and `NO FILES` (`role="status"`) only when loaded + empty + no error — the "still loading" and "empty workspace" states are now distinct

## Test plan

- [ ] 13 new tests covering: loading renders, loading-dismissed-after-resolve, loading-dismissed-on-error, loading-vs-empty distinction
- [ ] `pnpm exec vitest run` — 875 tests, 68 files, all pass
- [ ] `pnpm -r typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)