### PR TITLE
[F-450] @forge/design Button/IconButton/Tab/MenuItem primitives + 43-site migration

### DIFF
--- a/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.tsx
@@ -5,6 +5,7 @@ import {
   onMount,
   onCleanup,
 } from 'solid-js';
+import { Button, MenuItem, Tab, Tabs } from '@forge/design';
 import type { ApprovalScope, ApprovalLevel } from '@forge/ipc';
 import type { ApprovalPreview } from '../../stores/messages';
 import { defaultPatternForPath } from '../../stores/approvals';
@@ -183,47 +184,41 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
       {/* F-036: persistence level toggle. Hidden in pattern-editor mode so
           tab order stays predictable and the label-line stays clean. */}
       <Show when={!patternMode()}>
-        <div
+        <Tabs
+          variant="radio"
           class="approval-prompt__level-toggle"
           data-testid="level-toggle"
-          role="radiogroup"
           aria-label="Persistence level"
         >
           <span class="approval-prompt__level-label">Persist:</span>
-          <button
-            type="button"
-            class="approval-prompt__level-btn"
-            classList={{ 'approval-prompt__level-btn--active': level() === 'session' }}
+          <Tab
+            variant="radio"
+            selected={level() === 'session'}
+            class={`approval-prompt__level-btn${level() === 'session' ? ' approval-prompt__level-btn--active' : ''}`}
             data-testid="level-session-btn"
-            role="radio"
-            aria-checked={level() === 'session'}
             onClick={() => setLevel('session')}
           >
             Session
-          </button>
-          <button
-            type="button"
-            class="approval-prompt__level-btn"
-            classList={{ 'approval-prompt__level-btn--active': level() === 'workspace' }}
+          </Tab>
+          <Tab
+            variant="radio"
+            selected={level() === 'workspace'}
+            class={`approval-prompt__level-btn${level() === 'workspace' ? ' approval-prompt__level-btn--active' : ''}`}
             data-testid="level-workspace-btn"
-            role="radio"
-            aria-checked={level() === 'workspace'}
             onClick={() => setLevel('workspace')}
           >
             Workspace
-          </button>
-          <button
-            type="button"
-            class="approval-prompt__level-btn"
-            classList={{ 'approval-prompt__level-btn--active': level() === 'user' }}
+          </Tab>
+          <Tab
+            variant="radio"
+            selected={level() === 'user'}
+            class={`approval-prompt__level-btn${level() === 'user' ? ' approval-prompt__level-btn--active' : ''}`}
             data-testid="level-user-btn"
-            role="radio"
-            aria-checked={level() === 'user'}
             onClick={() => setLevel('user')}
           >
             User
-          </button>
-        </div>
+          </Tab>
+        </Tabs>
       </Show>
 
       {/* Pattern editor */}
@@ -241,22 +236,22 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
               value={pattern()}
               onInput={(e) => setPattern(e.currentTarget.value)}
             />
-            <button
-              type="button"
+            <Button
+              variant="primary"
               class="approval-prompt__btn approval-prompt__btn--primary"
               data-testid="pattern-confirm-btn"
               onClick={() => approveWithScope('ThisPattern', pattern())}
             >
               Confirm
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
+              variant="ghost"
               class="approval-prompt__btn approval-prompt__btn--ghost"
               data-testid="pattern-cancel-btn"
               onClick={() => setPatternMode(false)}
             >
               Cancel
-            </button>
+            </Button>
           </div>
         </div>
       </Show>
@@ -275,8 +270,8 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
       {/* Actions */}
       <Show when={!patternMode()}>
         <div class="approval-prompt__actions">
-          <button
-            type="button"
+          <Button
+            variant="ghost"
             class="approval-prompt__btn approval-prompt__btn--ghost"
             data-testid="reject-btn"
             disabled={persisting()}
@@ -284,12 +279,12 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
           >
             Reject
             <kbd class="approval-prompt__kbd">R</kbd>
-          </button>
+          </Button>
 
           <div class="approval-prompt__approve-group">
             {/* Primary approve button — Once (default) */}
-            <button
-              type="button"
+            <Button
+              variant="primary"
               class="approval-prompt__btn approval-prompt__btn--primary"
               data-testid="approve-once-btn"
               disabled={persisting()}
@@ -298,11 +293,11 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
               <Show when={persisting()} fallback={<>Approve<kbd class="approval-prompt__kbd">A</kbd></>}>
                 persisting…
               </Show>
-            </button>
+            </Button>
 
             {/* Dropdown toggle */}
-            <button
-              type="button"
+            <Button
+              variant="primary"
               class="approval-prompt__btn approval-prompt__btn--primary approval-prompt__dropdown-toggle"
               data-testid="approve-dropdown-btn"
               aria-label="More approval scopes"
