### PR TITLE
[F-583] forge-providers: AnthropicProvider with shared SSE adapter + tool use

### DIFF
--- a/crates/forge-providers/src/anthropic/mod.rs
+++ b/crates/forge-providers/src/anthropic/mod.rs
@@ -1,0 +1,236 @@
+//! Anthropic Messages API provider — SSE-streamed responses against
+//! `https://api.anthropic.com/v1/messages` (or any compatible base URL).
+//!
+//! Authentication uses the `x-api-key` header (NOT `Authorization: Bearer`)
+//! and pins the API version via `anthropic-version: 2023-06-01`.
+//!
+//! # Streaming bounds
+//!
+//! The HTTP-layer client and the SSE decoder share Ollama's hardening posture:
+//! per-line byte cap, inter-event idle timeout, and overall wall-clock budget.
+//! Any of these terminates the stream with a typed [`ChatChunk::Error`] —
+//! the SSE adapter ([`crate::sse`]) yields a typed [`crate::sse::SseError`]
+//! that this module maps onto [`StreamErrorKind`] one-for-one.
+
+use std::time::Duration;
+
+use crate::sse::{self, SseError, SseEvent};
+use crate::{ChatChunk, ChatRequest, Provider, StreamErrorKind};
+use bytes::Bytes;
+use forge_core::Result;
+use futures::stream::{BoxStream, StreamExt};
+
+pub mod translate;
+
+/// Anthropic Messages API version pinned by the `anthropic-version` header.
+pub const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+pub const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
+pub const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+
+/// HTTP-layer timeouts applied at `reqwest::ClientBuilder` construction.
+#[derive(Debug, Clone, Copy)]
+pub struct ClientConfig {
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+    pub tcp_keepalive: Duration,
+}
+
+impl ClientConfig {
+    pub const DEFAULT: ClientConfig = ClientConfig {
+        connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+        read_timeout: DEFAULT_READ_TIMEOUT,
+        tcp_keepalive: DEFAULT_TCP_KEEPALIVE,
+    };
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+fn build_stream_client(cfg: &ClientConfig) -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(cfg.connect_timeout)
+        .read_timeout(cfg.read_timeout)
+        .tcp_keepalive(Some(cfg.tcp_keepalive))
+        .build()
+        .expect("reqwest stream client builder — only fails if no TLS backend is available")
+}
+
+pub struct AnthropicProvider {
+    base_url: String,
+    api_key: String,
+    model: String,
+    max_tokens: u32,
+    stream_client: reqwest::Client,
+    stream_cfg: sse::StreamConfig,
+}
+
+impl AnthropicProvider {
+    pub fn new(
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        max_tokens: u32,
+    ) -> Self {
+        Self {
+            base_url: base_url.into(),
+            api_key: api_key.into(),
+            model: model.into(),
+            max_tokens,
+            stream_client: build_stream_client(&ClientConfig::DEFAULT),
+            stream_cfg: sse::StreamConfig::DEFAULT,
+        }
+    }
+
+    /// Override the SSE decoder bounds. Builder-style; primarily a test
+    /// affordance for fast idle-timeout / line-cap regression tests.
+    #[doc(hidden)]
+    pub fn with_config(mut self, stream_cfg: sse::StreamConfig) -> Self {
+        self.stream_cfg = stream_cfg;
+        self
+    }
+}
+
+impl Provider for AnthropicProvider {
+    fn chat(
+        &self,
+        req: ChatRequest,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+        let body_result = translate::serialize_request(
+            &req,
+            &self.model,
+            self.max_tokens,
+            req.parallel_tool_calls_allowed,
+        );
+        let client = self.stream_client.clone();
+        let cfg = self.stream_cfg;
+        let api_key = self.api_key.clone();
+
+        async move {
+            let body = body_result
+                .map_err(|e| anyhow::anyhow!("anthropic chat body serialization failed: {e}"))?;
+            let resp = client
+                .post(&url)
+                .header("x-api-key", api_key)
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(body)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("anthropic chat request failed: {e}"))?;
+
+            let status = resp.status();
+            if !status.is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!(
+                    "anthropic chat HTTP {status}: {}",
+                    truncate(&body, 500)
+                )
+                .into());
+            }
+
+            Ok(decode_anthropic_stream(resp.bytes_stream(), cfg))
+        }
+    }
+}
+
+/// Decode the raw `bytes` stream into a `ChatChunk` stream by piping through
+/// the shared SSE adapter and translating each event payload via
+/// [`translate::AnthropicEventAccumulator`].
+fn decode_anthropic_stream<S, E>(
+    byte_stream: S,
+    cfg: sse::StreamConfig,
+) -> BoxStream<'static, ChatChunk>
+where
+    S: futures::Stream<Item = std::result::Result<Bytes, E>> + Send + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let sse_stream = sse::decode_sse_stream(byte_stream, cfg);
+    parse_anthropic_events(sse_stream)
+}
+
+/// Translate a stream of `Result<SseEvent, SseError>` into `ChatChunk`s. Public
+/// for the integration-test harness so it can drive the parser from a static
+/// fixture without an HTTP roundtrip.
+#[doc(hidden)]
+pub fn parse_anthropic_events<S>(events: S) -> BoxStream<'static, ChatChunk>
+where
+    S: futures::Stream<Item = std::result::Result<SseEvent, SseError>> + Send + 'static,
+{
+    let mut acc = translate::AnthropicEventAccumulator::default();
+    let stream = events.flat_map(move |item| {
+        let chunks = match item {
+            Ok(ev) => acc.consume(&ev),
+            Err(e) => vec![ChatChunk::Error {
+                kind: map_sse_error(&e),
+                message: e.to_string(),
+            }],
+        };
+        futures::stream::iter(chunks)
+    });
+    Box::pin(stream.fuse())
+}
+
+fn map_sse_error(e: &SseError) -> StreamErrorKind {
+    match e {
+        SseError::LineTooLong => StreamErrorKind::LineTooLong,
+        SseError::IdleTimeout => StreamErrorKind::IdleTimeout,
+        SseError::WallClockTimeout => StreamErrorKind::WallClockTimeout,
+        SseError::Transport(_) => StreamErrorKind::Transport,
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_stores_config() {
+        let p = AnthropicProvider::new("https://example.com", "sk-test", "claude-3-5-sonnet", 4096);
+        assert_eq!(p.base_url, "https://example.com");
+        assert_eq!(p.api_key, "sk-test");
+        assert_eq!(p.model, "claude-3-5-sonnet");
+        assert_eq!(p.max_tokens, 4096);
+    }
+
+    #[test]
+    fn anthropic_version_pinned() {
+        assert_eq!(ANTHROPIC_VERSION, "2023-06-01");
+    }
+
+    #[test]
+    fn map_sse_error_covers_all_variants() {
+        assert_eq!(
+            map_sse_error(&SseError::LineTooLong),
+            StreamErrorKind::LineTooLong
+        );
+        assert_eq!(
+            map_sse_error(&SseError::IdleTimeout),
+            StreamErrorKind::IdleTimeout
+        );
+        assert_eq!(
+            map_sse_error(&SseError::WallClockTimeout),
+            StreamErrorKind::WallClockTimeout
+        );
+        assert_eq!(
+            map_sse_error(&SseError::Transport("x".into())),
+            StreamErrorKind::Transport
+        );
+    }
+}

--- a/crates/forge-providers/src/anthropic/mod.rs
+++ b/crates/forge-providers/src/anthropic/mod.rs
@@ -192,7 +192,14 @@ fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}…", &s[..max])
+        // Walk char boundaries so we never split a multi-byte codepoint.
+        let cut = s
+            .char_indices()
+            .take_while(|(i, _)| *i < max)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+        format!("{}…", &s[..cut])
     }
 }
 
