### PR TITLE
[F-326] Persistent smoke-UAT suite from contract-level UATs

### DIFF
--- a/docs/testing/phase0-uat.sh
+++ b/docs/testing/phase0-uat.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 # Phase 0 User Acceptance Test Harness
-# Usage: ./docs/testing/phase0-uat.sh [--build] [--test UAT-NN]
+# Usage: ./docs/testing/phase0-uat.sh [--build] [--test UAT-NN] [--contract-only] [--help]
 #
 # Flags:
-#   --build         Build forge + forged before running tests
-#   --test UAT-NN   Run only the specified test (e.g. --test UAT-01)
+#   --build           Build forge + forged before running tests
+#   --test UAT-NN     Run only the specified test (e.g. --test UAT-01)
+#   --contract-only   Run only the contract-level UATs as classified in
+#                     docs/testing/uat-conventions.md (consumed by
+#                     docs/testing/smoke-uat.sh — see F-326).
+#   --help, -h        Print this usage message and exit.
 #
 # Prerequisites: cargo, python3, socat (optional, for UAT-10)
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# ── Contract-level UAT manifest ─────────────────────────────────────────────
+# Sourced from docs/testing/uat-conventions.md (Phase 0 classification table).
+# Phase 0 is entirely contract-level — it pre-dates the GUI and tests CLI/IPC
+# primitives that everything else depends on.
+CONTRACT_LEVEL_UATS=(
+  UAT-01 UAT-02 UAT-03 UAT-04 UAT-05 UAT-06 UAT-07
+  UAT-08 UAT-09 UAT-10 UAT-11 UAT-12 UAT-13
+)
 
 # ── Colour helpers ──────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
@@ -23,19 +36,37 @@ header() { echo -e "\n${BOLD}$*${RESET}"; }
 
 PASS=0; FAIL=0; SKIP=0; FAILED_TESTS=()
 
+print_help() {
+  sed -n '2,12p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
 # ── Argument parsing ────────────────────────────────────────────────────────
 DO_BUILD=false
 ONLY_TEST=""
+CONTRACT_ONLY=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --build) DO_BUILD=true; shift ;;
     --test)  ONLY_TEST="$2"; shift 2 ;;
+    --contract-only) CONTRACT_ONLY=true; shift ;;
+    -h|--help) print_help; exit 0 ;;
     *) echo "Unknown flag: $1"; exit 1 ;;
   esac
 done
 
+is_contract_level() {
+  local id="$1"
+  for c in "${CONTRACT_LEVEL_UATS[@]}"; do
+    [[ "$c" == "$id" ]] && return 0
+  done
+  return 1
+}
+
 run_test() {
   local id="$1"
+  if $CONTRACT_ONLY && ! is_contract_level "$id"; then
+    return 1
+  fi
   [[ -z "$ONLY_TEST" || "$ONLY_TEST" == "$id" ]] && return 0
   return 1
 }

--- a/docs/testing/phase1-uat.sh
+++ b/docs/testing/phase1-uat.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Phase 1 User Acceptance Test Harness
-# Usage: ./docs/testing/phase1-uat.sh [--build] [--test UAT-NN] [--gui-only] [--cli-only]
+# Usage: ./docs/testing/phase1-uat.sh [--build] [--test UAT-NN] [--gui-only] [--cli-only] [--contract-only] [--help]
 #
 # Flags:
-#   --build         Build Rust workspace + web app before running tests
-#   --test UAT-NN   Run only the specified test (e.g. --test UAT-09)
-#   --gui-only      Run only Playwright specs (UAT-01..08, 11, 12)
-#   --cli-only      Run only bash-driven disk-state UATs (UAT-09, 10, 13)
+#   --build           Build Rust workspace + web app before running tests
+#   --test UAT-NN     Run only the specified test (e.g. --test UAT-09)
+#   --gui-only        Run only Playwright specs (UAT-01..08, 11, 12)
+#   --cli-only        Run only bash-driven disk-state UATs (UAT-09, 10, 13)
+#   --contract-only   Run only the contract-level UATs as classified in
+#                     docs/testing/uat-conventions.md (consumed by
+#                     docs/testing/smoke-uat.sh — see F-326).
+#   --help, -h        Print this usage message and exit.
 #
 # Prerequisites: cargo, python3, pnpm, @playwright/test installed.
 # See docs/testing/phase1-uat-setup.md for full setup.