@@ -311,56 +306,48 @@ export const ApprovalPrompt: Component<ApprovalPromptProps> = (props) => {
               onClick={() => setMenuOpen((v) => !v)}
             >
               ▾
-            </button>
+            </Button>
 
             {/* Scope menu */}
             <Show when={menuOpen()}>
               <div class="approval-prompt__menu" data-testid="scope-menu" role="menu">
-                <button
-                  type="button"
+                <MenuItem
                   class="approval-prompt__menu-item"
                   data-testid="scope-once-btn"
-                  role="menuitem"
                   onClick={() => approveWithScope('Once')}
                 >
                   Once
                   <kbd class="approval-prompt__kbd">A</kbd>
-                </button>
+                </MenuItem>
 
                 <Show when={showFileScopes()}>
-                  <button
-                    type="button"
+                  <MenuItem
                     class="approval-prompt__menu-item"
                     data-testid="scope-file-btn"
-                    role="menuitem"
                     onClick={() => approveWithScope('ThisFile')}
                   >
                     This file
                     <kbd class="approval-prompt__kbd">F</kbd>
-                  </button>
+                  </MenuItem>
 
-                  <button
-                    type="button"
+                  <MenuItem
                     class="approval-prompt__menu-item"
                     data-testid="scope-pattern-btn"
-                    role="menuitem"
                     onClick={openPatternEditor}
                   >
                     This pattern
                     <kbd class="approval-prompt__kbd">P</kbd>
-                  </button>
+                  </MenuItem>
                 </Show>
 
-                <button
-                  type="button"
+                <MenuItem
                   class="approval-prompt__menu-item"
                   data-testid="scope-tool-btn"
-                  role="menuitem"
                   onClick={() => approveWithScope('ThisTool')}
                 >
                   This tool
                   <kbd class="approval-prompt__kbd">T</kbd>
-                </button>
+                </MenuItem>
               </div>
             </Show>
           </div>

--- a/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.tsx
+++ b/web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.tsx
@@ -5,6 +5,7 @@ import {
   onCleanup,
   Show,
 } from 'solid-js';
+import { Button, MenuItem } from '@forge/design';
 import type { ApprovalLevel } from '@forge/ipc';
 import './WhitelistedPill.css';
 
@@ -76,8 +77,9 @@ export const WhitelistedPill: Component<WhitelistedPillProps> = (props) => {
 
   return (
     <div ref={wrapperRef} class="whitelisted-pill-wrapper">
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
         class="whitelisted-pill"
         data-testid="whitelisted-pill"
         aria-haspopup="true"
@@ -87,7 +89,7 @@ export const WhitelistedPill: Component<WhitelistedPillProps> = (props) => {
         <span class="whitelisted-pill__dot" aria-hidden="true" />
         whitelisted · {props.label}
         {provenanceSuffix(props.level)}
-      </button>
+      </Button>
 
       <Show when={popoverOpen()}>
         <div
@@ -96,18 +98,16 @@ export const WhitelistedPill: Component<WhitelistedPillProps> = (props) => {
           role="menu"
           aria-label="Revoke approval"
         >
-          <button
-            type="button"
+          <MenuItem
             class="whitelisted-pill__revoke-btn"
             data-testid="revoke-btn"
-            role="menuitem"
             onClick={() => {
               setPopoverOpen(false);
               props.onRevoke();
             }}
           >
             {revokeLabel(props.level)}
-          </button>
+          </MenuItem>
         </div>
       </Show>
     </div>

--- a/web/packages/app/src/components/BranchMetadataPopover.tsx
+++ b/web/packages/app/src/components/BranchMetadataPopover.tsx
@@ -1,4 +1,5 @@
 import { type Component, For, Show, createMemo } from 'solid-js';
+import { Button } from '@forge/design';
 import { useFocusTrap } from '../lib/useFocusTrap';
 import './BranchMetadataPopover.css';
 
@@ -150,8 +151,9 @@ export const BranchMetadataPopover: Component<BranchMetadataPopoverProps> = (pro
                     &quot;{preview}&quot;
                   </span>
                 </button>
-                <button
-                  type="button"
+                <Button
+                  variant="danger"
+                  size="sm"
                   class="branch-popover__delete"
                   data-testid={`branch-popover-delete-${row.index}`}
                   aria-label={`Delete variant ${row.index}`}
@@ -159,21 +161,22 @@ export const BranchMetadataPopover: Component<BranchMetadataPopoverProps> = (pro
                   onClick={() => props.onDelete(row.index)}
                 >
                   DELETE VARIANT
-                </button>
+                </Button>
               </li>
             );
           }}
         </For>
       </ul>
       <footer class="branch-popover__footer">
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="sm"
           class="branch-popover__export"
           data-testid="branch-popover-export"
           onClick={props.onExportAll}
         >
           EXPORT ALL
-        </button>
+        </Button>
       </footer>
     </div>
   );

--- a/web/packages/app/src/components/BranchSelectorStrip.tsx
+++ b/web/packages/app/src/components/BranchSelectorStrip.tsx
@@ -1,4 +1,5 @@
 import { type Component, Show, createMemo } from 'solid-js';
+import { IconButton } from '@forge/design';
 import './BranchSelectorStrip.css';
 
 /**
@@ -73,15 +74,14 @@ export const BranchSelectorStrip: Component<BranchSelectorStripProps> = (props) 
       tabIndex={0}
       onKeyDown={handleKey}
     >
-      <button
-        type="button"
+      <IconButton
+        size="sm"
         class="branch-strip__arrow branch-strip__arrow--prev"
         data-testid="branch-strip-prev"
-        aria-label="Previous variant"
+        label="Previous variant"
         onClick={props.onPrev}
-      >
-        {'\u25c0'}
-      </button>
+        icon={'\u25c0'}
+      />
       <Show
         when={!isLoading()}
         fallback={
@@ -98,28 +98,28 @@ export const BranchSelectorStrip: Component<BranchSelectorStripProps> = (props) 
           variant {props.position} of {props.total}
         </span>
       </Show>
-      <button
-        type="button"
+      <IconButton
+        size="sm"
         class="branch-strip__arrow branch-strip__arrow--next"
         data-testid="branch-strip-next"
-        aria-label="Next variant"
+        label="Next variant"
         onClick={props.onNext}
-      >
-        {'\u25b6'}
-      </button>
+        icon={'\u25b6'}
+      />
       <span class="branch-strip__spacer" aria-hidden="true" />
-      <button
-        type="button"
+      <IconButton
+        size="sm"
         class="branch-strip__info"
         data-testid="branch-strip-info"
-        aria-label="Branch variant details"
+        label="Branch variant details"
         aria-expanded={props.infoOpen}
         onClick={props.onToggleInfo}
-      >
-        <Show when={props.infoOpen} fallback={<span aria-hidden="true">{'\u24d8'}</span>}>
-          <span aria-hidden="true">{'\u24d8'}</span>
-        </Show>
-      </button>
+        icon={
+          <Show when={props.infoOpen} fallback={<span aria-hidden="true">{'\u24d8'}</span>}>
+            <span aria-hidden="true">{'\u24d8'}</span>
+          </Show>
+        }
+      />
     </div>
   );
 };

--- a/web/packages/app/src/components/ContextChip.tsx
+++ b/web/packages/app/src/components/ContextChip.tsx
@@ -4,6 +4,7 @@ import {
   onCleanup,
   Show,
 } from 'solid-js';
+import { IconButton } from '@forge/design';
 import type { ContextCategory } from './ContextPicker';
 import './ContextChip.css';
 
@@ -126,15 +127,14 @@ export const ContextChip: Component<ContextChipProps> = (props) => {
         {iconFor(props.category)}
       </span>
       <span class="ctx-chip__label">{props.label}</span>
-      <button
-        type="button"
+      <IconButton
+        size="sm"
         class="ctx-chip__dismiss"
         data-testid="ctx-chip-dismiss"
-        aria-label={`Remove ${props.label}`}
+        label={`Remove ${props.label}`}
         onClick={() => props.onDismiss()}
-      >
-        ×
-      </button>
+        icon={'×'}
+      />
       <Show when={canPreview() && hovered()}>
         <div
           class="ctx-chip__preview"

--- a/web/packages/app/src/components/ContextPicker.tsx
+++ b/web/packages/app/src/components/ContextPicker.tsx
@@ -7,6 +7,7 @@ import {
   onMount,
   onCleanup,
 } from 'solid-js';
+import { Tab } from '@forge/design';
 import './ContextPicker.css';
 
 // ---------------------------------------------------------------------------
@@ -334,14 +335,9 @@ export const ContextPicker: Component<ContextPickerProps> = (props) => {
       >
         <For each={CATEGORIES}>
           {(cat, i) => (
-            <button
-              type="button"
-              class="context-picker__tab"
-              classList={{
-                'context-picker__tab--active': i() === activeCategoryIndex(),
-              }}
-              role="tab"
-              aria-selected={i() === activeCategoryIndex()}
+            <Tab
+              selected={i() === activeCategoryIndex()}
+              class={`context-picker__tab${i() === activeCategoryIndex() ? ' context-picker__tab--active' : ''}`}
               data-testid={`context-picker-tab-${cat.id}`}
               onMouseDown={(e) => {
                 // onMouseDown so focus stays in the textarea.
@@ -353,7 +349,7 @@ export const ContextPicker: Component<ContextPickerProps> = (props) => {
                 {cat.icon}
               </span>
               <span class="context-picker__tab-label">{cat.label}</span>
-            </button>
+            </Tab>
           )}
         </For>
       </div>

--- a/web/packages/app/src/components/SubAgentBanner.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.tsx
@@ -1,4 +1,5 @@
 import { type Component, createSignal, For, Show } from 'solid-js';
+import { Button } from '@forge/design';
 import type { ChatTurn, SubAgentStatus } from '../stores/messages';
 import { SubAgentDetailsPopover } from './SubAgentDetailsPopover';
 import './SubAgentBanner.css';
@@ -230,14 +231,15 @@ export const SubAgentBanner: Component<SubAgentBannerProps> = (props) => {
           <Show
             when={!beyondMaxDepth()}
             fallback={
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="sm"
                 class="sub-agent-banner__open-monitor"
                 data-testid={`sub-agent-banner-open-monitor-${props.turn.child_instance_id}`}
                 onClick={openInMonitor}
               >
                 OPEN MONITOR
-              </button>
+              </Button>
             }
           >
             <Show

--- a/web/packages/app/src/routes/AgentMonitor.tsx
+++ b/web/packages/app/src/routes/AgentMonitor.tsx
@@ -24,6 +24,7 @@ import {
 } from 'solid-js';
 import { createMountedSubscription } from '../ipc/useEventListener';
 import { useParams, useSearchParams } from '@solidjs/router';
+import { Button, IconButton, Tab } from '@forge/design';
 import { useFocusTrap } from '../lib/useFocusTrap';
 import type { BgAgentSummary } from '@forge/ipc';
 import {
@@ -428,18 +429,15 @@ export const AgentList: Component<{
       <div role="tablist" class="agent-monitor__filters">
         <For each={FILTERS}>
           {(f) => (
-            <button
-              type="button"
-              role="tab"
+            <Tab
               id={filterTabId(f)}
               aria-controls={rowsPanelId}
-              aria-selected={props.filter === f}
-              class="agent-monitor__filter"
-              classList={{ 'agent-monitor__filter--active': props.filter === f }}
+              selected={props.filter === f}
+              class={`agent-monitor__filter${props.filter === f ? ' agent-monitor__filter--active' : ''}`}
               onClick={() => props.onFilter(f)}
             >
               {f}
-            </button>
+            </Tab>
           )}
         </For>
       </div>
@@ -466,13 +464,14 @@ export const AgentList: Component<{
               <div class="agent-monitor__error-body" role="alert">
                 <p class="agent-monitor__error-title">AGENT LIST UNAVAILABLE</p>
                 <p class="agent-monitor__error-detail">{err.detail}</p>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="sm"
                   class="agent-monitor__retry"
                   onClick={() => err.onRetry()}
                 >
                   RETRY
-                </button>
+                </Button>
               </div>
             </div>
           );
@@ -721,13 +720,13 @@ export const AgentInspector: Component<{
           </ul>
         </section>
         <section>
-          <button
-            type="button"
+          <Button
+            variant="danger"
             class="agent-monitor__stop"
             onClick={() => props.onStop(props.agent!.id)}
           >
             STOP AGENT
-          </button>
+          </Button>
         </section>
       </Show>
     </aside>
@@ -769,14 +768,13 @@ export const StepDrawer: Component<{
       >
         <header class="agent-monitor__drawer-head">
           <h3>{p.step.title}</h3>
-          <button
-            type="button"
+          <IconButton
+            size="sm"
             class="agent-monitor__drawer-close"
-            aria-label="Close step detail"
+            label="Close step detail"
             onClick={props.onClose}
-          >
-            ×
-          </button>
+            icon={'×'}
+          />
         </header>
         <dl class="agent-monitor__def">
           <dt>kind</dt>

--- a/web/packages/app/src/routes/Dashboard/ProviderPanel.tsx
+++ b/web/packages/app/src/routes/Dashboard/ProviderPanel.tsx
@@ -1,4 +1,5 @@
 import { type Component, createResource, createSignal, For, Show } from 'solid-js';
+import { Button } from '@forge/design';
 import type { ProviderId } from '@forge/ipc';
 import { providerStatus, type ProviderStatus } from '../../ipc/dashboard';
 import { providerAccent } from '../Session/providerAccent';
@@ -30,9 +31,9 @@ export const ProviderPanel: Component = () => {
             <p class="provider-panel__error-title">PROVIDER UNAVAILABLE</p>
             <p class="provider-panel__error-detail">{String(status.error)}</p>
             <div class="provider-panel__actions">
-              <button type="button" class="provider-panel__btn" onClick={() => refetch()}>
+              <Button variant="ghost" size="sm" class="provider-panel__btn" onClick={() => refetch()}>
                 RETRY
-              </button>
+              </Button>
             </div>
           </div>
         }
@@ -57,9 +58,9 @@ export const ProviderPanel: Component = () => {
               </Show>
 
               <div class="provider-panel__actions">
-                <button type="button" class="provider-panel__btn" onClick={() => refetch()}>
+                <Button variant="ghost" size="sm" class="provider-panel__btn" onClick={() => refetch()}>
                   REFRESH
-                </button>
+                </Button>
               </div>
             </>
           )}
@@ -92,8 +93,9 @@ const ModelSection: Component<{
   onToggle: () => void;
 }> = (props) => (
   <div class="provider-panel__models">
-    <button
-      type="button"
+    <Button
+      variant="ghost"
+      size="sm"
       class="provider-panel__btn provider-panel__btn--ghost"
       aria-expanded={props.expanded}
       onClick={props.onToggle}
@@ -103,7 +105,7 @@ const ModelSection: Component<{
         {' '}
         — {props.models.length} {props.models.length === 1 ? 'model' : 'models'}
       </span>
-    </button>
+    </Button>
     <Show when={props.expanded}>
       <ul class="provider-panel__model-list">
         <For each={props.models}>

--- a/web/packages/app/src/routes/Dashboard/SessionsPanel.tsx
+++ b/web/packages/app/src/routes/Dashboard/SessionsPanel.tsx
@@ -5,6 +5,7 @@ import {
   type SessionWireState,
   type SessionSummary,
 } from '../../ipc/dashboard';
+import { Button, Tab } from '@forge/design';
 import { useRovingTabindex } from '../../lib/useRovingTabindex';
 import './SessionsPanel.css';
 
@@ -121,13 +122,14 @@ export const SessionsPanel: Component = () => {
             <div class="sessions__list-error-body" role="alert">
               <p class="sessions__list-error-title">SESSIONS UNAVAILABLE</p>
               <p class="sessions__list-error-detail">{detail()}</p>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="sm"
                 class="sessions__retry"
                 onClick={() => void refetch()}
               >
                 RETRY
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -173,19 +175,16 @@ interface TabButtonProps {
 const TabButton: Component<TabButtonProps> = (props) => {
   const selected = () => props.tab === props.current;
   return (
-    <button
-      type="button"
-      role="tab"
+    <Tab
       id={`sessions-tab-${props.tab}`}
       aria-controls={`sessions-panel-${props.tab}`}
-      class="sessions__tab"
-      classList={{ 'sessions__tab--active': selected() }}
-      aria-selected={selected()}
+      class={`sessions__tab${selected() ? ' sessions__tab--active' : ''}`}
+      selected={selected()}
       onClick={() => props.onSelect(props.tab)}
     >
       <span class="sessions__tab-label">{props.tab}</span>
       <span class="sessions__tab-count">{count(props.count)}</span>
-    </button>
+    </Tab>
   );
 };
 

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -6,6 +6,7 @@ import {
   Show,
   createMemo,
 } from 'solid-js';
+import { Button } from '@forge/design';
 import { activeSessionId, activeWorkspaceRoot } from '../../stores/session';
 import {
   getMessagesState,
@@ -1244,27 +1245,27 @@ export const Composer: Component<ComposerProps> = (props) => {
           {/* F-391: Stop flips to primary/ember while streaming (spec §4.1) and
               fires `onCancel` — same path as Esc. */}
           <Show when={props.disabled}>
-            <button
-              type="button"
+            <Button
+              variant="primary"
               class="composer__btn composer__btn--primary"
               data-testid="composer-stop-btn"
               onClick={() => props.onCancel?.()}
             >
               STOP TURN
-            </button>
+            </Button>
           </Show>
           {/* F-391: Send is a real primary/ember button, UPPERCASE per
               voice-terminology.md, disabled while streaming, and shares the
               bare-Enter code path via `handleSend`. */}
-          <button
-            type="button"
+          <Button
+            variant="primary"
             class="composer__btn composer__btn--primary"
             data-testid="composer-send-btn"
             disabled={props.disabled}
             onClick={handleSend}
           >
             SEND <span class="composer__btn-kbd">↵</span>
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/web/packages/app/src/routes/Session/PaneHeader.tsx
+++ b/web/packages/app/src/routes/Session/PaneHeader.tsx
@@ -1,5 +1,6 @@
 import type { Component, JSX } from 'solid-js';
 import { Show } from 'solid-js';
+import { Button } from '@forge/design';
 import type { ProviderId } from '@forge/ipc';
 import { providerAccent } from './providerAccent';
 import './PaneHeader.css';
@@ -167,14 +168,15 @@ export const PaneHeader: Component<PaneHeaderProps> = (props) => {
           {props.costLabel}
         </span>
       </Show>
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
         class="pane-header__close"
         aria-label={props.closeAriaLabel ?? 'Close session window'}
         onClick={props.onClose}
       >
         {props.closeLabel ?? 'CLOSE SESSION'}
-      </button>
+      </Button>
     </header>
   );
 };

--- a/web/packages/app/src/shell/ActivityBar.tsx
+++ b/web/packages/app/src/shell/ActivityBar.tsx
@@ -13,6 +13,7 @@
 
 import type { Component } from 'solid-js';
 import { For } from 'solid-js';
+import { IconButton } from '@forge/design';
 import './ActivityBar.css';
 
 export type ActivityId = 'files' | 'search' | 'git';
@@ -74,30 +75,29 @@ export const ActivityBar: Component<ActivityBarProps> = (props) => {
           const title = () =>
             item.shortcut ? `${item.label} (${item.shortcut})` : item.label;
           return (
-            <button
-              type="button"
-              class="activity-bar__item"
-              classList={{ 'activity-bar__item--active': isActive() }}
-              aria-label={item.label}
-              aria-pressed={isActive()}
+            <IconButton
+              class={`activity-bar__item${isActive() ? ' activity-bar__item--active' : ''}`}
+              label={item.label}
               title={title()}
+              pressed={isActive()}
               disabled={item.disabled}
               data-testid={`activity-bar-${item.id}`}
               onClick={() => props.onSelect(item.id)}
-            >
-              <svg
-                class="activity-bar__icon"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.7"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
-              >
-                <path d={item.svg} />
-              </svg>
-            </button>
+              icon={
+                <svg
+                  class="activity-bar__icon"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d={item.svg} />
+                </svg>
+              }
+            />
           );
         }}
       </For>

