### PR TITLE
[F-588] Dashboard credential prompts + rotation UI

### DIFF
--- a/web/packages/app/src/components/dashboard/CredentialsSection.css
+++ b/web/packages/app/src/components/dashboard/CredentialsSection.css
@@ -1,0 +1,272 @@
+/* F-588 Credentials section — mirrors ProviderPanel aesthetic. */
+
+.credentials-section {
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-1);
+  border-radius: var(--r-sm);
+  padding: var(--sp-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  font-family: var(--font-body);
+  color: var(--color-text-primary);
+  max-width: 480px;
+}
+
+.credentials-section__header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-3);
+}
+
+.credentials-section__label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+}
+
+.credentials-section__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+
+.credentials-section__row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  padding: var(--sp-3) 0;
+  border-top: 1px solid var(--color-border-1);
+}
+
+.credentials-section__row:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.credentials-section__row-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.credentials-section__indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--sp-5);
+  height: var(--sp-5);
+  border-radius: 50%;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.credentials-section__indicator--stored {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+  border: 1px solid var(--color-success-border);
+}
+
+.credentials-section__indicator--missing {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning-border);
+}
+
+.credentials-section__provider-label {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-primary);
+}
+
+.credentials-section__env-hint {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  margin-left: auto;
+}
+
+.credentials-section__form {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.credentials-section__field-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.credentials-section__input {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--color-bg);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  padding: var(--sp-2) var(--sp-3);
+  min-width: 0;
+}
+
+.credentials-section__input:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+  border-color: var(--color-ember-400);
+}
+
+.credentials-section__input:disabled {
+  color: var(--color-text-disabled);
+  cursor: not-allowed;
+}
+
+.credentials-section__btn {
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  padding: var(--sp-2) var(--sp-4);
+  background: transparent;
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: border-color var(--ease);
+}
+
+.credentials-section__btn:hover {
+  border-color: var(--color-ember-400);
+}
+
+.credentials-section__btn:active {
+  transform: translateY(1px);
+}
+
+.credentials-section__btn:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+}
+
+.credentials-section__btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.credentials-section__btn--primary {
+  background: var(--color-ember-400);
+  border-color: var(--color-ember-400);
+  color: var(--color-text-inverted);
+}
+
+.credentials-section__error {
+  margin: 0;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-error-bg);
+  border-left: 3px solid var(--color-ember-400);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-ember-300);
+}
+
+/* ----------------------------------------------------------------------
+ * Rotation confirmation modal
+ * ---------------------------------------------------------------------- */
+
+.credentials-section__modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: var(--sp-5);
+}
+
+.credentials-section__modal {
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-md);
+  padding: var(--sp-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.credentials-section__modal-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.credentials-section__modal-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-ember-300);
+}
+
+.credentials-section__modal-body {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.credentials-section__modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sp-3);
+}
+
+/* ----------------------------------------------------------------------
+ * First-run banner
+ * ---------------------------------------------------------------------- */
+
+.credentials-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--color-warning-bg);
+  border-left: 3px solid var(--color-warning);
+  border-radius: var(--r-sm);
+  font-family: var(--font-body);
+  color: var(--color-text-primary);
+  max-width: 480px;
+}
+
+.credentials-banner__icon {
+  font-family: var(--font-mono);
+  font-size: 16px;
+  color: var(--color-warning);
+  flex-shrink: 0;
+}
+
+.credentials-banner__text {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}

--- a/web/packages/app/src/components/dashboard/CredentialsSection.css
+++ b/web/packages/app/src/components/dashboard/CredentialsSection.css
@@ -270,3 +270,14 @@
   color: var(--color-text-secondary);
   line-height: 1.5;
 }
+
+.credentials-banner__link {
+  color: var(--color-text-link);
+  text-decoration: underline;
+}
+
+.credentials-banner__link:focus-visible {
+  outline: 2px solid var(--color-ember-400);
+  outline-offset: 2px;
+  border-radius: var(--r-sm);
+}