@@ -14,6 +18,18 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# ── Contract-level UAT manifest ─────────────────────────────────────────────
+# Sourced from docs/testing/uat-conventions.md (Phase 1 classification table).
+# CLI subset (uat_NN bash functions): UAT-09, UAT-10, UAT-13.
+# GUI subset (Playwright specs):       UAT-01c, UAT-08, UAT-11, UAT-14 (CSP).
+CONTRACT_LEVEL_UATS=(
+  UAT-01c UAT-08 UAT-09 UAT-10 UAT-11 UAT-13 UAT-14
+)
+# Playwright filename stems for GUI contract-level UATs (matched as a regex
+# against the spec file basename — Playwright's positional arg is a substring
+# filter that accepts | alternation).
+CONTRACT_LEVEL_GUI_FILTER="uat-01c|uat-08|uat-11|uat-csp"
 
 # ── Colour helpers ──────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
@@ -26,23 +42,41 @@ header() { echo -e "\n${BOLD}$*${RESET}"; }
 
 PASS=0; FAIL=0; SKIP=0; FAILED_TESTS=()
 
+print_help() {
+  sed -n '2,16p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
 # ── Argument parsing ────────────────────────────────────────────────────────
 DO_BUILD=false
 ONLY_TEST=""
 GUI_ONLY=false
 CLI_ONLY=false
+CONTRACT_ONLY=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --build) DO_BUILD=true; shift ;;
     --test)  ONLY_TEST="$2"; shift 2 ;;
     --gui-only) GUI_ONLY=true; shift ;;
     --cli-only) CLI_ONLY=true; shift ;;
+    --contract-only) CONTRACT_ONLY=true; shift ;;
+    -h|--help) print_help; exit 0 ;;
     *) echo "Unknown flag: $1"; exit 1 ;;
   esac
 done
 
+is_contract_level() {
+  local id="$1"
+  for c in "${CONTRACT_LEVEL_UATS[@]}"; do
+    [[ "$c" == "$id" ]] && return 0
+  done
+  return 1
+}
+
 run_test() {
   local id="$1"
+  if $CONTRACT_ONLY && ! is_contract_level "$id"; then
+    return 1
+  fi
   [[ -z "$ONLY_TEST" || "$ONLY_TEST" == "$id" ]] && return 0
   return 1
 }
@@ -202,6 +236,8 @@ run_gui_suite() {
   if [[ -n "$ONLY_TEST" ]]; then
     local num="${ONLY_TEST#UAT-}"
     filter="uat-${num}"
+  elif $CONTRACT_ONLY; then
+    filter="$CONTRACT_LEVEL_GUI_FILTER"
   fi
   # `pnpm run test:e2e foo` forwards `foo` to Playwright as a file-name filter.
   # Playwright does NOT use the `--` separator the way npm does.
@@ -223,9 +259,9 @@ run_gui_suite() {
 
 # ── Main ────────────────────────────────────────────────────────────────────
 if ! $GUI_ONLY; then
-  if [[ -z "$ONLY_TEST" || "$ONLY_TEST" == "UAT-09" ]]; then uat_09; fi
-  if [[ -z "$ONLY_TEST" || "$ONLY_TEST" == "UAT-10" ]]; then uat_10; fi
-  if [[ -z "$ONLY_TEST" || "$ONLY_TEST" == "UAT-13" ]]; then uat_13; fi
+  if run_test UAT-09; then uat_09; fi
+  if run_test UAT-10; then uat_10; fi
+  if run_test UAT-13; then uat_13; fi
 fi
 
 if ! $CLI_ONLY; then

--- a/docs/testing/phase2-uat.sh
+++ b/docs/testing/phase2-uat.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Phase 2 User Acceptance Test Harness
-# Usage: ./docs/testing/phase2-uat.sh [--build] [--test UAT-NN] [--gui-only] [--cli-only]
+# Usage: ./docs/testing/phase2-uat.sh [--build] [--test UAT-NN] [--gui-only] [--cli-only] [--contract-only] [--help]
 #
 # Flags:
-#   --build         Build Rust workspace + web app + MCP mocks before running tests
-#   --test UAT-NN   Run only the specified test (e.g. --test UAT-04)
-#   --gui-only      Run only Playwright specs (UAT-01, 02, 03, 05, 06, 07, 08, 09, 11, 12-GUI)
-#   --cli-only      Run only bash-driven UATs (UAT-04, UAT-10, UAT-12-CLI portion)
+#   --build           Build Rust workspace + web app + MCP mocks before running tests
+#   --test UAT-NN     Run only the specified test (e.g. --test UAT-04)
+#   --gui-only        Run only Playwright specs (UAT-01, 02, 03, 05, 06, 07, 08, 09, 11, 12-GUI)
+#   --cli-only        Run only bash-driven UATs (UAT-04, UAT-10, UAT-12-CLI portion)
+#   --contract-only   Run only the contract-level UATs as classified in
+#                     docs/testing/uat-conventions.md (consumed by
+#                     docs/testing/smoke-uat.sh — see F-326).
+#   --help, -h        Print this usage message and exit.
 #
 # Prerequisites: cargo, python3, pnpm, @playwright/test installed.
 # See docs/testing/phase2-uat-setup.md for full setup.
@@ -14,6 +18,15 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# ── Contract-level UAT manifest ─────────────────────────────────────────────
+# Sourced from docs/testing/uat-conventions.md (Phase 2 classification table).
+# CLI subset (uat_NN bash functions): UAT-04, UAT-10.
+# GUI subset (Playwright specs):       UAT-05, UAT-12.
+CONTRACT_LEVEL_UATS=(
+  UAT-04 UAT-05 UAT-10 UAT-12
+)
+CONTRACT_LEVEL_GUI_FILTER="uat-05|uat-12"
 
 # ── Colour helpers ──────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
@@ -26,20 +39,44 @@ header() { echo -e "\n${BOLD}$*${RESET}"; }
 
 PASS=0; FAIL=0; SKIP=0; FAILED_TESTS=()
 
+print_help() {
+  sed -n '2,16p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
 # ── Argument parsing ────────────────────────────────────────────────────────
 DO_BUILD=false
 ONLY_TEST=""
 GUI_ONLY=false
 CLI_ONLY=false
+CONTRACT_ONLY=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --build) DO_BUILD=true; shift ;;
     --test)  ONLY_TEST="$2"; shift 2 ;;
     --gui-only) GUI_ONLY=true; shift ;;
     --cli-only) CLI_ONLY=true; shift ;;