--- a/web/packages/app/src/shell/FilesSidebar.tsx
+++ b/web/packages/app/src/shell/FilesSidebar.tsx
@@ -28,6 +28,7 @@ import {
   onMount,
 } from 'solid-js';
 import { createStore } from 'solid-js/store';
+import { IconButton, MenuItem } from '@forge/design';
 import type { TreeNodeDto } from '@forge/ipc';
 import {
   tree as defaultTree,
@@ -216,21 +217,21 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
     >
       <header class="files-sidebar__header">
         <span class="files-sidebar__title">EXPLORER</span>
-        <button
-          type="button"
+        <IconButton
           class="files-sidebar__refresh"
-          aria-label="Refresh file tree"
+          label="Refresh file tree"
           title="Refresh"
           onClick={() => {
             void refresh();
           }}
-        >
-          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M4 4v5h5" />
-            <path d="M20 20v-5h-5" />
-            <path d="M5 9a9 9 0 0 1 14-3l1 3M19 15a9 9 0 0 1-14 3l-1-3" />
-          </svg>
-        </button>
+          icon={
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M4 4v5h5" />
+              <path d="M20 20v-5h-5" />
+              <path d="M5 9a9 9 0 0 1 14-3l1 3M19 15a9 9 0 0 1-14 3l-1-3" />
+            </svg>
+          }
+        />
       </header>
       <Show when={isLoading()}>
         <div class="files-sidebar__loading" role="status" data-testid="files-sidebar-loading">
@@ -276,39 +277,34 @@ export const FilesSidebar: Component<FilesSidebarProps> = (props) => {
             onClick={(e) => e.stopPropagation()}
           >
             <li role="none">
-              <button
-                type="button"
-                role="menuitem"
+              <MenuItem
                 data-testid="files-sidebar-menu-open"
                 disabled={target().isDir}
                 onClick={() => doOpen(target().path)}
               >
                 OPEN
-              </button>
+              </MenuItem>
             </li>
             <li role="none">
-              <button
-                type="button"
-                role="menuitem"
+              <MenuItem
                 data-testid="files-sidebar-menu-rename"
                 onClick={() => {
                   void doRename();
                 }}
               >
                 RENAME
-              </button>
+              </MenuItem>
             </li>
             <li role="none">
-              <button
-                type="button"
-                role="menuitem"
+              <MenuItem
+                variant="danger"
                 data-testid="files-sidebar-menu-delete"
                 onClick={() => {
                   void doDelete();
                 }}
               >
                 DELETE
-              </button>
+              </MenuItem>
             </li>
           </ul>
         )}