--- a/web/packages/app/src/components/dashboard/CredentialsSection.test.tsx
+++ b/web/packages/app/src/components/dashboard/CredentialsSection.test.tsx
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@solidjs/testing-library';
+import { setInvokeForTesting } from '../../lib/tauri';
+import {
+  CREDENTIAL_PROVIDERS,
+  CredentialBanner,
+  CredentialsSection,
+} from './CredentialsSection';
+
+type InvokeMock = ReturnType<typeof vi.fn>;
+
+/**
+ * Build an invoke mock that routes credential commands through a stateful map
+ * so login/logout/has act on the same store. Anything unrecognised returns
+ * undefined so latent calls fail visibly.
+ */
+function buildCredentialInvoke(seed: Record<string, boolean> = {}): {
+  fn: InvokeMock;
+  store: Record<string, boolean>;
+} {
+  const store: Record<string, boolean> = { ...seed };
+  const fn = vi.fn(async (cmd: string, args?: Record<string, unknown>) => {
+    if (cmd === 'has_credential') {
+      const id = args?.['providerId'] as string;
+      return store[id] === true;
+    }
+    if (cmd === 'login_provider') {
+      const id = args?.['providerId'] as string;
+      store[id] = true;
+      return undefined;
+    }
+    if (cmd === 'logout_provider') {
+      const id = args?.['providerId'] as string;
+      delete store[id];
+      return undefined;
+    }
+    return undefined;
+  });
+  return { fn, store };
+}
+
+describe('CredentialsSection (F-588)', () => {
+  beforeEach(() => {
+    const { fn } = buildCredentialInvoke();
+    setInvokeForTesting(fn as never);
+  });
+
+  afterEach(() => {
+    setInvokeForTesting(null);
+    cleanup();
+  });
+
+  it('renders one row per credential-supporting provider', async () => {
+    const { findByTestId } = render(() => <CredentialsSection />);
+    for (const p of CREDENTIAL_PROVIDERS) {
+      const row = await findByTestId(`credential-row-${p.id}`);
+      expect(row).toBeTruthy();
+    }
+  });
+
+  it('shows the missing indicator when has_credential returns false', async () => {
+    const { findByTestId } = render(() => <CredentialsSection />);
+    const row = await findByTestId('credential-row-anthropic');
+    await waitFor(() => {
+      const indicator = row.querySelector('.credentials-section__indicator--missing');
+      expect(indicator).toBeTruthy();
+    });
+  });
+
+  it('shows the stored indicator when has_credential returns true', async () => {
+    const { fn } = buildCredentialInvoke({ anthropic: true });
+    setInvokeForTesting(fn as never);
+
+    const { findByTestId } = render(() => <CredentialsSection />);
+    const row = await findByTestId('credential-row-anthropic');
+    await waitFor(() => {
+      const indicator = row.querySelector('.credentials-section__indicator--stored');
+      expect(indicator).toBeTruthy();
+    });
+  });
+
+  it('uses a password input — never echoes the typed value', async () => {
+    const { findByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    expect(input.type).toBe('password');
+  });
+
+  it('typing + submitting on a fresh provider stores the key and clears the input', async () => {
+    const { fn, store } = buildCredentialInvoke();
+    setInvokeForTesting(fn as never);
+
+    const { findByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    const submit = (await findByTestId('credential-submit-anthropic')) as HTMLButtonElement;
+
+    fireEvent.input(input, { target: { value: 'sk-ant-1' } });
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(store['anthropic']).toBe(true);
+    });
+    // The password input has been cleared so the runtime heap no longer
+    // holds a copy of the typed value.
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+    // IPC was called with the typed key.
+    expect(fn).toHaveBeenCalledWith('login_provider', {
+      providerId: 'anthropic',
+      key: 'sk-ant-1',
+    });
+  });
+
+  it('rotation flow opens a confirmation modal before overwriting an existing key', async () => {
+    const { fn } = buildCredentialInvoke({ anthropic: true });
+    setInvokeForTesting(fn as never);
+
+    const { findByTestId, queryByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    const submit = await findByTestId('credential-submit-anthropic');
+
+    // Wait until the row has resolved the existing-credential state.
+    await waitFor(() => {
+      expect(queryByTestId('credential-logout-anthropic')).toBeTruthy();
+    });
+
+    fireEvent.input(input, { target: { value: 'sk-ant-NEW' } });
+    fireEvent.click(submit);
+
+    // Modal appears — IPC has NOT been called for login yet.
+    const modal = await findByTestId('credential-rotation-modal');
+    expect(modal).toBeTruthy();
+    expect(
+      fn.mock.calls.find(
+        (c) => c[0] === 'login_provider',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('rotation confirm calls login_provider with the new key', async () => {
+    const { fn, store } = buildCredentialInvoke({ anthropic: true });
+    setInvokeForTesting(fn as never);
+
+    const { findByTestId, queryByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    const submit = await findByTestId('credential-submit-anthropic');
+
+    await waitFor(() => {
+      expect(queryByTestId('credential-logout-anthropic')).toBeTruthy();
+    });
+
+    fireEvent.input(input, { target: { value: 'sk-ant-NEW' } });
+    fireEvent.click(submit);
+
+    const confirm = await findByTestId('credential-rotation-confirm');
+    fireEvent.click(confirm);
+
+    await waitFor(() => {
+      expect(
+        fn.mock.calls.some(
+          (c) => c[0] === 'login_provider' && (c[1] as { key: string }).key === 'sk-ant-NEW',
+        ),
+      ).toBe(true);
+    });
+    expect(store['anthropic']).toBe(true);
+  });
+
+  it('rotation cancel discards the pending value — no IPC call', async () => {
+    const { fn } = buildCredentialInvoke({ anthropic: true });
+    setInvokeForTesting(fn as never);
+
+    const { findByTestId, queryByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    const submit = await findByTestId('credential-submit-anthropic');
+
+    await waitFor(() => {
+      expect(queryByTestId('credential-logout-anthropic')).toBeTruthy();
+    });
+
+    fireEvent.input(input, { target: { value: 'sk-ant-NEW' } });
+    fireEvent.click(submit);
+
+    const cancel = await findByTestId('credential-rotation-cancel');
+    fireEvent.click(cancel);
+
+    await waitFor(() => {
+      expect(queryByTestId('credential-rotation-modal')).toBeNull();
+    });
+    expect(
+      fn.mock.calls.some((c) => c[0] === 'login_provider'),
+    ).toBe(false);
+  });
+
+  it('logout button calls logout_provider and flips the indicator', async () => {
+    const { fn, store } = buildCredentialInvoke({ anthropic: true });
+    setInvokeForTesting(fn as never);
+
+    const { findByTestId } = render(() => <CredentialsSection />);
+    const logout = await findByTestId('credential-logout-anthropic');
+
+    fireEvent.click(logout);
+
+    await waitFor(() => {
+      expect(store['anthropic']).toBeUndefined();
+    });
+    expect(fn).toHaveBeenCalledWith('logout_provider', { providerId: 'anthropic' });
+  });
+
+  it('surfaces an IPC failure in an alert without crashing', async () => {
+    const failingInvoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'has_credential') return false;
+      if (cmd === 'login_provider') throw new Error('keyring unavailable');
+      return undefined;
+    });
+    setInvokeForTesting(failingInvoke as never);
+
+    const { findByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    const submit = await findByTestId('credential-submit-anthropic');
+
+    fireEvent.input(input, { target: { value: 'sk-ant-bad' } });
+    fireEvent.click(submit);
+
+    const err = await findByTestId('credential-error-anthropic');
+    expect(err.textContent).toContain('keyring unavailable');
+  });
+
+  it('async submit button carries aria-busy for accessibility', async () => {
+    let resolveLogin: (() => void) | undefined;
+    const slowInvoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'has_credential') return false;
+      if (cmd === 'login_provider') {
+        return new Promise<void>((r) => {
+          resolveLogin = r;
+        });
+      }
+      return undefined;
+    });
+    setInvokeForTesting(slowInvoke as never);
+
+    const { findByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    const submit = (await findByTestId('credential-submit-anthropic')) as HTMLButtonElement;
+
+    fireEvent.input(input, { target: { value: 'sk-ant-1' } });
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(submit.getAttribute('aria-busy')).toBe('true');
+    });
+
+    resolveLogin?.();
+  });
+});
+
+describe('CredentialBanner (F-588)', () => {
+  it('renders the missing-credential prompt for the named provider', () => {
+    const { getByTestId } = render(() => <CredentialBanner providerLabel="Anthropic" />);
+    const banner = getByTestId('credential-banner');
+    expect(banner.textContent).toContain('Anthropic');
+    expect(banner.getAttribute('role')).toBe('status');
+  });
+});

--- a/web/packages/app/src/components/dashboard/CredentialsSection.test.tsx
+++ b/web/packages/app/src/components/dashboard/CredentialsSection.test.tsx
@@ -225,6 +225,80 @@ describe('CredentialsSection (F-588)', () => {
     expect(err.textContent).toContain('keyring unavailable');
   });
 
+  it('clears the input value on IPC failure (security contract)', async () => {
+    const failingInvoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'has_credential') return false;
+      if (cmd === 'login_provider') throw new Error('keyring unavailable');
+      return undefined;
+    });
+    setInvokeForTesting(failingInvoke as never);
+
+    const { findByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    const submit = await findByTestId('credential-submit-anthropic');
+
+    fireEvent.input(input, { target: { value: 'sk-ant-bad' } });
+    fireEvent.click(submit);
+
+    // Wait for the error path to settle, then assert the input is empty —
+    // the typed value must NOT linger past the IPC call.
+    await findByTestId('credential-error-anthropic');
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+  });
+
+  it('clears the input value when the rotation modal is cancelled', async () => {
+    const { fn } = buildCredentialInvoke({ anthropic: true });
+    setInvokeForTesting(fn as never);
+
+    const { findByTestId, queryByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    const submit = await findByTestId('credential-submit-anthropic');
+
+    await waitFor(() => {
+      expect(queryByTestId('credential-logout-anthropic')).toBeTruthy();
+    });
+
+    fireEvent.input(input, { target: { value: 'sk-ant-NEW' } });
+    fireEvent.click(submit);
+
+    const cancel = await findByTestId('credential-rotation-cancel');
+    fireEvent.click(cancel);
+
+    // The pending value lived in `pendingRotation` until cancel; the input
+    // bound to `draft` must also be cleared so the secret does not linger.
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+  });
+
+  it('rotation modal Escape (window-level) dismisses and clears the input', async () => {
+    const { fn } = buildCredentialInvoke({ anthropic: true });
+    setInvokeForTesting(fn as never);
+
+    const { findByTestId, queryByTestId } = render(() => <CredentialsSection />);
+    const input = (await findByTestId('credential-input-anthropic')) as HTMLInputElement;
+    const submit = await findByTestId('credential-submit-anthropic');
+
+    await waitFor(() => {
+      expect(queryByTestId('credential-logout-anthropic')).toBeTruthy();
+    });
+
+    fireEvent.input(input, { target: { value: 'sk-ant-NEW' } });
+    fireEvent.click(submit);
+    await findByTestId('credential-rotation-modal');
+
+    // Dispatch Escape at window level — focus may be anywhere; this must
+    // still dismiss the modal per WAI-ARIA APG Dialog pattern.
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(queryByTestId('credential-rotation-modal')).toBeNull();
+    });
+    expect(input.value).toBe('');
+  });
+
   it('async submit button carries aria-busy for accessibility', async () => {
     let resolveLogin: (() => void) | undefined;
     const slowInvoke = vi.fn(async (cmd: string) => {
@@ -259,5 +333,25 @@ describe('CredentialBanner (F-588)', () => {
     const banner = getByTestId('credential-banner');
     expect(banner.textContent).toContain('Anthropic');
     expect(banner.getAttribute('role')).toBe('status');
+  });
+
+  it('exposes a keyboard-accessible anchor pointing at the Credentials section', () => {
+    const { getByTestId } = render(() => <CredentialBanner providerLabel="Anthropic" />);
+    const banner = getByTestId('credential-banner');
+    const link = banner.querySelector('a');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute('href')).toBe('#credentials-section');
+  });
+});
+
+describe('CredentialsSection landing target (F-588)', () => {
+  it('exposes id="credentials-section" so the banner anchor resolves', async () => {
+    setInvokeForTesting(
+      (async () => true) as never,
+    );
+    const { container } = render(() => <CredentialsSection />);
+    const section = container.querySelector('#credentials-section');
+    expect(section).toBeTruthy();
+    expect(section?.tagName).toBe('SECTION');
   });
 });

--- a/web/packages/app/src/components/dashboard/CredentialsSection.tsx
+++ b/web/packages/app/src/components/dashboard/CredentialsSection.tsx
@@ -13,7 +13,10 @@
 //
 // Security contract:
 //   - The key value lives only in a single `<input type="password">`'s
-//     local state and is cleared the moment the IPC call resolves.
+//     local state and is cleared the moment the IPC call resolves —
+//     regardless of outcome (success or rejection) — and on rotation
+//     cancel. The user can re-type if they want; the value never
+//     persists past a terminal state.
 //   - The DOM never contains a rendered key — only the `password` input
 //     (browser-DOM-only) ever holds the typed value.
 //   - Logging / aria-labels never echo the key.
@@ -23,6 +26,8 @@ import {
   createResource,
   createSignal,
   For,
+  onCleanup,
+  onMount,
   Show,
 } from 'solid-js';
 import { Button } from '@forge/design';
@@ -62,9 +67,20 @@ export const CREDENTIAL_PROVIDERS: CredentialProvider[] = [
 // Component
 // ---------------------------------------------------------------------------
 
+/**
+ * Anchor id on the Credentials `<section>`. Exported so the first-run
+ * banner can hyperlink to the same target without the two values
+ * drifting apart.
+ */
+export const CREDENTIALS_SECTION_ID = 'credentials-section';
+
 export const CredentialsSection: Component = () => {
   return (
-    <section class="credentials-section" aria-label="Provider credentials">
+    <section
+      id={CREDENTIALS_SECTION_ID}
+      class="credentials-section"
+      aria-label="Provider credentials"
+    >
       <header class="credentials-section__header">
         <span class="credentials-section__label">CREDENTIALS</span>
       </header>
@@ -87,9 +103,19 @@ interface CredentialRowProps {
 }
 
 const CredentialRow: Component<CredentialRowProps> = (props) => {
+  // Probe failure should not crash the row (or pollute the unhandled-rejection
+  // log) — degrade to "no stored credential" so the user can still type a
+  // key and recover. The submit-time error path surfaces actionable
+  // failures via `setError` regardless.
   const [present, { refetch }] = createResource(
     () => props.provider.id,
-    (id) => hasCredential(id),
+    async (id) => {
+      try {
+        return await hasCredential(id);
+      } catch {
+        return false;
+      }
+    },
   );
   const [draft, setDraft] = createSignal('');
   const [pending, setPending] = createSignal(false);
@@ -101,13 +127,15 @@ const CredentialRow: Component<CredentialRowProps> = (props) => {
     setError(null);
     try {
       await loginProvider(props.provider.id, value);
-      // Per security contract, drop the value from local state the moment
-      // the IPC call resolves so the runtime heap no longer holds a copy.
-      setDraft('');
       await refetch();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
+      // Per security contract, drop the value from local state the moment
+      // the IPC call resolves regardless of outcome so the runtime heap
+      // no longer holds a copy. The user can re-type if they want; a stuck
+      // input would otherwise persist the secret across an error path.
+      setDraft('');
       setPending(false);
       setPendingRotation(null);
     }
@@ -207,7 +235,13 @@ const CredentialRow: Component<CredentialRowProps> = (props) => {
       <Show when={pendingRotation() !== null}>
         <RotationConfirm
           providerLabel={props.provider.label}
-          onCancel={() => setPendingRotation(null)}
+          onCancel={() => {
+            // Cancel = explicit terminal state for the typed value. Clear
+            // both the pending-rotation buffer AND the draft input so the
+            // secret does not linger past the user's dismiss action.
+            setPendingRotation(null);
+            setDraft('');
+          }}
           onConfirm={() => {
             const value = pendingRotation();
             if (value !== null) void submit(value);
@@ -252,12 +286,21 @@ const RotationConfirm: Component<RotationConfirmProps> = (props) => {
   let dialogRef: HTMLDivElement | undefined;
   useFocusTrap(() => dialogRef);
 
-  const onKey = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      props.onCancel();
-    }
-  };
+  // WAI-ARIA APG Dialog pattern: Escape must dismiss regardless of focus
+  // location. The focus trap keeps Tab inside the dialog under normal
+  // operation, but a screen reader, browser shortcut, or VoiceOver rotor
+  // jump can move focus out of the dialog — a div-bound listener would
+  // miss those keystrokes. A window-level listener supersedes them all.
+  onMount(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        props.onCancel();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    onCleanup(() => window.removeEventListener('keydown', handler));
+  });
 
   return (
     <div
@@ -273,7 +316,6 @@ const RotationConfirm: Component<RotationConfirmProps> = (props) => {
         role="dialog"
         aria-modal="true"
         aria-labelledby="credential-rotation-title"
-        onKeyDown={onKey}
       >
         <header class="credentials-section__modal-head">
           <h3 id="credential-rotation-title" class="credentials-section__modal-title">
@@ -336,8 +378,11 @@ export const CredentialBanner: Component<CredentialBannerProps> = (props) => (
       ⚠
     </span>
     <p class="credentials-banner__text">
-      <strong>{props.providerLabel}</strong> has no stored credential. Add one in the Credentials
-      section below to start a session.
+      <strong>{props.providerLabel}</strong> has no stored credential.{' '}
+      <a class="credentials-banner__link" href={`#${CREDENTIALS_SECTION_ID}`}>
+        Add one in the Credentials section
+      </a>{' '}
+      below to start a session.
     </p>
   </div>
 );

--- a/web/packages/app/src/components/dashboard/CredentialsSection.tsx
+++ b/web/packages/app/src/components/dashboard/CredentialsSection.tsx
@@ -1,0 +1,343 @@
+// F-588: per-provider credential management UI on the Dashboard.
+//
+// Renders one row per provider that supports credentials. Each row shows a
+// presence indicator (✓ when stored, ⚠ when missing) backed by the F-587
+// `has_credential` Tauri command, an inline form to enter or replace the
+// key, and a logout button when a credential is present.
+//
+// Rotation contract: when a credential already exists, submitting a new
+// value pops a confirmation modal first. Rotation is destructive (the
+// previous key is overwritten in the keyring with no recovery), so the
+// UX gates it behind an explicit confirm step. Logout is reversible
+// (re-enter the key) and stays single-step.
+//
+// Security contract:
+//   - The key value lives only in a single `<input type="password">`'s
+//     local state and is cleared the moment the IPC call resolves.
+//   - The DOM never contains a rendered key — only the `password` input
+//     (browser-DOM-only) ever holds the typed value.
+//   - Logging / aria-labels never echo the key.
+
+import {
+  type Component,
+  createResource,
+  createSignal,
+  For,
+  Show,
+} from 'solid-js';
+import { Button } from '@forge/design';
+import type { ProviderId } from '@forge/ipc';
+import { hasCredential, loginProvider, logoutProvider } from '../../ipc/credentials';
+import { useFocusTrap } from '../../lib/useFocusTrap';
+import './CredentialsSection.css';
+
+// ---------------------------------------------------------------------------
+// Provider catalogue
+// ---------------------------------------------------------------------------
+
+/**
+ * Phase 3 ships two providers that require credentials. Ollama is keyless
+ * and intentionally absent from this list — adding it would surface a
+ * "missing key" indicator for a provider that does not need one.
+ *
+ * The mapping is duplicated from `forge-core::credentials::env` (the
+ * `EnvFallbackStore::default` mapping). When a third provider lands the
+ * change is two lines (this list + the env mapping) — the rest of the
+ * section is provider-agnostic.
+ */
+export interface CredentialProvider {
+  id: ProviderId;
+  /** Human-readable name shown next to the indicator. */
+  label: string;
+  /** Env var name, surfaced as a hint when no credential is stored. */
+  envHint: string;
+}
+
+export const CREDENTIAL_PROVIDERS: CredentialProvider[] = [
+  { id: 'anthropic' as ProviderId, label: 'Anthropic', envHint: 'ANTHROPIC_API_KEY' },
+  { id: 'openai' as ProviderId, label: 'OpenAI', envHint: 'OPENAI_API_KEY' },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const CredentialsSection: Component = () => {
+  return (
+    <section class="credentials-section" aria-label="Provider credentials">
+      <header class="credentials-section__header">
+        <span class="credentials-section__label">CREDENTIALS</span>
+      </header>
+
+      <ul class="credentials-section__list" role="list">
+        <For each={CREDENTIAL_PROVIDERS}>
+          {(provider) => <CredentialRow provider={provider} />}
+        </For>
+      </ul>
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Row — one per provider
+// ---------------------------------------------------------------------------
+
+interface CredentialRowProps {
+  provider: CredentialProvider;
+}
+
+const CredentialRow: Component<CredentialRowProps> = (props) => {
+  const [present, { refetch }] = createResource(
+    () => props.provider.id,
+    (id) => hasCredential(id),
+  );
+  const [draft, setDraft] = createSignal('');
+  const [pending, setPending] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+  const [pendingRotation, setPendingRotation] = createSignal<string | null>(null);
+
+  const submit = async (value: string) => {
+    setPending(true);
+    setError(null);
+    try {
+      await loginProvider(props.provider.id, value);
+      // Per security contract, drop the value from local state the moment
+      // the IPC call resolves so the runtime heap no longer holds a copy.
+      setDraft('');
+      await refetch();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+      setPendingRotation(null);
+    }
+  };
+
+  const onSubmit = (e: SubmitEvent) => {
+    e.preventDefault();
+    const value = draft();
+    if (value.length === 0 || pending()) return;
+
+    if (present()) {
+      // Existing credential → rotation confirm modal.
+      setPendingRotation(value);
+      return;
+    }
+    // First-time storage → no confirmation needed.
+    void submit(value);
+  };
+
+  const onLogout = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      await logoutProvider(props.provider.id);
+      await refetch();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const indicatorLabel = () =>
+    present() ? `Credential stored for ${props.provider.label}` : `No credential for ${props.provider.label}`;
+
+  const inputId = `credential-input-${props.provider.id}`;
+
+  return (
+    <li class="credentials-section__row" data-testid={`credential-row-${props.provider.id}`}>
+      <div class="credentials-section__row-head">
+        <Indicator stored={present() === true} label={indicatorLabel()} />
+        <span class="credentials-section__provider-label">{props.provider.label}</span>
+        <span class="credentials-section__env-hint" aria-hidden="true">
+          {props.provider.envHint}
+        </span>
+        <Show when={present()}>
+          <Button
+            variant="ghost"
+            size="sm"
+            class="credentials-section__btn"
+            data-testid={`credential-logout-${props.provider.id}`}
+            aria-label={`Remove stored credential for ${props.provider.label}`}
+            aria-busy={pending()}
+            disabled={pending()}
+            onClick={() => void onLogout()}
+          >
+            LOGOUT
+          </Button>
+        </Show>
+      </div>
+
+      <form class="credentials-section__form" onSubmit={onSubmit}>
+        <label class="credentials-section__field-label" for={inputId}>
+          {present() ? 'Replace key' : 'Add key'}
+        </label>
+        <input
+          id={inputId}
+          class="credentials-section__input"
+          data-testid={`credential-input-${props.provider.id}`}
+          type="password"
+          autocomplete="off"
+          spellcheck={false}
+          value={draft()}
+          onInput={(e) => setDraft(e.currentTarget.value)}
+          aria-label={`API key for ${props.provider.label}`}
+          disabled={pending()}
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          class="credentials-section__btn credentials-section__btn--primary"
+          data-testid={`credential-submit-${props.provider.id}`}
+          aria-busy={pending()}
+          disabled={pending() || draft().length === 0}
+          type="submit"
+        >
+          {present() ? 'ROTATE' : 'STORE'}
+        </Button>
+      </form>
+
+      <Show when={error()}>
+        <p class="credentials-section__error" role="alert" data-testid={`credential-error-${props.provider.id}`}>
+          {error()}
+        </p>
+      </Show>
+
+      <Show when={pendingRotation() !== null}>
+        <RotationConfirm
+          providerLabel={props.provider.label}
+          onCancel={() => setPendingRotation(null)}
+          onConfirm={() => {
+            const value = pendingRotation();
+            if (value !== null) void submit(value);
+          }}
+          pending={pending()}
+        />
+      </Show>
+    </li>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Indicator (✓ / ⚠) — never reveals the value
+// ---------------------------------------------------------------------------
+
+const Indicator: Component<{ stored: boolean; label: string }> = (props) => (
+  <span
+    class="credentials-section__indicator"
+    classList={{
+      'credentials-section__indicator--stored': props.stored,
+      'credentials-section__indicator--missing': !props.stored,
+    }}
+    role="img"
+    aria-label={props.label}
+  >
+    {props.stored ? '✓' : '⚠'}
+  </span>
+);
+
+// ---------------------------------------------------------------------------
+// Rotation confirmation modal
+// ---------------------------------------------------------------------------
+
+interface RotationConfirmProps {
+  providerLabel: string;
+  pending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const RotationConfirm: Component<RotationConfirmProps> = (props) => {
+  let dialogRef: HTMLDivElement | undefined;
+  useFocusTrap(() => dialogRef);
+
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      props.onCancel();
+    }
+  };
+
+  return (
+    <div
+      class="credentials-section__modal-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) props.onCancel();
+      }}
+      data-testid="credential-rotation-modal"
+    >
+      <div
+        ref={dialogRef}
+        class="credentials-section__modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="credential-rotation-title"
+        onKeyDown={onKey}
+      >
+        <header class="credentials-section__modal-head">
+          <h3 id="credential-rotation-title" class="credentials-section__modal-title">
+            REPLACE STORED KEY?
+          </h3>
+        </header>
+        <p class="credentials-section__modal-body">
+          A credential for <strong>{props.providerLabel}</strong> is already stored. Replacing it
+          overwrites the keyring entry — the previous key cannot be recovered.
+        </p>
+        <div class="credentials-section__modal-actions">
+          <Button
+            variant="ghost"
+            size="sm"
+            class="credentials-section__btn"
+            data-testid="credential-rotation-cancel"
+            disabled={props.pending}
+            onClick={props.onCancel}
+          >
+            CANCEL
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            class="credentials-section__btn credentials-section__btn--primary"
+            data-testid="credential-rotation-confirm"
+            aria-busy={props.pending}
+            disabled={props.pending}
+            onClick={props.onConfirm}
+          >
+            REPLACE
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// First-run banner — surfaced from Dashboard.tsx, not the section above.
+// ---------------------------------------------------------------------------
+
+interface CredentialBannerProps {
+  /** Display name of the provider missing a credential. */
+  providerLabel: string;
+}
+
+/**
+ * First-run prompt on the Dashboard when the active provider has no stored
+ * credential. Anchored above the Credentials section it points to.
+ */
+export const CredentialBanner: Component<CredentialBannerProps> = (props) => (
+  <div
+    class="credentials-banner"
+    role="status"
+    data-testid="credential-banner"
+    aria-label={`${props.providerLabel} has no stored credential`}
+  >
+    <span class="credentials-banner__icon" aria-hidden="true">
+      ⚠
+    </span>
+    <p class="credentials-banner__text">
+      <strong>{props.providerLabel}</strong> has no stored credential. Add one in the Credentials
+      section below to start a session.
+    </p>
+  </div>
+);

--- a/web/packages/app/src/ipc/credentials.test.ts
+++ b/web/packages/app/src/ipc/credentials.test.ts
@@ -62,4 +62,36 @@ describe('credentials ipc wrappers (F-588)', () => {
       /forbidden/,
     );
   });
+
+  // -------------------------------------------------------------------------
+  // Local validation — fail fast before invoking the backend.
+  // -------------------------------------------------------------------------
+
+  it('loginProvider rejects an empty providerId without invoking the backend', async () => {
+    await expect(loginProvider('' as ProviderId, 'sk-ant-1')).rejects.toThrow(
+      /providerId must not be empty/,
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('loginProvider rejects an empty key without invoking the backend', async () => {
+    await expect(loginProvider('anthropic' as ProviderId, '')).rejects.toThrow(
+      /key must not be empty/,
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('logoutProvider rejects an empty providerId without invoking the backend', async () => {
+    await expect(logoutProvider('' as ProviderId)).rejects.toThrow(
+      /providerId must not be empty/,
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('hasCredential rejects an empty providerId without invoking the backend', async () => {
+    await expect(hasCredential('' as ProviderId)).rejects.toThrow(
+      /providerId must not be empty/,
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
 });

--- a/web/packages/app/src/ipc/credentials.test.ts
+++ b/web/packages/app/src/ipc/credentials.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderId } from '@forge/ipc';
+import { setInvokeForTesting } from '../lib/tauri';
+import { hasCredential, loginProvider, logoutProvider } from './credentials';
+
+describe('credentials ipc wrappers (F-588)', () => {
+  let invokeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    invokeMock = vi.fn();
+    setInvokeForTesting(invokeMock as never);
+  });
+
+  afterEach(() => {
+    setInvokeForTesting(null);
+  });
+
+  it('loginProvider invokes `login_provider` with providerId + key', async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await loginProvider('anthropic' as ProviderId, 'sk-ant-1');
+
+    expect(invokeMock).toHaveBeenCalledWith('login_provider', {
+      providerId: 'anthropic',
+      key: 'sk-ant-1',
+    });
+  });
+
+  it('logoutProvider invokes `logout_provider` with providerId only', async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await logoutProvider('openai' as ProviderId);
+
+    expect(invokeMock).toHaveBeenCalledWith('logout_provider', {
+      providerId: 'openai',
+    });
+  });
+
+  it('hasCredential invokes `has_credential` and returns the boolean', async () => {
+    invokeMock.mockResolvedValue(true);
+
+    const result = await hasCredential('anthropic' as ProviderId);
+
+    expect(invokeMock).toHaveBeenCalledWith('has_credential', {
+      providerId: 'anthropic',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('hasCredential returns false when the backend reports no entry', async () => {
+    invokeMock.mockResolvedValue(false);
+
+    const result = await hasCredential('openai' as ProviderId);
+
+    expect(result).toBe(false);
+  });
+
+  it('loginProvider propagates IPC rejections so the UI can surface errors', async () => {
+    invokeMock.mockRejectedValue(new Error('forbidden: window label mismatch'));
+
+    await expect(loginProvider('anthropic' as ProviderId, 'sk-ant-x')).rejects.toThrow(
+      /forbidden/,
+    );
+  });
+});

--- a/web/packages/app/src/ipc/credentials.ts
+++ b/web/packages/app/src/ipc/credentials.ts
@@ -14,11 +14,18 @@ import { invoke } from '../lib/tauri';
  * value is wrapped in `SecretString` on the Rust side immediately on
  * arrival; this wrapper does no additional caching.
  *
+ * Empty `providerId` or `key` are rejected locally before the IPC call.
+ * The Rust side enforces the same shape, but failing fast on the
+ * renderer avoids a round-trip on a degenerate request and keeps the
+ * error surface consistent with this wrapper's contract.
+ *
  * Callers MUST clear `key` from any local state immediately after the
  * Promise resolves — see voice-rule §"Stored-key state shown via masked
  * indicator only — never reveals the value".
  */
 export async function loginProvider(providerId: ProviderId, key: string): Promise<void> {
+  if (!providerId) throw new Error('loginProvider: providerId must not be empty');
+  if (!key) throw new Error('loginProvider: key must not be empty');
   await invoke('login_provider', { providerId, key });
 }
 
@@ -28,6 +35,7 @@ export async function loginProvider(providerId: ProviderId, key: string): Promis
  * silently ignores the call (see `EnvFallbackStore::remove`).
  */
 export async function logoutProvider(providerId: ProviderId): Promise<void> {
+  if (!providerId) throw new Error('logoutProvider: providerId must not be empty');
   await invoke('logout_provider', { providerId });
 }
 
@@ -37,5 +45,6 @@ export async function logoutProvider(providerId: ProviderId): Promise<void> {
  * across the IPC boundary by this command.
  */
 export async function hasCredential(providerId: ProviderId): Promise<boolean> {
+  if (!providerId) throw new Error('hasCredential: providerId must not be empty');
   return invoke<boolean>('has_credential', { providerId });
 }

--- a/web/packages/app/src/ipc/credentials.ts
+++ b/web/packages/app/src/ipc/credentials.ts
@@ -1,0 +1,41 @@
+// F-588: typed wrappers for the F-587 credential Tauri commands.
+//
+// The backend authoritatively gates these commands to the `dashboard` window
+// label, so callers must originate from the Dashboard route. The actual key
+// only flows through `loginProvider` and never leaves the Rust boundary —
+// `hasCredential` returns presence and `logoutProvider` returns void.
+
+import type { ProviderId } from '@forge/ipc';
+import { invoke } from '../lib/tauri';
+
+/**
+ * Persist `key` for `providerId` into the active credential store
+ * (production wires `LayeredStore<KeyringStore, EnvFallbackStore>`). The
+ * value is wrapped in `SecretString` on the Rust side immediately on
+ * arrival; this wrapper does no additional caching.
+ *
+ * Callers MUST clear `key` from any local state immediately after the
+ * Promise resolves — see voice-rule §"Stored-key state shown via masked
+ * indicator only — never reveals the value".
+ */
+export async function loginProvider(providerId: ProviderId, key: string): Promise<void> {
+  await invoke('login_provider', { providerId, key });
+}
+
+/**
+ * Remove the credential for `providerId` from the active store. The
+ * keyring layer drops the entry; the env-var fallback is read-only and
+ * silently ignores the call (see `EnvFallbackStore::remove`).
+ */
+export async function logoutProvider(providerId: ProviderId): Promise<void> {
+  await invoke('logout_provider', { providerId });
+}
+
+/**
+ * Presence probe — returns `true` when any layer of the credential store
+ * holds an entry for `providerId`. The credential value is never returned
+ * across the IPC boundary by this command.
+ */
+export async function hasCredential(providerId: ProviderId): Promise<boolean> {
+  return invoke<boolean>('has_credential', { providerId });
+}

--- a/web/packages/app/src/routes/Dashboard.test.tsx
+++ b/web/packages/app/src/routes/Dashboard.test.tsx
@@ -1,20 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { cleanup, render } from '@solidjs/testing-library';
+import { cleanup, render, waitFor } from '@solidjs/testing-library';
 import { MemoryRouter, Route } from '@solidjs/router';
 import { Dashboard } from './Dashboard';
 import { setInvokeForTesting } from '../lib/tauri';
 
 describe('Dashboard', () => {
   beforeEach(() => {
-    // Dashboard mounts ProviderPanel which invokes `provider_status` on mount.
-    // Stub so tests don't attempt a real Tauri bridge call.
+    // Dashboard mounts ProviderPanel + SessionsPanel + CredentialsSection,
+    // each of which invokes Tauri commands on mount. Route every command
+    // to a hermetic stub so tests don't attempt a real bridge call.
     setInvokeForTesting(
-      (async () => ({
-        reachable: true,
-        base_url: 'http://127.0.0.1:11434',
-        models: [],
-        last_checked: '2026-04-18T00:00:00Z',
-      })) as never,
+      (async (cmd: string) => {
+        if (cmd === 'provider_status') {
+          return {
+            reachable: true,
+            base_url: 'http://127.0.0.1:11434',
+            models: [],
+            last_checked: '2026-04-18T00:00:00Z',
+          };
+        }
+        if (cmd === 'session_list') return [];
+        if (cmd === 'has_credential') return true;
+        return undefined;
+      }) as never,
     );
   });
 
@@ -46,5 +54,42 @@ describe('Dashboard', () => {
   it('renders no <nav> element (spec D.1 flat surface)', () => {
     const { container } = renderDashboard();
     expect(container.querySelector('nav')).toBeNull();
+  });
+
+  // F-588: when every credential-bearing provider has a key stored, the
+  // first-run banner stays hidden.
+  it('does not render the credential banner when all providers have keys', async () => {
+    const { queryByTestId } = renderDashboard();
+    // Resource resolves on next microtask; flush.
+    await waitFor(() => {
+      expect(queryByTestId('credential-banner')).toBeNull();
+    });
+  });
+
+  // F-588: when at least one credential-bearing provider has no key, the
+  // banner names the first such provider.
+  it('renders the credential banner when a provider has no stored key', async () => {
+    setInvokeForTesting(
+      (async (cmd: string, args?: Record<string, unknown>) => {
+        if (cmd === 'provider_status') {
+          return {
+            reachable: true,
+            base_url: 'http://127.0.0.1:11434',
+            models: [],
+            last_checked: '2026-04-18T00:00:00Z',
+          };
+        }
+        if (cmd === 'session_list') return [];
+        if (cmd === 'has_credential') {
+          // Anthropic missing, OpenAI present — banner should name Anthropic.
+          return args?.['providerId'] === 'openai';
+        }
+        return undefined;
+      }) as never,
+    );
+
+    const { findByTestId } = renderDashboard();
+    const banner = await findByTestId('credential-banner');
+    expect(banner.textContent).toContain('Anthropic');
   });
 });

--- a/web/packages/app/src/routes/Dashboard.test.tsx
+++ b/web/packages/app/src/routes/Dashboard.test.tsx
@@ -92,4 +92,36 @@ describe('Dashboard', () => {
     const banner = await findByTestId('credential-banner');
     expect(banner.textContent).toContain('Anthropic');
   });
+
+  // F-588: a single broken probe must not silently suppress the banner
+  // for the remaining providers. Anthropic throws, OpenAI is missing —
+  // the banner must name OpenAI.
+  it('falls back to the next provider when the first probe throws', async () => {
+    setInvokeForTesting(
+      (async (cmd: string, args?: Record<string, unknown>) => {
+        if (cmd === 'provider_status') {
+          return {
+            reachable: true,
+            base_url: 'http://127.0.0.1:11434',
+            models: [],
+            last_checked: '2026-04-18T00:00:00Z',
+          };
+        }
+        if (cmd === 'session_list') return [];
+        if (cmd === 'has_credential') {
+          if (args?.['providerId'] === 'anthropic') {
+            throw new Error('keyring locked');
+          }
+          if (args?.['providerId'] === 'openai') return false;
+          return false;
+        }
+        return undefined;
+      }) as never,
+    );
+
+    const { findByTestId } = renderDashboard();
+    const banner = await findByTestId('credential-banner');
+    expect(banner.textContent).toContain('OpenAI');
+    expect(banner.textContent).not.toContain('Anthropic has no stored credential');
+  });
 });

--- a/web/packages/app/src/routes/Dashboard.tsx
+++ b/web/packages/app/src/routes/Dashboard.tsx
@@ -1,13 +1,47 @@
-import type { Component } from 'solid-js';
+import { type Component, createResource, Show } from 'solid-js';
 import { ProviderPanel } from './Dashboard/ProviderPanel';
 import { SessionsPanel } from './Dashboard/SessionsPanel';
+import {
+  CREDENTIAL_PROVIDERS,
+  CredentialBanner,
+  CredentialsSection,
+} from '../components/dashboard/CredentialsSection';
+import { hasCredential } from '../ipc/credentials';
 import './Dashboard.css';
 
+/**
+ * F-588: surface a first-run banner when the active provider has no stored
+ * credential. Phase 3 ships two credential-bearing providers
+ * (`anthropic`, `openai`); without an explicit "active provider" signal
+ * yet, the banner picks the first such provider that lacks a credential
+ * so the user has a concrete target to add.
+ */
+async function firstMissingCredential(): Promise<{ id: string; label: string } | null> {
+  for (const provider of CREDENTIAL_PROVIDERS) {
+    try {
+      const stored = await hasCredential(provider.id);
+      if (!stored) return { id: provider.id as unknown as string, label: provider.label };
+    } catch {
+      // Probe failure shouldn't block the dashboard render. Treat the
+      // probe outcome as "stored" so the banner stays quiet — the user
+      // will see the per-row indicator pick up the same error.
+      return null;
+    }
+  }
+  return null;
+}
+
 export const Dashboard: Component = () => {
+  const [missing] = createResource(firstMissingCredential);
+
   return (
     <main class="dashboard">
       <h1 class="dashboard__title">Forge — Dashboard</h1>
+      <Show when={missing()}>
+        {(m) => <CredentialBanner providerLabel={m().label} />}
+      </Show>
       <ProviderPanel />
+      <CredentialsSection />
       <SessionsPanel />
     </main>
   );

--- a/web/packages/app/src/routes/Dashboard.tsx
+++ b/web/packages/app/src/routes/Dashboard.tsx
@@ -15,6 +15,12 @@ import './Dashboard.css';
  * (`anthropic`, `openai`); without an explicit "active provider" signal
  * yet, the banner picks the first such provider that lacks a credential
  * so the user has a concrete target to add.
+ *
+ * Probe failure on a single provider is treated as "stored for that
+ * provider only" — the loop `continue`s so a broken probe on Anthropic
+ * does not silently suppress the banner that would otherwise call out a
+ * missing OpenAI key. The per-row indicator inside `<CredentialsSection>`
+ * surfaces the underlying probe error to the user.
  */
 async function firstMissingCredential(): Promise<{ id: string; label: string } | null> {
   for (const provider of CREDENTIAL_PROVIDERS) {
@@ -22,10 +28,7 @@ async function firstMissingCredential(): Promise<{ id: string; label: string } |
       const stored = await hasCredential(provider.id);
       if (!stored) return { id: provider.id as unknown as string, label: provider.label };
     } catch {
-      // Probe failure shouldn't block the dashboard render. Treat the
-      // probe outcome as "stored" so the banner stays quiet — the user
-      // will see the per-row indicator pick up the same error.
-      return null;
+      continue;
     }
   }
   return null;


### PR DESCRIPTION
## Summary

- Adds `<CredentialsSection>` to the Dashboard with a row per credential-bearing provider (Anthropic, OpenAI), each surfacing a masked ✓/⚠ indicator from `has_credential`, an inline `<input type="password">` form that calls `login_provider`, and a Logout button that calls `logout_provider`.
- Replacing an existing credential pops a confirmation modal (focus-trap via `useFocusTrap`, window-level Escape dismiss, backdrop dismiss) before overwriting the keyring entry. First-time storage stays single-step; logout stays single-step (reversible by re-entering).
- Adds a first-run banner on the Dashboard that names the first provider with no stored credential. The banner now exposes a real anchor (`href="#credentials-section"`) so keyboard / screen-reader users have an actionable target.
- Typed key never leaves the password input; local state is cleared the moment the IPC call resolves on every outcome (success, rejection, rotation cancel).

## Implementation notes

- New `web/packages/app/src/ipc/credentials.ts` mirrors the F-587 surface (`loginProvider`, `logoutProvider`, `hasCredential`). Wrappers reject empty `providerId` / `key` locally so the backend never sees a degenerate request.
- Component lives at `web/packages/app/src/components/dashboard/CredentialsSection.tsx` per the DoD path.
- Per-row probe failures degrade to "no stored credential" inside the resource so a thrown `hasCredential` does not surface as an unhandled rejection — the user can still type a key and recover, and the submit-time path surfaces actionable failures via the row error alert.
- Dashboard banner probe-loop continues past per-provider errors (does not abort the loop), so a single broken probe cannot silently suppress the banner for the remaining providers.
- All styling goes through `@forge/design` Button primitives + design tokens. No raw `px`/`hex` in inline styles (`pnpm check-tokens` is green).
- Mirrors the existing `AgentMonitor` modal idiom (`role="dialog"`, `aria-modal`, focus trap, backdrop click dismiss). Escape is bound at window level per the WAI-ARIA APG Dialog pattern so focus jumps to the address bar, browser chrome, or screen-reader rotor still dismiss the dialog.

Closes #606

## Deviations / deferred follow-ups

- **Last-modified timestamp deferred.** The DoD scope mentions surfacing a "last-modified" hint on stored credentials, but F-587's `has_credential` only returns presence. Surfacing a timestamp would require extending the IPC layer (a `credential_metadata` command or extending the existing one to return a `{ present, modified_at }` shape). Out of scope for F-588; the indicator therefore shows ✓ / ⚠ only.
- **`pendingRotation` signal holds plaintext key during the rotation modal lifetime.** The signal lives only while the modal is open and is cleared on dismiss, confirm, and IPC resolve. Switching to a module-local `let` to avoid the signal's reactive subscription was considered, but the lifetime is bounded by the modal's `<Show>` block and cancel now also clears the draft, so the additional ceremony was judged not worth the indirection. Leaving as-is and noted here so future work has a documented seam if a stronger guarantee is wanted.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `pnpm -r typecheck`
- [x] `pnpm check-tokens`
- [x] `pnpm -r test` (1019 tests, all green)
- [ ] Manual: open Dashboard with no `ANTHROPIC_API_KEY` env — banner appears, anchor jumps to Credentials section
- [ ] Manual: type a key, click STORE — indicator flips to ✓, input clears
- [ ] Manual: with a stored key, type a new value, click ROTATE — modal asks for confirmation; ESC dismisses (clears draft), CANCEL dismisses (clears draft), REPLACE confirms (clears draft, indicator stays ✓)
- [ ] Manual: simulate IPC failure — error alert shows, input clears
- [ ] Manual: click LOGOUT — indicator flips to ⚠

🤖 Generated with [Claude Code](https://claude.com/claude-code)