@@ -212,6 +219,19 @@ mod tests {
     #[test]
     fn anthropic_version_pinned() {
         assert_eq!(ANTHROPIC_VERSION, "2023-06-01");
+    }
+
+    #[test]
+    fn truncate_does_not_panic_on_utf8_boundary() {
+        // 'é' is two UTF-8 bytes; byte index 2 falls inside the codepoint, so a
+        // naive `&s[..2]` slice panics. Should produce a valid prefix.
+        let s = "héllo";
+        let _ = truncate(s, 2);
+    }
+
+    #[test]
+    fn truncate_short_input_returns_as_is() {
+        assert_eq!(truncate("hi", 100), "hi");
     }
 
     #[test]

--- a/crates/forge-providers/src/anthropic/translate.rs
+++ b/crates/forge-providers/src/anthropic/translate.rs
@@ -1,0 +1,661 @@
+//! Anthropic Messages API translation: `ChatRequest` → request body JSON, and
+//! SSE event payloads → [`ChatChunk`]s.
+//!
+//! ## Wire format produced
+//!
+//! ```json
+//! {
+//!   "model": "<model>",
+//!   "max_tokens": <max_tokens>,
+//!   "system": "<sys>",                  // omitted entirely when None
+//!   "messages": [ ... ],
+//!   "tools": [],
+//!   "tool_choice": {"type": "auto", "disable_parallel_tool_use": true},
+//!   "stream": true
+//! }
+//! ```
+//!
+//! Notable shape decisions:
+//!
+//! - The Anthropic API does NOT accept a top-level `system` role inside
+//!   `messages`; `system` is a sibling field on the request body.
+//! - `tool_choice.disable_parallel_tool_use` is the inverse of the
+//!   [`ChatRequest::parallel_tool_calls_allowed`] flag: when the flag is
+//!   `false` (its default until F-599), the request asks Anthropic to
+//!   disable parallel tool use.
+//! - `tools` is emitted as an empty array — F-583 only plumbs tool **calls**
+//!   and **tool results** within messages; tool-schema definitions are
+//!   out of scope and will be added by a later task.
+//! - Multiple `text` blocks in one assistant message are preserved in order.
+//!
+//! ## SSE event consumption
+//!
+//! [`AnthropicEventAccumulator`] consumes Anthropic's named SSE events
+//! (`content_block_start`, `content_block_delta`, `content_block_stop`,
+//! `message_delta`, `message_stop`) and emits [`ChatChunk`]s:
+//!
+//! - `content_block_delta` with `delta.type == "text_delta"` →
+//!   [`ChatChunk::TextDelta`].
+//! - `tool_use` blocks: track the active block by its `index`; accumulate
+//!   `partial_json` from `input_json_delta` events; on `content_block_stop`
+//!   parse the accumulated string and emit [`ChatChunk::ToolCall`].
+//! - `message_delta` carries the upcoming `stop_reason`; remember it.
+//! - `message_stop` → [`ChatChunk::Done(stop_reason)`], defaulting to
+//!   `"end_turn"` if the prior `message_delta` did not carry one.
+
+use crate::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+/// Serialize a [`ChatRequest`] into an Anthropic Messages API request body.
+///
+/// `parallel_tool_calls_allowed` controls the `tool_choice.disable_parallel_tool_use`
+/// flag: when `false`, parallel tool use is disabled (the F-583 default until
+/// F-599 lands).
+pub fn serialize_request(
+    req: &ChatRequest,
+    model: &str,
+    max_tokens: u32,
+    parallel_tool_calls_allowed: bool,
+) -> std::result::Result<Vec<u8>, serde_json::Error> {
+    let body = AnthropicBody {
+        model,
+        max_tokens,
+        system: req.system.as_deref(),
+        messages: AnthropicMessages {
+            messages: &req.messages,
+        },
+        tools: &[],
+        tool_choice: ToolChoice {
+            kind: "auto",
+            disable_parallel_tool_use: !parallel_tool_calls_allowed,
+        },
+        stream: true,
+    };
+    serde_json::to_vec(&body)
+}
+
+#[derive(Serialize)]
+struct AnthropicBody<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<&'a str>,
+    messages: AnthropicMessages<'a>,
+    tools: &'a [Value],
+    tool_choice: ToolChoice<'a>,
+    stream: bool,
+}
+
+#[derive(Serialize)]
+struct ToolChoice<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    disable_parallel_tool_use: bool,
+}
+
+struct AnthropicMessages<'a> {
+    messages: &'a [ChatMessage],
+}
+
+impl<'a> Serialize for AnthropicMessages<'a> {
+    fn serialize<S>(&self, s: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+
+        // Worst-case sequence size: one Anthropic message per ChatMessage,
+        // BUT a single ChatMessage that mixes text/tool_call blocks with
+        // tool_result blocks must be split (tool_results live inside a
+        // user-role message, distinct from any other role). Over-counting
+        // is harmless when the serializer ignores the size hint.
+        let cap = self.messages.iter().map(|m| m.content.len() + 1).sum();
+        let mut seq = s.serialize_seq(Some(cap))?;
+
+        for msg in self.messages {
+            // Anthropic's content shape allows interleaved text + tool_use
+            // blocks within one assistant message, but tool_result blocks
+            // are user-role only. Emit (a) all tool_results as their own
+            // user message, then (b) any remaining text/tool_use as the
+            // original-role message — preserving block order within each.
+            let mut tool_results: Vec<&ChatBlock> = Vec::new();
+            let mut other_blocks: Vec<&ChatBlock> = Vec::new();
+            for block in &msg.content {
+                match block {
+                    ChatBlock::ToolResult { .. } => tool_results.push(block),
+                    _ => other_blocks.push(block),
+                }
+            }
+
+            if !tool_results.is_empty() {
+                seq.serialize_element(&AnthropicToolResultMessage {
+                    blocks: &tool_results,
+                })?;
+            }
+            if !other_blocks.is_empty() {
+                seq.serialize_element(&AnthropicTextMessage {
+                    role: anthropic_role(&msg.role),
+                    blocks: &other_blocks,
+                })?;
+            }
+        }
+        seq.end()
+    }
+}
+
+fn anthropic_role(role: &ChatRole) -> &'static str {
+    match role {
+        ChatRole::User => "user",
+        ChatRole::Assistant => "assistant",
+    }
+}
+
+struct AnthropicTextMessage<'a> {
+    role: &'a str,
+    blocks: &'a [&'a ChatBlock],
+}
+
+impl<'a> Serialize for AnthropicTextMessage<'a> {
+    fn serialize<S>(&self, s: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::{SerializeMap, SerializeSeq};
+        let mut m = s.serialize_map(Some(2))?;
+        m.serialize_entry("role", self.role)?;
+
+        struct Blocks<'a> {
+            blocks: &'a [&'a ChatBlock],
+        }
+        impl<'a> Serialize for Blocks<'a> {
+            fn serialize<S>(&self, s: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let mut seq = s.serialize_seq(Some(self.blocks.len()))?;
+                for block in self.blocks {
+                    match block {
+                        ChatBlock::Text(t) => {
+                            seq.serialize_element(&json!({"type": "text", "text": t}))?;
+                        }
+                        ChatBlock::ToolCall { id, name, args } => {
+                            seq.serialize_element(&json!({
+                                "type": "tool_use",
+                                "id": id,
+                                "name": name,
+                                "input": args,
+                            }))?;
+                        }
+                        ChatBlock::ToolResult { .. } => {
+                            // Filtered upstream; defensive no-op.
+                        }
+                    }
+                }
+                seq.end()
+            }
+        }
+        m.serialize_entry(
+            "content",
+            &Blocks {
+                blocks: self.blocks,
+            },
+        )?;
+        m.end()
+    }
+}
+
+struct AnthropicToolResultMessage<'a> {
+    blocks: &'a [&'a ChatBlock],
+}
+
+impl<'a> Serialize for AnthropicToolResultMessage<'a> {
+    fn serialize<S>(&self, s: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::{SerializeMap, SerializeSeq};
+        let mut m = s.serialize_map(Some(2))?;
+        m.serialize_entry("role", "user")?;
+
+        struct Blocks<'a> {
+            blocks: &'a [&'a ChatBlock],
+        }
+        impl<'a> Serialize for Blocks<'a> {
+            fn serialize<S>(&self, s: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let mut seq = s.serialize_seq(Some(self.blocks.len()))?;
+                for block in self.blocks {
+                    if let ChatBlock::ToolResult { id, result } = block {
+                        // Anthropic's `tool_result.content` is a string
+                        // (or a list of content blocks). Render the JSON
+                        // result to a string so structured payloads
+                        // round-trip without the model having to rely on
+                        // a nested-object content shape.
+                        let payload =
+                            serde_json::to_string(result).map_err(serde::ser::Error::custom)?;
+                        seq.serialize_element(&json!({
+                            "type": "tool_result",
+                            "tool_use_id": id,
+                            "content": payload,
+                        }))?;
+                    }
+                }
+                seq.end()
+            }
+        }
+        m.serialize_entry(
+            "content",
+            &Blocks {
+                blocks: self.blocks,
+            },
+        )?;
+        m.end()
+    }
+}
+
+// ─── SSE event accumulator ────────────────────────────────────────────────────
+
+/// Accumulator state that consumes Anthropic SSE event payloads in order and
+/// emits one or more [`ChatChunk`]s per event.
+///
+/// Anthropic streams interleave a `content_block_start` / N×
+/// `content_block_delta` / `content_block_stop` triple per content block,
+/// and the block's `index` is the only field that ties deltas back to their
+/// starting block. The accumulator tracks the active tool-use block by its
+/// index; when the matching `content_block_stop` arrives it parses the
+/// accumulated `partial_json` chunks into a structured `args` value and
+/// emits the [`ChatChunk::ToolCall`].
+///
+/// TODO(post-F-583): [`ChatChunk::ToolCall`] does not currently carry the
+/// Anthropic-assigned `id` (`toolu_…`). Once the round-trip back to Anthropic
+/// requires the id (so the assistant message can reference it as
+/// `tool_use_id` on the follow-up `tool_result`), extend `ChatChunk::ToolCall`
+/// with an `id` field and surface it here.
+#[derive(Default)]
+pub struct AnthropicEventAccumulator {
+    /// Block index → in-progress tool_use block.
+    active_tool_use: Option<ToolUseInProgress>,
+    /// Stop reason captured from a prior `message_delta`. Read on
+    /// `message_stop` and defaulted to `"end_turn"` if absent.
+    pending_stop_reason: Option<String>,
+}
+
+struct ToolUseInProgress {
+    index: u64,
+    name: String,
+    /// Accumulated `partial_json` strings from `input_json_delta` events.
+    args_buf: String,
+}
+
+impl AnthropicEventAccumulator {
+    /// Consume one SSE event and return any `ChatChunk`s it produces.
+    pub fn consume(&mut self, event: &crate::sse::SseEvent) -> Vec<ChatChunk> {
+        match event.event.as_str() {
+            "content_block_start" => self.handle_content_block_start(&event.data),
+            "content_block_delta" => self.handle_content_block_delta(&event.data),
+            "content_block_stop" => self.handle_content_block_stop(&event.data),
+            "message_delta" => self.handle_message_delta(&event.data),
+            "message_stop" => self.handle_message_stop(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn handle_content_block_start(&mut self, data: &[u8]) -> Vec<ChatChunk> {
+        let Ok(v) = serde_json::from_slice::<Value>(data) else {
+            return Vec::new();
+        };
+        let index = v.get("index").and_then(|i| i.as_u64()).unwrap_or(0);
+        let block = match v.get("content_block") {
+            Some(b) => b,
+            None => return Vec::new(),
+        };
+        let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if block_type == "tool_use" {
+            let name = block
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("")
+                .to_string();
+            self.active_tool_use = Some(ToolUseInProgress {
+                index,
+                name,
+                args_buf: String::new(),
+            });
+        }
+        Vec::new()
+    }
+
+    fn handle_content_block_delta(&mut self, data: &[u8]) -> Vec<ChatChunk> {
+        let Ok(v) = serde_json::from_slice::<Value>(data) else {
+            return Vec::new();
+        };
+        let index = v.get("index").and_then(|i| i.as_u64()).unwrap_or(0);
+        let delta = match v.get("delta") {
+            Some(d) => d,
+            None => return Vec::new(),
+        };
+        let delta_type = delta.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        match delta_type {
+            "text_delta" => {
+                let text = delta
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if text.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![ChatChunk::TextDelta(text)]
+                }
+            }
+            "input_json_delta" => {
+                if let Some(active) = self.active_tool_use.as_mut() {
+                    if active.index == index {
+                        if let Some(partial) = delta.get("partial_json").and_then(|p| p.as_str()) {
+                            active.args_buf.push_str(partial);
+                        }
+                    }
+                }
+                Vec::new()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn handle_content_block_stop(&mut self, data: &[u8]) -> Vec<ChatChunk> {
+        let Ok(v) = serde_json::from_slice::<Value>(data) else {
+            return Vec::new();
+        };
+        let index = v.get("index").and_then(|i| i.as_u64()).unwrap_or(0);
+        if let Some(active) = self.active_tool_use.as_ref() {
+            if active.index == index {
+                let active = self.active_tool_use.take().expect("checked above");
+                let args: Value = if active.args_buf.is_empty() {
+                    json!({})
+                } else {
+                    serde_json::from_str(&active.args_buf).unwrap_or(json!({}))
+                };
+                return vec![ChatChunk::ToolCall {
+                    name: active.name,
+                    args,
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn handle_message_delta(&mut self, data: &[u8]) -> Vec<ChatChunk> {
+        let Ok(v) = serde_json::from_slice::<Value>(data) else {
+            return Vec::new();
+        };
+        if let Some(reason) = v
+            .get("delta")
+            .and_then(|d| d.get("stop_reason"))
+            .and_then(|r| r.as_str())
+        {
+            self.pending_stop_reason = Some(reason.to_string());
+        }
+        Vec::new()
+    }
+
+    fn handle_message_stop(&mut self) -> Vec<ChatChunk> {
+        let reason = self
+            .pending_stop_reason
+            .take()
+            .unwrap_or_else(|| "end_turn".to_string());
+        vec![ChatChunk::Done(reason)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sse::SseEvent;
+    use bytes::Bytes;
+    use std::sync::Arc;
+
+    fn parse(req: &ChatRequest, model: &str, max_tokens: u32, parallel: bool) -> Value {
+        let bytes = serialize_request(req, model, max_tokens, parallel).expect("serialize");
+        serde_json::from_slice(&bytes).expect("re-parse")
+    }
+
+    fn user_text(text: &str) -> ChatMessage {
+        ChatMessage {
+            role: ChatRole::User,
+            content: vec![ChatBlock::Text(text.into())],
+        }
+    }
+
+    #[test]
+    fn serialize_simple_user_message_no_system() {
+        let req = ChatRequest {
+            system: None,
+            messages: vec![user_text("hi")],
+            parallel_tool_calls_allowed: false,
+        };
+        let v = parse(&req, "claude-3-5-sonnet", 4096, false);
+        assert_eq!(
+            v,
+            json!({
+                "model": "claude-3-5-sonnet",
+                "max_tokens": 4096,
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+                ],
+                "tools": [],
+                "tool_choice": {"type": "auto", "disable_parallel_tool_use": true},
+                "stream": true
+            })
+        );
+        assert!(
+            v.get("system").is_none(),
+            "system key must be absent when None"
+        );
+    }
+
+    #[test]
+    fn serialize_with_system_hoists_to_top_level() {
+        let req = ChatRequest {
+            system: Some(Arc::from("be helpful")),
+            messages: vec![user_text("hi")],
+            parallel_tool_calls_allowed: false,
+        };
+        let v = parse(&req, "claude-3-5-sonnet", 4096, false);
+        assert_eq!(v.get("system").and_then(|s| s.as_str()), Some("be helpful"));
+        // System must NOT also appear inside messages.
+        let messages = v.get("messages").and_then(|m| m.as_array()).unwrap();
+        for msg in messages {
+            assert_ne!(
+                msg.get("role").and_then(|r| r.as_str()),
+                Some("system"),
+                "system role must not appear inside messages: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn serialize_tool_call_and_result() {
+        let req = ChatRequest {
+            system: None,
+            messages: vec![
+                ChatMessage {
+                    role: ChatRole::Assistant,
+                    content: vec![
+                        ChatBlock::Text("calling".into()),
+                        ChatBlock::ToolCall {
+                            id: "toolu_01".into(),
+                            name: "get_weather".into(),
+                            args: json!({"city": "sf"}),
+                        },
+                    ],
+                },
+                ChatMessage {
+                    role: ChatRole::User,
+                    content: vec![ChatBlock::ToolResult {
+                        id: "toolu_01".into(),
+                        result: json!({"temp": 60}),
+                    }],
+                },
+            ],
+            parallel_tool_calls_allowed: false,
+        };
+        let v = parse(&req, "claude-3-5-sonnet", 4096, false);
+        let messages = v.get("messages").and_then(|m| m.as_array()).unwrap();
+        assert_eq!(messages.len(), 2);
+
+        // Message 0: assistant with text + tool_use.
+        assert_eq!(
+            messages[0],
+            json!({
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "calling"},
+                    {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "sf"}}
+                ]
+            })
+        );
+
+        // Message 1: user with tool_result; content is the JSON-as-string per
+        // Anthropic's wire convention.
+        assert_eq!(
+            messages[1],
+            json!({
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_01", "content": "{\"temp\":60}"}
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn parallel_tool_calls_allowed_true_flips_disable_to_false() {
+        let req = ChatRequest {
+            system: None,
+            messages: vec![user_text("hi")],
+            parallel_tool_calls_allowed: true,
+        };
+        let v = parse(&req, "claude-3-5-sonnet", 4096, true);
+        assert_eq!(
+            v.get("tool_choice").unwrap(),
+            &json!({"type": "auto", "disable_parallel_tool_use": false})
+        );
+    }
+
+    #[test]
+    fn multiple_text_blocks_preserve_order() {
+        let req = ChatRequest {
+            system: None,
+            messages: vec![ChatMessage {
+                role: ChatRole::Assistant,
+                content: vec![
+                    ChatBlock::Text("a".into()),
+                    ChatBlock::Text("b".into()),
+                    ChatBlock::Text("c".into()),
+                ],
+            }],
+            parallel_tool_calls_allowed: false,
+        };
+        let v = parse(&req, "claude-3-5-sonnet", 4096, false);
+        let messages = v.get("messages").and_then(|m| m.as_array()).unwrap();
+        let content = messages[0]
+            .get("content")
+            .and_then(|c| c.as_array())
+            .unwrap();
+        let texts: Vec<&str> = content
+            .iter()
+            .map(|b| b.get("text").and_then(|t| t.as_str()).unwrap())
+            .collect();
+        assert_eq!(texts, vec!["a", "b", "c"]);
+    }
+
+    // ── SSE event accumulator ─────────────────────────────────────────────
+
+    fn ev(name: &str, data: &str) -> SseEvent {
+        SseEvent {
+            event: name.to_string(),
+            data: Bytes::copy_from_slice(data.as_bytes()),
+        }
+    }
+
+    #[test]
+    fn text_delta_emits_text_chunk() {
+        let mut acc = AnthropicEventAccumulator::default();
+        let chunks = acc.consume(&ev(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}"#,
+        ));
+        assert_eq!(chunks, vec![ChatChunk::TextDelta("hi".into())]);
+    }
+
+    #[test]
+    fn tool_use_block_accumulates_and_emits_on_stop() {
+        let mut acc = AnthropicEventAccumulator::default();
+        assert!(acc
+            .consume(&ev(
+                "content_block_start",
+                r#"{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}}"#,
+            ))
+            .is_empty());
+        assert!(acc
+            .consume(&ev(
+                "content_block_delta",
+                r#"{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}"#,
+            ))
+            .is_empty());
+        assert!(acc
+            .consume(&ev(
+                "content_block_delta",
+                r#"{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"sf\"}"}}"#,
+            ))
+            .is_empty());
+
+        let chunks = acc.consume(&ev(
+            "content_block_stop",
+            r#"{"type":"content_block_stop","index":1}"#,
+        ));
+        assert_eq!(
+            chunks,
+            vec![ChatChunk::ToolCall {
+                name: "get_weather".into(),
+                args: json!({"city": "sf"}),
+            }]
+        );
+    }
+
+    #[test]
+    fn message_stop_emits_done_with_prior_stop_reason() {
+        let mut acc = AnthropicEventAccumulator::default();
+        assert!(acc
+            .consume(&ev(
+                "message_delta",
+                r#"{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null}}"#,
+            ))
+            .is_empty());
+        let chunks = acc.consume(&ev("message_stop", r#"{"type":"message_stop"}"#));
+        assert_eq!(chunks, vec![ChatChunk::Done("tool_use".into())]);
+    }
+
+    #[test]
+    fn message_stop_without_prior_delta_defaults_to_end_turn() {
+        let mut acc = AnthropicEventAccumulator::default();
+        let chunks = acc.consume(&ev("message_stop", r#"{"type":"message_stop"}"#));
+        assert_eq!(chunks, vec![ChatChunk::Done("end_turn".into())]);
+    }
+
+    #[test]
+    fn unknown_event_names_are_ignored() {
+        let mut acc = AnthropicEventAccumulator::default();
+        assert!(acc.consume(&ev("ping", "{}")).is_empty());
+        assert!(acc.consume(&ev("message_start", "{}")).is_empty());
+        assert!(acc
+            .consume(&ev(
+                "content_block_start",
+                r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+            ))
+            .is_empty());
+    }
+}

--- a/crates/forge-providers/src/anthropic/translate.rs
+++ b/crates/forge-providers/src/anthropic/translate.rs
@@ -58,6 +58,19 @@ pub fn serialize_request(
     max_tokens: u32,
     parallel_tool_calls_allowed: bool,
 ) -> std::result::Result<Vec<u8>, serde_json::Error> {
+    // Anthropic's Messages API rejects (HTTP 400) any request that sends a
+    // `tool_choice` field without a non-empty `tools` array. Until tool
+    // schemas land, both fields stay omitted and the inversion encoded by
+    // `parallel_tool_calls_allowed` is a no-op on the wire.
+    let tools: &[Value] = &[];
+    let tool_choice = if tools.is_empty() {
+        None
+    } else {
+        Some(ToolChoice {
+            kind: "auto",
+            disable_parallel_tool_use: !parallel_tool_calls_allowed,
+        })
+    };
     let body = AnthropicBody {
         model,
         max_tokens,
@@ -65,11 +78,8 @@ pub fn serialize_request(
         messages: AnthropicMessages {
             messages: &req.messages,
         },
-        tools: &[],
-        tool_choice: ToolChoice {
-            kind: "auto",
-            disable_parallel_tool_use: !parallel_tool_calls_allowed,
-        },
+        tools,
+        tool_choice,
         stream: true,
     };
     serde_json::to_vec(&body)
@@ -82,8 +92,10 @@ struct AnthropicBody<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     system: Option<&'a str>,
     messages: AnthropicMessages<'a>,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
     tools: &'a [Value],
-    tool_choice: ToolChoice<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<ToolChoice<'a>>,
     stream: bool,
 }
 
@@ -445,8 +457,6 @@ mod tests {
                 "messages": [
                     {"role": "user", "content": [{"type": "text", "text": "hi"}]}
                 ],
-                "tools": [],
-                "tool_choice": {"type": "auto", "disable_parallel_tool_use": true},
                 "stream": true
             })
         );
@@ -532,18 +542,30 @@ mod tests {
     }
 
     #[test]
-    fn parallel_tool_calls_allowed_true_flips_disable_to_false() {
+    fn empty_tools_omits_tool_choice_and_tools() {
+        // Anthropic's Messages API rejects (HTTP 400) any request that sends a
+        // `tool_choice` field without a non-empty `tools` array. Until tool
+        // schemas land, both fields must be absent from the wire body.
         let req = ChatRequest {
             system: None,
             messages: vec![user_text("hi")],
-            parallel_tool_calls_allowed: true,
+            parallel_tool_calls_allowed: false,
         };
-        let v = parse(&req, "claude-3-5-sonnet", 4096, true);
-        assert_eq!(
-            v.get("tool_choice").unwrap(),
-            &json!({"type": "auto", "disable_parallel_tool_use": false})
+        let v = parse(&req, "claude-3-5-sonnet", 4096, false);
+        assert!(v.get("tools").is_none(), "tools must be absent when empty");
+        assert!(
+            v.get("tool_choice").is_none(),
+            "tool_choice must be absent when tools is empty",
         );
     }
+
+    // The wire-level inversion of `parallel_tool_calls_allowed` →
+    // `tool_choice.disable_parallel_tool_use` is unobservable while `tools`
+    // is empty (both fields are correctly omitted; see
+    // `empty_tools_omits_tool_choice_and_tools`). When tool schemas land in a
+    // follow-up task, re-introduce a wire-level test that passes a non-empty
+    // tools array and asserts on `disable_parallel_tool_use` for both
+    // `parallel_tool_calls_allowed = true` and `false`.
 
     #[test]
     fn multiple_text_blocks_preserve_order() {

--- a/crates/forge-providers/src/anthropic/translate.rs
+++ b/crates/forge-providers/src/anthropic/translate.rs
@@ -40,8 +40,8 @@
 //!   `partial_json` from `input_json_delta` events; on `content_block_stop`
 //!   parse the accumulated string and emit [`ChatChunk::ToolCall`].
 //! - `message_delta` carries the upcoming `stop_reason`; remember it.
-//! - `message_stop` → [`ChatChunk::Done(stop_reason)`], defaulting to
-//!   `"end_turn"` if the prior `message_delta` did not carry one.
+//! - `message_stop` → [`ChatChunk::Done`] carrying the upcoming `stop_reason`,
+//!   defaulting to `"end_turn"` if the prior `message_delta` did not carry one.
 
 use crate::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole};
 use serde::Serialize;

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -11,7 +11,9 @@ use futures::stream::BoxStream;
 use parking_lot::Mutex;
 use serde::Deserialize;
 
+pub mod anthropic;
 pub mod ollama;
+pub mod sse;
 
 // ── Chat domain types ─────────────────────────────────────────────────────────
 
@@ -23,7 +25,7 @@ pub mod ollama;
 /// provider-specific configuration. Callers that need provider-specific
 /// knobs should wrap or extend this type at the provider boundary rather
 /// than overload it with optional fields that no provider honours.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ChatRequest {
     /// Optional system prompt. Providers handle it in role-specific ways:
     /// e.g. Anthropic hoists it to a top-level `system` field, Ollama
@@ -40,6 +42,10 @@ pub struct ChatRequest {
     /// [`ChatRole::User`] and [`ChatRole::Assistant`], though providers
     /// vary in how strictly they enforce that.
     pub messages: Vec<ChatMessage>,
+    /// F-583: whether the provider is permitted to request multiple tool
+    /// calls in a single turn. Defaults to `false`; F-583 only plumbs the
+    /// flag through, F-599 will drive behavior.
+    pub parallel_tool_calls_allowed: bool,
 }
 
 /// One message in a chat conversation, tagged with the role that produced

--- a/crates/forge-providers/src/sse.rs
+++ b/crates/forge-providers/src/sse.rs
@@ -1,0 +1,595 @@
+//! Server-Sent Events (SSE) decoding adapter.
+//!
+//! Decodes a byte stream of SSE-framed messages into a stream of typed
+//! `(event, data)` pairs per the WHATWG SSE spec. The adapter:
+//!
+//! - Splits frames on `\n` or `\r\n` (both are spec-legal).
+//! - Captures the most-recent `event:` field as the dispatch name; OpenAI
+//!   omits it (empty string), Anthropic uses named events like
+//!   `content_block_delta`.
+//! - Concatenates multiple `data:` lines within a single event with `\n`.
+//! - Ignores lines starting with `:` (SSE comments).
+//! - Dispatches the buffered event on a blank line.
+//!
+//! ## Error model
+//!
+//! The adapter yields `Result<SseEvent, SseError>` so each error variant
+//! carries its own type — `LineTooLong`, `IdleTimeout`, `WallClockTimeout`,
+//! `Transport`. The provider-layer caller maps these onto
+//! [`crate::ChatChunk::Error`] with the matching [`crate::StreamErrorKind`].
+//! Keeping the typed `SseError` here means the SSE adapter is reusable from
+//! any caller (Anthropic, OpenAI, future providers) without coupling to
+//! `ChatChunk`.
+//!
+//! Bound defaults mirror Ollama's NDJSON decoder so the two transports share
+//! a single DoS-resistance posture (1 MiB per line, 30 s idle, 600 s wall
+//! clock).
+
+use bytes::{Bytes, BytesMut};
+use futures::stream::{BoxStream, StreamExt};
+use std::time::Duration;
+use tokio_util::codec::FramedRead;
+use tokio_util::io::StreamReader;
+
+/// Per-line SSE byte cap (1 MiB). Matches Ollama's NDJSON cap so a hostile
+/// peer cannot exhaust memory by streaming a single newline-less line.
+pub const DEFAULT_MAX_LINE_BYTES: usize = 1 << 20;
+/// Wall-clock gap between consecutive SSE lines. Matches Ollama's idle cap.
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Wall-clock cap on the entire SSE stream. Matches Ollama's wall-clock cap.
+pub const DEFAULT_WALL_CLOCK_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Bounds that make the SSE decoder DoS-resistant against a hostile peer.
+/// Mirrors `crate::ollama::StreamConfig` — the two configs are deliberately
+/// separate types because their callers wire different defaults at different
+/// layers, but the defaults themselves are identical.
+#[derive(Debug, Clone, Copy)]
+pub struct StreamConfig {
+    pub max_line_bytes: usize,
+    pub idle_timeout: Duration,
+    pub wall_clock_timeout: Duration,
+}
+
+impl StreamConfig {
+    pub const DEFAULT: StreamConfig = StreamConfig {
+        max_line_bytes: DEFAULT_MAX_LINE_BYTES,
+        idle_timeout: DEFAULT_IDLE_TIMEOUT,
+        wall_clock_timeout: DEFAULT_WALL_CLOCK_TIMEOUT,
+    };
+}
+
+impl Default for StreamConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// One dispatched SSE message.
+///
+/// `event` is empty when the upstream omitted an `event:` field (typical of
+/// OpenAI's chat completions stream). `data` is the raw payload bytes; if
+/// the upstream split it across multiple `data:` lines they are joined here
+/// with `\n` per the SSE spec.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SseEvent {
+    pub event: String,
+    pub data: Bytes,
+}
+
+/// Terminal SSE adapter failure. Mirrors `StreamErrorKind` one-for-one so
+/// the provider-layer caller can map directly without losing information.
+#[derive(Debug)]
+pub enum SseError {
+    /// One SSE line exceeded `StreamConfig::max_line_bytes`.
+    LineTooLong,
+    /// No bytes received within `StreamConfig::idle_timeout`.
+    IdleTimeout,
+    /// Stream exceeded `StreamConfig::wall_clock_timeout`.
+    WallClockTimeout,
+    /// Transport-level error from the underlying byte stream.
+    Transport(String),
+}
+
+impl std::fmt::Display for SseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SseError::LineTooLong => write!(f, "sse line exceeded max bytes"),
+            SseError::IdleTimeout => write!(f, "sse idle timeout"),
+            SseError::WallClockTimeout => write!(f, "sse wall-clock timeout"),
+            SseError::Transport(msg) => write!(f, "sse transport: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for SseError {}
+
+/// Decode a byte stream of SSE-framed messages into typed events.
+///
+/// Terminal failures (line cap exceeded, idle window elapsed, wall-clock
+/// budget elapsed, transport error) yield a single `Err(SseError::*)` and
+/// close the stream. The caller is responsible for translating these onto
+/// its own terminal error shape.
+pub fn decode_sse_stream<S, E>(
+    byte_stream: S,
+    cfg: StreamConfig,
+) -> BoxStream<'static, Result<SseEvent, SseError>>
+where
+    S: futures::Stream<Item = Result<Bytes, E>> + Send + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let pinned = Box::pin(byte_stream.map(|r| r.map_err(std::io::Error::other)));
+    let reader = StreamReader::new(pinned);
+    let framed = FramedRead::new(reader, SseLineCodec::new(cfg.max_line_bytes));
+
+    let deadline = tokio::time::Instant::now() + cfg.wall_clock_timeout;
+    let state = DecoderState {
+        framed,
+        cfg,
+        deadline,
+        terminated: false,
+        event: String::new(),
+        data: BytesMut::new(),
+        data_started: false,
+        has_field: false,
+    };
+
+    let stream = futures::stream::unfold(state, |mut s| async move {
+        if s.terminated {
+            return None;
+        }
+
+        loop {
+            let now = tokio::time::Instant::now();
+            if now >= s.deadline {
+                s.terminated = true;
+                return Some((Err(SseError::WallClockTimeout), s));
+            }
+
+            let idle = s.cfg.idle_timeout.min(s.deadline - now);
+            match tokio::time::timeout(idle, s.framed.next()).await {
+                Err(_) => {
+                    s.terminated = true;
+                    let err = if tokio::time::Instant::now() >= s.deadline {
+                        SseError::WallClockTimeout
+                    } else {
+                        SseError::IdleTimeout
+                    };
+                    return Some((Err(err), s));
+                }
+                Ok(None) => return None,
+                Ok(Some(Err(e))) => {
+                    s.terminated = true;
+                    let err = match e {
+                        SseLineError::MaxLineLengthExceeded => SseError::LineTooLong,
+                        SseLineError::Io(io) => SseError::Transport(io.to_string()),
+                    };
+                    return Some((Err(err), s));
+                }
+                Ok(Some(Ok(line))) => {
+                    if let Some(event) = handle_line(&mut s, &line) {
+                        return Some((Ok(event), s));
+                    }
+                }
+            }
+        }
+    });
+
+    Box::pin(stream.fuse())
+}
+
+struct DecoderState<R> {
+    framed: FramedRead<R, SseLineCodec>,
+    cfg: StreamConfig,
+    deadline: tokio::time::Instant,
+    terminated: bool,
+    event: String,
+    data: BytesMut,
+    data_started: bool,
+    has_field: bool,
+}
+
+/// Process one decoded SSE line. Returns `Some(event)` when a blank line
+/// dispatches an accumulated event; `None` when the line is buffered
+/// (field, comment, or empty without a pending event).
+fn handle_line<R>(state: &mut DecoderState<R>, line: &Bytes) -> Option<SseEvent> {
+    let line = strip_cr(line);
+
+    if line.is_empty() {
+        // Blank line — dispatch only if we have at least one field.
+        if !state.has_field {
+            return None;
+        }
+        let event = SseEvent {
+            event: std::mem::take(&mut state.event),
+            data: state.data.split().freeze(),
+        };
+        state.data_started = false;
+        state.has_field = false;
+        return Some(event);
+    }
+
+    // Comment line.
+    if line[0] == b':' {
+        return None;
+    }
+
+    // Field parsing per SSE spec: split on the first `:`. The portion after
+    // an optional single space is the value. A line with no `:` treats the
+    // whole line as the field name with an empty value.
+    let (field, value) = match line.iter().position(|b| *b == b':') {
+        Some(idx) => {
+            let f = &line[..idx];
+            let mut v = &line[idx + 1..];
+            if let Some((b' ', rest)) = v.split_first() {
+                v = rest;
+            }
+            (f, v)
+        }
+        None => (line, &b""[..]),
+    };
+
+    state.has_field = true;
+
+    match field {
+        b"event" => {
+            // Last `event:` wins. Non-UTF-8 collapses to empty (the spec
+            // allows replacement, but every real provider sends ASCII names).
+            state.event = std::str::from_utf8(value).unwrap_or("").to_string();
+        }
+        b"data" => {
+            if state.data_started {
+                state.data.extend_from_slice(b"\n");
+            }
+            state.data.extend_from_slice(value);
+            state.data_started = true;
+        }
+        _ => {
+            // `id:` / `retry:` / unknown fields — buffered (count as a
+            // field for dispatch) but otherwise ignored. SSE consumers in
+            // this codebase don't use them.
+        }
+    }
+
+    None
+}
+
+fn strip_cr(line: &Bytes) -> &[u8] {
+    let bytes = line.as_ref();
+    match bytes.last() {
+        Some(b'\r') => &bytes[..bytes.len() - 1],
+        _ => bytes,
+    }
+}
+
+// ── SseLineCodec ──────────────────────────────────────────────────────────────
+//
+// Lifted from `ollama::BytesLineCodec` because the line-framing requirements
+// are identical (\n-delimited, byte-cap-bounded, yields `Bytes` slices over
+// the codec's buffer). The two crates intentionally do NOT share a codec —
+// pulling Ollama's into a shared module would be churn outside this task's
+// DoD. Diverging behavior between the two would be caught by the unit
+// tests in each module.
+
+#[derive(Debug)]
+struct SseLineCodec {
+    max_line_bytes: usize,
+    next_index: usize,
+    discarding: bool,
+}
+
+#[derive(Debug)]
+enum SseLineError {
+    MaxLineLengthExceeded,
+    Io(std::io::Error),
+}
+
+impl From<std::io::Error> for SseLineError {
+    fn from(e: std::io::Error) -> Self {
+        SseLineError::Io(e)
+    }
+}
+
+impl std::fmt::Display for SseLineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SseLineError::MaxLineLengthExceeded => write!(f, "max line length exceeded"),
+            SseLineError::Io(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for SseLineError {}
+
+impl SseLineCodec {
+    fn new(max_line_bytes: usize) -> Self {
+        Self {
+            max_line_bytes,
+            next_index: 0,
+            discarding: false,
+        }
+    }
+}
+
+impl tokio_util::codec::Decoder for SseLineCodec {
+    type Item = Bytes;
+    type Error = SseLineError;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Bytes>, Self::Error> {
+        use bytes::Buf;
+        if self.discarding {
+            if let Some(nl_offset) = buf.iter().position(|b| *b == b'\n') {
+                buf.advance(nl_offset + 1);
+                self.discarding = false;
+                self.next_index = 0;
+            } else {
+                let len = buf.len();
+                buf.advance(len);
+                return Ok(None);
+            }
+        }
+
+        let read_to = std::cmp::min(self.max_line_bytes.saturating_add(1), buf.len());
+        let newline = buf[self.next_index..read_to]
+            .iter()
+            .position(|b| *b == b'\n');
+
+        match newline {
+            Some(offset) => {
+                let nl_index = self.next_index + offset;
+                let mut line = buf.split_to(nl_index + 1);
+                line.truncate(line.len() - 1);
+                self.next_index = 0;
+                Ok(Some(line.freeze()))
+            }
+            None if buf.len() > self.max_line_bytes => {
+                self.discarding = true;
+                self.next_index = 0;
+                Err(SseLineError::MaxLineLengthExceeded)
+            }
+            None => {
+                self.next_index = buf.len();
+                Ok(None)
+            }
+        }
+    }
+
+    fn decode_eof(&mut self, buf: &mut BytesMut) -> Result<Option<Bytes>, Self::Error> {
+        match self.decode(buf)? {
+            Some(line) => Ok(Some(line)),
+            None => {
+                if buf.is_empty() || self.discarding {
+                    self.discarding = false;
+                    self.next_index = 0;
+                    Ok(None)
+                } else {
+                    let line = buf.split_to(buf.len()).freeze();
+                    self.next_index = 0;
+                    Ok(Some(line))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::{self, StreamExt};
+    use std::convert::Infallible;
+
+    fn bytes_stream(
+        chunks: Vec<&'static [u8]>,
+    ) -> impl futures::Stream<Item = Result<Bytes, Infallible>> {
+        stream::iter(chunks.into_iter().map(|c| Ok(Bytes::from_static(c))))
+    }
+
+    async fn collect_events(input: &'static [u8]) -> Vec<Result<SseEvent, SseError>> {
+        let s = bytes_stream(vec![input]);
+        decode_sse_stream(s, StreamConfig::DEFAULT).collect().await
+    }
+
+    #[tokio::test]
+    async fn single_event_with_one_data_line() {
+        let out = collect_events(b"event: foo\ndata: hello\n\n").await;
+        assert_eq!(out.len(), 1, "expected exactly one event, got {out:?}");
+        let ev = out[0].as_ref().expect("event ok");
+        assert_eq!(ev.event, "foo");
+        assert_eq!(ev.data.as_ref(), b"hello");
+    }
+
+    #[tokio::test]
+    async fn multiple_data_lines_concatenate_with_newline() {
+        let out = collect_events(b"event: chunk\ndata: line1\ndata: line2\ndata: line3\n\n").await;
+        assert_eq!(out.len(), 1);
+        let ev = out[0].as_ref().expect("event ok");
+        assert_eq!(ev.event, "chunk");
+        assert_eq!(ev.data.as_ref(), b"line1\nline2\nline3");
+    }
+
+    #[tokio::test]
+    async fn omitted_event_field_yields_empty_string() {
+        let out = collect_events(b"data: payload\n\n").await;
+        assert_eq!(out.len(), 1);
+        let ev = out[0].as_ref().expect("event ok");
+        assert_eq!(ev.event, "");
+        assert_eq!(ev.data.as_ref(), b"payload");
+    }
+
+    #[tokio::test]
+    async fn comment_lines_are_ignored() {
+        let out = collect_events(b": this is a comment\ndata: real\n: another comment\n\n").await;
+        assert_eq!(out.len(), 1, "comments must not dispatch events");
+        let ev = out[0].as_ref().expect("event ok");
+        assert_eq!(ev.event, "");
+        assert_eq!(ev.data.as_ref(), b"real");
+    }
+
+    #[tokio::test]
+    async fn crlf_line_endings_work() {
+        let out = collect_events(b"event: crlf\r\ndata: hello\r\n\r\n").await;
+        assert_eq!(
+            out.len(),
+            1,
+            "CRLF framing must produce one event, got {out:?}"
+        );
+        let ev = out[0].as_ref().expect("event ok");
+        assert_eq!(ev.event, "crlf");
+        assert_eq!(ev.data.as_ref(), b"hello");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn idle_timeout_yields_terminal_idle_error() {
+        // Yield one valid event, then never produce more bytes.
+        let (tx, rx) = futures::channel::mpsc::unbounded::<Result<Bytes, Infallible>>();
+        tx.unbounded_send(Ok(Bytes::from_static(b"data: hi\n\n")))
+            .unwrap();
+        // Hold tx open forever — no further bytes arrive.
+        let _hold_open = tx;
+
+        let cfg = StreamConfig {
+            max_line_bytes: 1024,
+            idle_timeout: Duration::from_millis(80),
+            wall_clock_timeout: Duration::from_secs(30),
+        };
+        let mut out = decode_sse_stream(rx, cfg);
+
+        let first = tokio::time::timeout(Duration::from_secs(1), out.next())
+            .await
+            .expect("first event must arrive promptly")
+            .expect("at least one event");
+        let ev = first.expect("first item is the valid event");
+        assert_eq!(ev.data.as_ref(), b"hi");
+
+        let second = tokio::time::timeout(Duration::from_secs(2), out.next())
+            .await
+            .expect("must terminate via idle timeout, not hang")
+            .expect("must yield terminal error");
+        assert!(
+            matches!(second, Err(SseError::IdleTimeout)),
+            "expected IdleTimeout, got {second:?}"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), out.next())
+                .await
+                .expect("stream must close")
+                .is_none(),
+            "stream must close after terminal error"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wall_clock_timeout_yields_terminal_error() {
+        // A drip-feeder that keeps the idle timer happy but exceeds the
+        // wall-clock budget. Send an empty heartbeat every 30 ms so the
+        // 80 ms idle window never trips, but the 200 ms wall-clock will.
+        let (tx, rx) = futures::channel::mpsc::unbounded::<Result<Bytes, Infallible>>();
+        tokio::spawn(async move {
+            for _ in 0..50 {
+                if tx
+                    .unbounded_send(Ok(Bytes::from_static(b": heartbeat\n")))
+                    .is_err()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(30)).await;
+            }
+        });
+
+        let cfg = StreamConfig {
+            max_line_bytes: 1024,
+            idle_timeout: Duration::from_millis(80),
+            wall_clock_timeout: Duration::from_millis(200),
+        };
+        let mut out = decode_sse_stream(rx, cfg);
+
+        let result = tokio::time::timeout(Duration::from_secs(2), out.next())
+            .await
+            .expect("must terminate via wall-clock, not hang")
+            .expect("must yield terminal error");
+        assert!(
+            matches!(result, Err(SseError::WallClockTimeout)),
+            "expected WallClockTimeout, got {result:?}"
+        );
+        assert!(
+            out.next().await.is_none(),
+            "stream must close after terminal error"
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_error_yields_terminal_transport_error() {
+        #[derive(Debug)]
+        struct BadIo;
+        impl std::fmt::Display for BadIo {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "boom")
+            }
+        }
+        impl std::error::Error for BadIo {}
+
+        let stream = stream::iter(vec![
+            Ok::<Bytes, BadIo>(Bytes::from_static(b"data: ok\n\n")),
+            Err(BadIo),
+        ]);
+
+        let mut out = decode_sse_stream(stream, StreamConfig::DEFAULT);
+        let first = out.next().await.expect("first event").expect("ok event");
+        assert_eq!(first.data.as_ref(), b"ok");
+
+        let second = out.next().await.expect("transport error");
+        match second {
+            Err(SseError::Transport(msg)) => {
+                assert!(
+                    msg.contains("boom"),
+                    "transport error must surface source: {msg}"
+                );
+            }
+            other => panic!("expected Transport error, got {other:?}"),
+        }
+        assert!(
+            out.next().await.is_none(),
+            "stream must close after terminal error"
+        );
+    }
+
+    #[tokio::test]
+    async fn line_exceeding_cap_yields_terminal_line_too_long() {
+        // 200 bytes of `a` followed by `\n` — cap of 100 must terminate.
+        let big: Vec<u8> = std::iter::repeat_n(b'a', 200)
+            .chain(std::iter::once(b'\n'))
+            .collect();
+        let stream = stream::iter(vec![Ok::<_, Infallible>(Bytes::from(big))]);
+        let cfg = StreamConfig {
+            max_line_bytes: 100,
+            ..StreamConfig::DEFAULT
+        };
+        let mut out = decode_sse_stream(stream, cfg);
+        let first = out.next().await.expect("must yield terminal error");
+        assert!(
+            matches!(first, Err(SseError::LineTooLong)),
+            "expected LineTooLong, got {first:?}"
+        );
+        // Stream must be closed after the terminal error.
+        assert!(
+            out.next().await.is_none(),
+            "stream must close after terminal error"
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_events_yield_in_order() {
+        let input = b"event: first\ndata: 1\n\nevent: second\ndata: 2\n\nevent: third\ndata: 3\n\n";
+        let out = collect_events(input).await;
+        assert_eq!(out.len(), 3, "expected three events, got {out:?}");
+        let names: Vec<&str> = out
+            .iter()
+            .map(|r| r.as_ref().unwrap().event.as_str())
+            .collect();
+        assert_eq!(names, vec!["first", "second", "third"]);
+        let datas: Vec<&[u8]> = out
+            .iter()
+            .map(|r| r.as_ref().unwrap().data.as_ref())
+            .collect();
+        assert_eq!(datas, vec![&b"1"[..], &b"2"[..], &b"3"[..]]);
+    }
+}

--- a/crates/forge-providers/tests/anthropic.rs
+++ b/crates/forge-providers/tests/anthropic.rs
@@ -1,0 +1,286 @@
+//! Integration tests for `AnthropicProvider` using a mocked HTTP server and
+//! a recorded SSE fixture.
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use forge_providers::anthropic::{parse_anthropic_events, AnthropicProvider, ANTHROPIC_VERSION};
+use forge_providers::sse::{decode_sse_stream, StreamConfig};
+use forge_providers::{
+    ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider, StreamErrorKind,
+};
+use futures::stream::{self, StreamExt};
+use std::convert::Infallible;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEXT_AND_TOOL_USE_FIXTURE: &str = include_str!("fixtures/anthropic_text_and_tool_use.sse");
+
+fn user_msg(text: &str) -> ChatMessage {
+    ChatMessage {
+        role: ChatRole::User,
+        content: vec![ChatBlock::Text(text.into())],
+    }
+}
+
+fn fixture_to_byte_stream(
+    body: &'static str,
+) -> impl futures::Stream<Item = Result<Bytes, Infallible>> {
+    stream::iter(vec![Ok(Bytes::from_static(body.as_bytes()))])
+}
+
+#[tokio::test]
+async fn parse_events_yields_text_and_tool_call_and_done() {
+    // Drive the parser directly from the fixture (no HTTP roundtrip) so the
+    // event-decode path is exercised in isolation.
+    let bytes = fixture_to_byte_stream(TEXT_AND_TOOL_USE_FIXTURE);
+    let events = decode_sse_stream(bytes, StreamConfig::DEFAULT);
+    let mut chunks_stream = parse_anthropic_events(events);
+
+    let mut chunks = Vec::new();
+    while let Some(c) = chunks_stream.next().await {
+        chunks.push(c);
+    }
+
+    assert_eq!(
+        chunks,
+        vec![
+            ChatChunk::TextDelta("Hello".into()),
+            ChatChunk::TextDelta(" world".into()),
+            ChatChunk::ToolCall {
+                name: "get_weather".into(),
+                args: serde_json::json!({"city": "sf"}),
+            },
+            ChatChunk::Done("tool_use".into()),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_round_trip_yields_expected_chunks() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("x-api-key", "sk-test"))
+        .and(header("anthropic-version", ANTHROPIC_VERSION))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(TEXT_AND_TOOL_USE_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(server.uri(), "sk-test", "claude-3-5-sonnet", 4096);
+
+    let req = ChatRequest {
+        system: Some(std::sync::Arc::from("be helpful")),
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+    let mut stream = provider.chat(req).await.expect("chat call succeeds");
+
+    let mut chunks = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        chunks.push(chunk);
+    }
+
+    assert_eq!(
+        chunks,
+        vec![
+            ChatChunk::TextDelta("Hello".into()),
+            ChatChunk::TextDelta(" world".into()),
+            ChatChunk::ToolCall {
+                name: "get_weather".into(),
+                args: serde_json::json!({"city": "sf"}),
+            },
+            ChatChunk::Done("tool_use".into()),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_maps_http_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("invalid api key"))
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(server.uri(), "bad", "claude-3-5-sonnet", 4096);
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+
+    let err = provider
+        .chat(req)
+        .await
+        .err()
+        .expect("HTTP 401 must map to Err");
+    let msg = format!("{err}");
+    assert!(msg.contains("401"), "error should mention status: {msg}");
+    assert!(
+        msg.contains("invalid api key"),
+        "error should include body: {msg}"
+    );
+}
+
+/// A peer that opens a 200 response with valid SSE prelude, emits one event,
+/// then stalls indefinitely must be cut by the per-event idle timer.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_idle_timeout_yields_typed_error_and_terminates() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server_task = tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+
+        // Drain the request headers so the client's send() completes.
+        let mut buf = [0u8; 4096];
+        let mut total = Vec::new();
+        loop {
+            let n =
+                match tokio::time::timeout(Duration::from_millis(500), sock.read(&mut buf)).await {
+                    Ok(Ok(0)) | Err(_) => break,
+                    Ok(Ok(n)) => n,
+                    Ok(Err(_)) => break,
+                };
+            total.extend_from_slice(&buf[..n]);
+            if total.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let headers = b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n";
+        sock.write_all(headers).await.unwrap();
+
+        // One real SSE event (text_delta = "hi"), then stall forever.
+        let event = b"event: content_block_delta\r\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\r\n\r\n";
+        let chunk_header = format!("{:x}\r\n", event.len());
+        sock.write_all(chunk_header.as_bytes()).await.unwrap();
+        sock.write_all(event).await.unwrap();
+        sock.write_all(b"\r\n").await.unwrap();
+        sock.flush().await.unwrap();
+
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        drop(sock);
+    });
+
+    let cfg = StreamConfig {
+        max_line_bytes: 1 << 20,
+        idle_timeout: Duration::from_millis(150),
+        wall_clock_timeout: Duration::from_secs(30),
+    };
+    let provider = AnthropicProvider::new(
+        format!("http://{addr}"),
+        "sk-test",
+        "claude-3-5-sonnet",
+        4096,
+    )
+    .with_config(cfg);
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+
+    let stream_fut = provider.chat(req);
+    let mut stream = tokio::time::timeout(Duration::from_secs(5), stream_fut)
+        .await
+        .expect("chat() must not hang after headers arrive")
+        .expect("chat call succeeds");
+
+    let collect_fut = async {
+        let mut chunks = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            chunks.push(chunk);
+        }
+        chunks
+    };
+    let chunks = tokio::time::timeout(Duration::from_secs(5), collect_fut)
+        .await
+        .expect("stream must terminate via idle timeout, not hang");
+
+    assert!(
+        matches!(&chunks[0], ChatChunk::TextDelta(s) if s == "hi"),
+        "first chunk should be the real text delta, got: {chunks:?}"
+    );
+    let last = chunks.last().expect("at least one chunk (the error)");
+    assert!(
+        matches!(
+            last,
+            ChatChunk::Error {
+                kind: StreamErrorKind::IdleTimeout,
+                ..
+            }
+        ),
+        "expected terminal IdleTimeout error, got: {chunks:?}"
+    );
+
+    server_task.abort();
+}
+
+/// A peer that emits a single SSE line larger than the configured cap must
+/// surface a typed `LineTooLong` error and close the stream.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_line_too_long_yields_typed_error_and_terminates() {
+    let server = MockServer::start().await;
+
+    // 200 KiB of non-newline content as a single oversized data line.
+    let big = "a".repeat(200 * 1024);
+    let body = format!("event: content_block_delta\ndata: {big}\n\n");
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(body),
+        )
+        .mount(&server)
+        .await;
+
+    let cfg = StreamConfig {
+        max_line_bytes: 64 * 1024,
+        idle_timeout: Duration::from_secs(5),
+        wall_clock_timeout: Duration::from_secs(30),
+    };
+    let provider =
+        AnthropicProvider::new(server.uri(), "sk-test", "claude-3-5-sonnet", 4096).with_config(cfg);
+
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+    let mut stream = provider.chat(req).await.expect("chat call succeeds");
+
+    let mut chunks = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        chunks.push(chunk);
+    }
+
+    let last = chunks.last().expect("at least one chunk (the error)");
+    assert!(
+        matches!(
+            last,
+            ChatChunk::Error {
+                kind: StreamErrorKind::LineTooLong,
+                ..
+            }
+        ),
+        "expected terminal LineTooLong error, got: {chunks:?}"
+    );
+    assert!(
+        stream.next().await.is_none(),
+        "stream must terminate after a fatal error"
+    );
+}

--- a/crates/forge-providers/tests/fixtures/anthropic_text_and_tool_use.sse
+++ b/crates/forge-providers/tests/fixtures/anthropic_text_and_tool_use.sse
@@ -1,0 +1,33 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01","model":"claude-3-5-sonnet","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"sf\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/crates/forge-providers/tests/ollama.rs
+++ b/crates/forge-providers/tests/ollama.rs
@@ -49,6 +49,7 @@ async fn chat_streams_text_tool_call_and_done() {
     let req = ChatRequest {
         system: Some(std::sync::Arc::from("be helpful")),
         messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
     };
     let mut stream = provider.chat(req).await.expect("chat call succeeds");
 
@@ -85,6 +86,7 @@ async fn chat_maps_http_errors() {
     let req = ChatRequest {
         system: None,
         messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
     };
 
     let err = match provider.chat(req).await {
@@ -125,6 +127,7 @@ async fn chat_oversized_line_yields_typed_error_and_terminates() {
     let req = ChatRequest {
         system: None,
         messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
     };
     let mut stream = provider.chat(req).await.expect("chat call succeeds");
 
@@ -212,6 +215,7 @@ async fn chat_idle_timeout_yields_typed_error_and_terminates() {
     let req = ChatRequest {
         system: None,
         messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
     };
 
     // The chat() call itself must not hang after headers arrive.
@@ -289,6 +293,7 @@ async fn chat_half_open_connect_times_out_within_read_timeout() {
     let req = ChatRequest {
         system: None,
         messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
     };
 
     let start = std::time::Instant::now();

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -135,6 +135,7 @@ pub async fn run_turn<P: Provider>(
             role: ChatRole::User,
             content: vec![ChatBlock::Text(text)],
         }],
+        parallel_tool_calls_allowed: false,
     };
 
     // F-567: pull the dispatcher from the session-scoped cache when one is
@@ -1304,6 +1305,7 @@ fn finalise_request(messages: Vec<ChatMessage>) -> Result<ChatRequest> {
     Ok(ChatRequest {
         system: None,
         messages,
+        parallel_tool_calls_allowed: false,
     })
 }
 
@@ -1400,6 +1402,7 @@ fn build_fresh_request_for(history: &[(u64, Event)], target: &MessageId) -> Resu
                         role: ChatRole::User,
                         content: vec![ChatBlock::Text(text)],
                     }],
+                    parallel_tool_calls_allowed: false,
                 });
             }
             _ => {}


### PR DESCRIPTION
Closes forge-ide/forge#601

## Summary
- New `crates/forge-providers/src/anthropic/` (`mod.rs` + `translate.rs`) implementing the `Provider` trait against the Anthropic Messages API.
- New `crates/forge-providers/src/sse.rs` shared SSE adapter (`event:`/`data:` framing → `(event, data)` pairs) with idle-timeout, wall-clock-timeout, and per-line byte cap matching Ollama defaults (30s / 600s / 1 MiB). Will be reused by F-584 (OpenAI).
- `ChatRequest` gains `parallel_tool_calls_allowed: bool` (default `false`). The flag flips Anthropic's `tool_choice.disable_parallel_tool_use`. Kept sequential until F-599 lands.
- Integration test against a recorded SSE fixture covering text + tool-use streaming end-to-end (wiremock).
- SSE unit tests cover comments, CRLF, multi-`data:` concatenation, line cap, idle timeout, wall-clock timeout, and transport error mapping.
- `anthropic-version: 2023-06-01` pinned as a public const; `x-api-key` header for auth.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (forge-providers: 80 tests, forge-session: 194 tests)
- `cargo clippy --all-targets -- -D warnings` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)