--- a/web/packages/app/src/shell/StatusBar.tsx
+++ b/web/packages/app/src/shell/StatusBar.tsx
@@ -26,6 +26,7 @@ import {
   onMount,
 } from 'solid-js';
 import { useNavigate } from '@solidjs/router';
+import { Button } from '@forge/design';
 import type { BgAgentSummary } from '@forge/ipc';
 import {
   isPermissionGranted as pluginIsPermissionGranted,
@@ -381,8 +382,9 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
                   {row.agent_name}
                 </span>
                 <span class="status-bar__bg-row-id">{row.id.slice(0, 8)}</span>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="sm"
                   class="status-bar__bg-row-action"
                   data-testid={`bg-agents-promote-${row.id}`}
                   onClick={() => {
@@ -390,9 +392,10 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
                   }}
                 >
                   PROMOTE AGENT
-                </button>
-                <button
-                  type="button"
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
                   class="status-bar__bg-row-action status-bar__bg-row-action--stop"
                   data-testid={`bg-agents-stop-${row.id}`}
                   onClick={() => {
@@ -400,7 +403,7 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
                   }}
                 >
                   STOP AGENT
-                </button>
+                </Button>
               </div>
             )}
           </For>

--- a/web/packages/app/src/styles/global.css
+++ b/web/packages/app/src/styles/global.css
@@ -1,4 +1,5 @@
 @import '@forge/design/tokens.css';
+@import '@forge/design/components.css';
 
 html,
 body {

--- a/web/packages/design/package.json
+++ b/web/packages/design/package.json
@@ -3,15 +3,34 @@
   "version": "0.2.0",
   "private": true,
   "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
-    "./tokens.css": "./src/tokens.css"
+    ".": "./src/index.ts",
+    "./tokens.css": "./src/tokens.css",
+    "./components.css": "./src/components/forge-button.css"
   },
   "files": [
-    "src/tokens.css"
+    "src/tokens.css",
+    "src/index.ts",
+    "src/components"
   ],
   "scripts": {
-    "build": "echo 'no build for @forge/design (static css)'",
-    "test": "echo 'no tests in @forge/design'",
-    "typecheck": "echo 'no typecheck for @forge/design'"
+    "build": "tsc --noEmit",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.9.3"
+  },
+  "devDependencies": {
+    "@solidjs/testing-library": "^0.8.10",
+    "@testing-library/jest-dom": "^6.6.3",
+    "jsdom": "^25.0.1",
+    "solid-js": "^1.9.3",
+    "typescript": "^5.6.3",
+    "vite": "^6.0.1",
+    "vite-plugin-solid": "^2.11.0",
+    "vitest": "^2.1.5"
   }
 }

--- a/web/packages/design/src/components/Button.test.tsx
+++ b/web/packages/design/src/components/Button.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@solidjs/testing-library';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('renders type="button" by default — never submits a parent form', () => {
+    const { getByRole } = render(() => <Button>Send</Button>);
+    expect(getByRole('button').getAttribute('type')).toBe('button');
+    cleanup();
+  });
+
+  it('applies the primary class by default', () => {
+    const { getByRole } = render(() => <Button>Send</Button>);
+    const btn = getByRole('button');
+    expect(btn.classList.contains('forge-button')).toBe(true);
+    expect(btn.classList.contains('forge-button--primary')).toBe(true);
+    expect(btn.classList.contains('forge-button--md')).toBe(true);
+    cleanup();
+  });
+
+  it.each(['primary', 'ghost', 'danger'] as const)(
+    'wires variant=%s to a class modifier',
+    (variant) => {
+      const { getByRole } = render(() => <Button variant={variant}>Go</Button>);
+      expect(getByRole('button').classList.contains(`forge-button--${variant}`)).toBe(true);
+      cleanup();
+    },
+  );
+
+  it('size=sm and md select the correct class modifier', () => {
+    const { getByRole, unmount } = render(() => <Button size="sm">A</Button>);
+    expect(getByRole('button').classList.contains('forge-button--sm')).toBe(true);
+    unmount();
+    const md = render(() => <Button size="md">A</Button>);
+    expect(md.getByRole('button').classList.contains('forge-button--md')).toBe(true);
+    md.unmount();
+  });
+
+  it('forwards onClick when not disabled', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(() => <Button onClick={onClick}>Send</Button>);
+    fireEvent.click(getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('disabled blocks click', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(() => (
+      <Button onClick={onClick} disabled>
+        Send
+      </Button>
+    ));
+    fireEvent.click(getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+    expect(getByRole('button').hasAttribute('disabled')).toBe(true);
+    cleanup();
+  });
+
+  it('loading implies disabled and sets aria-busy', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(() => (
+      <Button onClick={onClick} loading>
+        Send
+      </Button>
+    ));
+    const btn = getByRole('button');
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+    expect(btn.getAttribute('aria-busy')).toBe('true');
+    cleanup();
+  });
+
+  it('renders kbd hint when supplied', () => {
+    const { container } = render(() => <Button kbd="↵">Send</Button>);
+    const kbd = container.querySelector('kbd.forge-button__kbd');
+    expect(kbd?.textContent).toBe('↵');
+    cleanup();
+  });
+
+  it('forwards data-testid through ...rest', () => {
+    const { getByTestId } = render(() => (
+      <Button data-testid="composer-send-btn">Send</Button>
+    ));
+    expect(getByTestId('composer-send-btn')).toBeInstanceOf(HTMLButtonElement);
+    cleanup();
+  });
+
+  it('merges caller class with primitive class', () => {
+    const { getByRole } = render(() => <Button class="composer__btn">Send</Button>);
+    const btn = getByRole('button');
+    expect(btn.classList.contains('forge-button')).toBe(true);
+    expect(btn.classList.contains('composer__btn')).toBe(true);
+    cleanup();
+  });
+
+  it('focus-visible ring is reachable through keyboard focus', () => {
+    const { getByRole } = render(() => <Button>Send</Button>);
+    const btn = getByRole('button') as HTMLButtonElement;
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+    cleanup();
+  });
+});

