### PR TITLE
[F-396] Defer ToolCallCard expanded body + parallel grouping to Phase 3 (spec update)

### DIFF
--- a/docs/ui-specs/tool-call-card.md
+++ b/docs/ui-specs/tool-call-card.md
@@ -4,7 +4,32 @@
 
 ---
 
+## Phase scope
+
+This spec was originally drafted in full but only partially shipped in Phase 2.
+The expanded body and parallel-reads grouping were deferred to Phase 3 to keep
+Phase 2 focused on data plumbing and approval flow.
+
+**Phase 2 (shipped):** Placeholder collapsed row only —
+`web/packages/app/src/routes/Session/ChatPane.tsx` (`tool-placeholder` class)
+rendered the ⚙ icon in `--color-text-tertiary`, the tool name, a one-line arg
+summary, and the raw status string (`awaiting-approval` / `completed`). No
+per-tool icon color, no status glyph, no duration readout, no chevron, no
+expanded body, no parallel grouping.
+
+**Phase 3 (now shipped under F-447 / #448):** §5 expanded body and §5.1
+parallel-reads grouping. Sections below describe the full Phase 3 surface and
+are the source of truth going forward.
+
+---
+
 ## 5. Tool call card
+
+> **Phase 3 surface.** The full collapsed-row chrome (per-tool icon color,
+> status glyph, duration, chevron) and the expanded body described below
+> were deferred from Phase 2 and shipped in Phase 3 under F-447 (#448).
+> Phase 2 rendered only the placeholder row documented in the
+> "Phase scope" section above.
 
 **Purpose.** Surface every tool invocation inline in the chat, with full transparency — name, arguments, result, duration, and approval state.
 
@@ -30,6 +55,9 @@
 
 ### 5.1 Parallel tool call grouping
 
+> **Phase 3 surface.** Deferred from Phase 2 and shipped in Phase 3 under
+> F-447 (#448).
+
 When the model issues multiple read-only tool calls in the same turn, Forge executes them in parallel and visually groups them under a single expandable card:
 
 ```
@@ -47,3 +75,4 @@ When the model issues multiple read-only tool calls in the same turn, Forge exec
 **Doesn't do.**
 - Never collapses the *currently streaming* tool call
 - Never hides arguments for security review — truncation only
+- Phase 2 placeholder row did not render the expanded body or parallel-reads grouping; both surfaces ship in Phase 3 under F-447 (#448).


### PR DESCRIPTION
## Summary

Closes #397.

Path 2 from #397: rather than ship the substantial §5 / §5.1 surface under
Phase 2, update `docs/ui-specs/tool-call-card.md` to honestly reflect what
Phase 2 delivered and gate the deferred surface as Phase 3.

- Adds a "Phase scope" header documenting the Phase 2 placeholder row
  (`tool-placeholder` in `web/packages/app/src/routes/Session/ChatPane.tsx`):
  `--color-text-tertiary` ⚙ icon, tool name, arg summary, raw status string —
  no chevron, no expanded body, no parallel grouping.
- Marks §5 (expanded body) and §5.1 (parallel-reads grouping) with explicit
  Phase 3 admonitions; content preserved verbatim for Phase 3 implementers.
- Notes in "Doesn't do" that the Phase 2 placeholder did not render either
  surface.
- Records that the Phase 3 surface has since shipped under F-447 (#448), so
  the spec doubles as historical context for the original Phase 2 → Phase 3
  defer.

Pure docs change — no code under `web/packages/app/src/` is touched.

## Rationale

The placeholder stub already passes Phase 2 acceptance, the Phase 1 audit
report treated §5/§5.1 as Phase-3 territory, and ChatPane's own comments
flagged it as future F-026 work. UAT-06 already `test.skip`s the affected
surfaces. Aligning the spec with reality removes the misleading promise
without losing the design intent for Phase 3.

## Test plan

- [x] `node scripts/check-tokens.mjs` passes (prose-only edit; no token drift)
- [ ] Reviewer confirms §5 / §5.1 content is unchanged from prior revision
      (only callouts and the new "Phase scope" header are additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)