+    --contract-only) CONTRACT_ONLY=true; shift ;;
+    -h|--help) print_help; exit 0 ;;
     *) echo "Unknown flag: $1"; exit 1 ;;
   esac
 done
+
+is_contract_level() {
+  local id="$1"
+  for c in "${CONTRACT_LEVEL_UATS[@]}"; do
+    [[ "$c" == "$id" ]] && return 0
+  done
+  return 1
+}
+
+run_test() {
+  local id="$1"
+  if $CONTRACT_ONLY && ! is_contract_level "$id"; then
+    return 1
+  fi
+  [[ -z "$ONLY_TEST" || "$ONLY_TEST" == "$id" ]] && return 0
+  return 1
+}
 
 # ── Build ───────────────────────────────────────────────────────────────────
 if $DO_BUILD; then
@@ -230,6 +267,8 @@ run_gui_suite() {
   if [[ -n "$ONLY_TEST" ]]; then
     local num="${ONLY_TEST#UAT-}"
     filter="uat-${num}"
+  elif $CONTRACT_ONLY; then
+    filter="$CONTRACT_LEVEL_GUI_FILTER"
   fi
   local pw_cmd="test:e2e:phase2"
   if [[ -n "$filter" ]]; then
@@ -249,8 +288,8 @@ run_gui_suite() {
 
 # ── Main ────────────────────────────────────────────────────────────────────
 if ! $GUI_ONLY; then
-  if [[ -z "$ONLY_TEST" || "$ONLY_TEST" == "UAT-04" ]]; then uat_04; fi
-  if [[ -z "$ONLY_TEST" || "$ONLY_TEST" == "UAT-10" ]]; then uat_10; fi
+  if run_test UAT-04; then uat_04; fi
+  if run_test UAT-10; then uat_10; fi
 fi
 
 if ! $CLI_ONLY; then

--- a/docs/testing/smoke-uat.sh
+++ b/docs/testing/smoke-uat.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Persistent Smoke-UAT Suite (F-326)
+# Usage: ./docs/testing/smoke-uat.sh [--build] [--phases 0,1,2] [--cli-only] [--gui-only] [--help]
+#
+# Aggregates the contract-level UATs from every existing phase harness into
+# a single regression sweep that is safe to run on every release-cut and
+# (eventually) every main-commit CI build. Each per-phase script remains the
+# canonical home of its scenarios; this runner only invokes them with the
+# `--contract-only` flag defined in docs/testing/uat-conventions.md.
+#
+# Flags:
+#   --build         Forwarded to each phase script (builds Rust + web + mocks).
+#   --phases LIST   Comma-separated subset of phases to run (default: 0,1,2).
+#                   Example: --phases 0,2  skips Phase 1.
+#   --cli-only      Forwarded to each phase script that supports it (1, 2).
+#   --gui-only      Forwarded to each phase script that supports it (1, 2).
+#                   Phase 0 is skipped under --gui-only since it has no GUI.
+#   --help, -h      Print this usage message and exit.
+#
+# Exit code: non-zero if any phase script fails or if invalid flags are given.
+#
+# Notes:
+#   --cli-only and --gui-only are mutually exclusive.
+#   Skipped scenarios (missing prerequisites, etc.) do NOT fail the suite.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TESTING_DIR="$REPO_ROOT/docs/testing"
+
+# ── Colour helpers ──────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BOLD='\033[1m'; CYAN='\033[0;36m'; RESET='\033[0m'
+
+print_help() {
+  sed -n '2,23p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+DO_BUILD=false
+PHASES_RAW="0,1,2"
+CLI_ONLY=false
+GUI_ONLY=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build) DO_BUILD=true; shift ;;
+    --phases) PHASES_RAW="$2"; shift 2 ;;
+    --cli-only) CLI_ONLY=true; shift ;;
+    --gui-only) GUI_ONLY=true; shift ;;
+    -h|--help) print_help; exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; print_help; exit 2 ;;
+  esac
+done
+
+if $CLI_ONLY && $GUI_ONLY; then
+  echo "ERROR: --cli-only and --gui-only are mutually exclusive" >&2
+  exit 2
+fi
+
+IFS=',' read -ra PHASES <<<"$PHASES_RAW"
+
+# ── Aggregate counters ──────────────────────────────────────────────────────
+TOTAL_PHASES=0
+PASSED_PHASES=0
+FAILED_PHASES=()
+
+# Per-phase pass/fail/skip counts are parsed from each script's "Results:"
+# (phase 0) or "Summary:" (phase 1/2) line.
+TOTAL_PASS=0
+TOTAL_FAIL=0
+TOTAL_SKIP=0
+
+# ── Per-phase invocation ────────────────────────────────────────────────────
+run_phase() {
+  local phase="$1"
+  local script="$TESTING_DIR/phase${phase}-uat.sh"
+
+  if [[ ! -x "$script" && ! -f "$script" ]]; then
+    echo -e "${YELLOW}SKIP${RESET} phase ${phase}: $script not found"
+    return 0
+  fi
+
+  # Phase 0 has no GUI — under --gui-only there is nothing to do.
+  if $GUI_ONLY && [[ "$phase" == "0" ]]; then
+    echo -e "${YELLOW}SKIP${RESET} phase 0 under --gui-only (no GUI surface)"
+    return 0
+  fi
+
+  local args=(--contract-only)
+  $DO_BUILD && args+=(--build)
+  # Phase 0 has no --cli-only / --gui-only flags; only forward to 1+.
+  if [[ "$phase" != "0" ]]; then
+    $CLI_ONLY && args+=(--cli-only)
+    $GUI_ONLY && args+=(--gui-only)
+  fi
+
+  echo
+  echo -e "${BOLD}${CYAN}═══ Phase ${phase} smoke (contract-only) ═══${RESET}"
+  echo -e "${CYAN}> bash $script ${args[*]}${RESET}"
+
+  local log
+  log="$(mktemp)"
+  local rc=0
+  bash "$script" "${args[@]}" 2>&1 | tee "$log"
+  rc="${PIPESTATUS[0]}"
+
+  TOTAL_PHASES=$((TOTAL_PHASES + 1))
+
+  # Best-effort parse of the per-phase summary line.
+  # Phase 0 prints:   "Results: N passed  M failed  K skipped  (T total)"
+  # Phase 1/2 print: "Summary: N passed, M failed, K skipped"
+  local summary
+  summary="$(grep -E 'Results:|Summary:' "$log" | tail -1 || true)"
+  if [[ -n "$summary" ]]; then
+    local p f s
+    p="$(echo "$summary" | grep -oE '[0-9]+ passed'   | grep -oE '[0-9]+' || echo 0)"
+    f="$(echo "$summary" | grep -oE '[0-9]+ failed'   | grep -oE '[0-9]+' || echo 0)"
+    s="$(echo "$summary" | grep -oE '[0-9]+ skipped'  | grep -oE '[0-9]+' || echo 0)"
+    TOTAL_PASS=$((TOTAL_PASS + p))
+    TOTAL_FAIL=$((TOTAL_FAIL + f))
+    TOTAL_SKIP=$((TOTAL_SKIP + s))
+  fi
+
+  rm -f "$log"
+
+  if [[ $rc -ne 0 ]]; then
+    FAILED_PHASES+=("phase${phase}")
+  else
+    PASSED_PHASES=$((PASSED_PHASES + 1))
+  fi
+  return 0  # never abort — aggregate every phase before final exit
+}
+
+for ph in "${PHASES[@]}"; do
+  case "$ph" in
+    0|1|2) run_phase "$ph" ;;
+    *) echo -e "${RED}ERROR${RESET}: unknown phase '$ph' — expected 0, 1, or 2" >&2; exit 2 ;;
+  esac
+done
+
+# ── Aggregate summary ───────────────────────────────────────────────────────
+echo
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+echo -e "${BOLD}Smoke-UAT aggregate${RESET}"
+echo -e "  Phases run:   ${TOTAL_PHASES}"
+echo -e "  Phases pass:  ${GREEN}${PASSED_PHASES}${RESET}"
+echo -e "  Phases fail:  ${RED}${#FAILED_PHASES[@]}${RESET}"
+echo -e "  Scenarios:    ${GREEN}${TOTAL_PASS} passed${RESET}  ${RED}${TOTAL_FAIL} failed${RESET}  ${YELLOW}${TOTAL_SKIP} skipped${RESET}"
+
+if [[ ${#FAILED_PHASES[@]} -gt 0 ]]; then
+  echo -e "${RED}Failed phases:${RESET}"
+  for ph in "${FAILED_PHASES[@]}"; do
+    echo "  - $ph"
+  done
+  echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+  exit 1
+fi
+
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+exit 0

--- a/docs/testing/uat-conventions.md
+++ b/docs/testing/uat-conventions.md
@@ -89,9 +89,9 @@ Rules:
 
 ## How the harness consumes the label
 
-> **Status:** documented here; not yet implemented. Implementation is part of F-326. Author UATs to this convention now so the harness has labels to extract once it lands.
+> **Status:** implemented in F-326. Each `docs/testing/phaseN-uat.sh` accepts `--contract-only`, and `docs/testing/smoke-uat.sh` aggregates them.
 
-The phase harness scripts (`docs/testing/phaseN-uat.sh`) gain a single new flag:
+The phase harness scripts (`docs/testing/phaseN-uat.sh`) accept a single flag:
 
 ```bash
 ./docs/testing/phase2-uat.sh --contract-only
@@ -103,6 +103,59 @@ Behaviour:
 - With `--contract-only`: filters to scenarios whose `**Type:**` line equals `contract-level`, regardless of phase.
 
 The persistent smoke-UAT runner (F-326) is conceptually `for each phaseN-uat.sh; phaseN-uat.sh --contract-only`. The runner does not duplicate scenarios into a separate file — the per-phase plan stays the canonical source. This avoids classification drift between two copies of the same scenario.
+
+Implementation note: the `**Type:**` line is the **specification** of which scenarios are contract-level. Each phase script encodes the same set as a `CONTRACT_LEVEL_UATS=(UAT-NN ...)` array near the top of the file; the array is the **executable** form of the same classification. When you change a label in the markdown, update the array in the matching phase script in the same PR. F-326's smoke runner relies on the two staying in sync.
+
+---
+
+## The persistent smoke-UAT suite (F-326)
+
+The persistent suite lives at `docs/testing/smoke-uat.sh`. It exists so that contract-level scenarios from older phases continue to be exercised on every release-cut and (eventually) every main-commit CI build, instead of going stale until someone re-runs the originating phase's full UAT.
+
+### How to run it
+
+```bash
+# Full sweep (Phases 0, 1, 2; bash + Playwright):
+./docs/testing/smoke-uat.sh --build
+
+# Without rebuilding (assumes binaries + web build already exist):
+./docs/testing/smoke-uat.sh
+
+# Only the bash-driven contract-level UATs (no Playwright):
+./docs/testing/smoke-uat.sh --cli-only
+
+# Only the Playwright-driven contract-level UATs (skips Phase 0):
+./docs/testing/smoke-uat.sh --gui-only
+
+# Subset of phases (e.g. skip Phase 1 until Ollama is wired):
+./docs/testing/smoke-uat.sh --phases 0,2
+```
+
+The runner forwards `--contract-only` to every selected `phaseN-uat.sh` and aggregates pass/fail/skip counts. It exits non-zero if any phase script exits non-zero.
+
+### What it covers
+
+The suite runs the union of all `contract-level` UATs across every existing phase plan. The current contents are sourced from the [migration tables](#migration-classifying-the-existing-phase-0--1--2-uats) above:
+
+- **Phase 0** — all 13 UATs (`UAT-01` .. `UAT-13`).
+- **Phase 1** — `UAT-01c`, `UAT-08`, `UAT-09`, `UAT-10`, `UAT-11`, `UAT-13`, `UAT-14`.
+- **Phase 2** — `UAT-04`, `UAT-05`, `UAT-10`, `UAT-12`.
+
+If you need the executable enumeration (e.g. for CI matrix logic), grep the `CONTRACT_LEVEL_UATS=` array in the matching `phaseN-uat.sh`.
+
+### When to run
+
+- Before every release-cut, in addition to the new milestone's full phase UAT.
+- Ideally on every `main` push in CI. (Wiring this into the GitHub Actions workflow is a follow-up — the suite is intentionally a single shell entry point so the CI step is one line.)
+
+### Adding new contract-level UATs
+
+When authoring a new milestone's UAT plan:
+
+1. Apply the `**Type:** contract-level` label per the [How to apply the label](#how-to-apply-the-label) section.
+2. Add the scenario's UAT-id to the matching `CONTRACT_LEVEL_UATS=(...)` array in the new `phaseN-uat.sh`. Include the scenario in `CONTRACT_LEVEL_GUI_FILTER` (a `|`-joined Playwright filename pattern) if it is a GUI scenario.
+3. The `smoke-uat.sh` runner will pick the scenario up automatically — no edits to the runner are required.
+4. The convention doc's [migration tables](#migration-classifying-the-existing-phase-0--1--2-uats) are a tentative starting point; the executable source of truth for any phase is its script's `CONTRACT_LEVEL_UATS` array.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `docs/testing/smoke-uat.sh` — a single entry point that aggregates the contract-level UATs from every existing phase harness into one regression sweep, intended for release-cuts and (eventually) every main-commit CI build.
- Adds `--contract-only` to each `phaseN-uat.sh`, backed by a `CONTRACT_LEVEL_UATS` array sourced from the classification tables in `docs/testing/uat-conventions.md`.
- Extends `uat-conventions.md` with a "persistent smoke-UAT suite" section covering invocation, coverage, when to run, and how to keep the per-phase arrays in sync with the markdown labels.

No existing UAT scenarios are modified, no Playwright specs are touched, and no production code paths are changed.

## Per-phase contract-level coverage (matches uat-conventions.md exactly)

| Phase | Contract-level UATs | CLI subset | GUI subset |
|-------|---------------------|------------|------------|
| 0 | UAT-01..13 (all) | UAT-01..13 | none |
| 1 | UAT-01c, 08, 09, 10, 11, 13, 14 | UAT-09, 10, 13 | UAT-01c, 08, 11, csp |
| 2 | UAT-04, 05, 10, 12 | UAT-04, 10 | UAT-05, 12 |

## smoke-uat.sh flag set

- `--build` — forward to each phase script (rebuild Rust + web + mocks).
- `--phases LIST` — comma-separated subset (default `0,1,2`).
- `--cli-only` / `--gui-only` — forwarded to phases that support it (Phase 0 has no GUI; it is skipped under `--gui-only`).
- `--help, -h`.
- `--cli-only` and `--gui-only` are mutually exclusive.

## Test plan

- [x] `bash docs/testing/smoke-uat.sh --help` runs without error.
- [x] `bash docs/testing/phase{0,1,2}-uat.sh --contract-only --help` each runs without error.
- [x] `bash docs/testing/smoke-uat.sh --cli-only` dry-run dispatches all three phase scripts with the expected `--contract-only [--cli-only]` flag combinations and aggregates exit codes (binaries absent, so each phase exits 1 — expected on a non-built tree; the dispatcher itself runs cleanly).
- [x] `node scripts/check-tokens.mjs` still passes (no app code changed).
- [ ] CI smoke-suite step (out of scope for this PR per the issue's "wiring CI" follow-up bullet — the suite is intentionally one shell entry point so the CI step is one line whenever it lands).

Closes #326

Generated with [Claude Code](https://claude.com/claude-code)