--- a/web/packages/design/src/components/Button.tsx
+++ b/web/packages/design/src/components/Button.tsx
@@ -1,0 +1,85 @@
+import { type Component, type JSX, splitProps, Show } from 'solid-js';
+
+/** Visual variant. */
+export type ButtonVariant = 'primary' | 'ghost' | 'danger';
+
+/** Sizing token. */
+export type ButtonSize = 'sm' | 'md';
+
+export interface ButtonProps
+  extends Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
+  /** Visual treatment. Defaults to `'primary'`. */
+  variant?: ButtonVariant;
+  /** Padding/typography size. Defaults to `'md'`. */
+  size?: ButtonSize;
+  /** Icon rendered before the label. */
+  leadingIcon?: JSX.Element;
+  /** Icon rendered after the label. */
+  trailingIcon?: JSX.Element;
+  /** Loading state — also disables the click and sets `aria-busy`. */
+  loading?: boolean;
+  /** Right-aligned keyboard-shortcut hint (e.g. `↵`, `A`). */
+  kbd?: string;
+  /**
+   * Forwarded to the native `type` attribute. Defaults to `'button'` so a
+   * stray button inside a `<form>` never accidentally submits — this is the
+   * single most common foot-gun the primitive closes.
+   */
+  type?: 'button' | 'submit' | 'reset';
+}
+
+/**
+ * Forge Button primitive (F-450). Three variants — `primary`, `ghost`,
+ * `danger` — render with the four-part state machine documented in
+ * `docs/design/component-principles.md §Buttons`. Children supply the verb-
+ * noun display-caps label; pass `kbd` for a trailing keyboard hint.
+ */
+export const Button: Component<ButtonProps> = (props) => {
+  const [own, rest] = splitProps(props, [
+    'variant',
+    'size',
+    'leadingIcon',
+    'trailingIcon',
+    'loading',
+    'kbd',
+    'class',
+    'children',
+    'disabled',
+    'type',
+    'aria-busy',
+  ]);
+
+  const variant = (): ButtonVariant => own.variant ?? 'primary';
+  const size = (): ButtonSize => own.size ?? 'md';
+  const isDisabled = (): boolean => own.disabled === true || own.loading === true;
+  const className = (): string => {
+    const parts = ['forge-button', `forge-button--${variant()}`, `forge-button--${size()}`];
+    if (own.class) parts.push(own.class);
+    return parts.join(' ');
+  };
+
+  return (
+    <button
+      type={own.type ?? 'button'}
+      class={className()}
+      disabled={isDisabled()}
+      aria-busy={own.loading === true ? 'true' : own['aria-busy']}
+      {...rest}
+    >
+      <Show when={own.leadingIcon}>
+        <span class="forge-button__leading" aria-hidden="true">
+          {own.leadingIcon}
+        </span>
+      </Show>
+      {own.children}
+      <Show when={own.trailingIcon}>
+        <span class="forge-button__trailing" aria-hidden="true">
+          {own.trailingIcon}
+        </span>
+      </Show>
+      <Show when={own.kbd}>
+        <kbd class="forge-button__kbd">{own.kbd}</kbd>
+      </Show>
+    </button>
+  );
+};

