### PR TITLE
[F-601] Cross-session memory: file format, per-agent storage, system-prompt injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,6 +1404,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "dirs 5.0.1",
  "forge-core",
  "futures",
  "gray_matter",

--- a/crates/forge-agents/Cargo.toml
+++ b/crates/forge-agents/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+dirs = "5"
 forge-core = { path = "../forge-core" }
 gray_matter = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/crates/forge-agents/src/def.rs
+++ b/crates/forge-agents/src/def.rs
@@ -46,6 +46,19 @@ pub struct AgentDef {
     pub allowed_paths: Vec<String>,
     /// Runtime isolation policy applied when this def is spawned.
     pub isolation: Isolation,
+    /// F-601: opt-in cross-session memory.
+    ///
+    /// Defaults to `false`. When `true`, the loader gates two behaviors:
+    ///
+    /// 1. The agent's `~/.config/forge/memory/<name>.md` body is appended to
+    ///    the system prompt under a `## Memory` heading after `AGENTS.md`.
+    /// 2. The `memory.write` tool is exposed to the agent so it can update
+    ///    its own memory.
+    ///
+    /// Both default OFF; the agent author opts in by setting `memory: true`
+    /// (or the explicit `memory_enabled: true`) in the agent's YAML
+    /// frontmatter.
+    pub memory_enabled: bool,
 }
 
 #[derive(Deserialize, Default)]
@@ -54,6 +67,9 @@ struct Frontmatter {
     description: Option<String>,
     isolation: Option<String>,
     allowed_paths: Option<Vec<String>>,
+    /// F-601: terse alias `memory: true` accepted alongside `memory_enabled: true`.
+    memory: Option<bool>,
+    memory_enabled: Option<bool>,
 }
 
 pub(crate) fn parse_agent_file(path: &Path) -> Result<AgentDef> {
@@ -125,12 +141,14 @@ pub(crate) fn parse_agent_file(path: &Path) -> Result<AgentDef> {
                     )));
                 }
             };
+            let memory_enabled = fm.memory_enabled.or(fm.memory).unwrap_or(false);
             Ok(AgentDef {
                 name,
                 description: fm.description,
                 body: parsed.content,
                 allowed_paths: fm.allowed_paths.unwrap_or_default(),
                 isolation,
+                memory_enabled,
             })
         }
         None => Ok(AgentDef {
@@ -139,6 +157,7 @@ pub(crate) fn parse_agent_file(path: &Path) -> Result<AgentDef> {
             body: parsed.content,
             allowed_paths: vec![],
             isolation: Isolation::Process,
+            memory_enabled: false,
         }),
     }
 }

--- a/crates/forge-agents/src/lib.rs
+++ b/crates/forge-agents/src/lib.rs
@@ -11,6 +11,7 @@
 
 mod def;
 mod error;
+pub mod memory;
 mod orchestrator;
 pub mod skill_loader;
 
@@ -26,6 +27,9 @@ pub const AGENTS_MD_SIZE_CAP: u64 = 256 * 1024; // 256 KiB
 
 pub use def::{AgentDef, Isolation};
 pub use error::{Error, Result};
+pub use memory::{
+    assemble_system_prompt, Memory, MemoryFrontmatter, MemoryStore, WriteMode, MEMORY_HEADING,
+};
 pub use orchestrator::{
     AgentEvent, AgentInstance, AgentScope, InitialPrompt, InstanceState, Orchestrator, SpawnContext,
 };

--- a/crates/forge-agents/src/memory.rs
+++ b/crates/forge-agents/src/memory.rs
@@ -1,10 +1,16 @@
 //! F-601: cross-session, per-agent memory.
 //!
 //! [`MemoryStore`] reads/writes one Markdown-with-frontmatter file per agent
-//! at `~/.config/forge/memory/<agent>.md`. The file body is appended to the
-//! agent's system prompt under a `## Memory` heading after `AGENTS.md` when
-//! the agent's per-agent memory flag is enabled — see
-//! [`assemble_system_prompt`].
+//! at `<config_dir>/forge/memory/<agent>.md`, where `<config_dir>` is
+//! resolved via [`dirs::config_dir`]:
+//!
+//! - Linux: `$XDG_CONFIG_HOME` (default `~/.config`)
+//! - macOS: `~/Library/Application Support`
+//! - Windows: `%APPDATA%`
+//!
+//! The file body is appended to the agent's system prompt under a `## Memory`
+//! heading after `AGENTS.md` when the agent's per-agent memory flag is
+//! enabled — see [`assemble_system_prompt`].
 //!
 //! ## Format
 //!
@@ -106,9 +112,9 @@ impl WriteMode {
 /// Filesystem-backed per-agent memory store rooted at
 /// `<config_root>/forge/memory/<agent>.md`.
 ///
-/// `config_root` is normally `~/.config` on Unix; tests inject a tempdir.
-/// The store creates the `forge/memory/` directory on first write with
-/// mode `0700` on Unix.
+/// `config_root` is the platform's user-config directory (see
+/// [`MemoryStore::from_home`]); tests inject a tempdir. The store creates
+/// the `forge/memory/` directory on first write with mode `0700` on Unix.
 #[derive(Debug, Clone)]
 pub struct MemoryStore {
     root: PathBuf,
@@ -125,14 +131,22 @@ impl MemoryStore {
         }
     }
 
-    /// Build a store anchored at the user's home `~/.config` directory.
+    /// Build a store anchored at the platform's user-config directory.
     ///
-    /// Returns `None` when the home directory cannot be resolved — callers
-    /// should treat that as "memory disabled for this session" rather than
-    /// failing the session.
+    /// Resolution delegates to [`dirs::config_dir`], which honors:
+    ///
+    /// - Linux: `$XDG_CONFIG_HOME` if set, else `~/.config`.
+    /// - macOS: `~/Library/Application Support`.
+    /// - Windows: `%APPDATA%` (Roaming).
+    ///
+    /// The resulting memory file lives at
+    /// `<config_dir>/forge/memory/<agent>.md`.
+    ///
+    /// Returns `None` when the platform's config directory cannot be
+    /// resolved — callers should treat that as "memory disabled for this
+    /// session" rather than failing the session.
     pub fn from_home() -> Option<Self> {
-        let home = dirs::home_dir()?;
-        Some(Self::new(home.join(".config")))
+        Some(Self::new(dirs::config_dir()?))
     }
 
     /// Path the store would read/write for the named agent.
@@ -564,5 +578,32 @@ mod tests {
         assert_eq!(WriteMode::parse("append").unwrap(), WriteMode::Append);
         assert_eq!(WriteMode::parse("replace").unwrap(), WriteMode::Replace);
         assert!(WriteMode::parse("clobber").is_err());
+    }
+
+    /// Regression: `from_home` must anchor at the platform's
+    /// `dirs::config_dir`, not a hand-rolled `~/.config` join. On Linux this
+    /// honors `$XDG_CONFIG_HOME`; on macOS it picks
+    /// `~/Library/Application Support`; on Windows it picks `%APPDATA%`.
+    /// We assert by composing the same `dirs::config_dir` lookup the
+    /// implementation uses and comparing the resolved file paths — when
+    /// `dirs::config_dir()` returns `None` (extremely rare; e.g. `$HOME`
+    /// unset on Unix) `from_home()` must agree by also returning `None`.
+    #[test]
+    fn from_home_uses_platform_config_dir() {
+        match (MemoryStore::from_home(), dirs::config_dir()) {
+            (Some(store), Some(expected_root)) => {
+                let expected = expected_root
+                    .join("forge")
+                    .join("memory")
+                    .join("scribe.md");
+                assert_eq!(store.path_for("scribe"), expected);
+            }
+            (None, None) => {
+                // Both lookups failed in lockstep — the contract holds.
+            }
+            (got, expected) => panic!(
+                "from_home / dirs::config_dir disagreed: from_home={got:?}, config_dir={expected:?}"
+            ),
+        }
     }
 }

