### PR TITLE
[F-586] Provider selection: IPC commands + Dashboard provider picker UI

### DIFF
--- a/crates/forge-core/src/event.rs
+++ b/crates/forge-core/src/event.rs
@@ -279,4 +279,19 @@ pub enum Event {
         /// `docs/architecture/event-conventions.md` as a pinned exception.
         sampled_at: DateTime<Utc>,
     },
+    /// F-586: dashboard-driven active-provider switch.
+    ///
+    /// Emitted by the shell's `set_active_provider` IPC command after the
+    /// new id has been validated and persisted to `[providers.active]`.
+    /// Subscribers (the orchestrator's per-session provider holder) swap
+    /// the active `Provider` for the **next** turn — the in-flight turn
+    /// (if any) finishes on the old provider. Mid-stream switching is out
+    /// of scope; this event is informational + the swap takes effect at
+    /// the next `run_turn` boundary.
+    ///
+    /// `provider_id` is the stable slug the dashboard selected (e.g.
+    /// `"ollama"`, `"anthropic"`, `"openai"`, `"custom_openai:<name>"`).
+    /// The same string is what `Credentials::has_credential` keys on, and
+    /// what `[providers.active]` now persists.
+    ProviderChanged { provider_id: String },
 }

--- a/crates/forge-core/src/settings.rs
+++ b/crates/forge-core/src/settings.rs
@@ -164,6 +164,18 @@ fn default_auth_shape() -> AuthShapeSettings {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../web/packages/ipc/src/generated/")]
 pub struct ProvidersSettings {
+    /// F-586: id of the active provider (e.g. `"ollama"`, `"anthropic"`,
+    /// `"openai"`, `"custom_openai:vllm-local"`). `None` means "no
+    /// preference" — the orchestrator falls through to whatever the daemon
+    /// was started with (Phase-1 default: Ollama keyless).
+    ///
+    /// Stored as `Option<String>` rather than the random-hex `ProviderId`
+    /// id type from `ids.rs`: provider selection is keyed by stable, human-
+    /// readable slugs the user picks in the dashboard, not opaque ids.
+    /// Both the IPC command surface and the credential store key on this
+    /// same string shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active: Option<String>,
     /// One entry per user-named OpenAI-compatible server.
     #[serde(default)]
     pub custom_openai: BTreeMap<String, CustomOpenAiEntry>,
@@ -917,6 +929,7 @@ api_key = "sk-test"
             windows: WindowsSettings::default(),
             providers: ProvidersSettings {
                 custom_openai: entries,
+                ..Default::default()
             },
         };
         let serialized = toml::to_string(&cfg).unwrap();
@@ -954,8 +967,69 @@ api_key = "sk-test"
             windows: WindowsSettings::default(),
             providers: ProvidersSettings {
                 custom_openai: entries,
+                ..Default::default()
             },
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Active provider (F-586) — backwards-compat + round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn providers_active_absent_yields_none() {
+        // Settings files written before F-586 have no `active` key. They must
+        // still load (the field is `#[serde(default)]`) and the merged value
+        // is `None` — meaning "no preference, fall through to the daemon's
+        // startup default".
+        let body = r#"
+[providers.custom_openai.together]
+base_url = "https://api.together.xyz"
+model = "mixtral"
+api_key = "sk-test"
+"#;
+        let parsed: AppSettings = toml::from_str(body).unwrap();
+        assert!(parsed.providers.active.is_none());
+        assert_eq!(parsed.providers.custom_openai.len(), 1);
+    }
+
+    #[test]
+    fn providers_active_round_trips_through_save_load() {
+        let cfg = AppSettings {
+            providers: ProvidersSettings {
+                active: Some("anthropic".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let serialized = toml::to_string(&cfg).unwrap();
+        let reparsed: AppSettings = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed, cfg);
+        assert_eq!(reparsed.providers.active.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn providers_active_skip_serializing_when_none() {
+        // None must NOT serialize — keeping the wire shape stable for older
+        // readers and never promoting an implicit absent to a present-but-null.
+        let cfg = AppSettings::default();
+        let s = toml::to_string(&cfg).unwrap();
+        assert!(
+            !s.contains("active"),
+            "default AppSettings must not emit `active`, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn providers_active_persists_through_apply_setting_update() {
+        // Mirror the IPC `set_setting` path: `apply_setting_update` should
+        // accept `providers.active = "openai"` and produce TOML that
+        // round-trips into the new `active` field.
+        let updated =
+            apply_setting_update("", "providers.active", toml::Value::String("openai".into()))
+                .unwrap();
+        let reparsed: AppSettings = toml::from_str(&updated).unwrap();
+        assert_eq!(reparsed.providers.active.as_deref(), Some("openai"));
     }
 
     #[test]

--- a/crates/forge-core/tests/event_wire_shape.rs
+++ b/crates/forge-core/tests/event_wire_shape.rs
@@ -823,6 +823,23 @@ fn mcp_state_wire_shape_degraded_with_reason() {
     );
 }
 
+#[test]
+fn provider_changed_wire_shape() {
+    // F-586: dashboard-driven active-provider switch event. The wire shape
+    // is the snake_case discriminator plus a single `provider_id` string —
+    // matching the slug the dashboard selected and the key
+    // `Credentials::has_credential` accepts.
+    assert_wire_eq(
+        Event::ProviderChanged {
+            provider_id: "anthropic".into(),
+        },
+        json!({
+            "type": "provider_changed",
+            "provider_id": "anthropic",
+        }),
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Compile-time guard: adding a new `Event` variant must also add its
 // wire-shape pin above. This is enforced by an exhaustive `match` here —
@@ -862,6 +879,7 @@ fn variant_label(e: &Event) -> &'static str {
         Event::ToolReturned { .. } => "tool_returned",
         Event::McpState(_) => "mcp_state",
         Event::ResourceSample { .. } => "resource_sample",
+        Event::ProviderChanged { .. } => "provider_changed",
     }
 }
 

--- a/crates/forge-providers/Cargo.toml
+++ b/crates/forge-providers/Cargo.toml
@@ -4,6 +4,15 @@ version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[features]
+# F-586: enable the `RuntimeProvider::Mock` variant for callers outside the
+# `forge-providers` test target (e.g. `forge-session::tests::provider_swap`,
+# any future cross-crate integration suite). Production binaries leave this
+# off; the `Mock` arm vanishes from the enum, so the dashboard's IPC layer
+# cannot dispatch to it even via direct `SwappableProvider::swap` from
+# another crate.
+testing = []
+
 [dependencies]
 anyhow = "1"
 bytes = "1"

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -14,7 +14,13 @@ use serde::Deserialize;
 pub mod anthropic;
 pub mod ollama;
 pub mod openai;
+// F-586: hot-swappable [`Provider`] dispatcher used by the session daemon
+// when the dashboard's `set_active_provider` IPC command emits a
+// `ProviderChanged` event for the next turn.
+pub mod runtime;
 pub mod sse;
+
+pub use runtime::{RuntimeProvider, SwappableProvider};
 
 // ── Chat domain types ─────────────────────────────────────────────────────────
 

--- a/crates/forge-providers/src/runtime.rs
+++ b/crates/forge-providers/src/runtime.rs
@@ -1,0 +1,227 @@
+//! F-586: hot-swappable [`Provider`] dispatcher.
+//!
+//! The [`Provider`] trait uses `impl Future` (not object-safe), so
+//! `Arc<dyn Provider>` is not viable. To allow the dashboard's
+//! `set_active_provider` IPC command to swap the active provider for the
+//! next turn without restarting the session, we wrap the four built-ins
+//! plus the test mock in a runtime enum and provide a hot-swap holder
+//! via [`SwappableProvider`].
+//!
+//! The dispatch overhead is one `match` arm per `chat` call — negligible
+//! compared to the network round-trip every variant performs.
+//!
+//! Construction site: `forge-session::serve_with_session` swaps its
+//! `Arc<P>` parameter for an `Arc<SwappableProvider>` so a `ProviderChanged`
+//! event delivered through the per-session swap channel takes effect on
+//! the next `run_turn` invocation. The current turn finishes on the old
+//! inner provider — switching mid-stream is out of scope (matches
+//! F-586's DoD).
+
+use std::sync::Arc;
+
+use forge_core::Result;
+use futures::stream::BoxStream;
+use parking_lot::RwLock;
+
+use crate::anthropic::AnthropicProvider;
+use crate::ollama::OllamaProvider;
+use crate::openai::custom::CustomOpenAiProvider;
+use crate::openai::OpenAiProvider;
+#[cfg(any(test, feature = "testing"))]
+use crate::MockProvider;
+use crate::{ChatChunk, ChatRequest, Provider};
+
+/// Tagged-union of every concrete [`Provider`] implementation. Each chat
+/// call dispatches via `match` to the appropriate inner — no dynamic
+/// dispatch is needed because the trait is not object-safe today.
+///
+/// Each variant holds an [`Arc`] so the [`SwappableProvider`] can release
+/// its lock guard *after* cloning the `Arc` for the active variant. The
+/// concrete `chat()` futures borrow `&self` per the trait signature, so a
+/// `parking_lot::RwLockReadGuard` cannot survive the network round-trip
+/// (the guard isn't `Send`); the `Arc::clone` workaround keeps the
+/// captured reference alive on a refcounted handle that doesn't depend on
+/// the lock.
+///
+/// `Mock` is gated behind `#[cfg(any(test, feature = "testing"))]` so a
+/// production binary cannot construct it. Crates that need to drive the
+/// swap path from an integration test must enable
+/// `forge-providers/testing` in their dev-dependencies. Without the gate,
+/// any caller across the workspace could `swap()` to a Mock variant and
+/// silently route real prompts to a scripted source.
+#[derive(Clone)]
+pub enum RuntimeProvider {
+    Ollama(Arc<OllamaProvider>),
+    Anthropic(Arc<AnthropicProvider>),
+    OpenAi(Arc<OpenAiProvider>),
+    CustomOpenAi(Arc<CustomOpenAiProvider>),
+    #[cfg(any(test, feature = "testing"))]
+    Mock(Arc<MockProvider>),
+}
+
+impl RuntimeProvider {
+    /// Stable slug identifying which variant is currently active. Same
+    /// shape the dashboard's `[providers.active]` setting and
+    /// `Credentials::has_credential` use.
+    pub fn id(&self) -> &str {
+        match self {
+            RuntimeProvider::Ollama(_) => "ollama",
+            RuntimeProvider::Anthropic(_) => "anthropic",
+            RuntimeProvider::OpenAi(_) => "openai",
+            RuntimeProvider::CustomOpenAi(_) => "custom_openai",
+            #[cfg(any(test, feature = "testing"))]
+            RuntimeProvider::Mock(_) => "mock",
+        }
+    }
+}
+
+impl Provider for RuntimeProvider {
+    fn chat(
+        &self,
+        req: ChatRequest,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        // Clone the inner Arc so the future owns the inner state; this is
+        // a refcount bump, not a deep copy. Each arm boxes a different
+        // concrete future type into a uniform `BoxFuture` for return.
+        let cloned = self.clone();
+        async move {
+            let fut: futures::future::BoxFuture<'static, _> = match cloned {
+                RuntimeProvider::Ollama(p) => Box::pin(async move { p.chat(req).await }),
+                RuntimeProvider::Anthropic(p) => Box::pin(async move { p.chat(req).await }),
+                RuntimeProvider::OpenAi(p) => Box::pin(async move { p.chat(req).await }),
+                RuntimeProvider::CustomOpenAi(p) => Box::pin(async move { p.chat(req).await }),
+                #[cfg(any(test, feature = "testing"))]
+                RuntimeProvider::Mock(p) => Box::pin(async move { p.chat(req).await }),
+            };
+            fut.await
+        }
+    }
+}
+
+/// Hot-swappable [`Provider`] holder. Stores its inner [`RuntimeProvider`]
+/// behind an `Arc<RwLock<_>>` so the orchestrator can replace it in place
+/// from a `ProviderChanged` listener without breaking the
+/// `Arc<P: Provider>` shape `serve_with_session` expects.
+///
+/// Read-mostly: writers are only the swap path (one writer per
+/// `ProviderChanged` event), readers are every `run_turn` invocation.
+/// `parking_lot::RwLock` is used over `tokio::sync::RwLock` because the
+/// critical section is brief and synchronous (a `match` arm); a turn-bound
+/// async wait would only add latency.
+pub struct SwappableProvider {
+    inner: Arc<RwLock<RuntimeProvider>>,
+}
+
+impl SwappableProvider {
+    /// Construct with an initial provider. The inner can be hot-swapped via
+    /// [`Self::swap`].
+    pub fn new(initial: RuntimeProvider) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(initial)),
+        }
+    }
+
+    /// Atomically replace the inner provider. The replacement takes effect
+    /// on the next [`Provider::chat`] call — any chat-stream already in
+    /// flight continues against the previous inner because it captured a
+    /// boxed future before the swap.
+    pub fn swap(&self, next: RuntimeProvider) {
+        *self.inner.write() = next;
+    }
+
+    /// Slug of the currently-active provider (matches the dashboard's
+    /// `[providers.active]` shape).
+    pub fn active_id(&self) -> String {
+        self.inner.read().id().to_string()
+    }
+}
+
+impl Provider for SwappableProvider {
+    fn chat(
+        &self,
+        req: ChatRequest,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        // Snapshot the active inner `RuntimeProvider` (an `Arc`-cloning
+        // operation per variant) under a brief read lock, then drop the
+        // guard. The async block then owns the cloned snapshot, which
+        // holds Arc-backed state and can outlive any subsequent swap.
+        // This is the contract that lets the next turn use the new inner
+        // without disturbing the in-flight stream.
+        let snapshot: RuntimeProvider = self.inner.read().clone();
+        async move { snapshot.chat(req).await }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    fn mock_with_text(s: &str) -> MockProvider {
+        MockProvider::from_responses(vec![format!(
+            "{{\"delta\":\"{s}\"}}\n{{\"done\":\"end_turn\"}}\n"
+        )])
+        .expect("construct mock")
+    }
+
+    fn mock_arc(s: &str) -> Arc<MockProvider> {
+        Arc::new(mock_with_text(s))
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn runtime_provider_dispatches_to_inner_mock() {
+        let rp = RuntimeProvider::Mock(mock_arc("hello"));
+        let req = ChatRequest::default();
+        let mut stream = rp.chat(req).await.expect("chat");
+        let first = stream.next().await.expect("first chunk");
+        assert_eq!(first, ChatChunk::TextDelta("hello".into()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn swappable_provider_initially_dispatches_to_first_inner() {
+        let sp = SwappableProvider::new(RuntimeProvider::Mock(mock_arc("first")));
+        assert_eq!(sp.active_id(), "mock");
+        let mut stream = sp.chat(ChatRequest::default()).await.expect("chat");
+        let first = stream.next().await.expect("first chunk");
+        assert_eq!(first, ChatChunk::TextDelta("first".into()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn swappable_provider_uses_new_inner_after_swap() {
+        // F-586 DoD #4: after a `ProviderChanged` event the next turn must
+        // use the new provider. This test exercises the swap primitive that
+        // the orchestrator's listener calls.
+        let sp = SwappableProvider::new(RuntimeProvider::Mock(mock_arc("before")));
+
+        // First call against the initial inner.
+        {
+            let mut stream = sp.chat(ChatRequest::default()).await.expect("chat 1");
+            let chunk = stream.next().await.expect("chunk 1");
+            assert_eq!(chunk, ChatChunk::TextDelta("before".into()));
+        }
+
+        // Swap mid-session — the next chat() must dispatch to the new
+        // inner. Construct a fresh mock so the script is single-shot.
+        sp.swap(RuntimeProvider::Mock(mock_arc("after")));
+
+        let mut stream = sp.chat(ChatRequest::default()).await.expect("chat 2");
+        let chunk = stream.next().await.expect("chunk 2");
+        assert_eq!(chunk, ChatChunk::TextDelta("after".into()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn swappable_provider_active_id_reflects_swap() {
+        let sp = SwappableProvider::new(RuntimeProvider::Mock(mock_arc("x")));
+        assert_eq!(sp.active_id(), "mock");
+
+        // Swap to an Ollama variant — id must update without reaching the
+        // network. We can't easily construct a real `OllamaProvider` for
+        // unit tests, but the public API is keyless construction, so this
+        // is fine.
+        sp.swap(RuntimeProvider::Ollama(Arc::new(OllamaProvider::new(
+            "http://127.0.0.1:11434",
+            "mistral",
+        ))));
+        assert_eq!(sp.active_id(), "ollama");
+    }
+}

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -68,6 +68,9 @@ windows-sys = { version = "0.61", features = [
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support", "async_tokio"] }
 forge-cli = { path = "../forge-cli" }
+# F-586: enable the `RuntimeProvider::Mock` variant for the
+# `provider_swap` integration test. Production binaries leave this off.
+forge-providers = { path = "../forge-providers", features = ["testing"] }
 libc = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 similar = "2"
@@ -166,3 +169,7 @@ path = "tests/eprintln_audit.rs"
 [[test]]
 name = "credentials_pull"
 path = "tests/credentials_pull.rs"
+
+[[test]]
+name = "provider_swap"
+path = "tests/provider_swap.rs"

--- a/crates/forge-session/tests/provider_swap.rs
+++ b/crates/forge-session/tests/provider_swap.rs
@@ -1,0 +1,195 @@
+//! F-586: orchestrator subscription to mid-session provider swap.
+//!
+//! Demonstrates that an `Arc<SwappableProvider>` plumbed through
+//! `serve_with_session` honors a swap between turns: the next
+//! `SendUserMessage` arrives at the new inner without restarting the
+//! session.
+//!
+//! The current turn's stream is captured against the old inner before the
+//! swap (per F-586 spec: "the current turn finishes on the old provider").
+//! A second `SendUserMessage` after the swap exercises the new inner.
+//!
+//! This is the in-process counterpart to the dashboard wiring: in
+//! production the shell's `set_active_provider` IPC command emits a
+//! `provider:changed` Tauri event; a session-window listener forwards it
+//! over the per-session UDS, the connection loop picks it up and calls
+//! `SwappableProvider::swap`. This test exercises the same primitive
+//! (`SwappableProvider::swap`) directly so the orchestrator-side contract
+//! is pinned without a Tauri runtime.
+
+use forge_core::Event;
+use forge_ipc::{
+    ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, PROTO_VERSION,
+};
+use forge_providers::{MockProvider, RuntimeProvider, SwappableProvider};
+use forge_session::{server::serve_with_session, session::Session};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+async fn connect_with_retry(path: &std::path::PathBuf) -> UnixStream {
+    for _ in 0..50 {
+        match UnixStream::connect(path).await {
+            Ok(s) => return s,
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+        }
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("server did not start in time")
+}
+
+async fn do_handshake(stream: &mut UnixStream) {
+    let hello = IpcMessage::Hello(Hello {
+        proto: PROTO_VERSION,
+        client: ClientInfo {
+            kind: "test".into(),
+            pid: std::process::id(),
+            user: "tester".into(),
+        },
+    });
+    forge_ipc::write_frame(stream, &hello).await.unwrap();
+    let response = forge_ipc::read_frame(stream).await.unwrap();
+    assert!(
+        matches!(response, IpcMessage::HelloAck(_)),
+        "expected HelloAck"
+    );
+}
+
+fn extract_event(msg: &IpcMessage) -> Option<Event> {
+    if let IpcMessage::Event(IpcEvent { event, .. }) = msg {
+        Some(event.clone())
+    } else {
+        None
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn next_turn_uses_new_provider_after_swap() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("test.sock");
+
+    // Build two distinct mocks. Each emits a single token then `done` so
+    // the assistant reply text equals exactly the labeled token.
+    let mock_before = Arc::new(
+        MockProvider::from_responses(vec![
+            "{\"delta\":\"BEFORE\"}\n{\"done\":\"end_turn\"}\n".into()
+        ])
+        .unwrap(),
+    );
+    let mock_after = Arc::new(
+        MockProvider::from_responses(vec![
+            "{\"delta\":\"AFTER\"}\n{\"done\":\"end_turn\"}\n".into()
+        ])
+        .unwrap(),
+    );
+
+    // Wire the SwappableProvider through `serve_with_session`. The daemon
+    // calls `chat()` on it per turn — the snapshot is taken at chat-call
+    // time, so a swap between turns takes effect on the next call.
+    let swap = Arc::new(SwappableProvider::new(RuntimeProvider::Mock(Arc::clone(
+        &mock_before,
+    ))));
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&swap);
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            server_session,
+            server_provider,
+            false, // auto_approve
+            false, // ephemeral
+            None,
+            None,
+            None, // F-587 keyless
+        )
+        .await
+        .ok();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+
+    // ── Turn 1 — should hit `mock_before` ────────────────────────────────
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "first turn".into(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    loop {
+        let frame = forge_ipc::read_frame(&mut stream).await.unwrap();
+        let Some(ev) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::AssistantMessage {
+            text,
+            stream_finalised: true,
+            ..
+        } = ev
+        {
+            assert_eq!(&*text, "BEFORE");
+            break;
+        }
+    }
+
+    // ── Swap mid-session ────────────────────────────────────────────────
+    swap.swap(RuntimeProvider::Mock(Arc::clone(&mock_after)));
+    assert_eq!(swap.active_id(), "mock");
+
+    // ── Turn 2 — must hit `mock_after` ──────────────────────────────────
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "second turn".into(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    loop {
+        let frame = forge_ipc::read_frame(&mut stream).await.unwrap();
+        let Some(ev) = extract_event(&frame) else {
+            continue;
+        };
+        if let Event::AssistantMessage {
+            text,
+            stream_finalised: true,
+            ..
+        } = ev
+        {
+            assert_eq!(
+                &*text, "AFTER",
+                "post-swap turn must reach the new provider"
+            );
+            break;
+        }
+    }
+
+    // Sanity: each mock saw exactly one chat() call. The "before" mock
+    // received the first turn's request; the "after" mock received the
+    // second's. If swap had been ignored, mock_before would record both
+    // turns and mock_after would record none.
+    assert_eq!(
+        mock_before.recorded_requests().len(),
+        1,
+        "first turn went to the original provider"
+    );
+    assert_eq!(
+        mock_after.recorded_requests().len(),
+        1,
+        "second turn went to the new provider after swap"
+    );
+}

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -567,6 +567,15 @@ pub fn build_invoke_handler<R: Runtime>() -> Box<dyn Fn(tauri::ipc::Invoke<R>) -
         crate::credentials_ipc::login_provider,
         crate::credentials_ipc::logout_provider,
         crate::credentials_ipc::has_credential,
+        // F-586: provider selection. Dashboard-scoped — `set_active_provider`
+        // emits a `provider:changed` Tauri event app-wide so session
+        // windows / orchestrator subscribers swap on the next turn. The
+        // listing command is named `dashboard_list_providers` so the
+        // shorter `list_providers` slot stays free for F-591's catalog
+        // roster command.
+        crate::providers_ipc::dashboard_list_providers,
+        crate::providers_ipc::get_active_provider,
+        crate::providers_ipc::set_active_provider,
     ])
 }
 
@@ -712,7 +721,7 @@ impl PersistentApprovalEntry {
 /// when present. Returns `Ok(None)` when neither the override nor the
 /// platform resolution yields a path (extremely unusual — no `$HOME`, no
 /// Known Folder). Callers should treat `Ok(None)` as "empty user config."
-fn resolve_user_config_dir(state: &BridgeState) -> Option<PathBuf> {
+pub(crate) fn resolve_user_config_dir(state: &BridgeState) -> Option<PathBuf> {
     #[cfg(feature = "webview-test")]
     {
         if let Some(override_dir) = state.test_user_config_dir_override.as_ref() {
@@ -748,7 +757,7 @@ fn resolve_workspaces_toml(state: &BridgeState) -> PathBuf {
 /// - **`dashboard` callers**: the supplied `workspace_root` is validated
 ///   against the workspaces registry (`workspaces.toml`). A path not present
 ///   in the registry is rejected.
-async fn resolve_workspace_root_for_command(
+pub(crate) async fn resolve_workspace_root_for_command(
     webview_label: &str,
     webview_supplied: &str,
     state: &BridgeState,

--- a/crates/forge-shell/src/lib.rs
+++ b/crates/forge-shell/src/lib.rs
@@ -38,6 +38,14 @@ pub mod context_fetch;
 pub mod credentials_ipc;
 pub mod dashboard;
 pub mod dashboard_sessions;
+// F-586: provider-selection commands (`dashboard_list_providers`,
+// `get_active_provider`, `set_active_provider`). Pure helpers
+// (`build_provider_list`, `is_known_provider_id`, `validate_provider_id`)
+// are always compiled so non-webview tests link without Tauri; the
+// `#[tauri::command]` wrappers are gated behind `webview`. The
+// `dashboard_` prefix on `list_providers` disambiguates from F-591's
+// roster-catalog command of the same short name.
+pub mod providers_ipc;
 pub mod window_spec;
 
 #[cfg(feature = "webview")]

--- a/crates/forge-shell/src/providers_ipc.rs
+++ b/crates/forge-shell/src/providers_ipc.rs
@@ -1,0 +1,579 @@
+//! F-586: Tauri command surface for active-provider selection.
+//!
+//! Three commands, all gated on `webview` so non-webview builds compile
+//! without Tauri:
+//!
+//! - [`dashboard_list_providers`] — returns the four built-in provider
+//!   entries (Ollama, Anthropic, OpenAI, Custom OpenAI) plus any
+//!   user-configured `[providers.custom_openai.<name>]` entries, each
+//!   enriched with a credential-presence flag pulled from the shell's
+//!   `Credentials` store. Named with the `dashboard_` prefix to
+//!   disambiguate from F-591's roster catalog `list_providers` (Tauri's
+//!   `generate_handler!` rejects two commands with the same wire name).
+//! - [`get_active_provider`] — reads the persisted active id from
+//!   `[providers.active]` of the merged settings.
+//! - [`set_active_provider`] — validates the id matches a known provider,
+//!   writes through the same `apply_setting_update` path the generic
+//!   `set_setting` uses, then emits `provider:changed` Tauri event app-wide
+//!   so any open session window's bridge can broadcast a `ProviderChanged`
+//!   into its session log for the orchestrator's next turn.
+//!
+//! # Authorization
+//!
+//! Provider commands are dashboard-scoped — only the `dashboard` window
+//! label may invoke them. Same model as `credentials_ipc`.
+
+#[cfg(feature = "webview")]
+use std::sync::Arc;
+
+#[cfg(feature = "webview")]
+use forge_core::{
+    settings::{apply_setting_update, save_user_settings_raw_in},
+    Credentials, Event,
+};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "webview")]
+use tauri::{AppHandle, Emitter, Runtime, State, Webview};
+#[cfg(feature = "webview")]
+use tokio::sync::Mutex;
+#[allow(unused_imports)]
+use tracing;
+
+#[cfg(feature = "webview")]
+use crate::credentials_ipc::CredentialsState;
+
+/// Process-wide guard that serializes `set_active_provider`'s
+/// read-modify-write of the user-tier settings file. The dashboard's
+/// double-tap UX (rapid card clicks) and any future programmatic caller
+/// could otherwise race two readers, leaving the second writer's TOML to
+/// silently overwrite the first. The guard is held only across the
+/// `read → apply_setting_update → save_user_settings_raw_in` triple, so
+/// the worst-case latency is one disk write — well below human reaction
+/// time.
+///
+/// Scoped to F-586 today; if a future task wants to serialize *every*
+/// settings write across crates, lift this into `forge_core::settings`
+/// and have `set_setting` (the generic command) acquire it too.
+#[cfg(feature = "webview")]
+fn settings_write_guard() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD.get_or_init(|| Mutex::new(()))
+}
+
+/// Built-in provider slugs. Stable ids the dashboard, settings file, and
+/// keyring all key on. Adding a new built-in: extend the
+/// `BUILTIN_PROVIDERS` table below and add a matching credential-required
+/// hint.
+pub const PROVIDER_OLLAMA: &str = "ollama";
+pub const PROVIDER_ANTHROPIC: &str = "anthropic";
+pub const PROVIDER_OPENAI: &str = "openai";
+pub const PROVIDER_CUSTOM_OPENAI: &str = "custom_openai";
+
+/// Prefix used for user-configured CustomOpenAI entries:
+/// `custom_openai:<name>` where `<name>` is the user-chosen key under
+/// `[providers.custom_openai.<name>]`. The colon is the separator the
+/// dashboard tokenises on.
+pub const CUSTOM_OPENAI_PREFIX: &str = "custom_openai:";
+
+/// Per-built-in metadata used to render the dashboard cards.
+struct BuiltinDescriptor {
+    id: &'static str,
+    display_name: &'static str,
+    credential_required: bool,
+    /// When `true`, the dashboard skips the "available models" enrichment
+    /// step — the user supplies the model identifier per entry.
+    user_supplied_model: bool,
+}
+
+const BUILTIN_PROVIDERS: &[BuiltinDescriptor] = &[
+    BuiltinDescriptor {
+        id: PROVIDER_OLLAMA,
+        display_name: "Ollama",
+        credential_required: false,
+        user_supplied_model: false,
+    },
+    BuiltinDescriptor {
+        id: PROVIDER_ANTHROPIC,
+        display_name: "Anthropic",
+        credential_required: true,
+        user_supplied_model: true,
+    },
+    BuiltinDescriptor {
+        id: PROVIDER_OPENAI,
+        display_name: "OpenAI",
+        credential_required: true,
+        user_supplied_model: true,
+    },
+    BuiltinDescriptor {
+        id: PROVIDER_CUSTOM_OPENAI,
+        display_name: "Custom OpenAI-compat",
+        credential_required: true,
+        user_supplied_model: true,
+    },
+];
+
+/// One row of the `dashboard_list_providers` response — what the dashboard renders
+/// per card.
+///
+/// `model_available` is `Some(true)` when the provider has a configured
+/// default model (built-in providers carry one out-of-the-box, custom
+/// entries declare it explicitly), `Some(false)` when none is available
+/// (e.g. a custom entry with an empty `model` field), and `None` when the
+/// presence is not yet probed.
+///
+/// `has_credential` is `false` when the keyring backend reports no entry
+/// for the provider id, when the backend is unavailable (treated as
+/// "absent" by contract), or when the credential is irrelevant
+/// (Ollama keyless). The dashboard renders the warning glyph only when
+/// `credential_required && !has_credential`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderEntry {
+    pub id: String,
+    pub display_name: String,
+    pub credential_required: bool,
+    pub has_credential: bool,
+    pub model_available: bool,
+    /// Optional human-readable model id for the dashboard's secondary line
+    /// (e.g. the configured `model` field of a `[providers.custom_openai.X]`
+    /// entry). `None` for built-ins without a baked-in model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exercised by unit tests under `--no-default-features`.
+// ---------------------------------------------------------------------------
+
+/// Build the list of [`ProviderEntry`] for the dashboard. Pure: takes the
+/// merged settings + the credential probe results as inputs so tests can
+/// drive every shape (missing keys, unavailable backend, custom entries,
+/// etc.) without a live keyring.
+///
+/// `cred_present(id)` returns `true` when the credential store reported
+/// the entry as present. Backend-failure callers should pass a closure
+/// that returns `false` for every id — matching the spec's "if the keyring
+/// backend is unavailable, treat as `false`".
+pub fn build_provider_list(
+    settings: &forge_core::settings::AppSettings,
+    cred_present: impl Fn(&str) -> bool,
+) -> Vec<ProviderEntry> {
+    let mut out: Vec<ProviderEntry> = BUILTIN_PROVIDERS
+        .iter()
+        .map(|b| ProviderEntry {
+            id: b.id.to_string(),
+            display_name: b.display_name.to_string(),
+            credential_required: b.credential_required,
+            has_credential: if b.credential_required {
+                cred_present(b.id)
+            } else {
+                false
+            },
+            // Built-ins always claim a model is available — the daemon
+            // either ships one (Ollama via env / discovery) or the user
+            // supplies it via the spec / a custom entry.
+            model_available: !b.user_supplied_model,
+            model: None,
+        })
+        .collect();
+
+    // User-configured CustomOpenAI entries are reachable both individually
+    // (their credential keyed under `custom_openai:<name>`) and through
+    // the umbrella `custom_openai` builtin. Render each as its own card so
+    // the user can pick one without going through a sub-picker.
+    for (name, entry) in &settings.providers.custom_openai {
+        let id = format!("{CUSTOM_OPENAI_PREFIX}{name}");
+        let model_available = !entry.model.is_empty();
+        out.push(ProviderEntry {
+            display_name: format!("{} — {}", PROVIDER_CUSTOM_OPENAI, name),
+            credential_required: !matches!(
+                entry.auth,
+                forge_core::settings::AuthShapeSettings::None
+            ),
+            has_credential: cred_present(&id),
+            model_available,
+            model: if model_available {
+                Some(entry.model.clone())
+            } else {
+                None
+            },
+            id,
+        });
+    }
+
+    out
+}
+
+/// `true` when `id` matches one of the built-in slugs or one of the
+/// user-configured `custom_openai:<name>` entries in `settings`. Pure
+/// helper exposed so `set_active_provider` can validate the id without
+/// going through the credential store.
+pub fn is_known_provider_id(settings: &forge_core::settings::AppSettings, id: &str) -> bool {
+    if BUILTIN_PROVIDERS.iter().any(|b| b.id == id) {
+        return true;
+    }
+    if let Some(rest) = id.strip_prefix(CUSTOM_OPENAI_PREFIX) {
+        return settings.providers.custom_openai.contains_key(rest);
+    }
+    false
+}
+
+/// Per-field byte cap on the inbound `provider_id` argument. Slugs are
+/// short; 128 bytes is a generous upper bound that still rejects a
+/// hostile renderer driving megabyte calls.
+pub const MAX_PROVIDER_ID_BYTES: usize = 128;
+
+/// Pure validation helper exposed for unit tests.
+pub fn validate_provider_id(provider_id: &str) -> Result<(), String> {
+    if provider_id.is_empty() {
+        return Err("provider_id is empty".to_string());
+    }
+    if provider_id.len() > MAX_PROVIDER_ID_BYTES {
+        return Err(format!(
+            "provider_id too large: {} bytes exceeds cap of {} bytes",
+            provider_id.len(),
+            MAX_PROVIDER_ID_BYTES
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tauri command surface
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "webview")]
+async fn cred_presence_map(store: &Arc<dyn Credentials>, ids: &[String]) -> Vec<(String, bool)> {
+    use futures::future::join_all;
+    let probes = ids.iter().map(|id| async move {
+        // F-587 contract: Ok(None) → false, Err(_) → false (treat as absent
+        // when the backend is unavailable, per the F-586 spec).
+        let present = store.has(id).await.unwrap_or(false);
+        (id.clone(), present)
+    });
+    join_all(probes).await
+}
+
+#[cfg(feature = "webview")]
+#[tauri::command]
+pub async fn dashboard_list_providers<R: Runtime>(
+    webview: Webview<R>,
+    state: State<'_, crate::ipc::BridgeState>,
+    creds: State<'_, CredentialsState>,
+) -> Result<Vec<ProviderEntry>, String> {
+    crate::ipc::require_window_label(&webview, "dashboard", "dashboard_list_providers")?;
+
+    // Provider selection is a user-tier setting (no workspace scope today).
+    // Read user settings directly without an unused workspace path.
+    let user_dir = crate::ipc::resolve_user_config_dir(&state);
+    let settings = match user_dir.as_deref() {
+        Some(dir) => forge_core::settings::load_user_settings_in(dir)
+            .await
+            .map_err(|e| e.to_string())?,
+        None => forge_core::settings::AppSettings::default(),
+    };
+
+    // Probe credential presence for every id we'll emit. Two passes so the
+    // map drives the closure — `build_provider_list` is sync.
+    let mut ids: Vec<String> = BUILTIN_PROVIDERS.iter().map(|b| b.id.to_string()).collect();
+    for name in settings.providers.custom_openai.keys() {
+        ids.push(format!("{CUSTOM_OPENAI_PREFIX}{name}"));
+    }
+    let store = creds.store();
+    let presence = cred_presence_map(&store, &ids).await;
+    let presence_map: std::collections::HashMap<String, bool> = presence.into_iter().collect();
+
+    Ok(build_provider_list(&settings, |id| {
+        presence_map.get(id).copied().unwrap_or(false)
+    }))
+}
+
+#[cfg(feature = "webview")]
+#[tauri::command]
+pub async fn get_active_provider<R: Runtime>(
+    webview: Webview<R>,
+    state: State<'_, crate::ipc::BridgeState>,
+) -> Result<Option<String>, String> {
+    crate::ipc::require_window_label(&webview, "dashboard", "get_active_provider")?;
+
+    let user_dir = crate::ipc::resolve_user_config_dir(&state);
+    let settings = match user_dir.as_deref() {
+        Some(dir) => forge_core::settings::load_user_settings_in(dir)
+            .await
+            .map_err(|e| e.to_string())?,
+        None => forge_core::settings::AppSettings::default(),
+    };
+
+    Ok(settings.providers.active)
+}
+
+/// Tauri event name carrying a [`Event::ProviderChanged`] payload to any
+/// listener (session windows, the dashboard's own state). The session
+/// window's IPC bridge (when wired) re-emits this onto its session log so
+/// the in-daemon orchestrator picks up the change for its next turn.
+pub const PROVIDER_CHANGED_EVENT: &str = "provider:changed";
+
+#[cfg(feature = "webview")]
+#[tauri::command]
+pub async fn set_active_provider<R: Runtime>(
+    provider_id: String,
+    app: AppHandle<R>,
+    webview: Webview<R>,
+    state: State<'_, crate::ipc::BridgeState>,
+) -> Result<(), String> {
+    crate::ipc::require_window_label(&webview, "dashboard", "set_active_provider")?;
+    validate_provider_id(&provider_id)?;
+
+    // Serialize the read-modify-write under a process-wide guard so a
+    // double-tap of the dashboard cards (or any future programmatic
+    // caller) can't lose updates. The lock holds across the triple:
+    // read user-tier TOML → apply_setting_update → save raw TOML.
+    let _write_lock = settings_write_guard().lock().await;
+
+    let user_dir = crate::ipc::resolve_user_config_dir(&state);
+    let settings = match user_dir.as_deref() {
+        Some(dir) => forge_core::settings::load_user_settings_in(dir)
+            .await
+            .map_err(|e| e.to_string())?,
+        None => forge_core::settings::AppSettings::default(),
+    };
+
+    if !is_known_provider_id(&settings, &provider_id) {
+        return Err(format!("unknown provider: {provider_id}"));
+    }
+
+    // Persist to user-tier so the choice survives across workspaces. Same
+    // semantics as the existing settings-write path: load → mutate raw TOML
+    // → validate → save.
+    let user_dir = user_dir.ok_or_else(|| "could not resolve user config directory".to_string())?;
+    let user_path = forge_core::settings::user_settings_path_in(&user_dir);
+    let existing = tokio::fs::read_to_string(&user_path)
+        .await
+        .unwrap_or_default();
+    let updated = apply_setting_update(
+        &existing,
+        "providers.active",
+        toml::Value::String(provider_id.clone()),
+    )
+    .map_err(|e| e.to_string())?;
+    save_user_settings_raw_in(&user_dir, &updated)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // Workspace tier is left untouched — provider preference is a global
+    // user setting in F-586. If a future task wants to scope per-workspace,
+    // extend the IPC with a `level: SettingsLevel` argument and route to
+    // `save_workspace_settings_raw` like the generic `set_setting` does.
+
+    tracing::trace!(
+        target: "forge_shell::providers",
+        provider_id = %provider_id,
+        "set_active_provider persisted",
+    );
+
+    // F-586 DoD #4: emit `ProviderChanged` so the orchestrator picks up
+    // the change for its next turn. We dispatch through Tauri's app-wide
+    // emitter so every session window's bridge can fan it out onto its
+    // session log; the dashboard itself also listens to update its UI
+    // optimistically without waiting for a refetch.
+    let event = Event::ProviderChanged {
+        provider_id: provider_id.clone(),
+    };
+    if let Err(e) = app.emit(PROVIDER_CHANGED_EVENT, &event) {
+        tracing::warn!(
+            target: "forge_shell::providers",
+            provider_id = %provider_id,
+            error = %e,
+            "ProviderChanged emit failed",
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use forge_core::settings::{
+        AppSettings, AuthShapeSettings, CustomOpenAiEntry, ProvidersSettings,
+    };
+    use std::collections::BTreeMap;
+
+    fn empty_settings() -> AppSettings {
+        AppSettings::default()
+    }
+
+    fn settings_with_custom(name: &str, entry: CustomOpenAiEntry) -> AppSettings {
+        let mut entries = BTreeMap::new();
+        entries.insert(name.to_string(), entry);
+        AppSettings {
+            providers: ProvidersSettings {
+                custom_openai: entries,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn build_provider_list_emits_four_builtins_in_stable_order() {
+        let s = empty_settings();
+        let entries = build_provider_list(&s, |_| false);
+        let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["ollama", "anthropic", "openai", "custom_openai"],
+            "builtin order is the user-facing card order; do not reorder casually"
+        );
+    }
+
+    #[test]
+    fn build_provider_list_marks_ollama_as_keyless() {
+        let s = empty_settings();
+        let entries = build_provider_list(&s, |_| false);
+        let ollama = entries.iter().find(|e| e.id == "ollama").unwrap();
+        assert!(!ollama.credential_required);
+        assert!(!ollama.has_credential);
+        assert!(ollama.model_available);
+    }
+
+    #[test]
+    fn build_provider_list_marks_anthropic_credential_present_when_store_says_so() {
+        let s = empty_settings();
+        let entries = build_provider_list(&s, |id| id == "anthropic");
+        let anthropic = entries.iter().find(|e| e.id == "anthropic").unwrap();
+        assert!(anthropic.credential_required);
+        assert!(anthropic.has_credential);
+    }
+
+    #[test]
+    fn build_provider_list_treats_keyring_failure_as_absent() {
+        // Spec: "if the keyring backend is unavailable, treat as `false`".
+        let s = empty_settings();
+        let entries = build_provider_list(&s, |_| false);
+        for e in &entries {
+            if e.credential_required {
+                assert!(!e.has_credential, "{e:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn build_provider_list_appends_custom_openai_entries() {
+        let s = settings_with_custom(
+            "vllm-local",
+            CustomOpenAiEntry {
+                base_url: "http://127.0.0.1:8000".into(),
+                model: "Qwen2".into(),
+                model_list: vec!["Qwen2".into()],
+                auth: AuthShapeSettings::None,
+                api_key: None,
+            },
+        );
+        let entries = build_provider_list(&s, |_| false);
+        assert_eq!(entries.len(), 5);
+        let custom = entries.last().unwrap();
+        assert_eq!(custom.id, "custom_openai:vllm-local");
+        // `auth = none` ⇒ credential not required.
+        assert!(!custom.credential_required);
+        assert!(custom.model_available);
+        assert_eq!(custom.model.as_deref(), Some("Qwen2"));
+    }
+
+    #[test]
+    fn build_provider_list_marks_custom_openai_with_bearer_as_credential_required() {
+        let s = settings_with_custom(
+            "together",
+            CustomOpenAiEntry {
+                base_url: "https://api.together.xyz".into(),
+                model: "mixtral".into(),
+                model_list: vec![],
+                auth: AuthShapeSettings::Bearer,
+                api_key: Some("sk-test".into()),
+            },
+        );
+        let entries = build_provider_list(&s, |id| id == "custom_openai:together");
+        let custom = entries
+            .iter()
+            .find(|e| e.id == "custom_openai:together")
+            .unwrap();
+        assert!(custom.credential_required);
+        assert!(custom.has_credential);
+    }
+
+    #[test]
+    fn build_provider_list_marks_custom_openai_without_model_as_unavailable() {
+        let s = settings_with_custom(
+            "stub",
+            CustomOpenAiEntry {
+                base_url: "https://api.example.com".into(),
+                model: String::new(),
+                model_list: vec![],
+                auth: AuthShapeSettings::Bearer,
+                api_key: None,
+            },
+        );
+        let entries = build_provider_list(&s, |_| false);
+        let custom = entries
+            .iter()
+            .find(|e| e.id == "custom_openai:stub")
+            .unwrap();
+        assert!(!custom.model_available);
+        assert!(custom.model.is_none());
+    }
+
+    #[test]
+    fn is_known_provider_id_accepts_builtins() {
+        let s = empty_settings();
+        for id in &["ollama", "anthropic", "openai", "custom_openai"] {
+            assert!(is_known_provider_id(&s, id), "expected `{id}` known");
+        }
+    }
+
+    #[test]
+    fn is_known_provider_id_rejects_unknown_slug() {
+        let s = empty_settings();
+        assert!(!is_known_provider_id(&s, "gemini"));
+        assert!(!is_known_provider_id(&s, ""));
+        assert!(!is_known_provider_id(&s, "custom_openai:does-not-exist"));
+    }
+
+    #[test]
+    fn is_known_provider_id_accepts_configured_custom_openai_entry() {
+        let s = settings_with_custom(
+            "vllm",
+            CustomOpenAiEntry {
+                base_url: "http://x".into(),
+                model: "m".into(),
+                model_list: vec![],
+                auth: AuthShapeSettings::None,
+                api_key: None,
+            },
+        );
+        assert!(is_known_provider_id(&s, "custom_openai:vllm"));
+        assert!(!is_known_provider_id(&s, "custom_openai:other"));
+    }
+
+    #[test]
+    fn validate_provider_id_rejects_empty() {
+        let err = validate_provider_id("").unwrap_err();
+        assert!(err.contains("empty"));
+    }
+
+    #[test]
+    fn validate_provider_id_rejects_oversize() {
+        let huge = "x".repeat(MAX_PROVIDER_ID_BYTES + 1);
+        let err = validate_provider_id(&huge).unwrap_err();
+        assert!(err.contains("exceeds cap"));
+    }
+
+    #[test]
+    fn validate_provider_id_accepts_realistic_slugs() {
+        validate_provider_id("anthropic").expect("anthropic");
+        validate_provider_id("custom_openai:together").expect("custom_openai:together");
+    }
+}

--- a/crates/forge-shell/src/window_manager.rs
+++ b/crates/forge-shell/src/window_manager.rs
@@ -123,6 +123,12 @@ pub fn run() -> Result<()> {
             crate::credentials_ipc::login_provider,
             crate::credentials_ipc::logout_provider,
             crate::credentials_ipc::has_credential,
+            // F-586: provider selection — dashboard list / get-active / set-active.
+            // `dashboard_list_providers` keeps the shorter `list_providers`
+            // wire-name free for F-591's roster catalog command.
+            crate::providers_ipc::dashboard_list_providers,
+            crate::providers_ipc::get_active_provider,
+            crate::providers_ipc::set_active_provider,
         ])
         .setup(|app| {
             crate::ipc::manage_bridge(&app.handle().clone());

--- a/crates/forge-shell/tests/ipc_providers.rs
+++ b/crates/forge-shell/tests/ipc_providers.rs
@@ -1,0 +1,456 @@
+//! F-586 provider-selection IPC tests.
+//!
+//! Covers `dashboard_list_providers`, `get_active_provider`, `set_active_provider`
+//! end-to-end through Tauri's `test::get_ipc_response`. Mirrors the
+//! `ipc_settings.rs` wiring (F-151): user-config-dir override, dashboard
+//! caller, mocked credential store via `MemoryStore`.
+
+#![cfg(feature = "webview-test")]
+
+use std::sync::Arc;
+
+use forge_core::workspaces::{write_workspaces, WorkspaceEntry};
+use forge_core::{Credentials, MemoryStore};
+use forge_shell::bridge::SessionConnections;
+use forge_shell::credentials_ipc::manage_credentials_with;
+use forge_shell::ipc::{build_invoke_handler, BridgeState};
+use secrecy::SecretString;
+use tauri::test::{mock_builder, mock_context, noop_assets, INVOKE_KEY};
+use tauri::Manager;
+use tempfile::TempDir;
+
+/// Build a mock app for dashboard-caller tests: workspaces registry seeded
+/// with `workspace_paths`, user-config-dir at `user_cfg_dir`, and a
+/// caller-supplied credential store.
+async fn make_app(
+    workspace_paths: &[&std::path::Path],
+    user_cfg_dir: &std::path::Path,
+    creds: Arc<dyn Credentials>,
+) -> (tauri::App<tauri::test::MockRuntime>, TempDir) {
+    let registry_dir = TempDir::new().unwrap();
+    let toml_path = registry_dir.path().join("workspaces.toml");
+    let entries: Vec<WorkspaceEntry> = workspace_paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| WorkspaceEntry {
+            id: forge_core::WorkspaceId::new(),
+            path: p.to_path_buf(),
+            name: format!("ws-{i}"),
+            last_opened: chrono::Utc::now(),
+            pinned: false,
+        })
+        .collect();
+    write_workspaces(&toml_path, &entries)
+        .await
+        .expect("seed workspaces.toml");
+
+    let connections = SessionConnections::new();
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::with_test_user_config_and_workspaces(
+        connections,
+        user_cfg_dir.to_path_buf(),
+        toml_path,
+    ));
+    manage_credentials_with(&app.handle().clone(), creds);
+    (app, registry_dir)
+}
+
+fn make_dashboard_window(
+    app: &tauri::App<tauri::test::MockRuntime>,
+) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
+    tauri::WebviewWindowBuilder::new(
+        app,
+        "dashboard",
+        tauri::WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("mock dashboard window")
+}
+
+fn make_session_window(
+    app: &tauri::App<tauri::test::MockRuntime>,
+    session_id: &str,
+) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
+    tauri::WebviewWindowBuilder::new(
+        app,
+        format!("session-{session_id}"),
+        tauri::WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("mock session window")
+}
+
+fn invoke_ok(
+    window: &tauri::WebviewWindow<tauri::test::MockRuntime>,
+    cmd: &str,
+    payload: serde_json::Value,
+) -> serde_json::Value {
+    let res = tauri::test::get_ipc_response(
+        window,
+        tauri::webview::InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+    res.expect("invoke returned Ok").deserialize().unwrap()
+}
+
+fn invoke_err(
+    window: &tauri::WebviewWindow<tauri::test::MockRuntime>,
+    cmd: &str,
+    payload: serde_json::Value,
+) -> String {
+    let res = tauri::test::get_ipc_response(
+        window,
+        tauri::webview::InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+    match res {
+        Ok(ok) => panic!("expected error, got Ok: {ok:?}"),
+        Err(serde_json::Value::String(s)) => s,
+        Err(other) => other.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// list_providers
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_providers_returns_four_builtins_when_no_custom_entries() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let result = invoke_ok(&window, "dashboard_list_providers", serde_json::json!({}));
+    let entries = result.as_array().expect("list");
+    assert_eq!(entries.len(), 4);
+    let ids: Vec<&str> = entries.iter().map(|e| e["id"].as_str().unwrap()).collect();
+    assert_eq!(ids, vec!["ollama", "anthropic", "openai", "custom_openai"]);
+
+    // Ollama is keyless ⇒ credential_required false.
+    assert_eq!(entries[0]["credential_required"], false);
+    // Anthropic is keyed ⇒ credential_required true, has_credential false (empty store).
+    assert_eq!(entries[1]["credential_required"], true);
+    assert_eq!(entries[1]["has_credential"], false);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_providers_reflects_credential_store_presence() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let store = Arc::new(MemoryStore::new());
+    store
+        .set("anthropic", SecretString::from("sk-ant-1"))
+        .await
+        .unwrap();
+    let creds: Arc<dyn Credentials> = store;
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let result = invoke_ok(&window, "dashboard_list_providers", serde_json::json!({}));
+    let entries = result.as_array().expect("list");
+    let anthropic = entries
+        .iter()
+        .find(|e| e["id"] == "anthropic")
+        .expect("anthropic entry");
+    assert_eq!(anthropic["has_credential"], true);
+    let openai = entries.iter().find(|e| e["id"] == "openai").unwrap();
+    assert_eq!(openai["has_credential"], false);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_providers_appends_user_configured_custom_openai_entries() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    // Seed user settings with a custom_openai entry.
+    let user_settings_dir = user_cfg_dir.path().join("forge");
+    tokio::fs::create_dir_all(&user_settings_dir).await.unwrap();
+    let user_settings_path = user_settings_dir.join("settings.toml");
+    tokio::fs::write(
+        &user_settings_path,
+        r#"
+[providers.custom_openai.vllm-local]
+base_url = "http://127.0.0.1:8000"
+model = "Qwen2"
+auth = { shape = "none" }
+"#,
+    )
+    .await
+    .unwrap();
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let result = invoke_ok(&window, "dashboard_list_providers", serde_json::json!({}));
+    let entries = result.as_array().expect("list");
+    assert_eq!(entries.len(), 5);
+    let custom = entries.last().unwrap();
+    assert_eq!(custom["id"], "custom_openai:vllm-local");
+    // `auth = none` ⇒ credential not required.
+    assert_eq!(custom["credential_required"], false);
+    assert_eq!(custom["model"], "Qwen2");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_providers_rejects_session_callers() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_session_window(&app, "abcdef0123456789");
+
+    let err = invoke_err(&window, "dashboard_list_providers", serde_json::json!({}));
+    assert!(
+        err.contains("forbidden"),
+        "expected authz rejection, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// get_active_provider
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_active_provider_returns_none_when_unset() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let result = invoke_ok(&window, "get_active_provider", serde_json::json!({}));
+    assert!(result.is_null(), "expected null, got: {result}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_active_provider_returns_persisted_id() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    // Pre-seed user settings with active = "openai".
+    let user_settings_dir = user_cfg_dir.path().join("forge");
+    tokio::fs::create_dir_all(&user_settings_dir).await.unwrap();
+    let user_settings_path = user_settings_dir.join("settings.toml");
+    tokio::fs::write(
+        &user_settings_path,
+        r#"
+[providers]
+active = "openai"
+"#,
+    )
+    .await
+    .unwrap();
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let result = invoke_ok(&window, "get_active_provider", serde_json::json!({}));
+    assert_eq!(result, serde_json::Value::String("openai".into()));
+}
+
+// ---------------------------------------------------------------------------
+// set_active_provider
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_active_provider_persists_known_builtin() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let _: serde_json::Value = invoke_ok(
+        &window,
+        "set_active_provider",
+        serde_json::json!({"providerId": "anthropic"}),
+    );
+
+    let got = invoke_ok(&window, "get_active_provider", serde_json::json!({}));
+    assert_eq!(got, serde_json::Value::String("anthropic".into()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_active_provider_rejects_unknown_id() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let err = invoke_err(
+        &window,
+        "set_active_provider",
+        serde_json::json!({"providerId": "made-up-provider"}),
+    );
+    assert!(err.contains("unknown provider"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_active_provider_accepts_user_configured_custom_openai() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    // Pre-seed user settings with a custom_openai entry.
+    let user_settings_dir = user_cfg_dir.path().join("forge");
+    tokio::fs::create_dir_all(&user_settings_dir).await.unwrap();
+    let user_settings_path = user_settings_dir.join("settings.toml");
+    tokio::fs::write(
+        &user_settings_path,
+        r#"
+[providers.custom_openai.vllm]
+base_url = "http://x"
+model = "m"
+auth = { shape = "none" }
+"#,
+    )
+    .await
+    .unwrap();
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let _: serde_json::Value = invoke_ok(
+        &window,
+        "set_active_provider",
+        serde_json::json!({"providerId": "custom_openai:vllm"}),
+    );
+
+    let got = invoke_ok(&window, "get_active_provider", serde_json::json!({}));
+    assert_eq!(got, serde_json::Value::String("custom_openai:vllm".into()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_active_provider_rejects_empty_id() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let err = invoke_err(
+        &window,
+        "set_active_provider",
+        serde_json::json!({"providerId": ""}),
+    );
+    assert!(err.contains("empty"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_active_provider_rejects_session_callers() {
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_session_window(&app, "abcdef0123456789");
+
+    let err = invoke_err(
+        &window,
+        "set_active_provider",
+        serde_json::json!({"providerId": "anthropic"}),
+    );
+    assert!(err.contains("forbidden"), "got: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_active_provider_then_list_reflects_choice_through_credential_store_unchanged() {
+    // After persisting, the list view doesn't change shape — has_credential
+    // continues to reflect the keyring state, not the active selection.
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let store = Arc::new(MemoryStore::new());
+    store
+        .set("openai", SecretString::from("sk-test"))
+        .await
+        .unwrap();
+    let creds: Arc<dyn Credentials> = store;
+
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let _: serde_json::Value = invoke_ok(
+        &window,
+        "set_active_provider",
+        serde_json::json!({"providerId": "openai"}),
+    );
+
+    let result = invoke_ok(&window, "dashboard_list_providers", serde_json::json!({}));
+    let entries = result.as_array().unwrap();
+    let openai = entries.iter().find(|e| e["id"] == "openai").unwrap();
+    assert_eq!(openai["has_credential"], true);
+    let anthropic = entries.iter().find(|e| e["id"] == "anthropic").unwrap();
+    assert_eq!(anthropic["has_credential"], false);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency guard (F-586 review)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rapid_set_active_provider_calls_leave_settings_in_a_known_state() {
+    // `set_active_provider`'s read-modify-write is now wrapped in a
+    // process-wide `tokio::sync::Mutex` (see
+    // `providers_ipc::settings_write_guard`). The Tauri MockRuntime is
+    // !Send, so we cannot spawn invokes onto separate tokio tasks; we
+    // instead drive them sequentially from the same task and assert
+    // that every call commits a valid known-id TOML file (no torn write,
+    // no lost setting).
+    //
+    // The serialization contract is unit-pinned by the guard's existence
+    // and the per-call read-then-write structure inside
+    // `set_active_provider`; this test ensures the surrounding code path
+    // doesn't leave the file in a broken state on rapid switches.
+    let workspace = TempDir::new().unwrap();
+    let user_cfg_dir = TempDir::new().unwrap();
+    let creds: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+    let (app, _registry) = make_app(&[workspace.path()], user_cfg_dir.path(), creds).await;
+    let window = make_dashboard_window(&app);
+
+    let candidates = ["anthropic", "openai", "ollama"];
+    for id in candidates.iter().cycle().take(20) {
+        invoke_ok(
+            &window,
+            "set_active_provider",
+            serde_json::json!({"providerId": *id}),
+        );
+        // Read-after-write: the value must be one of the three known
+        // ids. A torn write would surface as a parse failure inside
+        // get_active_provider.
+        let active = invoke_ok(&window, "get_active_provider", serde_json::json!({}));
+        let active = active.as_str().expect("active provider is a string");
+        assert!(
+            candidates.contains(&active),
+            "expected one of the three contended ids, got {active:?}"
+        );
+    }
+}

--- a/web/packages/app/src/components/dashboard/ProvidersSection.css
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.css
@@ -1,0 +1,197 @@
+/* F-586: Dashboard providers section.
+ *
+ * Cards are `@forge/design` Tab primitives in `radio` variant — they
+ * already carry `role="radio"` + `aria-checked` + `forge-tab--selected`
+ * styling baked into `@forge/design/components.css`. The custom rules
+ * here only paint the card shape (multi-line, two-row body) and the
+ * credential / model hint pills. Every value comes from a design token.
+ */
+
+.providers {
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-1);
+  border-radius: var(--r-sm);
+  padding: var(--sp-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  font-family: var(--font-body);
+  color: var(--color-text-primary);
+}
+
+.providers__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.providers__label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+}
+
+.providers__loading {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.2em;
+  margin: 0;
+}
+
+.providers__error,
+.providers__action-error {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  padding: var(--sp-3);
+  background: var(--color-error-bg);
+  border-left: 3px solid var(--color-ember-400);
+  border-radius: var(--r-sm);
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-ember-300);
+}
+
+.providers__error-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  color: var(--color-ember-300);
+}
+
+.providers__error-detail {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+/* Override the .forge-tabs flex-row default — provider cards stack as a
+ * grid so each can carry two rows of metadata.
+ */
+.providers__grid.forge-tabs {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--sp-3);
+  align-items: stretch;
+}
+
+/* The Tab primitive's baseline is a single-line pill (.forge-tab in
+ * components.css). Cards expand to a stacked layout — same selected /
+ * focus / hover semantics, taller body.
+ */
+.provider-card.forge-tab {
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: var(--sp-3);
+  min-height: 72px;
+  text-align: left;
+  text-transform: none;
+  letter-spacing: 0;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 400;
+  border: 1px solid var(--color-border-2);
+  background: var(--color-surface-2);
+}
+
+.provider-card.forge-tab[aria-checked='true'] {
+  background: var(--color-surface-3);
+  border-color: var(--color-ember-400);
+  color: var(--color-text-primary);
+}
+
+.provider-card.forge-tab:hover:not(:disabled) {
+  border-color: var(--color-border-2);
+  color: var(--color-text-primary);
+}
+
+/* F-586 review: visual feedback while a switch is in flight. The
+ * `aria-busy` attribute is the source of truth for screen readers; the
+ * `--pending` class signals "we heard your click" without letting a
+ * second click race the first.
+ */
+.provider-card.forge-tab[aria-busy='true'],
+.provider-card.forge-tab--pending {
+  border-color: var(--color-ember-300);
+}
+
+.provider-card.forge-tab:disabled {
+  cursor: progress;
+}
+
+.provider-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  width: 100%;
+}
+
+.provider-card__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+}
+
+.provider-card__row--meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.provider-card__name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 14px;
+  color: var(--color-text-primary);
+}
+
+.provider-card__active-pip {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-ember-400);
+  box-shadow: 0 0 6px var(--color-ember-400);
+  flex-shrink: 0;
+}
+
+.provider-card__hint {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.provider-card__hint--missing {
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}
+
+.provider-card__cred {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 0 var(--sp-1);
+  flex-shrink: 0;
+}
+
+.provider-card__cred--present {
+  color: var(--color-success);
+}
+
+.provider-card__cred--missing {
+  color: var(--color-ember-300);
+}

--- a/web/packages/app/src/components/dashboard/ProvidersSection.test.tsx
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.test.tsx
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, fireEvent } from '@solidjs/testing-library';
+import { ProvidersSection, type ProviderEntry } from './ProvidersSection';
+import { setInvokeForTesting } from '../../lib/tauri';
+
+const invokeMock = vi.fn();
+
+const sample = (over: Partial<ProviderEntry> = {}): ProviderEntry => ({
+  id: 'ollama',
+  display_name: 'Ollama',
+  credential_required: false,
+  has_credential: false,
+  model_available: true,
+  ...over,
+});
+
+const FOUR_BUILTINS: ProviderEntry[] = [
+  sample({ id: 'ollama', display_name: 'Ollama' }),
+  sample({
+    id: 'anthropic',
+    display_name: 'Anthropic',
+    credential_required: true,
+    has_credential: false,
+    model_available: false,
+  }),
+  sample({
+    id: 'openai',
+    display_name: 'OpenAI',
+    credential_required: true,
+    has_credential: true,
+    model_available: false,
+  }),
+  sample({
+    id: 'custom_openai',
+    display_name: 'Custom OpenAI-compat',
+    credential_required: true,
+    has_credential: false,
+    model_available: false,
+  }),
+];
+
+/**
+ * Default invoke shim: routes by command name.
+ * - `list_providers` → resolves with whatever was stubbed last
+ * - `get_active_provider` → resolves with the active id stub
+ * - `set_active_provider` → resolves undefined
+ */
+function setupInvokeMock(opts: {
+  entries?: ProviderEntry[];
+  active?: string | null;
+  setActiveError?: string;
+} = {}) {
+  invokeMock.mockImplementation((cmd: string) => {
+    switch (cmd) {
+      case 'dashboard_list_providers':
+        return Promise.resolve(opts.entries ?? FOUR_BUILTINS);
+      case 'get_active_provider':
+        return Promise.resolve(opts.active ?? null);
+      case 'set_active_provider':
+        if (opts.setActiveError) return Promise.reject(new Error(opts.setActiveError));
+        return Promise.resolve(undefined);
+      default:
+        return Promise.resolve(undefined);
+    }
+  });
+}
+
+async function waitForFetch() {
+  // Resource needs a few microtask flushes to settle (Promise.all + setStore).
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  setInvokeForTesting(invokeMock as never);
+});
+
+afterEach(() => {
+  setInvokeForTesting(null);
+  cleanup();
+});
+
+describe('ProvidersSection (F-586)', () => {
+  it('renders a card per provider returned by list_providers', async () => {
+    setupInvokeMock();
+    const { findAllByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+
+    const radios = await findAllByRole('radio');
+    expect(radios.length).toBe(4);
+    const labels = radios.map((r) => r.textContent ?? '');
+    expect(labels.some((l) => l.includes('Ollama'))).toBe(true);
+    expect(labels.some((l) => l.includes('Anthropic'))).toBe(true);
+    expect(labels.some((l) => l.includes('OpenAI'))).toBe(true);
+    expect(labels.some((l) => l.includes('Custom OpenAI-compat'))).toBe(true);
+  });
+
+  it('marks the active provider with aria-checked=true', async () => {
+    setupInvokeMock({ active: 'anthropic' });
+    const { findAllByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+
+    const radios = await findAllByRole('radio');
+    const anthropic = radios.find((r) => r.textContent?.includes('Anthropic'));
+    const ollama = radios.find((r) => r.textContent?.includes('Ollama'));
+    expect(anthropic?.getAttribute('aria-checked')).toBe('true');
+    expect(ollama?.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('renders no aria-checked card when active is null', async () => {
+    setupInvokeMock({ active: null });
+    const { findAllByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+
+    const radios = await findAllByRole('radio');
+    for (const r of radios) {
+      expect(r.getAttribute('aria-checked')).toBe('false');
+    }
+  });
+
+  it('shows credential warning glyph only when required and missing', async () => {
+    setupInvokeMock();
+    const { findAllByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+
+    const radios = await findAllByRole('radio');
+    const anthropic = radios.find((r) => r.textContent?.includes('Anthropic'));
+    const openai = radios.find((r) => r.textContent?.includes('OpenAI'));
+    const ollama = radios.find((r) => r.textContent?.includes('Ollama'));
+
+    // Anthropic: required + absent → warning glyph
+    expect(anthropic?.querySelector('[aria-label="credential missing"]')).toBeTruthy();
+    // OpenAI in the fixture: required + present → check glyph
+    expect(openai?.querySelector('[aria-label="credential present"]')).toBeTruthy();
+    // Ollama: not required → neither glyph
+    expect(ollama?.querySelector('[aria-label="credential missing"]')).toBeFalsy();
+    expect(ollama?.querySelector('[aria-label="credential present"]')).toBeFalsy();
+  });
+
+  it('clicking a card invokes set_active_provider with that id', async () => {
+    setupInvokeMock();
+    const { findAllByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+
+    const radios = await findAllByRole('radio');
+    const anthropic = radios.find((r) => r.textContent?.includes('Anthropic'));
+    expect(anthropic).toBeTruthy();
+
+    fireEvent.click(anthropic!);
+    await waitForFetch();
+
+    expect(invokeMock).toHaveBeenCalledWith('set_active_provider', { providerId: 'anthropic' });
+  });
+
+  it('after a click, refetches list to reflect the new active state', async () => {
+    let activeAfterSet: string | null = null;
+    invokeMock.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      switch (cmd) {
+        case 'dashboard_list_providers':
+          return Promise.resolve(FOUR_BUILTINS);
+        case 'get_active_provider':
+          return Promise.resolve(activeAfterSet);
+        case 'set_active_provider':
+          activeAfterSet = String(args?.providerId);
+          return Promise.resolve(undefined);
+        default:
+          return Promise.resolve(undefined);
+      }
+    });
+
+    const { findAllByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+
+    const radios = await findAllByRole('radio');
+    const openai = radios.find((r) => r.textContent?.includes('OpenAI'))!;
+
+    fireEvent.click(openai);
+    await waitForFetch();
+    await waitForFetch();
+
+    const radiosAfter = await findAllByRole('radio');
+    const openaiAfter = radiosAfter.find((r) => r.textContent?.includes('OpenAI'));
+    expect(openaiAfter?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('surfaces set_active_provider rejection inline', async () => {
+    setupInvokeMock({ setActiveError: 'unknown provider: xyz' });
+    const { findAllByRole, findByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+
+    const radios = await findAllByRole('radio');
+    expect(radios[0]).toBeTruthy();
+    fireEvent.click(radios[0]!);
+    await waitForFetch();
+    await waitForFetch();
+
+    const alert = await findByRole('alert');
+    expect(alert.textContent).toMatch(/unknown provider/i);
+  });
+
+  it('surfaces list_providers rejection as a "providers unavailable" block', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'dashboard_list_providers') return Promise.reject(new Error('keyring backend down'));
+      if (cmd === 'get_active_provider') return Promise.resolve(null);
+      return Promise.resolve(undefined);
+    });
+
+    const { findByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+    await waitForFetch();
+
+    const alert = await findByRole('alert');
+    expect(alert.textContent).toMatch(/providers unavailable/i);
+    expect(alert.textContent).toMatch(/keyring backend down/i);
+  });
+
+  it('drops a second click while the first switch is in flight', async () => {
+    // F-586 review: double-tap guard. The first `setActiveProvider` IPC
+    // is still pending (its promise hasn't resolved), so a second click
+    // on a different card must NOT fire another invocation. Once the
+    // first round-trip completes the UI is unlocked again.
+    type Resolver = (value: unknown) => void;
+    const resolverHolder: { fn: Resolver | null } = { fn: null };
+    const firstSet = new Promise<unknown>((res) => {
+      resolverHolder.fn = res;
+    });
+    let setActiveCallCount = 0;
+    invokeMock.mockImplementation((cmd: string) => {
+      switch (cmd) {
+        case 'dashboard_list_providers':
+          return Promise.resolve(FOUR_BUILTINS);
+        case 'get_active_provider':
+          return Promise.resolve(null);
+        case 'set_active_provider':
+          setActiveCallCount += 1;
+          return firstSet; // never resolves until we say so
+        default:
+          return Promise.resolve(undefined);
+      }
+    });
+
+    const { findAllByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+
+    const radios = await findAllByRole('radio');
+    const anthropic = radios.find((r) => r.textContent?.includes('Anthropic'))!;
+    const openai = radios.find((r) => r.textContent?.includes('OpenAI'))!;
+
+    // First click — fires the IPC. Pending state engages.
+    fireEvent.click(anthropic);
+    await waitForFetch();
+    expect(setActiveCallCount).toBe(1);
+
+    // Second click on a different card while the first is still in
+    // flight — must be ignored.
+    fireEvent.click(openai);
+    await waitForFetch();
+    expect(setActiveCallCount).toBe(1);
+
+    // Resolve the first call; UI unlocks.
+    resolverHolder.fn?.(undefined);
+    await waitForFetch();
+    await waitForFetch();
+
+    // Subsequent click now fires.
+    const radiosAfter = await findAllByRole('radio');
+    const openaiAfter = radiosAfter.find((r) => r.textContent?.includes('OpenAI'))!;
+    fireEvent.click(openaiAfter);
+    await waitForFetch();
+    expect(setActiveCallCount).toBe(2);
+  });
+
+  it('marks the pending card with aria-busy while the IPC is in flight', async () => {
+    type Resolver = (value: unknown) => void;
+    const resolverHolder: { fn: Resolver | null } = { fn: null };
+    const firstSet = new Promise<unknown>((res) => {
+      resolverHolder.fn = res;
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      switch (cmd) {
+        case 'dashboard_list_providers':
+          return Promise.resolve(FOUR_BUILTINS);
+        case 'get_active_provider':
+          return Promise.resolve(null);
+        case 'set_active_provider':
+          return firstSet;
+        default:
+          return Promise.resolve(undefined);
+      }
+    });
+
+    const { findAllByRole } = render(() => <ProvidersSection />);
+    await waitForFetch();
+
+    const radios = await findAllByRole('radio');
+    const anthropic = radios.find((r) => r.textContent?.includes('Anthropic'))!;
+
+    fireEvent.click(anthropic);
+    await waitForFetch();
+
+    // The clicked card carries aria-busy=true; siblings stay
+    // aria-busy=false but are disabled.
+    const radiosNow = await findAllByRole('radio');
+    const pending = radiosNow.find((r) => r.textContent?.includes('Anthropic'))!;
+    expect(pending.getAttribute('aria-busy')).toBe('true');
+
+    resolverHolder.fn?.(undefined);
+    await waitForFetch();
+    await waitForFetch();
+  });
+});

--- a/web/packages/app/src/components/dashboard/ProvidersSection.tsx
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.tsx
@@ -1,0 +1,199 @@
+import { createResource, createSignal, For, Show, type Component } from 'solid-js';
+import { Tab, Tabs } from '@forge/design';
+import {
+  getActiveProvider,
+  listProviders,
+  setActiveProvider,
+  type ProviderEntry,
+} from '../../ipc/dashboard';
+import { useRovingTabindex } from '../../lib/useRovingTabindex';
+import './ProvidersSection.css';
+
+export type { ProviderEntry };
+
+interface Snapshot {
+  entries: ProviderEntry[];
+  active: string | null;
+}
+
+async function fetchSnapshot(): Promise<Snapshot> {
+  const [entries, active] = await Promise.all([listProviders(), getActiveProvider()]);
+  return { entries, active };
+}
+
+/**
+ * F-586 Providers section for the Dashboard.
+ *
+ * Renders one card per built-in provider plus any user-configured
+ * `[providers.custom_openai.<name>]` entry. The active provider is the
+ * one whose id matches `[providers.active]`. Clicking a card invokes
+ * `set_active_provider` and refetches; the IPC command emits a
+ * `provider:changed` Tauri event app-wide so any open session window's
+ * orchestrator picks up the change for the next turn.
+ *
+ * Uses the `@forge/design` Tab primitive in `radio` variant so the cards
+ * are a single-select radiogroup with proper ARIA. Roving-tabindex via
+ * the existing helper keeps the panel a single Tab stop with internal
+ * arrow navigation.
+ */
+export const ProvidersSection: Component = () => {
+  const [snapshot, { refetch }] = createResource(fetchSnapshot);
+  const [actionError, setActionError] = createSignal<string | null>(null);
+  // F-586 review: prevents the dashboard's double-tap race. Two quick
+  // clicks would otherwise fire two `setActiveProvider` IPCs whose
+  // refetch() resolutions could land out-of-order and leave the UI in a
+  // stale intermediate state. The backend now serializes its
+  // read-modify-write through `settings_write_guard`, but we still want
+  // the UI to feel locked-in during the round-trip so the user sees a
+  // single transition rather than a flicker.
+  const [pendingId, setPendingId] = createSignal<string | null>(null);
+  const isSubmitting = () => pendingId() !== null;
+
+  const handleSelect = (id: string) => {
+    if (isSubmitting()) return;
+    setActionError(null);
+    setPendingId(id);
+    setActiveProvider(id)
+      .then(() => refetch())
+      .catch((err) => {
+        const detail = err instanceof Error ? err.message : String(err);
+        setActionError(`set_active_provider failed: ${detail}`);
+      })
+      .finally(() => setPendingId(null));
+  };
+
+  const errorDetail = () => {
+    const err = snapshot.error;
+    if (!err) return null;
+    return err instanceof Error ? `Error: ${err.message}` : String(err);
+  };
+
+  const [gridRef, setGridRef] = createSignal<HTMLDivElement | undefined>();
+  useRovingTabindex(gridRef, '.provider-card');
+
+  return (
+    <section class="providers" aria-label="AI providers">
+      <header class="providers__header">
+        <span class="providers__label">PROVIDERS</span>
+      </header>
+
+      <Show when={snapshot.loading}>
+        <p class="providers__loading">providers · probing</p>
+      </Show>
+
+      <Show when={errorDetail()}>
+        {(detail) => (
+          <div class="providers__error" role="alert">
+            <p class="providers__error-title">PROVIDERS UNAVAILABLE</p>
+            <p class="providers__error-detail">{detail()}</p>
+          </div>
+        )}
+      </Show>
+
+      <Show when={actionError()}>
+        {(msg) => (
+          <p class="providers__action-error" role="alert">
+            {msg()}
+          </p>
+        )}
+      </Show>
+
+      <Show when={snapshot.state === 'ready' && snapshot()}>
+        {(data) => (
+          <Tabs
+            variant="radio"
+            class="providers__grid"
+            aria-label="Active provider"
+            aria-busy={isSubmitting()}
+            ref={setGridRef as never}
+          >
+            <For each={data().entries}>
+              {(entry) => (
+                <ProviderCard
+                  entry={entry}
+                  active={data().active === entry.id}
+                  pending={pendingId() === entry.id}
+                  disabled={isSubmitting()}
+                  onSelect={handleSelect}
+                />
+              )}
+            </For>
+          </Tabs>
+        )}
+      </Show>
+    </section>
+  );
+};
+
+interface ProviderCardProps {
+  entry: ProviderEntry;
+  active: boolean;
+  pending: boolean;
+  disabled: boolean;
+  onSelect: (id: string) => void;
+}
+
+const ProviderCard: Component<ProviderCardProps> = (props) => {
+  const credentialNeeded = () => props.entry.credential_required && !props.entry.has_credential;
+  const ariaLabel = () => {
+    const parts = [`Select ${props.entry.display_name}`];
+    if (credentialNeeded()) parts.push('credential missing');
+    if (!props.entry.model_available) parts.push('no model configured');
+    if (props.pending) parts.push('switching');
+    return parts.join(', ');
+  };
+
+  return (
+    <Tab
+      variant="radio"
+      selected={props.active}
+      class="provider-card"
+      classList={{ 'provider-card--pending': props.pending }}
+      aria-label={ariaLabel()}
+      aria-busy={props.pending}
+      disabled={props.disabled && !props.pending}
+      onClick={() => props.onSelect(props.entry.id)}
+    >
+      <div class="provider-card__body">
+        <div class="provider-card__row">
+          <span class="provider-card__name">{props.entry.display_name}</span>
+          <Show when={props.active}>
+            <span class="provider-card__active-pip" aria-hidden="true" />
+          </Show>
+        </div>
+        <div class="provider-card__row provider-card__row--meta">
+          <ModelHint entry={props.entry} />
+          <CredentialHint entry={props.entry} />
+        </div>
+      </div>
+    </Tab>
+  );
+};
+
+const ModelHint: Component<{ entry: ProviderEntry }> = (props) => (
+  <Show
+    when={props.entry.model_available}
+    fallback={<span class="provider-card__hint provider-card__hint--missing">no model</span>}
+  >
+    <span class="provider-card__hint">
+      {props.entry.model ?? 'model ready'}
+    </span>
+  </Show>
+);
+
+const CredentialHint: Component<{ entry: ProviderEntry }> = (props) => (
+  <Show when={props.entry.credential_required}>
+    <Show
+      when={props.entry.has_credential}
+      fallback={
+        <span class="provider-card__cred provider-card__cred--missing" aria-label="credential missing">
+          ⚠ key
+        </span>
+      }
+    >
+      <span class="provider-card__cred provider-card__cred--present" aria-label="credential present">
+        ✓ key
+      </span>
+    </Show>
+  </Show>
+);

--- a/web/packages/app/src/ipc/dashboard.test.ts
+++ b/web/packages/app/src/ipc/dashboard.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setInvokeForTesting } from '../lib/tauri';
-import { sessionList, openSession, providerStatus } from './dashboard';
+import {
+  sessionList,
+  openSession,
+  providerStatus,
+  listProviders,
+  getActiveProvider,
+  setActiveProvider,
+} from './dashboard';
 
 describe('dashboard ipc wrappers (F-365)', () => {
   let invokeMock: ReturnType<typeof vi.fn>;
@@ -44,5 +51,36 @@ describe('dashboard ipc wrappers (F-365)', () => {
 
     expect(invokeMock).toHaveBeenCalledWith('provider_status', undefined);
     expect(result).toEqual(status);
+  });
+
+  it('listProviders invokes `dashboard_list_providers` with no args', async () => {
+    const entries = [
+      { id: 'ollama', display_name: 'Ollama', credential_required: false, has_credential: false, model_available: true },
+    ];
+    invokeMock.mockResolvedValue(entries);
+
+    const result = await listProviders();
+
+    expect(invokeMock).toHaveBeenCalledWith('dashboard_list_providers', undefined);
+    expect(result).toEqual(entries);
+  });
+
+  it('getActiveProvider invokes `get_active_provider` with no args', async () => {
+    invokeMock.mockResolvedValue('anthropic');
+
+    const result = await getActiveProvider();
+
+    expect(invokeMock).toHaveBeenCalledWith('get_active_provider', undefined);
+    expect(result).toBe('anthropic');
+  });
+
+  it('setActiveProvider forwards providerId only', async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await setActiveProvider('anthropic');
+
+    expect(invokeMock).toHaveBeenCalledWith('set_active_provider', {
+      providerId: 'anthropic',
+    });
   });
 });

--- a/web/packages/app/src/ipc/dashboard.ts
+++ b/web/packages/app/src/ipc/dashboard.ts
@@ -51,3 +51,49 @@ export interface ProviderStatus {
 export async function providerStatus(): Promise<ProviderStatus> {
   return invoke<ProviderStatus>('provider_status');
 }
+
+// ---------------------------------------------------------------------------
+// Provider selection (F-586)
+// ---------------------------------------------------------------------------
+
+/**
+ * One row of `dashboard_list_providers`. Stable id (slug), display name,
+ * and the dashboard's three-state model:
+ *   - `credential_required && !has_credential` → warning glyph
+ *   - `model_available` false                  → secondary "no model" hint
+ *   - `model` populated                        → secondary line shows it
+ *
+ * Mirrors the Rust `ProviderEntry` shape one-for-one.
+ */
+export interface ProviderEntry {
+  id: string;
+  display_name: string;
+  credential_required: boolean;
+  has_credential: boolean;
+  model_available: boolean;
+  model?: string;
+}
+
+/**
+ * List the four built-in providers plus any user-configured custom_openai
+ * entries. Wraps the `dashboard_list_providers` Tauri command — the
+ * `dashboard_` prefix disambiguates from F-591's planned roster catalog
+ * `list_providers` command (Tauri rejects duplicate command names).
+ */
+export async function listProviders(): Promise<ProviderEntry[]> {
+  return invoke<ProviderEntry[]>('dashboard_list_providers');
+}
+
+/** Read the persisted `[providers.active]` setting (user-tier, global). */
+export async function getActiveProvider(): Promise<string | null> {
+  return invoke<string | null>('get_active_provider');
+}
+
+/**
+ * Persist the active provider id and emit `provider:changed` app-wide so
+ * any open session window's bridge can swap its inner Provider for the
+ * next turn.
+ */
+export async function setActiveProvider(providerId: string): Promise<void> {
+  await invoke('set_active_provider', { providerId });
+}

--- a/web/packages/app/src/routes/Dashboard.tsx
+++ b/web/packages/app/src/routes/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { type Component, createResource, Show } from 'solid-js';
 import { ProviderPanel } from './Dashboard/ProviderPanel';
+import { ProvidersSection } from '../components/dashboard/ProvidersSection';
 import { SessionsPanel } from './Dashboard/SessionsPanel';
 import {
   CREDENTIAL_PROVIDERS,
@@ -44,6 +45,7 @@ export const Dashboard: Component = () => {
         {(m) => <CredentialBanner providerLabel={m().label} />}
       </Show>
       <ProviderPanel />
+      <ProvidersSection />
       <CredentialsSection />
       <SessionsPanel />
     </main>

--- a/web/packages/ipc/src/generated/ProvidersSettings.ts
+++ b/web/packages/ipc/src/generated/ProvidersSettings.ts
@@ -13,6 +13,19 @@ import type { CustomOpenAiEntry } from "./CustomOpenAiEntry";
  */
 export type ProvidersSettings = { 
 /**
+ * F-586: id of the active provider (e.g. `"ollama"`, `"anthropic"`,
+ * `"openai"`, `"custom_openai:vllm-local"`). `None` means "no
+ * preference" — the orchestrator falls through to whatever the daemon
+ * was started with (Phase-1 default: Ollama keyless).
+ *
+ * Stored as `Option<String>` rather than the random-hex `ProviderId`
+ * id type from `ids.rs`: provider selection is keyed by stable, human-
+ * readable slugs the user picks in the dashboard, not opaque ids.
+ * Both the IPC command surface and the credential store key on this
+ * same string shape.
+ */
+active?: string | null, 
+/**
  * One entry per user-named OpenAI-compatible server.
  */
 custom_openai: { [key in string]: CustomOpenAiEntry }, };


### PR DESCRIPTION
## Summary

Wires F-586 provider selection end-to-end. Closes #604.

- Settings: `[providers.active] = Option<String>` slug, backwards-compatible (`#[serde(default, skip_serializing_if)]`), persists through `apply_setting_update`.
- Event: `forge_core::Event::ProviderChanged { provider_id }` with wire-shape pin + exhaustive-match guard.
- IPC: three dashboard-scoped Tauri commands in `forge_shell::providers_ipc` — `dashboard_list_providers` returns the four built-ins (Ollama / Anthropic / OpenAI / CustomOpenAI) plus user-configured `[providers.custom_openai.<name>]` entries with credential-presence flags, `get_active_provider` reads `[providers.active]`, `set_active_provider` validates + persists + emits `provider:changed` plus `ProviderChanged`.
- Orchestrator: `forge_providers::{RuntimeProvider, SwappableProvider}` provide a hot-swappable Provider dispatcher; `serve_with_session(Arc<SwappableProvider>)` plumbs swap-takes-effect-on-next-turn behavior. The current turn finishes on the old inner per spec.
- Frontend: `<ProvidersSection>` Solid component in `web/packages/app/src/components/dashboard/ProvidersSection.tsx` using `@forge/design` Tab in `radio` variant, design tokens only, roving-tabindex grid.
- ts-rs: regenerated `ProvidersSettings.ts` with `active?: string | null`.

## Rebase + adjustments since first push

This branch was rebased onto current `main` (now at `8f62788d08b`) to incorporate F-587 / F-588 / F-598 / F-600. Three deliberate adjustments during the rebase:

1. **`list_providers` → `dashboard_list_providers`.** F-591 (queued behind this PR) plans to register `list_providers` for its catalog roster — Tauri's `generate_handler!` rejects duplicate command names. Renaming the F-586 command keeps both PRs landable in either order. Mirrors F-591's own `list_mcp_servers` → `session_list_mcp_servers` rename precedent.
2. **`<ProvidersSection>` lives at `components/dashboard/ProvidersSection.tsx`.** F-588 introduced `web/packages/app/src/components/dashboard/CredentialsSection.tsx`; the F-586 DoD always asked for `components/dashboard/`, and now that the directory exists this PR places the component there.
3. **Dashboard.tsx integration order:** `ProviderPanel → ProvidersSection → CredentialsSection → SessionsPanel`, with F-588's `<CredentialBanner>` retained at the top.

## Review-feedback follow-ups (this commit)

- **`RuntimeProvider::Mock` is now feature-gated.** `crates/forge-providers/Cargo.toml` declares a `testing` feature; `RuntimeProvider::Mock` and its match arms are `#[cfg(any(test, feature = "testing"))]`. Production binaries cannot construct the variant via direct `SwappableProvider::swap` from another crate. `forge-session` enables `forge-providers/testing` only in `dev-dependencies` so the `provider_swap` integration test still builds.
- **Concurrency guards (frontend + backend).**
  - Frontend: `<ProvidersSection>` now tracks an `isSubmitting` signal. The first click engages a pending state on the target card (`aria-busy=true`, `--pending` class for visual feedback); subsequent clicks while the round-trip is in flight are dropped. Once `setActiveProvider` resolves the UI unlocks. New tests pin both behaviors.
  - Backend: `set_active_provider`'s read-modify-write of the user-tier TOML is wrapped in a process-wide `tokio::sync::Mutex` (`settings_write_guard()` in `providers_ipc.rs`). Concurrent dashboard taps cannot interleave their reads-then-writes; integration test `rapid_set_active_provider_calls_leave_settings_in_a_known_state` exercises 20 sequential rapid switches and asserts no torn write. (The Tauri MockRuntime is `!Send`, so true cross-thread tokio-task interleaving isn't directly testable; the guard's existence + the per-call read-then-write structure guarantee correctness.)

## Deferred to follow-up — issue #640

The `provider:changed` Tauri event is emitted by `set_active_provider`, and `SwappableProvider::swap` is the orchestrator-side hot-swap primitive (verified by `crates/forge-session/tests/provider_swap.rs`). What is **not** wired in production: the cross-process delivery — Tauri-side window listener → per-session UDS → daemon connection loop → `SwappableProvider::swap`. Filed as **#640**. Switching the active provider in production today persists the choice and emits the event, but the primitive isn't called by anyone except the test. The next session start picks up the new active provider; live sessions don't hot-swap until #640 lands.

The DoD's strict reading ("consumed by the orchestrator without restarting the session") is partially deferred — the primitive is shipped, the cross-process glue is deferred. The orchestrator-side contract is fully pinned.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` — **1144** tests pass (4 settings, 1 wire-shape, 13 IPC including new concurrency probe, 4 RuntimeProvider, 1 swap integration, plus existing)
- [x] `cargo clippy --all-targets -- -D warnings` (also with `--features webview-test`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `pnpm -r typecheck`
- [x] `pnpm check-tokens`
- [x] `pnpm -r test` — **1058** frontend tests pass (10 `ProvidersSection` including new pending-state + double-tap-guard, 3 IPC wrapper)

## Notes

- `set_active_provider` writes to the user-tier (`{config_dir}/forge/settings.toml`) — provider preference is global, not per-workspace. A future task can add a `level` argument to scope per-workspace.
- Constraint honored: no provider impl was modified. The four providers retain their `Provider` impls; `RuntimeProvider` wraps each in an `Arc` per variant for lock-free swap snapshotting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)