--- a/web/packages/design/src/components/IconButton.test.tsx
+++ b/web/packages/design/src/components/IconButton.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@solidjs/testing-library';
+import { IconButton } from './IconButton';
+
+describe('IconButton', () => {
+  it('renders type="button" by default', () => {
+    const { getByRole } = render(() => <IconButton icon="×" label="Close" />);
+    expect(getByRole('button').getAttribute('type')).toBe('button');
+    cleanup();
+  });
+
+  it('label drives both aria-label and title', () => {
+    const { getByRole } = render(() => <IconButton icon="×" label="Close pane" />);
+    const btn = getByRole('button');
+    expect(btn.getAttribute('aria-label')).toBe('Close pane');
+    expect(btn.getAttribute('title')).toBe('Close pane');
+    cleanup();
+  });
+
+  it('applies the ghost variant class by default', () => {
+    const { getByRole } = render(() => <IconButton icon="×" label="X" />);
+    const btn = getByRole('button');
+    expect(btn.classList.contains('forge-icon-button')).toBe(true);
+    expect(btn.classList.contains('forge-icon-button--ghost')).toBe(true);
+    expect(btn.classList.contains('forge-icon-button--md')).toBe(true);
+    cleanup();
+  });
+
+  it('pressed wires aria-pressed', () => {
+    const { getByRole, unmount } = render(() => (
+      <IconButton icon="◐" label="Toggle" pressed={true} />
+    ));
+    expect(getByRole('button').getAttribute('aria-pressed')).toBe('true');
+    unmount();
+    const off = render(() => <IconButton icon="◐" label="Toggle" pressed={false} />);
+    expect(off.getByRole('button').getAttribute('aria-pressed')).toBe('false');
+    off.unmount();
+  });
+
+  it('omits aria-pressed when pressed is undefined', () => {
+    const { getByRole } = render(() => <IconButton icon="×" label="X" />);
+    expect(getByRole('button').hasAttribute('aria-pressed')).toBe(false);
+    cleanup();
+  });
+
+  it('forwards onClick', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(() => (
+      <IconButton icon="×" label="Close" onClick={onClick} />
+    ));
+    fireEvent.click(getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('disabled blocks click', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(() => (
+      <IconButton icon="×" label="Close" onClick={onClick} disabled />
+    ));
+    fireEvent.click(getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/web/packages/design/src/components/IconButton.tsx
+++ b/web/packages/design/src/components/IconButton.tsx
@@ -1,0 +1,78 @@
+import { type Component, type JSX, splitProps } from 'solid-js';
+import type { ButtonSize } from './Button';
+
+export type IconButtonVariant = 'ghost' | 'danger';
+
+export interface IconButtonProps
+  extends Omit<
+    JSX.ButtonHTMLAttributes<HTMLButtonElement>,
+    'aria-label' | 'children' | 'type' | 'title'
+  > {
+  /** The glyph (SVG, text, etc.) rendered inside the square trigger. */
+  icon: JSX.Element;
+  /**
+   * Required accessible name. Forwarded as `aria-label` and as the default
+   * `title` (override via the explicit `title` prop when the tooltip needs
+   * a richer string, e.g. label + keyboard shortcut).
+   */
+  label: string;
+  /**
+   * Optional tooltip override. When omitted, falls back to `label` so screen
+   * readers and tooltip surfaces stay in sync by default.
+   */
+  title?: string;
+  /** Visual treatment. Defaults to `'ghost'`. */
+  variant?: IconButtonVariant;
+  /** Sizing token. Defaults to `'md'`. */
+  size?: ButtonSize;
+  /** Toggle state. When supplied, renders as `aria-pressed`. */
+  pressed?: boolean;
+  /** Forwarded native `type`. Defaults to `'button'`. */
+  type?: 'button' | 'submit' | 'reset';
+}
+
+/**
+ * Forge IconButton primitive (F-450). Square icon-only trigger with a
+ * required accessible `label` — that requirement is the primary lint payoff
+ * the design migration captures, so an icon-only control without a name is
+ * a compile error rather than a runtime audit miss.
+ */
+export const IconButton: Component<IconButtonProps> = (props) => {
+  const [own, rest] = splitProps(props, [
+    'icon',
+    'label',
+    'title',
+    'variant',
+    'size',
+    'pressed',
+    'class',
+    'type',
+  ]);
+
+  const variant = (): IconButtonVariant => own.variant ?? 'ghost';
+  const size = (): ButtonSize => own.size ?? 'md';
+  const className = (): string => {
+    const parts = [
+      'forge-icon-button',
+      `forge-icon-button--${variant()}`,
+      `forge-icon-button--${size()}`,
+    ];
+    if (own.class) parts.push(own.class);
+    return parts.join(' ');
+  };
+
+  return (
+    <button
+      type={own.type ?? 'button'}
+      class={className()}
+      aria-label={own.label}
+      title={own.title ?? own.label}
+      aria-pressed={own.pressed === undefined ? undefined : own.pressed}
+      {...rest}
+    >
+      <span class="forge-icon-button__icon" aria-hidden="true">
+        {own.icon}
+      </span>
+    </button>
+  );
+};

--- a/web/packages/design/src/components/MenuItem.test.tsx
+++ b/web/packages/design/src/components/MenuItem.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@solidjs/testing-library';
+import { MenuItem } from './MenuItem';
+
+describe('MenuItem', () => {
+  it('renders role="menuitem"', () => {
+    const { getByRole } = render(() => <MenuItem>Open</MenuItem>);
+    expect(getByRole('menuitem')).toBeTruthy();
+    cleanup();
+  });
+
+  it('renders type="button" by default', () => {
+    const { getByRole } = render(() => <MenuItem>Open</MenuItem>);
+    expect(getByRole('menuitem').getAttribute('type')).toBe('button');
+    cleanup();
+  });
+
+  it('forwards onClick when not disabled', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(() => (
+      <MenuItem onClick={onClick}>Open</MenuItem>
+    ));
+    fireEvent.click(getByRole('menuitem'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('disabled blocks click and sets aria-disabled', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(() => (
+      <MenuItem onClick={onClick} disabled>
+        Open
+      </MenuItem>
+    ));
+    const item = getByRole('menuitem');
+    fireEvent.click(item);
+    expect(onClick).not.toHaveBeenCalled();
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+    cleanup();
+  });
+
+  it('renders kbd hint when supplied', () => {
+    const { container } = render(() => (
+      <MenuItem kbd="A">Approve once</MenuItem>
+    ));
+    expect(container.querySelector('kbd.forge-menu-item__kbd')?.textContent).toBe('A');
+    cleanup();
+  });
+
+  it('renders leadingText when supplied', () => {
+    const { container } = render(() => (
+      <MenuItem leadingText="src/foo.ts">Open file</MenuItem>
+    ));
+    expect(container.querySelector('.forge-menu-item__leading')?.textContent).toBe(
+      'src/foo.ts',
+    );
+    cleanup();
+  });
+
+  it('danger variant gets the danger modifier class', () => {
+    const { getByRole } = render(() => (
+      <MenuItem variant="danger">Delete</MenuItem>
+    ));
+    expect(
+      getByRole('menuitem').classList.contains('forge-menu-item--danger'),
+    ).toBe(true);
+    cleanup();
+  });
+});

--- a/web/packages/design/src/components/MenuItem.tsx
+++ b/web/packages/design/src/components/MenuItem.tsx
@@ -1,0 +1,57 @@
+import { type Component, type JSX, splitProps, Show } from 'solid-js';
+
+export type MenuItemVariant = 'default' | 'danger';
+
+export interface MenuItemProps
+  extends Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'role'> {
+  /** Optional left-rail hint (e.g. file path scope). */
+  leadingText?: string;
+  /** Right-aligned keyboard shortcut hint (e.g. `A`, `T`). */
+  kbd?: string;
+  /** Visual treatment. Defaults to `'default'`. */
+  variant?: MenuItemVariant;
+  /** Forwarded native `type`. Defaults to `'button'`. */
+  type?: 'button' | 'submit' | 'reset';
+}
+
+/**
+ * Forge MenuItem primitive (F-450). Row inside a `role="menu"` container —
+ * the parent owns the menu container, the primitive owns the row's
+ * `role="menuitem"` + label/leading-text/kbd layout. Disabled rows render
+ * `aria-disabled` so a focused-but-disabled row keeps its keyboard hit-box.
+ */
+export const MenuItem: Component<MenuItemProps> = (props) => {
+  const [own, rest] = splitProps(props, [
+    'leadingText',
+    'kbd',
+    'variant',
+    'class',
+    'children',
+    'type',
+    'disabled',
+  ]);
+  const variant = (): MenuItemVariant => own.variant ?? 'default';
+  const className = (): string => {
+    const parts = ['forge-menu-item', `forge-menu-item--${variant()}`];
+    if (own.class) parts.push(own.class);
+    return parts.join(' ');
+  };
+  return (
+    <button
+      type={own.type ?? 'button'}
+      class={className()}
+      role="menuitem"
+      disabled={own.disabled}
+      aria-disabled={own.disabled === true ? 'true' : undefined}
+      {...rest}
+    >
+      <Show when={own.leadingText}>
+        <span class="forge-menu-item__leading">{own.leadingText}</span>
+      </Show>
+      <span class="forge-menu-item__label">{own.children}</span>
+      <Show when={own.kbd}>
+        <kbd class="forge-menu-item__kbd">{own.kbd}</kbd>
+      </Show>
+    </button>
+  );
+};

--- a/web/packages/design/src/components/Tab.test.tsx
+++ b/web/packages/design/src/components/Tab.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@solidjs/testing-library';
+import { Tabs, Tab } from './Tab';
+
+describe('Tabs container', () => {
+  it('renders role="tablist" by default', () => {
+    const { container } = render(() => (
+      <Tabs>
+        <Tab selected={true}>One</Tab>
+        <Tab selected={false}>Two</Tab>
+      </Tabs>
+    ));
+    expect(container.querySelector('[role=tablist]')).toBeTruthy();
+    cleanup();
+  });
+
+  it('renders role="radiogroup" when variant="radio"', () => {
+    const { container } = render(() => (
+      <Tabs variant="radio">
+        <Tab variant="radio" selected={true}>
+          A
+        </Tab>
+      </Tabs>
+    ));
+    expect(container.querySelector('[role=radiogroup]')).toBeTruthy();
+    cleanup();
+  });
+});
+
+describe('Tab', () => {
+  it('renders role="tab" + aria-selected when variant=tab', () => {
+    const { getByRole } = render(() => <Tab selected={true}>One</Tab>);
+    const tab = getByRole('tab');
+    expect(tab.getAttribute('aria-selected')).toBe('true');
+    expect(tab.hasAttribute('aria-checked')).toBe(false);
+    cleanup();
+  });
+
+  it('renders role="radio" + aria-checked when variant=radio', () => {
+    const { getByRole } = render(() => (
+      <Tab variant="radio" selected={true}>
+        Pick
+      </Tab>
+    ));
+    const radio = getByRole('radio');
+    expect(radio.getAttribute('aria-checked')).toBe('true');
+    expect(radio.hasAttribute('aria-selected')).toBe(false);
+    cleanup();
+  });
+
+  it('selected tab is in the tab order; unselected gets tabindex=-1', () => {
+    const { getByText } = render(() => (
+      <Tabs>
+        <Tab selected={true}>One</Tab>
+        <Tab selected={false}>Two</Tab>
+      </Tabs>
+    ));
+    expect(getByText('One').getAttribute('tabindex')).toBe('0');
+    expect(getByText('Two').getAttribute('tabindex')).toBe('-1');
+    cleanup();
+  });
+
+  it('forwards onClick', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(() => (
+      <Tab selected={false} onClick={onClick}>
+        Hit
+      </Tab>
+    ));
+    fireEvent.click(getByRole('tab'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('renders type="button" so a parent form is never submitted', () => {
+    const { getByRole } = render(() => <Tab selected={true}>One</Tab>);
+    expect(getByRole('tab').getAttribute('type')).toBe('button');
+    cleanup();
+  });
+
+  it('renders badgeCount when supplied', () => {
+    const { container } = render(() => (
+      <Tab selected={true} badgeCount={3}>
+        Active
+      </Tab>
+    ));
+    expect(container.querySelector('.forge-tab__badge')?.textContent).toBe('3');
+    cleanup();
+  });
+});

--- a/web/packages/design/src/components/Tab.tsx
+++ b/web/packages/design/src/components/Tab.tsx
@@ -1,0 +1,90 @@
+import { type Component, type JSX, splitProps, Show } from 'solid-js';
+
+export type TabsVariant = 'tab' | 'radio';
+
+export interface TabsProps
+  extends Omit<JSX.HTMLAttributes<HTMLDivElement>, 'role' | 'onSelect'> {
+  /** Variant — `'tab'` renders `role="tablist"`; `'radio'` renders `role="radiogroup"`. Defaults to `'tab'`. */
+  variant?: TabsVariant;
+}
+
+/**
+ * Container for a row of `Tab` primitives. Apply `role="tablist"` (default)
+ * or `role="radiogroup"` (`variant="radio"`); the individual `Tab` children
+ * pick up the matching `role` automatically through their own `variant` prop.
+ *
+ * Roving-tabindex / arrow-key navigation is the parent feature's
+ * responsibility — this primitive owns DOM shape and ARIA role only, mirroring
+ * how the existing per-feature tablists are wired (e.g. `useRovingTabindex`
+ * in `app/lib/`).
+ */
+export const Tabs: Component<TabsProps> = (props) => {
+  const [own, rest] = splitProps(props, ['variant', 'class', 'children']);
+  const variant = (): TabsVariant => own.variant ?? 'tab';
+  const className = (): string => {
+    const parts = ['forge-tabs', `forge-tabs--${variant()}`];
+    if (own.class) parts.push(own.class);
+    return parts.join(' ');
+  };
+  return (
+    <div
+      class={className()}
+      role={variant() === 'radio' ? 'radiogroup' : 'tablist'}
+      {...rest}
+    >
+      {own.children}
+    </div>
+  );
+};
+
+export interface TabProps
+  extends Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'role' | 'aria-selected' | 'aria-checked'> {
+  /** Whether this tab is the currently-selected one. */
+  selected: boolean;
+  /** Variant — `'tab'` for `role="tab"` + `aria-selected`, `'radio'` for `role="radio"` + `aria-checked`. Defaults to `'tab'`. */
+  variant?: TabsVariant;
+  /** Optional badge count rendered after the label. */
+  badgeCount?: number;
+  /** Forwarded native `type`. Defaults to `'button'`. */
+  type?: 'button' | 'submit' | 'reset';
+}
+
+/**
+ * Forge Tab primitive (F-450). Renders `role="tab"` + `aria-selected`
+ * (default) or `role="radio"` + `aria-checked` when `variant="radio"`; the
+ * latter covers the approval-scope pill pattern that historically abused
+ * `role="radio"` on a raw `<button>`.
+ */
+export const Tab: Component<TabProps> = (props) => {
+  const [own, rest] = splitProps(props, [
+    'selected',
+    'variant',
+    'badgeCount',
+    'class',
+    'children',
+    'type',
+  ]);
+  const variant = (): TabsVariant => own.variant ?? 'tab';
+  const className = (): string => {
+    const parts = ['forge-tab', `forge-tab--${variant()}`];
+    if (own.selected) parts.push('forge-tab--selected');
+    if (own.class) parts.push(own.class);
+    return parts.join(' ');
+  };
+  return (
+    <button
+      type={own.type ?? 'button'}
+      class={className()}
+      role={variant() === 'radio' ? 'radio' : 'tab'}
+      aria-selected={variant() === 'tab' ? own.selected : undefined}
+      aria-checked={variant() === 'radio' ? own.selected : undefined}
+      tabIndex={own.selected ? 0 : -1}
+      {...rest}
+    >
+      {own.children}
+      <Show when={own.badgeCount !== undefined}>
+        <span class="forge-tab__badge">{own.badgeCount}</span>
+      </Show>
+    </button>
+  );
+};

--- a/web/packages/design/src/components/forge-button.css
+++ b/web/packages/design/src/components/forge-button.css
@@ -1,0 +1,322 @@
+/* ---------------------------------------------------------------------------
+ * @forge/design — button primitive baseline (F-450)
+ *
+ * Source-of-truth CSS for the four button archetypes shared by the app:
+ *
+ *   .forge-button        — primary / ghost / danger action button
+ *   .forge-icon-button   — icon-only square trigger
+ *   .forge-tab           — tab inside a tablist (or radio inside a radiogroup)
+ *   .forge-menu-item     — row inside a role="menu" container
+ *
+ * Spec: docs/design/component-principles.md §Buttons. All primitives are
+ * Barlow Condensed 700, uppercase, letter-spacing 0.1em; the active state
+ * always includes `transform: translateY(1px)`. Disabled buttons render with
+ * the iron-600 background — never opacity.
+ * ------------------------------------------------------------------------- */
+
+/* =============================================================================
+ * Button
+ * ============================================================================= */
+
+.forge-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--r-sm);
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  transition: var(--ease);
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-text-primary);
+}
+
+.forge-button:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}
+
+.forge-button:disabled,
+.forge-button[aria-disabled='true'] {
+  cursor: default;
+  background: var(--color-border-2);
+  border-color: var(--color-border-2);
+  color: var(--color-text-disabled);
+}
+
+.forge-button--sm {
+  padding: 0 var(--sp-2);
+  font-size: 10px;
+}
+
+.forge-button--md {
+  padding: var(--sp-1) var(--sp-3);
+  font-size: 11px;
+}
+
+/* Primary — the most important action; one per view. */
+.forge-button--primary {
+  background: var(--color-ember-400);
+  border-color: var(--color-ember-400);
+  color: var(--color-text-primary);
+}
+
+.forge-button--primary:hover:not(:disabled):not([aria-disabled='true']) {
+  background: var(--color-ember-300);
+  border-color: var(--color-ember-300);
+}
+
+.forge-button--primary:active:not(:disabled):not([aria-disabled='true']) {
+  background: var(--color-ember-500);
+  border-color: var(--color-ember-500);
+  transform: translateY(1px);
+}
+
+/* Ghost — neutral border. Cancel / skip / non-default secondary actions. */
+.forge-button--ghost {
+  background: transparent;
+  border-color: var(--color-border-2);
+  color: var(--color-text-secondary);
+}
+
+.forge-button--ghost:hover:not(:disabled):not([aria-disabled='true']) {
+  border-color: var(--color-text-secondary);
+  color: var(--color-text-primary);
+}
+
+.forge-button--ghost:active:not(:disabled):not([aria-disabled='true']) {
+  background: var(--color-surface-3);
+  transform: translateY(1px);
+}
+
+/* Danger — destructive primary. */
+.forge-button--danger {
+  background: transparent;
+  border-color: var(--color-error-border);
+  color: var(--color-error);
+}
+
+.forge-button--danger:hover:not(:disabled):not([aria-disabled='true']) {
+  background: var(--color-error-bg);
+  border-color: var(--color-error);
+}
+
+.forge-button--danger:active:not(:disabled):not([aria-disabled='true']) {
+  transform: translateY(1px);
+}
+
+/* Keyboard shortcut hint — shown at the trailing edge. */
+.forge-button__kbd {
+  display: inline-block;
+  padding: 0 var(--sp-1);
+  border: 1px solid currentColor;
+  border-radius: 2px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  opacity: 0.6;
+  line-height: 1.4;
+}
+
+/* =============================================================================
+ * IconButton
+ * ============================================================================= */
+
+.forge-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--sp-6);
+  height: var(--sp-6);
+  padding: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: var(--ease);
+  line-height: 1;
+}
+
+.forge-icon-button:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}
+
+.forge-icon-button:disabled,
+.forge-icon-button[aria-disabled='true'] {
+  cursor: default;
+  color: var(--color-text-disabled);
+}
+
+.forge-icon-button--sm {
+  width: var(--sp-5);
+  height: var(--sp-5);
+}
+
+.forge-icon-button--md {
+  width: var(--sp-6);
+  height: var(--sp-6);
+}
+
+.forge-icon-button--ghost:hover:not(:disabled):not([aria-disabled='true']) {
+  border-color: var(--color-border-2);
+  color: var(--color-text-primary);
+}
+
+.forge-icon-button--ghost:active:not(:disabled):not([aria-disabled='true']) {
+  background: var(--color-surface-3);
+  transform: translateY(1px);
+}
+
+.forge-icon-button--danger {
+  color: var(--color-error);
+}
+
+.forge-icon-button--danger:hover:not(:disabled):not([aria-disabled='true']) {
+  background: var(--color-error-bg);
+  border-color: var(--color-error);
+}
+
+.forge-icon-button--danger:active:not(:disabled):not([aria-disabled='true']) {
+  transform: translateY(1px);
+}
+
+.forge-icon-button[aria-pressed='true'] {
+  background: var(--color-surface-3);
+  color: var(--color-text-primary);
+}
+
+/* =============================================================================
+ * Tab
+ * ============================================================================= */
+
+.forge-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-3);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: var(--ease);
+}
+
+.forge-tab:hover:not(:disabled):not([aria-disabled='true']) {
+  color: var(--color-text-primary);
+}
+
+.forge-tab:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}
+
+.forge-tab:disabled,
+.forge-tab[aria-disabled='true'] {
+  cursor: default;
+  color: var(--color-text-disabled);
+}
+
+.forge-tab[aria-selected='true'],
+.forge-tab[aria-checked='true'] {
+  background: var(--color-surface-3);
+  border-color: var(--color-ember-400);
+  color: var(--color-ember-300);
+}
+
+.forge-tab__badge {
+  display: inline-block;
+  padding: 0 var(--sp-1);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--color-text-tertiary);
+}
+
+/* Tablist / radiogroup container — flex row by default. */
+.forge-tabs {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+/* =============================================================================
+ * MenuItem
+ * ============================================================================= */
+
+.forge-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  background: transparent;
+  border: none;
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 11px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  text-align: left;
+  transition: var(--ease);
+  line-height: 1;
+}
+
+.forge-menu-item:hover:not(:disabled):not([aria-disabled='true']) {
+  background: var(--color-surface-3);
+  color: var(--color-ember-300);
+}
+
+.forge-menu-item:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}
+
+.forge-menu-item:disabled,
+.forge-menu-item[aria-disabled='true'] {
+  cursor: default;
+  color: var(--color-text-disabled);
+}
+
+.forge-menu-item--danger {
+  color: var(--color-error);
+}
+
+.forge-menu-item--danger:hover:not(:disabled):not([aria-disabled='true']) {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.forge-menu-item__leading {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--color-text-tertiary);
+  margin-right: var(--sp-2);
+}
+
+.forge-menu-item__kbd {
+  display: inline-block;
+  padding: 0 var(--sp-1);
+  border: 1px solid currentColor;
+  border-radius: 2px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  opacity: 0.6;
+  line-height: 1.4;
+  margin-left: var(--sp-2);
+}

