### PR TITLE
[hotfix] Update F-602 ipc_memory test assertion to match new validator message

### DIFF
--- a/crates/forge-shell/tests/ipc_memory.rs
+++ b/crates/forge-shell/tests/ipc_memory.rs
@@ -287,7 +287,7 @@ async fn save_agent_memory_rejects_path_separators_in_id() {
         "save_agent_memory",
         serde_json::json!({ "agentId": "../etc/passwd", "body": "x" }),
     );
-    assert!(err.contains("path separators"), "got {err}");
+    assert!(err.contains("[A-Za-z0-9_-]"), "got {err}");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

F-602 fix iteration switched `validate_agent_id` in \`crates/forge-shell/src/memory_ipc.rs\` from a blocklist of separators to an allowlist of \`[A-Za-z0-9_-]\`. The validator's error message changed from "path separators" to "agent_id must contain only [A-Za-z0-9_-]".

The webview-test integration test \`save_agent_memory_rejects_path_separators_in_id\` (\`crates/forge-shell/tests/ipc_memory.rs:290\`) was not updated and continued to assert against the old message. The test failed only under \`--features webview-test\`, which the standard \`gh pr checks --watch\` rollup doesn't surface until late, so the parent merged F-602 before the failure was visible.

This one-line patch updates the assertion to match the current error string. The test still asserts the same intent (the validator rejects \`../etc/passwd\`); only the error-message substring is changed.

## Test plan

- \`cargo test --test ipc_memory --features webview-test save_agent_memory_rejects_path_separators_in_id\` passes locally.
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)