### PR TITLE
[F-581] Wire TerminalPane into SessionWindow grid layout

### DIFF
--- a/web/packages/app/src/routes/Session/SessionWindow.tsx
+++ b/web/packages/app/src/routes/Session/SessionWindow.tsx
@@ -40,6 +40,7 @@ import { seedSettings } from '../../stores/settings';
 import { PaneHeader } from './PaneHeader';
 import { ChatPane } from './ChatPane';
 import { EditorPane } from '../../panes/EditorPane';
+import { TerminalPane } from '../../panes/TerminalPane';
 import { usePaneWidth } from '../../layout/usePaneWidth';
 import {
   createLayoutStore,
@@ -328,6 +329,7 @@ export const SessionWindow: Component = () => {
         providerLabel={providerLabel()}
         costLabel={costLabel()}
         activeFile={paneStateFor(leaf.id)?.active_file ?? null}
+        workspaceRoot={activeWorkspaceRoot()}
         onCloseLeaf={() => onCloseLeaf(leaf.id)}
         onPointerDownHeader={dockApi.startDrag(leaf.id)}
       />
@@ -380,6 +382,7 @@ interface LeafHostProps {
   providerLabel: string;
   costLabel: string;
   activeFile: string | null;
+  workspaceRoot: string | null;
   onCloseLeaf: () => void;
   onPointerDownHeader: (e: PointerEvent) => void;
 }
@@ -395,10 +398,12 @@ const LeafHost: Component<LeafHostProps> = (props) => {
   const closeAriaLabel = (): string =>
     props.leaf.pane_type === 'chat' ? 'Close session window' : 'Close pane';
 
-  // The editor pane owns its own header (breadcrumb + CLOSE TAB), so we
-  // suppress the outer PaneHeader for editor leaves to avoid a double-header
-  // row. Everything else uses the standard PaneHeader.
-  const showOuterHeader = (): boolean => props.leaf.pane_type !== 'editor';
+  // The editor and terminal panes own their own headers (EditorPane:
+  // breadcrumb + CLOSE TAB; TerminalPane: shell subject + cwd + CLOSE PANE),
+  // so we suppress the outer PaneHeader for those leaves to avoid a
+  // double-header row. Everything else uses the standard PaneHeader.
+  const showOuterHeader = (): boolean =>
+    props.leaf.pane_type !== 'editor' && props.leaf.pane_type !== 'terminal';
 
   return (
     <div
@@ -454,9 +459,15 @@ const LeafHost: Component<LeafHostProps> = (props) => {
             No file open.
           </div>
         </Show>
-        <Show when={props.leaf.pane_type === 'terminal'}>
-          <div class="session-window__pane-empty" data-testid="terminal-pane-stub">
-            Terminal pane (F-125).
+        <Show when={props.leaf.pane_type === 'terminal' && props.workspaceRoot !== null}>
+          <TerminalPane
+            cwd={props.workspaceRoot as string}
+            onClose={props.onCloseLeaf}
+          />
+        </Show>
+        <Show when={props.leaf.pane_type === 'terminal' && props.workspaceRoot === null}>
+          <div class="session-window__pane-empty" data-testid="terminal-pane-empty">
+            Waiting for workspace…
           </div>
         </Show>
         <Show when={props.leaf.pane_type === 'files'}>


### PR DESCRIPTION
## Summary

- Replaces the `terminal-pane-stub` placeholder in `SessionWindow`'s leaf renderer with a real `<TerminalPane>` mount so grid leaves whose `pane_type === 'terminal'` produce a working xterm.js shell instead of a static placeholder div.
- Threads `activeWorkspaceRoot()` into `LeafHost` so the spawned shell's `cwd` matches the session's workspace; suppresses the outer `PaneHeader` for terminal leaves (TerminalPane owns its own header — same pattern as `EditorPane`).
- Leaves `shell` undefined so the Rust side resolves `$SHELL` (no new settings-store coupling) and renders a transient "Waiting for workspace…" empty state for the pre-HelloAck window.

## Test plan

- [x] `pnpm --filter app typecheck` — clean
- [x] `pnpm --filter app test -- TerminalPane` — 18/18 pass
- [x] `pnpm --filter app test -- SessionWindow` — 23/23 pass
- [ ] UAT-09 Playwright steps 7–9 — spec lives in PR #580 (not yet merged into `main`); un-skipping is a follow-up once both land
- [ ] Manual smoke: open a session, split to a terminal leaf, confirm shell spawns into the workspace root

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)