--- a/web/packages/design/src/components/index.ts
+++ b/web/packages/design/src/components/index.ts
@@ -1,0 +1,20 @@
+// @forge/design — button primitive surface (F-450).
+//
+// Re-exports the four primitives shared by the app and a single CSS file
+// (`./forge-button.css`) consumers must import once at the app shell so the
+// primitives' baseline styling is on the page.
+
+export { Button, type ButtonProps, type ButtonVariant, type ButtonSize } from './Button';
+export {
+  IconButton,
+  type IconButtonProps,
+  type IconButtonVariant,
+} from './IconButton';
+export {
+  Tab,
+  Tabs,
+  type TabProps,
+  type TabsProps,
+  type TabsVariant,
+} from './Tab';
+export { MenuItem, type MenuItemProps, type MenuItemVariant } from './MenuItem';

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -1,0 +1,11 @@
+// @forge/design — public surface.
+//
+// Two entry points:
+//   - `@forge/design`            — Solid component primitives (F-450).
+//   - `@forge/design/tokens.css` — design-token CSS file (single source of
+//                                   custom properties, mirrored from
+//                                   docs/design/token-reference.md).
+//   - `@forge/design/components.css` — primitive baseline CSS (imported once
+//                                       at the app shell next to tokens.css).
+
+export * from './components';

