### PR TITLE
[F-582] EditorPane: re-issue read_file on path change after error

### DIFF
--- a/web/packages/app/src/panes/EditorPane.test.tsx
+++ b/web/packages/app/src/panes/EditorPane.test.tsx
@@ -11,6 +11,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
 import type { SessionId } from '@forge/ipc';
 import {
   EditorPane,
@@ -145,6 +146,57 @@ describe('open-on-ready flow', () => {
     await Promise.resolve();
     const alert = queryByTestId('editor-pane-error');
     expect(alert?.textContent).toContain('path denied');
+  });
+
+  // F-582: after a failed initial read, changing `props.path` MUST re-issue
+  // `sendOpen()` so the user can recover by opening a different file in the
+  // same pane (the natural "I'll try a different file" motion). Previously
+  // the path-change effect gated on `currentValue !== null`, which silently
+  // dropped the second open and forced a close+reopen.
+  it('re-issues read_file when path changes after a prior failed read (recovery)', async () => {
+    const SECOND_FILE = '/workspace/demo/src/other.ts';
+    const readFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('path denied'))
+      .mockResolvedValueOnce({
+        path: SECOND_FILE,
+        content: 'recovered\n',
+        bytes: 10,
+        sha256: 'sha2',
+      });
+    const posted: unknown[] = [];
+    const [path, setPath] = createSignal(FILE);
+
+    const { getByTestId, queryByTestId } = render(() => (
+      <EditorPane
+        path={path()}
+        src="about:blank"
+        readFile={readFile}
+        writeFile={vi.fn().mockResolvedValue(undefined)}
+        postToIframe={(m) => posted.push(m)}
+        onClose={vi.fn()}
+      />
+    ));
+    const iframe = getByTestId('editor-pane-iframe') as HTMLIFrameElement;
+    fireFromIframe(iframe, { kind: 'ready' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getByTestId('editor-pane-error').textContent).toContain('path denied');
+
+    setPath(SECOND_FILE);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readFile).toHaveBeenCalledTimes(2);
+    expect(readFile).toHaveBeenLastCalledWith(SID, SECOND_FILE);
+    expect(queryByTestId('editor-pane-error')).not.toBeInTheDocument();
+    const openMsg = posted.find(
+      (m) =>
+        (m as { kind?: string }).kind === 'open' &&
+        (m as { uri?: string }).uri === `file://${SECOND_FILE}`,
+    );
+    expect(openMsg).toBeDefined();
   });
 });
 

--- a/web/packages/app/src/panes/EditorPane.tsx
+++ b/web/packages/app/src/panes/EditorPane.tsx
@@ -276,13 +276,33 @@ export const EditorPane: Component<EditorPaneProps> = (props) => {
   });
 
   // Re-open when the path changes mid-life.
+  //
+  // F-582: do NOT gate on `currentValue !== null`. The previous gate skipped
+  // re-opens whenever the prior load failed (currentValue stays null after a
+  // failed `read_file`), which trapped the pane in its error state — opening
+  // a different file in the same pane was silently ignored and recovery
+  // required close+reopen. We now re-issue `sendOpen()` on every path change
+  // once the iframe is ready, regardless of whether the previous attempt
+  // succeeded. The initial open is still driven by the iframe's `ready`
+  // message (see `handleMessage`), so we skip the first effect run when the
+  // iframe has not yet handshaked.
+  let lastPath: string | undefined;
   createEffect(() => {
-    // Tracked: props.path triggers a re-open. Use `void` to discard the
-    // promise — errors are already surfaced through the error signal.
-    void props.path;
-    if (currentValue !== null) {
-      void sendOpen();
-    }
+    const next = props.path;
+    const prev = lastPath;
+    lastPath = next;
+    // First run, or no actual change (memo invalidation w/ same value): the
+    // ready handler owns the initial open.
+    if (prev === undefined || prev === next) return;
+    // Reset stale error/dirty state up front so the new path's UI starts
+    // clean even if `sendOpen()` rejects early. `sendOpen()` will also clear
+    // the error on success.
+    setErrorMessage(null);
+    setIsDirty(false);
+    lastSavedValue = null;
+    currentValue = null;
+    if (!isReady()) return;
+    void sendOpen();
   });
 
   onCleanup(() => {

--- a/web/packages/app/tests/phase2/uat-09-state-coverage.spec.ts
+++ b/web/packages/app/tests/phase2/uat-09-state-coverage.spec.ts
@@ -248,9 +248,15 @@ test.describe('UAT-09 — F-400 — loading/empty/error states across panes', ()
       kind: 'Dir',
       children: [
         { path: `${WORKSPACE}/notes.txt`, name: 'notes.txt', kind: 'File' },
+        { path: `${WORKSPACE}/other.md`, name: 'other.md', kind: 'File' },
       ],
     }));
-    await tauri.onInvoke('read_file', async () => {
+    // First file rejects; second file succeeds. Drives the F-582 recovery
+    // assertion below — opening a different file in the same EditorPane
+    // after a failed initial read must clear the error and succeed.
+    await tauri.onInvoke('read_file', async (args) => {
+      const path = (args as { path?: string }).path ?? '';
+      if (path.endsWith('other.md')) return { content: 'recovered\n' };
       throw new Error('read denied');
     });
 
@@ -285,14 +291,15 @@ test.describe('UAT-09 — F-400 — loading/empty/error states across panes', ()
     await expect(errorBanner).toHaveAttribute('role', 'alert');
     await expect(errorBanner).toContainText('read denied');
 
-    // Note: error -> recovery via "open the next file in the same EditorPane"
-    // is intentionally NOT exercised here. EditorPane's path-change effect
-    // (see EditorPane.tsx createEffect on `props.path`) skips sendOpen()
-    // while `currentValue === null`, which is the state after a failed
-    // initial read. Production recovery is via close+reopen of the pane;
-    // the LSP-error Reload affordance documented in UAT-02 step 8 is a
-    // separate code path. The loading -> error transition (the F-400
-    // surface area) is fully verified above.
+    // F-582: error -> recovery via "open a different file in the same
+    // EditorPane". The path-change effect must re-issue `sendOpen()` even
+    // when the prior `read_file` failed (previously gated on
+    // `currentValue !== null`, which trapped the pane in its error state
+    // and forced close+reopen). Double-clicking the second sidebar row
+    // updates `props.path` on the live EditorPane; the new file's success
+    // payload should clear the error banner.
+    await rows.nth(1).dblclick();
+    await expect(errorBanner).toBeHidden();
   });
 
   // Steps 7-9 (TerminalPane loading / error / recovery) are not exercised


### PR DESCRIPTION
## Summary
- Drop the `currentValue !== null` gate on EditorPane's path-change `createEffect`; it trapped the pane in its error state after a failed initial `read_file`, silently ignoring path changes and forcing close+reopen for recovery.
- Track previous `props.path` so the iframe `ready` handler still owns the initial open; on subsequent path changes reset stale error/dirty/buffer state and re-issue `sendOpen()` once the iframe is ready.
- Reload button (same-path retry) is unaffected — it still resets state and calls `sendOpen()` directly.

## Test plan
- [x] `pnpm --filter app typecheck`
- [x] `pnpm --filter app test -- EditorPane` — 32 tests pass, including a new `re-issues read_file when path changes after a prior failed read (recovery)` case.
- [x] `pnpm --filter app exec playwright test tests/phase2 --reporter=list` — UAT-09 Step 6 now drives a second sidebar dblclick and asserts the error banner clears.

Closes #582

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>