--- a/crates/forge-agents/src/memory.rs
+++ b/crates/forge-agents/src/memory.rs
@@ -1,0 +1,568 @@
+//! F-601: cross-session, per-agent memory.
+//!
+//! [`MemoryStore`] reads/writes one Markdown-with-frontmatter file per agent
+//! at `~/.config/forge/memory/<agent>.md`. The file body is appended to the
+//! agent's system prompt under a `## Memory` heading after `AGENTS.md` when
+//! the agent's per-agent memory flag is enabled — see
+//! [`assemble_system_prompt`].
+//!
+//! ## Format
+//!
+//! ```text
+//! ---
+//! updated_at: 2026-04-26T12:00:00Z
+//! version: 1
+//! ---
+//! free-form markdown body the agent has accumulated
+//! ```
+//!
+//! ## Security model
+//!
+//! - Memory is plain Markdown — no executable content, no template
+//!   evaluation. Bytes round-trip verbatim.
+//! - Files are written with mode `0600` on Unix so only the owning user can
+//!   read them. The parent directory is created with mode `0700`.
+//! - **Secrets must NEVER be written to memory.** There is no encryption,
+//!   no redaction. The body is appended verbatim into the system prompt of
+//!   every subsequent agent turn, so anything in memory is visible to the
+//!   model and to every transport that carries the prompt.
+//! - Reads are best-effort: a corrupt frontmatter or a permission denial is
+//!   logged at WARN and skipped. The session continues without memory
+//!   injection — never crash on a bad file.
+//!
+//! See `docs/architecture/memory.md` for the full security and operational
+//! contract.
+
+use std::{
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use gray_matter::{engine::YAML, Matter, ParsedEntity};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+/// Per-file YAML frontmatter for a memory file.
+///
+/// Bumped by [`MemoryStore::write`] on every write — `version` increments
+/// monotonically and `updated_at` snaps to the current `Utc::now()`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryFrontmatter {
+    /// ISO 8601 / RFC 3339 timestamp of the last write.
+    pub updated_at: DateTime<Utc>,
+    /// Monotonic version counter — starts at 1, increments on every write.
+    pub version: u64,
+}
+
+impl Default for MemoryFrontmatter {
+    fn default() -> Self {
+        Self {
+            updated_at: Utc::now(),
+            version: 1,
+        }
+    }
+}
+
+/// Parsed memory file: frontmatter + free-form body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Memory {
+    /// Versioning metadata.
+    pub frontmatter: MemoryFrontmatter,
+    /// Markdown body — appended verbatim to the system prompt under a
+    /// `## Memory` heading when injection is enabled.
+    pub body: String,
+}
+
+/// Mode flag for [`MemoryStore::write`].
+///
+/// `Append` joins the new content to the existing body with a single
+/// newline separator. `Replace` discards the existing body in full.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteMode {
+    /// Concatenate `\n` + new content to the existing body.
+    Append,
+    /// Discard the existing body and write `content` as the entire new body.
+    Replace,
+}
+
+impl WriteMode {
+    /// Parse the wire-level string ("append" / "replace") into the typed
+    /// enum; the IPC tool surface uses these strings verbatim.
+    pub fn parse(s: &str) -> std::result::Result<Self, anyhow::Error> {
+        match s {
+            "append" => Ok(Self::Append),
+            "replace" => Ok(Self::Replace),
+            other => Err(anyhow::anyhow!(
+                "unknown memory.write mode '{other}': expected 'append' or 'replace'"
+            )),
+        }
+    }
+}
+
+/// Filesystem-backed per-agent memory store rooted at
+/// `<config_root>/forge/memory/<agent>.md`.
+///
+/// `config_root` is normally `~/.config` on Unix; tests inject a tempdir.
+/// The store creates the `forge/memory/` directory on first write with
+/// mode `0700` on Unix.
+#[derive(Debug, Clone)]
+pub struct MemoryStore {
+    root: PathBuf,
+}
+
+impl MemoryStore {
+    /// Build a store rooted at `<config_root>/forge/memory/`. The directory
+    /// is *not* created here — creation is deferred to the first
+    /// [`MemoryStore::save`] / [`MemoryStore::write`] so a read-only
+    /// session never touches the filesystem.
+    pub fn new(config_root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: config_root.into().join("forge").join("memory"),
+        }
+    }
+
+    /// Build a store anchored at the user's home `~/.config` directory.
+    ///
+    /// Returns `None` when the home directory cannot be resolved — callers
+    /// should treat that as "memory disabled for this session" rather than
+    /// failing the session.
+    pub fn from_home() -> Option<Self> {
+        let home = dirs::home_dir()?;
+        Some(Self::new(home.join(".config")))
+    }
+
+    /// Path the store would read/write for the named agent.
+    pub fn path_for(&self, agent_id: &str) -> PathBuf {
+        self.root.join(format!("{agent_id}.md"))
+    }
+
+    /// Load the agent's memory file.
+    ///
+    /// Returns `Ok(None)` when the file is absent. Returns
+    /// [`Error::Other`] only on hard IO errors (permission denied, etc.) —
+    /// a corrupt frontmatter is logged and surfaces as `Ok(None)` so a
+    /// session can never crash on a malformed memory file.
+    pub fn load(&self, agent_id: &str) -> Result<Option<Memory>> {
+        let path = self.path_for(agent_id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = match fs::read_to_string(&path)
+            .with_context(|| format!("reading memory file {}", path.display()))
+        {
+            Ok(s) => s,
+            Err(err) => {
+                tracing::warn!(
+                    target: "forge_agents::memory",
+                    path = %path.display(),
+                    error = %err,
+                    "failed to read memory file; treating as absent",
+                );
+                return Ok(None);
+            }
+        };
+
+        let matter = Matter::<YAML>::new();
+        let parsed: ParsedEntity<MemoryFrontmatter> = match matter.parse(&raw) {
+            Ok(p) => p,
+            Err(err) => {
+                tracing::warn!(
+                    target: "forge_agents::memory",
+                    path = %path.display(),
+                    error = %err,
+                    "memory frontmatter parse failed; skipping injection",
+                );
+                return Ok(None);
+            }
+        };
+
+        let Some(fm) = parsed.data else {
+            tracing::warn!(
+                target: "forge_agents::memory",
+                path = %path.display(),
+                "memory file missing YAML frontmatter; skipping injection",
+            );
+            return Ok(None);
+        };
+        if fm.version == 0 {
+            tracing::warn!(
+                target: "forge_agents::memory",
+                path = %path.display(),
+                "memory frontmatter version must be a positive integer; skipping injection",
+            );
+            return Ok(None);
+        }
+
+        Ok(Some(Memory {
+            frontmatter: fm,
+            body: parsed.content,
+        }))
+    }
+
+    /// Persist `memory` to the agent's file with an atomic temp + rename.
+    ///
+    /// On Unix the parent directory is enforced at mode `0700` and the
+    /// file at `0600`. On Windows the platform default ACL is used.
+    pub fn save(&self, agent_id: &str, memory: &Memory) -> Result<()> {
+        ensure_dir_secure(&self.root)?;
+        let path = self.path_for(agent_id);
+
+        let serialized = serialize(memory);
+
+        let tmp = path.with_extension("md.tmp");
+        let mut file = open_secure_temp(&tmp)?;
+        file.write_all(serialized.as_bytes())
+            .map_err(|e| Error::Other(anyhow::Error::from(e)))?;
+        file.sync_all()
+            .map_err(|e| Error::Other(anyhow::Error::from(e)))?;
+        // Drop the handle before rename — Windows requires it; on Unix it is
+        // a harmless tightening of the lifetime.
+        drop(file);
+
+        fs::rename(&tmp, &path).map_err(|e| {
+            // Clean up the temp file on failure — best-effort, ignore the
+            // unlink error since we are already returning the rename error.
+            let _ = fs::remove_file(&tmp);
+            Error::Other(anyhow::Error::from(e))
+        })?;
+
+        // Idempotent re-tighten — covers the case where rename(2) preserved
+        // a looser pre-existing destination mode. Best-effort.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+        }
+
+        Ok(())
+    }
+
+    /// Append or replace the agent's memory body.
+    ///
+    /// On `Append`: the existing body and `content` are joined with a single
+    /// `'\n'` separator. On `Replace`: `content` becomes the entire new body.
+    /// Either way, `version` is incremented (starting at `1` if no prior
+    /// file existed) and `updated_at` is set to the current `Utc::now()`.
+    pub fn write(&self, agent_id: &str, content: &str, mode: WriteMode) -> Result<Memory> {
+        let prior = self.load(agent_id)?;
+        let next_version = prior
+            .as_ref()
+            .map(|m| m.frontmatter.version + 1)
+            .unwrap_or(1);
+
+        let body = match (mode, prior.as_ref()) {
+            (WriteMode::Replace, _) => content.to_string(),
+            (WriteMode::Append, Some(p)) if p.body.is_empty() => content.to_string(),
+            (WriteMode::Append, Some(p)) => format!("{}\n{}", p.body, content),
+            (WriteMode::Append, None) => content.to_string(),
+        };
+
+        let memory = Memory {
+            frontmatter: MemoryFrontmatter {
+                updated_at: Utc::now(),
+                version: next_version,
+            },
+            body,
+        };
+        self.save(agent_id, &memory)?;
+        Ok(memory)
+    }
+}
+
+/// Serialize a [`Memory`] into the canonical on-disk shape:
+/// `---\n<yaml>\n---\n<body>`.
+///
+/// The frontmatter has exactly two scalar fields and both serialize safely
+/// without quoting (`updated_at` is ISO 8601, `version` is a positive
+/// integer), so we emit YAML by hand rather than depending on a generic
+/// YAML serializer for two lines.
+fn serialize(memory: &Memory) -> String {
+    let mut out = String::with_capacity(memory.body.len() + 96);
+    out.push_str("---\n");
+    out.push_str(&format!(
+        "updated_at: {}\nversion: {}\n",
+        memory.frontmatter.updated_at.to_rfc3339(),
+        memory.frontmatter.version,
+    ));
+    out.push_str("---\n");
+    out.push_str(&memory.body);
+    out
+}
+
+#[cfg(unix)]
+fn ensure_dir_secure(dir: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::create_dir_all(dir).map_err(|e| Error::Other(anyhow::Error::from(e)))?;
+    // Idempotent — tightens the dir even if create_dir_all observed it
+    // pre-existing under a more permissive mode.
+    let _ = fs::set_permissions(dir, fs::Permissions::from_mode(0o700));
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_dir_secure(dir: &Path) -> Result<()> {
+    fs::create_dir_all(dir).map_err(|e| Error::Other(anyhow::Error::from(e)))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_secure_temp(path: &Path) -> Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| Error::Other(anyhow::Error::from(e)))
+}
+
+#[cfg(not(unix))]
+fn open_secure_temp(path: &Path) -> Result<fs::File> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|e| Error::Other(anyhow::Error::from(e)))
+}
+
+/// Heading the memory body is injected under in the assembled system prompt.
+///
+/// Public so consumers (and tests) can assert the exact label without string
+/// duplication.
+pub const MEMORY_HEADING: &str = "\n\n---\n## Memory\n";
+
+/// Build the final system prompt for an agent turn.
+///
+/// Order: optional `AGENTS.md` (already labeled by the caller) followed by
+/// optional memory body under a `## Memory` heading. Returns `None` when
+/// both inputs are absent so the caller can leave `ChatRequest.system`
+/// unset rather than send an empty string.
+///
+/// Pure / side-effect-free so tests can drive every shape directly without
+/// touching the filesystem. Memory injection at the call site is gated on
+/// the per-agent flag — this helper does *not* re-check it.
+pub fn assemble_system_prompt(
+    agents_md_prefix: Option<&str>,
+    memory_body: Option<&str>,
+) -> Option<String> {
+    match (agents_md_prefix, memory_body) {
+        (None, None) => None,
+        (Some(a), None) => Some(a.to_string()),
+        (None, Some(m)) => Some(format!("{MEMORY_HEADING}{m}")),
+        (Some(a), Some(m)) => Some(format!("{a}{MEMORY_HEADING}{m}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn store(dir: &Path) -> MemoryStore {
+        MemoryStore::new(dir)
+    }
+
+    #[test]
+    fn load_returns_none_when_file_absent() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        assert!(s.load("ghost").unwrap().is_none());
+    }
+
+    #[test]
+    fn save_then_load_roundtrips_frontmatter_and_body() {
+        // Note: gray_matter trims one trailing newline from the content
+        // section. Memory injection happens under a `## Memory` heading
+        // and the body is concatenated, so a single trailing newline
+        // on either side is cosmetic — we tolerate the trim.
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        let original = Memory {
+            frontmatter: MemoryFrontmatter {
+                updated_at: Utc::now(),
+                version: 7,
+            },
+            body: "remember the milk".to_string(),
+        };
+        s.save("scribe", &original).unwrap();
+        let loaded = s.load("scribe").unwrap().unwrap();
+        assert_eq!(loaded.frontmatter.version, 7);
+        assert_eq!(loaded.body, "remember the milk");
+    }
+
+    #[test]
+    fn write_append_creates_file_and_starts_at_version_one() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        let result = s.write("scribe", "first note", WriteMode::Append).unwrap();
+        assert_eq!(result.frontmatter.version, 1);
+        assert_eq!(result.body, "first note");
+        let loaded = s.load("scribe").unwrap().unwrap();
+        assert_eq!(loaded.body, "first note");
+    }
+
+    #[test]
+    fn write_append_concatenates_with_newline() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        s.write("scribe", "alpha", WriteMode::Append).unwrap();
+        let second = s.write("scribe", "beta", WriteMode::Append).unwrap();
+        assert_eq!(second.frontmatter.version, 2);
+        assert_eq!(second.body, "alpha\nbeta");
+    }
+
+    #[test]
+    fn write_replace_discards_prior_body() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        s.write("scribe", "old", WriteMode::Append).unwrap();
+        let replaced = s.write("scribe", "new", WriteMode::Replace).unwrap();
+        assert_eq!(replaced.frontmatter.version, 2);
+        assert_eq!(replaced.body, "new");
+    }
+
+    #[test]
+    fn write_increments_version_monotonically() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        for expected in 1..=5u64 {
+            let m = s.write("scribe", "tick", WriteMode::Append).unwrap();
+            assert_eq!(m.frontmatter.version, expected);
+        }
+    }
+
+    #[test]
+    fn write_advances_updated_at() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        let first = s.write("scribe", "a", WriteMode::Append).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let second = s.write("scribe", "b", WriteMode::Append).unwrap();
+        assert!(
+            second.frontmatter.updated_at > first.frontmatter.updated_at,
+            "updated_at must advance on each write"
+        );
+    }
+
+    #[test]
+    fn corrupt_frontmatter_yields_none_without_panicking() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        ensure_dir_secure(&s.root).unwrap();
+        fs::write(
+            s.path_for("broken"),
+            "---\nthis: is\n: not [valid yaml\n---\nbody",
+        )
+        .unwrap();
+        assert!(s.load("broken").unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_frontmatter_yields_none() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        ensure_dir_secure(&s.root).unwrap();
+        fs::write(s.path_for("plain"), "no frontmatter here").unwrap();
+        assert!(s.load("plain").unwrap().is_none());
+    }
+
+    #[test]
+    fn version_zero_is_rejected() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        ensure_dir_secure(&s.root).unwrap();
+        fs::write(
+            s.path_for("zerover"),
+            "---\nupdated_at: 2026-04-26T12:00:00Z\nversion: 0\n---\nbody",
+        )
+        .unwrap();
+        assert!(s.load("zerover").unwrap().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_writes_file_at_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        let memory = Memory {
+            frontmatter: MemoryFrontmatter {
+                updated_at: Utc::now(),
+                version: 1,
+            },
+            body: "secrets-MUST-NOT-go-here-but-perms-still-tight".to_string(),
+        };
+        s.save("locked", &memory).unwrap();
+        let mode = fs::metadata(s.path_for("locked"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "memory file mode must be 0600, was {:o}",
+            mode & 0o777
+        );
+
+        let dir_mode = fs::metadata(&s.root).unwrap().permissions().mode();
+        assert_eq!(
+            dir_mode & 0o777,
+            0o700,
+            "memory parent dir mode must be 0700, was {:o}",
+            dir_mode & 0o777
+        );
+    }
+
+    #[test]
+    fn assemble_returns_none_when_both_inputs_absent() {
+        assert_eq!(assemble_system_prompt(None, None), None);
+    }
+
+    #[test]
+    fn assemble_passes_through_agents_md_only() {
+        assert_eq!(
+            assemble_system_prompt(Some("AGENTS prefix"), None).as_deref(),
+            Some("AGENTS prefix"),
+        );
+    }
+
+    #[test]
+    fn assemble_appends_memory_after_agents_md() {
+        let s = assemble_system_prompt(Some("AGENTS prefix"), Some("memo body")).unwrap();
+        assert!(s.starts_with("AGENTS prefix"));
+        assert!(
+            s.ends_with("memo body"),
+            "memory body must come last; got: {s:?}"
+        );
+        assert!(
+            s.contains("## Memory"),
+            "memory heading must be present; got: {s:?}"
+        );
+        let agents_idx = s.find("AGENTS prefix").unwrap();
+        let mem_idx = s.find("## Memory").unwrap();
+        assert!(
+            agents_idx < mem_idx,
+            "AGENTS.md must precede Memory in the assembled prompt"
+        );
+    }
+
+    #[test]
+    fn assemble_uses_memory_alone_when_agents_md_absent() {
+        let s = assemble_system_prompt(None, Some("memo body")).unwrap();
+        assert!(s.contains("## Memory"));
+        assert!(s.ends_with("memo body"));
+    }
+
+    #[test]
+    fn write_mode_parse_accepts_documented_strings() {
+        assert_eq!(WriteMode::parse("append").unwrap(), WriteMode::Append);
+        assert_eq!(WriteMode::parse("replace").unwrap(), WriteMode::Replace);
+        assert!(WriteMode::parse("clobber").is_err());
+    }
+}