--- a/web/packages/design/tsconfig.json
+++ b/web/packages/design/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "types": ["vite/client", "vitest/globals"],
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/web/packages/design/vite.config.ts
+++ b/web/packages/design/vite.config.ts
@@ -1,0 +1,19 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+import solid from 'vite-plugin-solid';
+
+export default defineConfig({
+  plugins: [solid({ ssr: false })],
+  resolve: {
+    conditions: ['development', 'browser'],
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    server: {
+      deps: {
+        inline: [/solid-js/, /@solidjs\/testing-library/],
+      },
+    },
+  },
+});

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -68,7 +68,32 @@ importers:
         specifier: ^2.1.5
         version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
-  packages/design: {}
+  packages/design:
+    devDependencies:
+      '@solidjs/testing-library':
+        specifier: ^0.8.10
+        version: 0.8.10(@solidjs/router@0.15.4(solid-js@1.9.12))(solid-js@1.9.12)
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      solid-js:
+        specifier: ^1.9.3
+        version: 1.9.12
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.2
+        version: 6.4.2(@types/node@22.19.17)
+      vite-plugin-solid:
+        specifier: ^2.11.0
+        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@6.4.2(@types/node@22.19.17))
+      vitest:
+        specifier: ^2.1.5
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   packages/ipc:
     devDependencies:


### PR DESCRIPTION
## Summary

Lands the four button primitives in `@forge/design` and migrates 43 of the 47 raw `<button>` sites in `web/packages/app/src/` (4 row/card-as-button sites stay raw per the F-398 allowlist). Closes #526.

### Primitives

All four ship from `@forge/design` and forward unrecognized props to the underlying `<button>` via `splitProps`:

- **`Button`** — `variant: primary | ghost | danger`, `size: sm | md`, `leadingIcon`, `trailingIcon`, `loading` → `aria-busy`, `kbd` hint. Bakes in `type=\"button\"`.
- **`IconButton`** — required `label` (drives `aria-label` + `title`), `variant: ghost | danger`, `pressed` → `aria-pressed`, optional `title` override.
- **`Tab` + `Tabs`** — `variant: tab | radio` (radio covers the approval-scope `role=\"radio\"` pill pattern). `Tabs` renders `role=\"tablist\"` / `role=\"radiogroup\"`; `Tab` renders the matching child role + `aria-selected` / `aria-checked` and roving `tabindex={0|-1}`.
- **`MenuItem`** — `role=\"menuitem\"` baked in, `leadingText`, `kbd`, `variant: default | danger`, disabled → `aria-disabled`.

Baseline CSS lives at `@forge/design/components.css` and is imported alongside `tokens.css` in the app's `global.css`. Per-site CSS classes are forwarded so existing CSS-contract tests (focus-visible, active transform, F-084/F-085/F-090 typography token adherence) keep passing byte-for-byte.

### Migration sweep — 16 files, 43 sites

`ApprovalPrompt.tsx` (12 → 12 primitives — 3 Tabs/radio level toggle, 4 MenuItems for scope, 5 Buttons for reject/approve/dropdown/pattern-confirm/pattern-cancel), `WhitelistedPill.tsx` (2 → Button + MenuItem), `BranchMetadataPopover.tsx` (Delete + Export migrate; row-body stays raw via allowlist), `BranchSelectorStrip.tsx` (3 → IconButton), `ContextChip.tsx` (1 → IconButton), `ContextPicker.tsx` (1 → Tab), `SubAgentBanner.tsx` (1 → Button), `EditorPane.tsx` (1 → Button), `AgentMonitor.tsx` (filter Tab + retry/stop Buttons + drawer-close IconButton; agent row + step button stay raw via allowlist), `ProviderPanel.tsx` (3 → Button), `SessionsPanel.tsx` (retry → Button + tab → Tab; session card stays raw via allowlist), `ChatPane.tsx` (composer Stop + Send → Button), `PaneHeader.tsx` (close → Button), `ActivityBar.tsx` (1 → IconButton), `FilesSidebar.tsx` (refresh → IconButton + 3 MenuItems for context menu), `StatusBar.tsx` (PROMOTE/STOP inside the bg-row migrate; the badge row itself stays raw via allowlist).

### Allowlist (4 sites stay raw)

`StatusBar` bg-agents badge, `BranchMetadataPopover` row body, `AgentMonitor` agent row + trace step, `SessionsPanel` session card. Each is a content-shaped row/card the primitive can't model cleanly. The drafted `scripts/check-raw-buttons.mjs` lint stays disabled in this PR — PR 4 of the F-398 plan flips it on.

## Test plan

- [x] `pnpm --filter @forge/design test` — 35 new primitive tests pass
- [x] `pnpm --filter app test` — 887 existing app tests pass unchanged
- [x] `pnpm -r typecheck` — clean across all 4 workspace packages
- [x] `pnpm check-tokens` — clean
- [x] `pnpm --filter app build` — Vite build succeeds end-to-end
- [ ] Manual smoke through the dev shell to confirm visual parity at every migrated site

🤖 Generated with [Claude Code](https://claude.com/claude-code)