--- a/crates/forge-agents/src/memory.rs
+++ b/crates/forge-agents/src/memory.rs
@@ -592,10 +592,7 @@ mod tests {
     fn from_home_uses_platform_config_dir() {
         match (MemoryStore::from_home(), dirs::config_dir()) {
             (Some(store), Some(expected_root)) => {
-                let expected = expected_root
-                    .join("forge")
-                    .join("memory")
-                    .join("scribe.md");
+                let expected = expected_root.join("forge").join("memory").join("scribe.md");
                 assert_eq!(store.path_for("scribe"), expected);
             }
             (None, None) => {

--- a/crates/forge-agents/src/orchestrator.rs
+++ b/crates/forge-agents/src/orchestrator.rs
@@ -211,6 +211,7 @@ impl Orchestrator {
     ///     body: "You review diffs.".into(),
     ///     allowed_paths: vec![],
     ///     isolation: Isolation::Process,
+    ///     memory_enabled: false,
     /// };
     /// let orchestrator = Orchestrator::new();
     /// let instance = orchestrator.spawn(def, SpawnContext::user()).await?;

--- a/crates/forge-agents/tests/agent_loader.rs
+++ b/crates/forge-agents/tests/agent_loader.rs
@@ -268,3 +268,50 @@ fn agent_loader_holds_parsed_agents() {
     assert_eq!(loader.agents().len(), 1);
     assert_eq!(loader.agents()[0].name, "bot");
 }
+
+#[test]
+fn memory_enabled_defaults_to_false_when_frontmatter_omits_it() {
+    // F-601: per-agent memory is OFF by default. An agent that does not
+    // set the flag must not silently opt into cross-session memory.
+    let workspace = tempdir().unwrap();
+    let agents_dir = workspace.path().join(".agents");
+    write_agent(
+        &agents_dir,
+        "quiet.md",
+        "---\nname: quiet\n---\n\nNo memory.",
+    );
+    let agents = load_workspace_agents(workspace.path()).unwrap();
+    assert_eq!(agents.len(), 1);
+    assert!(!agents[0].memory_enabled);
+}
+
+#[test]
+fn memory_enabled_explicit_alias_takes_effect() {
+    // F-601: `memory_enabled: true` opts the agent in.
+    let workspace = tempdir().unwrap();
+    let agents_dir = workspace.path().join(".agents");
+    write_agent(
+        &agents_dir,
+        "scribe.md",
+        "---\nname: scribe\nmemory_enabled: true\n---\n\nNotes.",
+    );
+    let agents = load_workspace_agents(workspace.path()).unwrap();
+    assert_eq!(agents.len(), 1);
+    assert!(agents[0].memory_enabled);
+}
+
+#[test]
+fn memory_terse_alias_takes_effect() {
+    // F-601: terse `memory: true` is a documented synonym so a single-key
+    // opt-in is also legal.
+    let workspace = tempdir().unwrap();
+    let agents_dir = workspace.path().join(".agents");
+    write_agent(
+        &agents_dir,
+        "scribe.md",
+        "---\nname: scribe\nmemory: true\n---\n\nNotes.",
+    );
+    let agents = load_workspace_agents(workspace.path()).unwrap();
+    assert_eq!(agents.len(), 1);
+    assert!(agents[0].memory_enabled);
+}

--- a/crates/forge-agents/tests/orchestrator.rs
+++ b/crates/forge-agents/tests/orchestrator.rs
@@ -21,6 +21,7 @@ fn process_def(name: &str) -> AgentDef {
         body: String::new(),
         allowed_paths: vec![],
         isolation: Isolation::Process,
+        memory_enabled: false,
     }
 }
 
@@ -31,6 +32,7 @@ fn trusted_def(name: &str) -> AgentDef {
         body: String::new(),
         allowed_paths: vec![],
         isolation: Isolation::Trusted,
+        memory_enabled: false,
     }
 }
 
@@ -238,6 +240,7 @@ async fn scope_marker_is_independent_of_parse_time_check() {
         body: String::new(),
         allowed_paths: vec![],
         isolation: Isolation::Trusted,
+        memory_enabled: false,
     };
     let result = orch
         .spawn(

--- a/crates/forge-session/src/bg_agents.rs
+++ b/crates/forge-session/src/bg_agents.rs
@@ -424,6 +424,7 @@ mod tests {
             body: String::new(),
             allowed_paths: vec![],
             isolation: Isolation::Process,
+            memory_enabled: false,
         }
     }
 

--- a/crates/forge-session/src/dispatcher_cache.rs
+++ b/crates/forge-session/src/dispatcher_cache.rs
@@ -27,9 +27,29 @@ use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::tools::{
-    AgentSpawnTool, FsEditTool, FsReadTool, FsWriteTool, McpTool, ShellExecTool, ToolDispatcher,
+    AgentSpawnTool, FsEditTool, FsReadTool, FsWriteTool, McpTool, MemoryWriteTool, ShellExecTool,
+    ToolDispatcher,
 };
+use forge_agents::MemoryStore;
 use forge_mcp::McpManager;
+
+/// F-601: per-agent memory binding consulted by the dispatcher cache.
+///
+/// Built once per session in `serve_with_session` only when the active
+/// agent has `memory_enabled: true`. When `Some`, the cache registers a
+/// [`MemoryWriteTool`] alongside the other built-ins so the agent can
+/// update its own `~/.config/forge/memory/<agent>.md` file. When `None`,
+/// the tool is omitted from the dispatcher entirely — an agent that has
+/// not opted in cannot discover the wire name and the surface area stays
+/// minimal.
+#[derive(Debug, Clone)]
+pub struct MemoryWriteBinding {
+    /// Shared store rooted at `~/.config/forge/memory/`.
+    pub store: Arc<MemoryStore>,
+    /// The agent name keyed against the store — same string used to derive
+    /// the `<agent>.md` filename and the `## Memory` injection.
+    pub agent_id: String,
+}
 
 /// Monotonic counter for the MCP tools-list snapshot.
 ///
@@ -73,6 +93,8 @@ struct CachedDispatcher {
 pub struct DispatcherCache {
     epoch: McpToolsEpoch,
     cache: AsyncMutex<Option<CachedDispatcher>>,
+    /// F-601: when `Some`, every cached dispatcher exposes `memory.write`.
+    memory: Option<MemoryWriteBinding>,
 }
 
 impl DispatcherCache {
@@ -80,6 +102,18 @@ impl DispatcherCache {
         Arc::new(Self {
             epoch,
             cache: AsyncMutex::new(None),
+            memory: None,
+        })
+    }
+
+    /// F-601: build a cache that also registers `memory.write` against the
+    /// agent identified by `binding`. Only called when the active agent
+    /// has opted into cross-session memory.
+    pub fn with_memory(epoch: McpToolsEpoch, binding: MemoryWriteBinding) -> Arc<Self> {
+        Arc::new(Self {
+            epoch,
+            cache: AsyncMutex::new(None),
+            memory: Some(binding),
         })
     }
 
@@ -99,7 +133,7 @@ impl DispatcherCache {
             }
         }
 
-        let dispatcher = build_dispatcher(mcp).await;
+        let dispatcher = build_dispatcher(mcp, self.memory.as_ref()).await;
         let dispatcher = Arc::new(dispatcher);
         *guard = Some(CachedDispatcher {
             epoch: observed_epoch,
@@ -112,7 +146,10 @@ impl DispatcherCache {
 /// Build a fresh dispatcher: register every builtin, then every MCP-server
 /// adapter exposed by `mgr.list().await`. Mirrors the previous in-line body
 /// of `run_turn` exactly so dispatch behavior stays identical.
-async fn build_dispatcher(mcp: Option<&Arc<McpManager>>) -> ToolDispatcher {
+async fn build_dispatcher(
+    mcp: Option<&Arc<McpManager>>,
+    memory: Option<&MemoryWriteBinding>,
+) -> ToolDispatcher {
     let mut dispatcher = ToolDispatcher::new();
     dispatcher
         .register(Box::new(FsReadTool))
@@ -129,6 +166,15 @@ async fn build_dispatcher(mcp: Option<&Arc<McpManager>>) -> ToolDispatcher {
     dispatcher
         .register(Box::new(AgentSpawnTool))
         .expect("agent.spawn must register on a fresh dispatcher");
+
+    if let Some(binding) = memory {
+        dispatcher
+            .register(Box::new(MemoryWriteTool::new(
+                Arc::clone(&binding.store),
+                binding.agent_id.clone(),
+            )))
+            .expect("memory.write must register on a fresh dispatcher");
+    }
 
     if let Some(mgr) = mcp {
         for server in mgr.list().await {
@@ -197,6 +243,52 @@ mod tests {
             assert!(
                 dispatcher.get(name).is_ok(),
                 "builtin {name} must be registered on a fresh cache"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn memory_write_is_omitted_when_binding_absent() {
+        // F-601: an agent that has not opted into memory must not see the
+        // tool. `DispatcherCache::new` creates a cache without a binding;
+        // `memory.write` must be absent.
+        let cache = DispatcherCache::new(McpToolsEpoch::new());
+        let dispatcher = cache.get(None).await;
+        assert!(
+            dispatcher.get("memory.write").is_err(),
+            "memory.write must NOT register without a binding"
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_write_is_registered_when_binding_present() {
+        // F-601: when the active agent has `memory_enabled: true`,
+        // `serve_with_session` constructs the cache via `with_memory` and
+        // the resulting dispatcher exposes `memory.write` alongside the
+        // other built-ins.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::new(dir.path()));
+        let binding = MemoryWriteBinding {
+            store,
+            agent_id: "scribe".to_string(),
+        };
+        let cache = DispatcherCache::with_memory(McpToolsEpoch::new(), binding);
+        let dispatcher = cache.get(None).await;
+        assert!(
+            dispatcher.get("memory.write").is_ok(),
+            "memory.write must register when a binding is present"
+        );
+        // The other built-ins must still register too.
+        for name in [
+            "fs.read",
+            "fs.write",
+            "fs.edit",
+            "shell.exec",
+            "agent.spawn",
+        ] {
+            assert!(
+                dispatcher.get(name).is_ok(),
+                "builtin {name} must still register alongside memory.write"
             );
         }
     }

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -68,6 +68,17 @@ async fn main() -> Result<()> {
     let log_path = event_log_path(&session_id, workspace.as_deref());
     let session = Arc::new(Session::create(log_path).await?);
 
+    // F-601: the daemon binary still accepts `FORGE_ACTIVE_AGENT` as the
+    // way an operator (or the Tauri shell launcher) names the agent this
+    // daemon process is bound to. Read once here at startup and hand off
+    // as a typed argument — `serve_with_session` no longer touches the
+    // environment for this concern, which is the fix for the persistent-
+    // mode multi-connection bug where two browser windows could share the
+    // first window's captured env value.
+    let active_agent = std::env::var("FORGE_ACTIVE_AGENT")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+
     // Provider selection (F-038):
     //   1. explicit `--provider <spec>` flag, OR `FORGE_PROVIDER` env, OR
     //   2. Mock when `FORGE_MOCK_SEQUENCE_FILE` is set, OR
@@ -89,6 +100,8 @@ async fn main() -> Result<()> {
                     Some(session_id),
                     // F-587: MockProvider is keyless; no credential pull.
                     None,
+                    // F-601: typed active-agent — `None` here keeps memory off.
+                    active_agent,
                 )
                 .await
             }
@@ -136,6 +149,8 @@ async fn main() -> Result<()> {
                     // providers will wire their LayeredStore + provider id
                     // here when they land.
                     None,
+                    // F-601: typed active-agent — `None` here keeps memory off.
+                    active_agent,
                 )
                 .await
             }
@@ -152,6 +167,8 @@ async fn main() -> Result<()> {
                 Some(session_id),
                 // F-587: MockProvider is keyless.
                 None,
+                // F-601: typed active-agent — `None` here keeps memory off.
+                active_agent,
             )
             .await
         }

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -141,23 +141,26 @@ async fn build_agent_runtime(workspace_path: Option<&Path>) -> Option<AgentRunti
 ///
 /// Selection rules:
 ///
-/// 1. The active agent name comes from `FORGE_ACTIVE_AGENT`. Unset → memory
-///    off (returns `(None, None)`); the session behaves exactly as before
-///    F-601.
+/// 1. The active agent name is the `active_agent` parameter — passed in
+///    by the caller (typically the Tauri shell, which knows which agent
+///    each window is targeting). `None` or an empty/whitespace string →
+///    memory off (returns `(None, None)`); the session behaves exactly
+///    as before F-601.
 /// 2. If the named agent is not found among loaded defs, memory stays off
 ///    and we log at WARN.
 /// 3. If the agent def has `memory_enabled: false`, memory stays off — the
 ///    per-agent flag defaults OFF as documented.
-/// 4. Otherwise, build a [`MemoryStore`] anchored at `~/.config` and try to
-///    load the existing file. A missing file yields an empty body but the
-///    binding is still produced so `memory.write` can create the file on
-///    the agent's first write.
+/// 4. Otherwise, build a [`MemoryStore`] anchored at the platform config
+///    dir and try to load the existing file. A missing file yields an
+///    empty body but the binding is still produced so `memory.write` can
+///    create the file on the agent's first write.
 ///
 /// Reads are best-effort: a corrupted memory file logs a warning inside
 /// [`MemoryStore::load`] and surfaces as `None` body — the session stays
 /// up.
 async fn resolve_session_memory(
     runtime: Option<&AgentRuntime>,
+    active_agent: Option<&str>,
 ) -> (
     Option<String>,
     Option<crate::dispatcher_cache::MemoryWriteBinding>,
@@ -165,18 +168,14 @@ async fn resolve_session_memory(
     let Some(rt) = runtime else {
         return (None, None);
     };
-    let Ok(active_agent) = std::env::var("FORGE_ACTIVE_AGENT") else {
+    let Some(active_agent) = active_agent.map(str::trim).filter(|s| !s.is_empty()) else {
         return (None, None);
     };
-    let active_agent = active_agent.trim();
-    if active_agent.is_empty() {
-        return (None, None);
-    }
     let Some(def) = rt.agent_defs.iter().find(|a| a.name == active_agent) else {
         tracing::warn!(
             target: "forge_session::server",
             requested = %active_agent,
-            "FORGE_ACTIVE_AGENT names an agent that is not loaded; memory disabled",
+            "active_agent names an agent that is not loaded; memory disabled",
         );
         return (None, None);
     };
@@ -186,11 +185,32 @@ async fn resolve_session_memory(
     let Some(store) = forge_agents::MemoryStore::from_home() else {
         tracing::warn!(
             target: "forge_session::server",
-            "could not resolve home directory for cross-session memory; disabling",
+            "could not resolve user config directory for cross-session memory; disabling",
         );
         return (None, None);
     };
-    let store = std::sync::Arc::new(store);
+    resolve_session_memory_with(active_agent, std::sync::Arc::new(store)).await
+}
+
+/// Pure helper extracted from [`resolve_session_memory`] so the
+/// active-agent → memory binding can be unit-tested without touching the
+/// platform config dir. The caller is responsible for skip / opt-in
+/// gating; this helper assumes the caller has already validated
+/// `active_agent` against a loaded def with `memory_enabled: true`.
+///
+/// Splitting the helper this way is what makes the F-601 regression test
+/// for two concurrent sessions in the same process tractable: the test
+/// spins up two `MemoryStore`s (one per agent) and asserts that each
+/// `active_agent` parameter resolves to its own body. The bug this
+/// guards against — the original `FORGE_ACTIVE_AGENT` env-var read —
+/// would have shared state across the two calls.
+async fn resolve_session_memory_with(
+    active_agent: &str,
+    store: std::sync::Arc<forge_agents::MemoryStore>,
+) -> (
+    Option<String>,
+    Option<crate::dispatcher_cache::MemoryWriteBinding>,
+) {
     let body = match store.load(active_agent) {
         Ok(Some(memory)) => Some(memory.body),
         Ok(None) => None,
@@ -565,6 +585,7 @@ pub async fn serve(path: &Path, auto_approve: bool, ephemeral: bool) -> Result<(
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -660,6 +681,15 @@ pub async fn serve_with_session<P: Provider + 'static>(
     // contract). `None` keeps the keyless `OllamaProvider` / `MockProvider`
     // path identical to pre-F-587 behaviour.
     credentials: Option<CredentialContext>,
+    // F-601: the agent the session is bound to for cross-session memory
+    // selection. `None` (or empty/whitespace) → memory off and the session
+    // behaves exactly as before F-601. The Tauri shell knows which agent
+    // each window targets and passes it in here; tests pass `None` unless
+    // the test exercises memory injection. Replaces the prior
+    // `FORGE_ACTIVE_AGENT` env-var indirection: a typed parameter is the
+    // only safe way to give different connections in a persistent-mode
+    // daemon distinct active agents.
+    active_agent: Option<String>,
 ) -> Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -707,11 +737,11 @@ pub async fn serve_with_session<P: Provider + 'static>(
     // inside `run_request_loop` is now refcount-only on the prefix even when
     // the prefix is hundreds of KiB.
     //
-    // F-601: when an active agent is selected via `FORGE_ACTIVE_AGENT` and
-    // that agent's def has `memory_enabled: true`, the cross-session memory
-    // body is appended after the AGENTS.md prefix under a `## Memory`
-    // heading; both the load and the assembly run once here so per-turn
-    // cost stays at the existing `Arc::clone`.
+    // F-601: when an active agent is selected via the `active_agent`
+    // parameter and that agent's def has `memory_enabled: true`, the
+    // cross-session memory body is appended after the AGENTS.md prefix
+    // under a `## Memory` heading; both the load and the assembly run
+    // once here so per-turn cost stays at the existing `Arc::clone`.
     let agents_md_prefix: Option<String> = match workspace_path.as_deref() {
         Some(ws) => match forge_agents::load_agents_md(ws) {
             Ok(Some(content)) => {
@@ -817,12 +847,13 @@ pub async fn serve_with_session<P: Provider + 'static>(
 
     // F-601: resolve the active agent + load its memory once per session.
     //
-    // The active agent is selected via `FORGE_ACTIVE_AGENT`. When set and
-    // matching a loaded def, the def's `memory_enabled` flag controls both
-    // memory injection and `memory.write` registration. When unset,
-    // unmatched, or set against a `memory_enabled: false` def, memory is
-    // off — the session behaves exactly as before F-601.
-    let (memory_body, memory_binding) = resolve_session_memory(agent_runtime.as_ref()).await;
+    // The active agent is selected via the `active_agent` parameter. When
+    // set and matching a loaded def, the def's `memory_enabled` flag
+    // controls both memory injection and `memory.write` registration.
+    // When `None`, unmatched, or set against a `memory_enabled: false`
+    // def, memory is off — the session behaves exactly as before F-601.
+    let (memory_body, memory_binding) =
+        resolve_session_memory(agent_runtime.as_ref(), active_agent.as_deref()).await;
 
     // F-601: assemble the final per-turn system prompt by appending the
     // optional memory body under a `## Memory` heading after AGENTS.md.
@@ -1640,6 +1671,57 @@ mod tests {
         assert!(
             msg.contains("not allowed by allowed_paths"),
             "expected path-denied error, got: {msg}"
+        );
+    }
+
+    /// F-601 regression: two concurrent sessions in the same process can
+    /// target different active agents (typed param) and each must receive
+    /// its own memory body.
+    ///
+    /// This is the test that would have caught the original
+    /// `FORGE_ACTIVE_AGENT` env-var bug: a single mutable process-global
+    /// captured at session start meant a second connection (or a second
+    /// `serve_with_session` invocation in the same process) silently
+    /// observed the first active agent's memory. With the typed
+    /// parameter, no shared state — calling `resolve_session_memory_with`
+    /// concurrently with two distinct `active_agent` strings keyed
+    /// against the same store must surface the per-agent body each time.
+    #[tokio::test]
+    async fn concurrent_sessions_with_different_active_agents_get_their_own_memory() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(forge_agents::MemoryStore::new(dir.path()));
+
+        // Seed two distinct memory bodies for two distinct agent ids.
+        store
+            .write("alpha", "alpha body", forge_agents::WriteMode::Append)
+            .unwrap();
+        store
+            .write("beta", "beta body", forge_agents::WriteMode::Append)
+            .unwrap();
+
+        // Resolve concurrently — the typed parameter is the only thing
+        // that distinguishes the two calls. With the prior env-var
+        // implementation, both calls would have observed whichever value
+        // `std::env::var("FORGE_ACTIVE_AGENT")` happened to return.
+        let (a_result, b_result) = tokio::join!(
+            resolve_session_memory_with("alpha", store.clone()),
+            resolve_session_memory_with("beta", store.clone()),
+        );
+
+        let (a_body, a_binding) = a_result;
+        let (b_body, b_binding) = b_result;
+
+        assert_eq!(a_body.as_deref(), Some("alpha body"));
+        assert_eq!(b_body.as_deref(), Some("beta body"));
+        assert_eq!(
+            a_binding.expect("alpha binding").agent_id,
+            "alpha",
+            "binding agent_id must reflect the typed parameter, not shared state"
+        );
+        assert_eq!(
+            b_binding.expect("beta binding").agent_id,
+            "beta",
+            "binding agent_id must reflect the typed parameter, not shared state"
         );
     }
 }

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -106,6 +106,7 @@ async fn build_agent_runtime(workspace_path: Option<&Path>) -> Option<AgentRunti
         body: String::new(),
         allowed_paths: vec![],
         isolation: forge_agents::Isolation::Process,
+        memory_enabled: false,
     };
     let root_instance = match orchestrator
         .spawn(root_def, forge_agents::SpawnContext::user())
@@ -127,6 +128,86 @@ async fn build_agent_runtime(workspace_path: Option<&Path>) -> Option<AgentRunti
         agent_defs: Arc::new(defs),
         parent_instance_id: root_instance.id,
     })
+}
+
+/// F-601: resolve the active agent's cross-session memory.
+///
+/// Returns `(memory_body, memory_binding)`:
+///
+/// - `memory_body`: the markdown body to append under `## Memory` after
+///   `AGENTS.md`, or `None` if memory is disabled / unavailable.
+/// - `memory_binding`: the [`MemoryWriteBinding`] used by the dispatcher
+///   cache to register `memory.write`, or `None` if memory is disabled.
+///
+/// Selection rules:
+///
+/// 1. The active agent name comes from `FORGE_ACTIVE_AGENT`. Unset → memory
+///    off (returns `(None, None)`); the session behaves exactly as before
+///    F-601.
+/// 2. If the named agent is not found among loaded defs, memory stays off
+///    and we log at WARN.
+/// 3. If the agent def has `memory_enabled: false`, memory stays off — the
+///    per-agent flag defaults OFF as documented.
+/// 4. Otherwise, build a [`MemoryStore`] anchored at `~/.config` and try to
+///    load the existing file. A missing file yields an empty body but the
+///    binding is still produced so `memory.write` can create the file on
+///    the agent's first write.
+///
+/// Reads are best-effort: a corrupted memory file logs a warning inside
+/// [`MemoryStore::load`] and surfaces as `None` body — the session stays
+/// up.
+async fn resolve_session_memory(
+    runtime: Option<&AgentRuntime>,
+) -> (
+    Option<String>,
+    Option<crate::dispatcher_cache::MemoryWriteBinding>,
+) {
+    let Some(rt) = runtime else {
+        return (None, None);
+    };
+    let Ok(active_agent) = std::env::var("FORGE_ACTIVE_AGENT") else {
+        return (None, None);
+    };
+    let active_agent = active_agent.trim();
+    if active_agent.is_empty() {
+        return (None, None);
+    }
+    let Some(def) = rt.agent_defs.iter().find(|a| a.name == active_agent) else {
+        tracing::warn!(
+            target: "forge_session::server",
+            requested = %active_agent,
+            "FORGE_ACTIVE_AGENT names an agent that is not loaded; memory disabled",
+        );
+        return (None, None);
+    };
+    if !def.memory_enabled {
+        return (None, None);
+    }
+    let Some(store) = forge_agents::MemoryStore::from_home() else {
+        tracing::warn!(
+            target: "forge_session::server",
+            "could not resolve home directory for cross-session memory; disabling",
+        );
+        return (None, None);
+    };
+    let store = std::sync::Arc::new(store);
+    let body = match store.load(active_agent) {
+        Ok(Some(memory)) => Some(memory.body),
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!(
+                target: "forge_session::server",
+                error = %e,
+                "memory load failed; injection skipped, write tool stays available",
+            );
+            None
+        }
+    };
+    let binding = crate::dispatcher_cache::MemoryWriteBinding {
+        store,
+        agent_id: active_agent.to_string(),
+    };
+    (body, Some(binding))
 }
 
 /// Static name for an `IpcMessage` discriminant — used for diagnostic logging
@@ -625,7 +706,13 @@ pub async fn serve_with_session<P: Provider + 'static>(
     // `ChatRequest.system` (refcount bump), and per-iteration `req.clone()`
     // inside `run_request_loop` is now refcount-only on the prefix even when
     // the prefix is hundreds of KiB.
-    let agents_md: Option<Arc<str>> = match workspace_path.as_deref() {
+    //
+    // F-601: when an active agent is selected via `FORGE_ACTIVE_AGENT` and
+    // that agent's def has `memory_enabled: true`, the cross-session memory
+    // body is appended after the AGENTS.md prefix under a `## Memory`
+    // heading; both the load and the assembly run once here so per-turn
+    // cost stays at the existing `Arc::clone`.
+    let agents_md_prefix: Option<String> = match workspace_path.as_deref() {
         Some(ws) => match forge_agents::load_agents_md(ws) {
             Ok(Some(content)) => {
                 tracing::warn!(
@@ -633,9 +720,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
                     "AGENTS.md injected into session system prompt; \
                      review the file if this workspace is not fully trusted"
                 );
-                Some(Arc::from(format!(
-                    "\n\n---\nAGENTS.md (workspace):\n{content}"
-                )))
+                Some(format!("\n\n---\nAGENTS.md (workspace):\n{content}"))
             }
             Ok(None) => None,
             Err(e) => {
@@ -712,11 +797,6 @@ pub async fn serve_with_session<P: Provider + 'static>(
         });
     }
 
-    // F-567: the per-session dispatcher cache. Lives across every turn so
-    // the builtins register exactly once and MCP adapters rebuild only
-    // when `mcp_tools_epoch` advances.
-    let dispatcher_cache = crate::dispatcher_cache::DispatcherCache::new(mcp_tools_epoch);
-
     // F-140: session-scoped agent runtime so live turns can actually spawn
     // sub-agents via `agent.spawn`.
     //
@@ -729,8 +809,43 @@ pub async fn serve_with_session<P: Provider + 'static>(
     // + `<home>/.agents` — a failed load downgrades the runtime to
     // `None` so a filesystem blip never kills the whole session, it just
     // reverts to the pre-F-140 "agent runtime not configured" behaviour.
+    //
+    // F-601: built before the dispatcher cache so the active agent's
+    // `memory_enabled` flag can decide whether `memory.write` registers
+    // and whether the memory body is appended to the system prompt.
     let agent_runtime: Option<AgentRuntime> = build_agent_runtime(workspace_path.as_deref()).await;
+
+    // F-601: resolve the active agent + load its memory once per session.
+    //
+    // The active agent is selected via `FORGE_ACTIVE_AGENT`. When set and
+    // matching a loaded def, the def's `memory_enabled` flag controls both
+    // memory injection and `memory.write` registration. When unset,
+    // unmatched, or set against a `memory_enabled: false` def, memory is
+    // off — the session behaves exactly as before F-601.
+    let (memory_body, memory_binding) = resolve_session_memory(agent_runtime.as_ref()).await;
+
+    // F-601: assemble the final per-turn system prompt by appending the
+    // optional memory body under a `## Memory` heading after AGENTS.md.
+    // Stored as `Arc<str>` so each turn clones the refcount, never the
+    // bytes.
+    let agents_md: Option<Arc<str>> =
+        forge_agents::assemble_system_prompt(agents_md_prefix.as_deref(), memory_body.as_deref())
+            .map(Arc::from);
+
     let agent_runtime = Arc::new(agent_runtime);
+
+    // F-567: the per-session dispatcher cache. Lives across every turn so
+    // the builtins register exactly once and MCP adapters rebuild only
+    // when `mcp_tools_epoch` advances.
+    //
+    // F-601: when the active agent has `memory_enabled: true`,
+    // `memory.write` registers alongside the other built-ins so the agent
+    // can update its own cross-session memory file. Without the binding,
+    // the tool stays unregistered.
+    let dispatcher_cache = match memory_binding {
+        Some(b) => crate::dispatcher_cache::DispatcherCache::with_memory(mcp_tools_epoch, b),
+        None => crate::dispatcher_cache::DispatcherCache::new(mcp_tools_epoch),
+    };
     let workspace = Arc::new(
         workspace
             .map(|w| w.display().to_string())

--- a/crates/forge-session/src/tools/agent_spawn.rs
+++ b/crates/forge-session/src/tools/agent_spawn.rs
@@ -212,6 +212,7 @@ mod tests {
             body: String::new(),
             allowed_paths: vec![],
             isolation,
+            memory_enabled: false,
         }
     }
 

--- a/crates/forge-session/src/tools/memory_write.rs
+++ b/crates/forge-session/src/tools/memory_write.rs
@@ -1,0 +1,202 @@
+//! `memory.write` tool (F-601): writes the active agent's cross-session
+//! memory file at `~/.config/forge/memory/<agent>.md`.
+//!
+//! The tool is gated on the per-agent memory flag — it is only registered on
+//! the dispatcher when the agent owning the session has `memory_enabled:
+//! true` in its frontmatter, so an agent that has not opted in cannot
+//! discover the tool name and the surface area stays minimal.
+//!
+//! Tool surface (matches the DoD verbatim):
+//!
+//! ```text
+//! memory.write { content: string, mode: "append" | "replace" }
+//! ```
+//!
+//! On success the tool returns `{ "ok": true, "version": N, "updated_at":
+//! "<iso8601>" }` so the agent observes its own write metadata. On any
+//! failure the tool returns `{ "error": "<message>" }` rather than
+//! propagating an exception — the dispatcher contract is that `invoke`
+//! always succeeds and the model decides what to do with the JSON shape.
+
+use std::sync::Arc;
+
+use forge_agents::{MemoryStore, WriteMode};
+use forge_core::ApprovalPreview;
+
+use super::{get_required_str, Tool, ToolCtx};
+
+/// `memory.write` registration. The active agent id is captured at
+/// registration time so the tool always writes to the same file regardless
+/// of how the dispatcher is later threaded through the request loop.
+pub struct MemoryWriteTool {
+    store: Arc<MemoryStore>,
+    agent_id: String,
+}
+
+impl MemoryWriteTool {
+    /// Wire-name surfaced to the model. Asserted by IPC-level tests.
+    pub const NAME: &'static str = "memory.write";
+
+    /// Build the tool with a shared [`MemoryStore`] and the agent id whose
+    /// memory file the tool will write.
+    pub fn new(store: Arc<MemoryStore>, agent_id: impl Into<String>) -> Self {
+        Self {
+            store,
+            agent_id: agent_id.into(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for MemoryWriteTool {
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+
+    fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
+        let mode = super::get_optional_str(args, "mode").unwrap_or("");
+        let content = super::get_optional_str(args, "content").unwrap_or("");
+        // Cap the preview length so a multi-KB body does not flood the
+        // approval UI; the full bytes still go through `invoke`.
+        let snippet: String = content.chars().take(120).collect();
+        let suffix = if content.len() > snippet.len() {
+            "…"
+        } else {
+            ""
+        };
+        ApprovalPreview {
+            description: format!(
+                "Write memory for agent '{}' (mode={mode}): {snippet}{suffix}",
+                self.agent_id
+            ),
+        }
+    }
+
+    async fn invoke(&self, args: &serde_json::Value, _ctx: &ToolCtx) -> serde_json::Value {
+        let content = match get_required_str(args, Self::NAME, "content") {
+            Ok(c) => c.to_owned(),
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
+        let mode_str = match get_required_str(args, Self::NAME, "mode") {
+            Ok(m) => m.to_owned(),
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
+        let mode = match WriteMode::parse(&mode_str) {
+            Ok(m) => m,
+            Err(e) => return serde_json::json!({ "error": e.to_string() }),
+        };
+
+        let store = Arc::clone(&self.store);
+        let agent_id = self.agent_id.clone();
+        // F-106: file IO off the tokio worker; mirrors fs.read / fs.write.
+        let result =
+            tokio::task::spawn_blocking(move || store.write(&agent_id, &content, mode)).await;
+        match result {
+            Ok(Ok(memory)) => serde_json::json!({
+                "ok": true,
+                "version": memory.frontmatter.version,
+                "updated_at": memory.frontmatter.updated_at.to_rfc3339(),
+            }),
+            Ok(Err(e)) => serde_json::json!({ "error": e.to_string() }),
+            Err(join_err) => serde_json::json!({
+                "error": format!("memory.write blocking task failed: {join_err}")
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use forge_agents::MemoryStore;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    fn fresh_tool(dir: &std::path::Path, agent_id: &str) -> MemoryWriteTool {
+        let store = Arc::new(MemoryStore::new(dir));
+        MemoryWriteTool::new(store, agent_id)
+    }
+
+    #[tokio::test]
+    async fn append_creates_file_and_returns_version_one() {
+        let dir = tempdir().unwrap();
+        let tool = fresh_tool(dir.path(), "scribe");
+        let ctx = ToolCtx::default();
+        let result = tool
+            .invoke(&json!({"content": "first note", "mode": "append"}), &ctx)
+            .await;
+        assert_eq!(result["ok"].as_bool(), Some(true));
+        assert_eq!(result["version"].as_u64(), Some(1));
+        assert!(result["updated_at"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn replace_then_append_increments_version() {
+        let dir = tempdir().unwrap();
+        let tool = fresh_tool(dir.path(), "scribe");
+        let ctx = ToolCtx::default();
+        let r1 = tool
+            .invoke(&json!({"content": "v1", "mode": "replace"}), &ctx)
+            .await;
+        assert_eq!(r1["version"].as_u64(), Some(1));
+        let r2 = tool
+            .invoke(&json!({"content": "v2", "mode": "append"}), &ctx)
+            .await;
+        assert_eq!(r2["version"].as_u64(), Some(2));
+    }
+
+    #[tokio::test]
+    async fn missing_content_yields_unified_error() {
+        let dir = tempdir().unwrap();
+        let tool = fresh_tool(dir.path(), "scribe");
+        let result = tool
+            .invoke(&json!({"mode": "append"}), &ToolCtx::default())
+            .await;
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.memory.write: missing required parameter 'content'")
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_mode_yields_unified_error() {
+        let dir = tempdir().unwrap();
+        let tool = fresh_tool(dir.path(), "scribe");
+        let result = tool
+            .invoke(&json!({"content": "hi"}), &ToolCtx::default())
+            .await;
+        assert_eq!(
+            result["error"].as_str(),
+            Some("tool.memory.write: missing required parameter 'mode'")
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_mode_is_rejected() {
+        let dir = tempdir().unwrap();
+        let tool = fresh_tool(dir.path(), "scribe");
+        let result = tool
+            .invoke(
+                &json!({"content": "hi", "mode": "clobber"}),
+                &ToolCtx::default(),
+            )
+            .await;
+        assert!(
+            result["error"].as_str().unwrap().contains("'clobber'"),
+            "unexpected error shape: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn approval_preview_includes_agent_id_and_mode() {
+        let dir = tempdir().unwrap();
+        let tool = fresh_tool(dir.path(), "scribe");
+        let preview = tool.approval_preview(&json!({
+            "content": "remember to ship",
+            "mode": "append",
+        }));
+        assert!(preview.description.contains("'scribe'"));
+        assert!(preview.description.contains("mode=append"));
+        assert!(preview.description.contains("remember to ship"));
+    }
+}

--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -14,6 +14,7 @@ pub mod fs_edit;
 pub mod fs_read;
 pub mod fs_write;
 pub mod mcp;
+pub mod memory_write;
 pub mod shell_exec;
 
 pub use agent_spawn::AgentSpawnTool;
@@ -22,6 +23,7 @@ pub use fs_edit::FsEditTool;
 pub use fs_read::FsReadTool;
 pub use fs_write::FsWriteTool;
 pub use mcp::McpTool;
+pub use memory_write::MemoryWriteTool;
 pub use shell_exec::ShellExecTool;
 
 #[derive(Default)]

--- a/crates/forge-session/tests/agent_spawn.rs
+++ b/crates/forge-session/tests/agent_spawn.rs
@@ -23,6 +23,7 @@ fn agent_def(name: &str, isolation: Isolation) -> AgentDef {
         body: String::new(),
         allowed_paths: vec![],
         isolation,
+        memory_enabled: false,
     }
 }
 

--- a/crates/forge-session/tests/agent_spawn_live.rs
+++ b/crates/forge-session/tests/agent_spawn_live.rs
@@ -34,6 +34,7 @@ fn agent_def(name: &str, isolation: Isolation) -> AgentDef {
         body: String::new(),
         allowed_paths: vec![],
         isolation,
+        memory_enabled: false,
     }
 }
 

--- a/crates/forge-session/tests/bg_agents_tracing.rs
+++ b/crates/forge-session/tests/bg_agents_tracing.rs
@@ -19,6 +19,7 @@ fn def(name: &str) -> AgentDef {
         body: String::new(),
         allowed_paths: vec![],
         isolation: Isolation::Process,
+        memory_enabled: false,
     }
 }
 

--- a/crates/forge-session/tests/fs_read_tool.rs
+++ b/crates/forge-session/tests/fs_read_tool.rs
@@ -94,6 +94,7 @@ async fn fs_read_tool_returns_content_bytes_sha256() {
             server_workspace,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/handshake.rs
+++ b/crates/forge-session/tests/handshake.rs
@@ -133,6 +133,7 @@ async fn session_id_stable_across_handshakes() {
             None,
             Some(server_id),
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();
@@ -176,6 +177,7 @@ async fn workspace_reported_as_absolute_path() {
             Some(server_workspace),
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/memory_injection.rs
+++ b/crates/forge-session/tests/memory_injection.rs
@@ -2,15 +2,29 @@
 //!
 //! These tests cover the seam that `serve_with_session` uses — they
 //! exercise the public `forge_agents` API (`MemoryStore` + frontmatter +
-//! `assemble_system_prompt`) that the server composes once per session.
-//! End-to-end coverage of the daemon path is deferred to the existing
-//! orchestrator-level AGENTS.md test, which is the precedent for
-//! per-turn system-prompt assertions.
+//! `assemble_system_prompt`) that the server composes once per session,
+//! plus a daemon-level smoke test that drives `serve_with_session` with
+//! the typed `active_agent` parameter (replacing the prior
+//! `FORGE_ACTIVE_AGENT` env-var indirection — see
+//! `crates/forge-session/src/server.rs::tests::concurrent_sessions_with_different_active_agents_get_their_own_memory`
+//! for the regression test that pins the multi-session correctness
+//! invariant).
+//!
+//! End-to-end coverage of system-prompt assembly is exercised by the
+//! pure `assemble_system_prompt` tests below and the orchestrator-level
+//! AGENTS.md test, which is the precedent for per-turn system-prompt
+//! assertions.
+
+use std::sync::Arc;
 
 use forge_agents::{
     assemble_system_prompt, Memory, MemoryFrontmatter, MemoryStore, WriteMode, MEMORY_HEADING,
 };
+use forge_ipc::{ClientInfo, Hello, IpcMessage, PROTO_VERSION};
+use forge_providers::MockProvider;
+use forge_session::{server::serve_with_session, session::Session};
 use tempfile::tempdir;
+use tokio::net::UnixStream;
 
 #[test]
 fn memory_body_injects_after_agents_md_under_memory_heading() {
@@ -91,4 +105,84 @@ fn explicit_save_with_chosen_metadata_round_trips() {
     let reread = store.load("scribe").unwrap().unwrap();
     assert_eq!(reread.frontmatter.version, 42);
     assert_eq!(reread.body, "frozen body");
+}
+
+/// F-601: daemon-level smoke test that `serve_with_session` accepts the
+/// typed `active_agent` parameter and a connection completes the
+/// handshake without crashing.
+///
+/// The new typed parameter replaces the prior `FORGE_ACTIVE_AGENT`
+/// env-var indirection. This test pins that the parameter is plumbed
+/// through the public surface — no env var is set or read by this test.
+/// The deeper "two sessions in the same process get their own memory
+/// body" invariant is covered by the unit test in `server.rs`.
+#[tokio::test]
+async fn serve_with_session_accepts_typed_active_agent_parameter() {
+    let dir = tempdir().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("memory.sock");
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(MockProvider::with_default_path());
+
+    let server_sock = sock_path.clone();
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            session,
+            provider,
+            false,
+            false,
+            None,
+            None,
+            None, // F-587: keyless test wiring
+            // F-601: typed `active_agent` exercised here. Memory is off
+            // because no agent runtime is loaded under this tempdir
+            // workspace — the rules in `resolve_session_memory` quietly
+            // disable memory and the session continues normally.
+            Some("scribe".to_string()),
+        )
+        .await
+        .unwrap();
+    });
+
+    // Connect with a small retry loop; the server task races our connect.
+    let mut stream = {
+        let mut last_err = None;
+        let mut connected = None;
+        for _ in 0..20 {
+            match UnixStream::connect(&sock_path).await {
+                Ok(s) => {
+                    connected = Some(s);
+                    break;
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            }
+        }
+        connected.unwrap_or_else(|| {
+            panic!(
+                "server did not start in time: {}",
+                last_err.expect("at least one connect error")
+            )
+        })
+    };
+
+    let hello = IpcMessage::Hello(Hello {
+        proto: PROTO_VERSION,
+        client: ClientInfo {
+            kind: "shell".into(),
+            pid: std::process::id(),
+            user: "test-user".into(),
+        },
+    });
+    forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
+
+    let response = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let IpcMessage::HelloAck(ack) = response else {
+        panic!("expected HelloAck, got {response:?}");
+    };
+    assert_eq!(ack.schema_version, 1);
+    assert!(!ack.session_id.is_empty());
 }

--- a/crates/forge-session/tests/memory_injection.rs
+++ b/crates/forge-session/tests/memory_injection.rs
@@ -1,0 +1,94 @@
+//! F-601: integration tests for cross-session memory injection.
+//!
+//! These tests cover the seam that `serve_with_session` uses — they
+//! exercise the public `forge_agents` API (`MemoryStore` + frontmatter +
+//! `assemble_system_prompt`) that the server composes once per session.
+//! End-to-end coverage of the daemon path is deferred to the existing
+//! orchestrator-level AGENTS.md test, which is the precedent for
+//! per-turn system-prompt assertions.
+
+use forge_agents::{
+    assemble_system_prompt, Memory, MemoryFrontmatter, MemoryStore, WriteMode, MEMORY_HEADING,
+};
+use tempfile::tempdir;
+
+#[test]
+fn memory_body_injects_after_agents_md_under_memory_heading() {
+    let agents_md_prefix = "\n\n---\nAGENTS.md (workspace):\nworkspace rules";
+    let memory_body = "remember: ship Phase 3 by Friday";
+
+    let assembled = assemble_system_prompt(Some(agents_md_prefix), Some(memory_body))
+        .expect("both inputs present must yield Some");
+
+    let agents_idx = assembled
+        .find("AGENTS.md (workspace):")
+        .expect("AGENTS.md label must appear");
+    let mem_idx = assembled
+        .find("## Memory")
+        .expect("Memory heading must appear");
+    assert!(
+        agents_idx < mem_idx,
+        "AGENTS.md must precede Memory heading; got: {assembled}"
+    );
+    assert!(
+        assembled.ends_with(memory_body),
+        "memory body must close out the prompt; got: {assembled}"
+    );
+    assert!(
+        assembled.contains(MEMORY_HEADING.trim()),
+        "MEMORY_HEADING must be present"
+    );
+}
+
+#[test]
+fn memory_alone_still_uses_memory_heading() {
+    let memory_body = "no agents.md, just memory";
+    let assembled = assemble_system_prompt(None, Some(memory_body)).unwrap();
+    assert!(assembled.contains("## Memory"));
+    assert!(assembled.ends_with(memory_body));
+}
+
+#[test]
+fn no_memory_no_agents_md_yields_none() {
+    assert!(assemble_system_prompt(None, None).is_none());
+}
+
+#[test]
+fn write_then_read_round_trips_for_a_named_agent() {
+    let dir = tempdir().unwrap();
+    let store = MemoryStore::new(dir.path());
+    let result = store
+        .write("scribe", "phase 3 plan", WriteMode::Append)
+        .unwrap();
+    assert_eq!(result.frontmatter.version, 1);
+
+    // A second session of the same agent observes the prior write.
+    let reread = store.load("scribe").unwrap().unwrap();
+    assert_eq!(reread.body, "phase 3 plan");
+    assert_eq!(reread.frontmatter.version, 1);
+}
+
+#[test]
+fn missing_file_does_not_crash_load_path() {
+    let dir = tempdir().unwrap();
+    let store = MemoryStore::new(dir.path());
+    assert!(store.load("never-written").unwrap().is_none());
+}
+
+#[test]
+fn explicit_save_with_chosen_metadata_round_trips() {
+    let dir = tempdir().unwrap();
+    let store = MemoryStore::new(dir.path());
+    let memory = Memory {
+        frontmatter: MemoryFrontmatter {
+            updated_at: chrono::Utc::now(),
+            version: 42,
+        },
+        body: "frozen body".to_string(),
+    };
+    store.save("scribe", &memory).unwrap();
+
+    let reread = store.load("scribe").unwrap().unwrap();
+    assert_eq!(reread.frontmatter.version, 42);
+    assert_eq!(reread.body, "frozen body");
+}

--- a/crates/forge-session/tests/orchestrator.rs
+++ b/crates/forge-session/tests/orchestrator.rs
@@ -100,6 +100,7 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();
@@ -268,6 +269,7 @@ async fn approval_gate_fires_and_blocks_until_client_approves() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();
@@ -358,6 +360,7 @@ async fn auto_approve_skips_approval_gate_and_emits_auto_approved() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();
@@ -488,6 +491,7 @@ async fn tool_result_fed_back_to_provider_in_continuation() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();
@@ -606,6 +610,7 @@ async fn approval_with_this_tool_scope_is_recorded_faithfully() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();
@@ -689,6 +694,7 @@ async fn malformed_approval_scope_rejects_instead_of_silently_downgrading_to_onc
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();
@@ -793,6 +799,7 @@ async fn unexpected_post_handshake_frame_is_logged_not_silently_dropped() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/provider_swap.rs
+++ b/crates/forge-session/tests/provider_swap.rs
@@ -107,6 +107,7 @@ async fn next_turn_uses_new_provider_after_swap() {
             None,
             None,
             None, // F-587 keyless
+            None, // F-601 active_agent: memory off
         )
         .await
         .ok();

--- a/crates/forge-session/tests/rerun_branch.rs
+++ b/crates/forge-session/tests/rerun_branch.rs
@@ -95,6 +95,7 @@ async fn rerun_branch_keeps_both_variants_and_branch_selected_gates_display() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();
@@ -287,6 +288,7 @@ async fn select_branch_with_variant_zero_resolves_to_parent() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/rerun_fresh.rs
+++ b/crates/forge-session/tests/rerun_fresh.rs
@@ -126,6 +126,7 @@ async fn rerun_fresh_regenerates_from_user_message_root_and_supersedes_original(
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/rerun_replace.rs
+++ b/crates/forge-session/tests/rerun_replace.rs
@@ -92,6 +92,7 @@ async fn rerun_replace_supersedes_original_message_in_fresh_replay() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/step_events.rs
+++ b/crates/forge-session/tests/step_events.rs
@@ -106,6 +106,7 @@ async fn capture_turn_events(auto_approve: bool) -> Vec<Event> {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/subscribe_replay.rs
+++ b/crates/forge-session/tests/subscribe_replay.rs
@@ -70,6 +70,7 @@ async fn subscribe_mid_stream_receives_historical_then_live_events() {
             None,
             None,
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-shell/tests/bridge_e2e.rs
+++ b/crates/forge-shell/tests/bridge_e2e.rs
@@ -48,6 +48,7 @@ async fn spawn_daemon(path: &Path, session_id: &str) -> TempDir {
             None,
             Some(sid),
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-shell/tests/ipc_bg_agents.rs
+++ b/crates/forge-shell/tests/ipc_bg_agents.rs
@@ -86,6 +86,7 @@ fn def(name: &str) -> AgentDef {
         body: String::new(),
         allowed_paths: vec![],
         isolation: Isolation::Process,
+        memory_enabled: false,
     }
 }
 

--- a/crates/forge-shell/tests/ipc_commands.rs
+++ b/crates/forge-shell/tests/ipc_commands.rs
@@ -65,6 +65,7 @@ async fn session_hello_command_round_trips_via_tauri_invoke() {
             None,
             Some("tauri-hello".to_string()),
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/crates/forge-shell/tests/ipc_mcp.rs
+++ b/crates/forge-shell/tests/ipc_mcp.rs
@@ -87,6 +87,7 @@ async fn spawn_daemon_with_workspace(
             Some(workspace),
             Some(sid),
             None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
         )
         .await
         .unwrap();

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -115,11 +115,19 @@ result as `Arc<str>` so per-turn cost stays at the existing refcount bump.
 
 ## Active-agent selection
 
-`serve_with_session` reads `FORGE_ACTIVE_AGENT` to decide which agent's
-memory backs the session. The named agent is looked up in the loaded
-`AgentDef` set:
+`serve_with_session` accepts an `active_agent: Option<String>` parameter
+that names which agent's memory backs the session. The Tauri shell knows
+which agent each window targets and passes it in explicitly; the daemon
+binary (`forged`) reads `FORGE_ACTIVE_AGENT` once at process start and
+forwards it as the typed parameter. **The server itself does not read the
+environment for this concern** — that distinction matters in
+persistent-mode operation, where one daemon serves multiple connections
+and a process-global mutable env var would let one window silently see
+another agent's memory.
 
-- Unset / empty → memory off.
+The named agent is looked up in the loaded `AgentDef` set:
+
+- `None` / empty / whitespace → memory off.
 - Names an agent that is not loaded → memory off, logged at WARN.
 - Names a loaded agent with `memory_enabled: false` → memory off.
 - Names a loaded agent with `memory_enabled: true` → memory on; body is

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -1,0 +1,201 @@
+# Cross-session memory
+
+Status: stable as of F-601 (Phase 3).
+
+Forge agents can opt into a small per-agent Markdown file that persists
+across sessions. When enabled, the file's body is appended to the agent's
+system prompt under a `## Memory` heading after `AGENTS.md`, and a
+`memory.write` tool is exposed so the agent can update its own memory.
+
+This document is the contract for `forge_agents::memory` and the wiring in
+`forge_session::server::serve_with_session`. See also
+`docs/architecture/crate-architecture.md` §3.4.
+
+## Scope
+
+- One Markdown file per agent. Multiple sessions of the same agent share
+  the same memory.
+- Memory is a coarse, agent-scoped scratchpad — not a key-value store, not
+  a vector store, not session history.
+- Reads are best-effort: a corrupt file logs a warning and the session
+  continues without memory injection.
+- Writes are atomic (temp file + rename) and increment a monotonic version
+  on every write.
+
+## Storage layout
+
+```
+~/.config/forge/memory/
+  <agent>.md            # one file per agent that has opted in
+```
+
+`<agent>` is the agent name from the `.agents/<name>.md` frontmatter (or
+the filename stem when frontmatter omits it). The same string is used to
+locate the memory file and to seed the `memory.write` tool registration.
+
+The parent directory is created on first write at mode `0700` on Unix.
+
+## File format
+
+```markdown
+---
+updated_at: 2026-04-26T12:00:00Z
+version: 1
+---
+free-form markdown body the agent has accumulated
+```
+
+Frontmatter fields:
+
+| Field        | Type    | Required | Notes                               |
+|--------------|---------|----------|-------------------------------------|
+| `updated_at` | ISO 8601 / RFC 3339 timestamp | yes | Snaps to `Utc::now()` on every write. |
+| `version`    | positive integer | yes | Increments by 1 on every write; first write writes `1`. |
+
+The body is free-form Markdown. Forge does not interpret it — bytes
+round-trip verbatim, modulo a single trailing newline that the YAML
+frontmatter parser may strip.
+
+`memory.write { mode: "append" }` joins the new content to the existing
+body with a single `\n` separator. `mode: "replace"` discards the existing
+body in full.
+
+## Per-agent opt-in
+
+Memory is OFF by default. An agent opts in by setting `memory: true`
+(or the explicit `memory_enabled: true`) in its frontmatter:
+
+```markdown
+---
+name: scribe
+memory: true
+---
+
+You are a long-running scribe...
+```
+
+The flag controls **both** behaviors:
+
+1. Whether the agent's memory body is loaded and appended to the system
+   prompt.
+2. Whether the `memory.write` tool is registered on the dispatcher and
+   thus discoverable by the agent.
+
+An agent that has not opted in cannot see the tool name and cannot read
+or write memory.
+
+## System-prompt injection
+
+When memory is enabled and the file exists, the assembled system prompt is:
+
+```text
+\n\n---\nAGENTS.md (workspace):\n<agents.md content>
+
+---
+## Memory
+<memory body>
+```
+
+Both halves are optional and assembled by `forge_agents::assemble_system_prompt`:
+
+| `AGENTS.md` | Memory body | Result                                 |
+|-------------|-------------|----------------------------------------|
+| absent      | absent      | `None` — no system prompt              |
+| present     | absent      | AGENTS.md prefix only                  |
+| absent      | present     | `## Memory` heading + body             |
+| present     | present     | AGENTS.md prefix, then `## Memory`     |
+
+The session does the assembly **once** per session start and stores the
+result as `Arc<str>` so per-turn cost stays at the existing refcount bump.
+
+## Active-agent selection
+
+`serve_with_session` reads `FORGE_ACTIVE_AGENT` to decide which agent's
+memory backs the session. The named agent is looked up in the loaded
+`AgentDef` set:
+
+- Unset / empty → memory off.
+- Names an agent that is not loaded → memory off, logged at WARN.
+- Names a loaded agent with `memory_enabled: false` → memory off.
+- Names a loaded agent with `memory_enabled: true` → memory on; body is
+  appended and `memory.write` registers.
+
+## `memory.write` tool
+
+```json
+{ "name": "memory.write",
+  "args": { "content": "...", "mode": "append" | "replace" } }
+```
+
+Returns:
+
+```json
+{ "ok": true, "version": 7, "updated_at": "2026-04-26T12:00:00Z" }
+```
+
+On failure (missing arg, unknown mode, IO error) the tool returns
+`{ "error": "<message>" }` rather than propagating an exception — the
+dispatcher contract is that `invoke` always succeeds and the model
+decides what to do with the JSON result.
+
+The tool is gated on the per-agent flag: it is registered on the
+dispatcher only when the active agent has `memory_enabled: true`. An
+agent that has not opted in cannot discover the wire name.
+
+## Security model
+
+**Memory is plain Markdown.** No template evaluation, no executable
+content, no macro expansion. Bytes round-trip verbatim through the YAML
+frontmatter parser.
+
+**File permissions:**
+- `~/.config/forge/memory/` directory: mode `0700` on Unix.
+- Each `<agent>.md` file: mode `0600` on Unix.
+- Windows: platform default ACL — no encryption, no extra hardening.
+
+**Atomicity:** writes go to `<agent>.md.tmp`, then `rename(2)` to the
+final path. A crashing write leaves the prior file intact.
+
+**Best-effort reads:** a corrupt YAML frontmatter, a missing
+`updated_at` or `version`, or a `version: 0` value all log a warning and
+yield "no memory" — the session never crashes on a malformed file.
+
+### DO NOT store secrets in memory
+
+The memory body is appended verbatim to the system prompt of every
+subsequent agent turn. That means anything in memory is:
+
+- visible to the model at every turn,
+- transmitted over every provider request (HTTPS or local socket),
+- logged or serialized by anything that captures the system prompt.
+
+There is **no encryption, no redaction, no scoping** of the memory body.
+If an agent or a user writes a secret (API key, password, private
+identifier, customer data) into memory, that secret is now part of the
+permanent system prompt for that agent.
+
+Forge does not scan memory for secrets and does not warn at write time —
+the `memory.write` tool accepts any string.
+
+**Rule of thumb:** treat the memory file the way you treat
+`~/.bash_history` — visible to anyone with shell access, persistent
+across reboots, and explicitly **not** a place for credentials.
+
+## Testing
+
+`crates/forge-agents/src/memory.rs` includes unit tests for:
+
+- frontmatter round-trip (write + load),
+- `append` vs `replace` semantics,
+- monotonic version increment,
+- `updated_at` advancement,
+- corrupt-frontmatter recovery (returns `None`, no panic),
+- file-mode `0600` on Unix.
+
+`crates/forge-session/tests/memory_injection.rs` exercises the
+session-level seam: `MemoryStore` + `assemble_system_prompt` composed the
+way `serve_with_session` composes them.
+
+`crates/forge-session/src/dispatcher_cache.rs` tests assert that
+`memory.write` is registered if-and-only-if a `MemoryWriteBinding` is
+provided.

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -24,16 +24,21 @@ This document is the contract for `forge_agents::memory` and the wiring in
 
 ## Storage layout
 
-```
-~/.config/forge/memory/
-  <agent>.md            # one file per agent that has opted in
-```
+The store is rooted at the platform's user-config directory, resolved via
+`dirs::config_dir`:
+
+| Platform | Path |
+|----------|------|
+| Linux    | `$XDG_CONFIG_HOME/forge/memory/<agent>.md` (default `~/.config/forge/memory/<agent>.md`) |
+| macOS    | `~/Library/Application Support/forge/memory/<agent>.md` |
+| Windows  | `%APPDATA%\forge\memory\<agent>.md` |
 
 `<agent>` is the agent name from the `.agents/<name>.md` frontmatter (or
 the filename stem when frontmatter omits it). The same string is used to
 locate the memory file and to seed the `memory.write` tool registration.
 
-The parent directory is created on first write at mode `0700` on Unix.
+The parent directory is created on first write at mode `0700` on Unix; on
+Windows the platform default ACL applies.
 
 ## File format
 


### PR DESCRIPTION
## Summary

Adds opt-in cross-session memory at `~/.config/forge/memory/<agent>.md`
so long-running agents can persist a small Markdown scratchpad across
sessions. The body is appended to the system prompt under a `## Memory`
heading after `AGENTS.md` when the agent's per-agent flag is enabled,
and a new `memory.write` tool is exposed (gated on the same flag).

- `MemoryStore` in `forge-agents/src/memory.rs` reads/writes the file
  with atomic temp+rename, monotonic version, and mode `0600` on Unix.
- `forge_agents::assemble_system_prompt` composes AGENTS.md + memory
  body for the session orchestrator to use.
- `AgentDef.memory_enabled` parsed from `memory: true` or
  `memory_enabled: true` frontmatter (defaults OFF).
- `memory.write { content, mode: "append" | "replace" }` registered on
  the dispatcher only when a `MemoryWriteBinding` is present.
- `serve_with_session` resolves the active agent via
  `FORGE_ACTIVE_AGENT`, loads memory once, and pre-builds the prompt
  prefix.
- `docs/architecture/memory.md` documents format, scope, and the
  explicit "no secrets in memory" security model.

Closes #619.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` — every test result line reports `ok`,
      including new unit tests in `forge-agents::memory`,
      `forge-session::tools::memory_write`,
      `forge-session::dispatcher_cache`, and the
      `forge-session::tests::memory_injection` integration test.
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`

New tests cover:
- frontmatter round-trip (write + load)
- `append` vs `replace` semantics + monotonic version
- corrupt-frontmatter recovery (no panic)
- file mode `0600` / dir mode `0700` on Unix
- `assemble_system_prompt` ordering (AGENTS.md before `## Memory`)
- `memory.write` tool error shapes (missing arg, unknown mode)
- dispatcher gating: `memory.write` registers iff binding present
- `AgentDef.memory_enabled` defaults OFF and parses both aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)