### PR TITLE
[F-606] Emit step index + total on StepStarted

### DIFF
--- a/crates/forge-core/src/event.rs
+++ b/crates/forge-core/src/event.rs
@@ -198,6 +198,30 @@ pub enum Event {
         /// pin on this field name; the divergence is documented in
         /// `docs/architecture/event-conventions.md` as a pinned exception.
         started_at: DateTime<Utc>,
+        /// F-606: 1-based step index within the enclosing turn.
+        ///
+        /// Counts every `StepStarted` emitted by the orchestrator for this
+        /// turn (Model and Tool steps included), in emission order. The UI
+        /// renders this as the `N` in the AgentMonitor §9.2 chip
+        /// `running · step N` (or `step N of M` when `total` is populated).
+        ///
+        /// `#[serde(default)]` lets event logs written before F-606
+        /// deserialize cleanly — older entries land with `index: 0`. New
+        /// emissions always start at `1`, so `0` on the wire is the
+        /// "legacy / unknown" marker.
+        #[serde(default)]
+        index: u32,
+        /// F-606: total step count for this turn, when known.
+        ///
+        /// `None` while the orchestrator is still streaming steps (today's
+        /// common case — the model decides what to call turn-by-turn so
+        /// the total is unknown until completion). A follow-up may emit a
+        /// retroactive companion event once the turn ends. UI falls back
+        /// to `step N` (no `of M`) when this is `None`.
+        ///
+        /// `#[serde(default)]` keeps old logs replayable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        total: Option<u32>,
     },
     /// F-139: fine-grained step trace — closes a step.
     ///

--- a/crates/forge-core/tests/event_conventions.rs
+++ b/crates/forge-core/tests/event_conventions.rs
@@ -48,6 +48,8 @@ fn step_started_retains_started_at_pinned_exception() {
         instance_id: None,
         kind: StepKind::Model,
         started_at: fixed_time(),
+        index: 1,
+        total: None,
     };
     let v = serde_json::to_value(&ev).unwrap();
     assert_eq!(

--- a/crates/forge-core/tests/event_wire_shape.rs
+++ b/crates/forge-core/tests/event_wire_shape.rs
@@ -653,6 +653,8 @@ fn step_started_wire_shape() {
             instance_id: None,
             kind: StepKind::Model,
             started_at: fixed_time(),
+            index: 1,
+            total: None,
         },
         json!({
             "type": "step_started",
@@ -660,6 +662,7 @@ fn step_started_wire_shape() {
             "instance_id": null,
             "kind": "model",
             "started_at": "2026-04-18T10:00:00Z",
+            "index": 1,
         }),
     );
 }
@@ -672,6 +675,8 @@ fn step_started_with_instance_id_wire_shape() {
             instance_id: Some(instance_id("inst-9")),
             kind: StepKind::Tool,
             started_at: fixed_time(),
+            index: 2,
+            total: None,
         },
         json!({
             "type": "step_started",
@@ -679,8 +684,58 @@ fn step_started_with_instance_id_wire_shape() {
             "instance_id": "inst-9",
             "kind": "tool",
             "started_at": "2026-04-18T10:00:00Z",
+            "index": 2,
         }),
     );
+}
+
+#[test]
+fn step_started_with_total_wire_shape() {
+    // F-606: when the orchestrator can populate `total`, it serializes
+    // alongside `index`. `total: None` is omitted via
+    // `#[serde(skip_serializing_if)]` so older clients never see a `null`
+    // they didn't previously read.
+    assert_wire_eq(
+        Event::StepStarted {
+            step_id: step_id("step-3"),
+            instance_id: None,
+            kind: StepKind::Model,
+            started_at: fixed_time(),
+            index: 3,
+            total: Some(7),
+        },
+        json!({
+            "type": "step_started",
+            "step_id": "step-3",
+            "instance_id": null,
+            "kind": "model",
+            "started_at": "2026-04-18T10:00:00Z",
+            "index": 3,
+            "total": 7,
+        }),
+    );
+}
+
+#[test]
+fn step_started_legacy_log_replay_defaults_index_zero() {
+    // F-606 backwards-compat: event logs written before the index/total
+    // fields existed must still deserialize. Missing fields fall back to
+    // `index: 0` (the "legacy / unknown" sentinel) and `total: None`.
+    let legacy: Event = serde_json::from_value(json!({
+        "type": "step_started",
+        "step_id": "step-legacy",
+        "instance_id": null,
+        "kind": "model",
+        "started_at": "2026-04-18T10:00:00Z",
+    }))
+    .expect("legacy step_started shape must round-trip via serde defaults");
+    match legacy {
+        Event::StepStarted { index, total, .. } => {
+            assert_eq!(index, 0, "legacy logs deserialize with index: 0 sentinel");
+            assert!(total.is_none(), "legacy logs deserialize with total: None");
+        }
+        other => panic!("expected StepStarted, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/forge-core/tests/schema_snapshot.rs
+++ b/crates/forge-core/tests/schema_snapshot.rs
@@ -57,6 +57,8 @@ fn step_started_model_top_level_turn_snapshot() {
             instance_id: None,
             kind: StepKind::Model,
             started_at: fixed_time(),
+            index: 1,
+            total: None,
         },
         json!({
             "type": "step_started",
@@ -64,6 +66,7 @@ fn step_started_model_top_level_turn_snapshot() {
             "instance_id": null,
             "kind": "model",
             "started_at": "2026-04-20T12:00:00Z",
+            "index": 1,
         }),
     );
 }
@@ -76,6 +79,8 @@ fn step_started_tool_under_instance_snapshot() {
             instance_id: Some(agent_instance_id("inst-1")),
             kind: StepKind::Tool,
             started_at: fixed_time(),
+            index: 2,
+            total: None,
         },
         json!({
             "type": "step_started",
@@ -83,6 +88,7 @@ fn step_started_tool_under_instance_snapshot() {
             "instance_id": "inst-1",
             "kind": "tool",
             "started_at": "2026-04-20T12:00:00Z",
+            "index": 2,
         }),
     );
 }
@@ -104,6 +110,8 @@ fn step_kind_wire_labels_are_snake_case() {
             instance_id: None,
             kind,
             started_at: fixed_time(),
+            index: 1,
+            total: None,
         };
         let v = serde_json::to_value(&ev).unwrap();
         assert_eq!(v["kind"], Value::String(expected.to_string()));

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -418,6 +418,14 @@ pub(crate) async fn run_request_loop<P: Provider>(
     let provider_id = ProviderId::new();
     let model = "mock".to_string();
 
+    // F-606: 1-based step counter for this turn. Incremented before every
+    // `StepStarted` emission (Model + Tool) so the AgentMonitor §9.2 chip
+    // can render `step N`. The total is unknown in advance — the model
+    // streams steps turn-by-turn — so `total` rides as `None` for now;
+    // the UI displays `step N` and a follow-up may emit a retroactive
+    // companion event when the turn ends.
+    let mut step_index: u32 = 0;
+
     loop {
         // F-139: open a `Model` step around each provider pass. The step
         // envelopes every event this iteration emits (AssistantMessage*,
@@ -431,12 +439,15 @@ pub(crate) async fn run_request_loop<P: Provider>(
         // Agent Monitor groups a session's trace under the stable id here.
         let model_step_id = StepId::new();
         let model_step_started = Instant::now();
+        step_index += 1;
         session
             .emit(Event::StepStarted {
                 step_id: model_step_id.clone(),
                 instance_id: instance_id.clone(),
                 kind: StepKind::Model,
                 started_at: Utc::now(),
+                index: step_index,
+                total: None,
             })
             .await?;
 
@@ -558,6 +569,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
             dispatcher,
             ctx,
             auto_approve,
+            &mut step_index,
         )
         .await?;
 
@@ -746,6 +758,11 @@ async fn dispatch_tool_calls(
     dispatcher: &ToolDispatcher,
     ctx: &ToolCtx,
     auto_approve: bool,
+    // F-606: turn-scoped step counter. Each `StepStarted(Tool)` emission in
+    // this dispatch increments the counter; the `index` field carries the
+    // updated value so the AgentMonitor chip renders `step N` consistently
+    // across Model and Tool steps within the same turn.
+    step_index: &mut u32,
 ) -> Result<DispatchOutcome> {
     if pending.is_empty() {
         return Ok(DispatchOutcome {
@@ -790,12 +807,15 @@ async fn dispatch_tool_calls(
                 let tool_step_id = StepId::new();
                 let started = Instant::now();
                 tool_steps[idx] = Some((tool_step_id.clone(), started));
+                *step_index += 1;
                 session
                     .emit(Event::StepStarted {
                         step_id: tool_step_id.clone(),
                         instance_id: instance_id.clone(),
                         kind: StepKind::Tool,
                         started_at: Utc::now(),
+                        index: *step_index,
+                        total: None,
                     })
                     .await?;
                 session
@@ -987,12 +1007,15 @@ async fn dispatch_tool_calls(
                 let pc = &pending[idx];
                 let tool_step_id = StepId::new();
                 let tool_step_started = Instant::now();
+                *step_index += 1;
                 session
                     .emit(Event::StepStarted {
                         step_id: tool_step_id.clone(),
                         instance_id: instance_id.clone(),
                         kind: StepKind::Tool,
                         started_at: Utc::now(),
+                        index: *step_index,
+                        total: None,
                     })
                     .await?;
                 session

--- a/crates/forge-session/tests/step_events.rs
+++ b/crates/forge-session/tests/step_events.rs
@@ -349,6 +349,55 @@ async fn model_step_contains_assistant_events() {
 }
 
 #[tokio::test]
+async fn step_started_index_is_monotonic_one_based_per_turn() {
+    // F-606: every `StepStarted` carries a 1-based `index` that increments
+    // by exactly 1 across the turn — Model and Tool steps share the same
+    // counter so the AgentMonitor §9.2 chip can render `step N`
+    // consistently regardless of step kind.
+    let events = capture_turn_events(true).await;
+
+    let indices: Vec<u32> = events
+        .iter()
+        .filter_map(|e| {
+            if let Event::StepStarted { index, .. } = e {
+                Some(*index)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        !indices.is_empty(),
+        "at least one StepStarted must be emitted; got: {:?}",
+        kinds_of(&events)
+    );
+    let expected: Vec<u32> = (1..=indices.len() as u32).collect();
+    assert_eq!(
+        indices, expected,
+        "StepStarted.index must be 1-based and monotonically increase by 1 per emission; got {indices:?}"
+    );
+}
+
+#[tokio::test]
+async fn step_started_total_is_unknown_during_turn() {
+    // F-606: today the orchestrator does not pre-plan the step list — the
+    // model decides what to call turn-by-turn — so `total` rides as
+    // `None`. UI falls back to `step N` (no `of M`). A future change may
+    // populate `total` retroactively or via a companion event.
+    let events = capture_turn_events(true).await;
+    for ev in &events {
+        if let Event::StepStarted { total, .. } = ev {
+            assert!(
+                total.is_none(),
+                "Phase-3 orchestrator emits StepStarted.total = None until step pre-planning lands; got Some({})",
+                total.unwrap()
+            );
+        }
+    }
+}
+
+#[tokio::test]
 async fn tool_invoked_matches_tool_call_started_id() {
     let events = capture_turn_events(true).await;
 

--- a/docs/ui-specs/agent-monitor.md
+++ b/docs/ui-specs/agent-monitor.md
@@ -31,9 +31,9 @@ running · 3m · $0.09              sonnet-4.5        ← meta row
 
 ### 9.2 Trace (middle)
 
-**Header (Phase 2).** Agent name big, id small, live state chip (`running · step N` when running; otherwise the bare state). The chip uses an ember accent while running and the neutral surface chip for `queued` / `done` / `error`.
+**Header (Phase 2).** Agent name big, id small, live state chip (`running · step N` when running; otherwise the bare state). The chip uses an ember accent while running and the neutral surface chip for `queued` / `done` / `error`. `N` reads from `StepStarted.index` (1-based, [F-606](https://github.com/forge-ide/forge/issues/652)).
 
-**Header (Phase 3 — deferred to [F-449](https://github.com/forge-ide/forge/issues/504)).** Expand the live chip to `running · step N of M` once the backend broadcasts a total-step count, and add the `Pause` / `Kill` buttons plus a `Promote to pane` button for background agents. Phase-2 surfaces `Stop agent` via the Inspector only (§9.3).
+**Header (Phase 3 — `Pause` / `Kill` / `Promote` deferred to [F-449](https://github.com/forge-ide/forge/issues/504)).** The chip's `step N of M` form is gated on `StepStarted.total` being populated. Today the orchestrator streams steps turn-by-turn so `total` rides as `None` and the UI shows the bare `step N` form; rendering `of M` lights up automatically once the orchestrator pre-plans (or emits a retroactive total). The `Pause` / `Kill` buttons plus `Promote to pane` for background agents remain blocked on F-449. Phase-2 surfaces `Stop agent` via the Inspector only (§9.3).
 
 **Toolbar (Phase 3 — deferred to [F-449](https://github.com/forge-ide/forge/issues/504)).** Elapsed, token in/out, cost, model, tools-used, spawned-by relationship — all in Fira Code 10px separated by `·`. Blocked on backend plumbing for cost/token/tool-use aggregation.
 

--- a/web/packages/ipc/src/generated/AppSettings.ts
+++ b/web/packages/ipc/src/generated/AppSettings.ts
@@ -15,22 +15,22 @@ import type { WindowsSettings } from "./WindowsSettings";
  * refuse to load. This is the opposite of `ApprovalConfig`, where strict
  * validation protects the approval trust boundary.
  */
-export type AppSettings = { notifications: NotificationsSettings, windows: WindowsSettings,
+export type AppSettings = { notifications: NotificationsSettings, windows: WindowsSettings, 
 /**
  * Built-in provider connection details (F-585). Optional and
  * backwards-compatible: settings files without `[providers]` deserialize
  * to an empty map.
  */
-providers: ProvidersSettings,
+providers: ProvidersSettings, 
 /**
  * Catalog UI enable/disable flags (F-592). Open-shape map; absent =
  * enabled.
  */
-catalog: CatalogSettings,
+catalog: CatalogSettings, 
 /**
  * Dashboard UI preferences (F-597). Optional and backwards-compatible.
  */
-dashboard: DashboardSettings,
+dashboard: DashboardSettings, 
 /**
  * Per-agent cross-session memory toggles (F-602). Absent agents fall
  * back to the def-level `memory_enabled` frontmatter flag.


### PR DESCRIPTION
## Summary

- Extends `Event::StepStarted` with `index: u32` and `total: Option<u32>` so the AgentMonitor §9.2 chip can render `running · step N` (Option B from the issue).
- The orchestrator threads a per-turn counter through `run_request_loop` and `dispatch_tool_calls`, incrementing before every Model and Tool step emission so step-N reads identically across kinds within a turn.
- `total` rides as `None` until step pre-planning lands. UI shows `step N` today; `step N of M` lights up automatically when `total` becomes populated.
- Both new fields use `#[serde(default)]` (and `total` adds `skip_serializing_if`) so pre-F-606 event logs replay cleanly: legacy entries deserialize with `index: 0` (sentinel) and `total: None`; the wire shape only grows by one key (`index`) when `total` is absent.
- §9.2 footnote updated to reflect the chip is now implementable for `step N`; `step N of M` is gated on a future `total` source.

Closes forge-ide/forge#652

## Test plan

- [x] `cargo test -p forge-core` (event_wire_shape, schema_snapshot, event_conventions)
- [x] `cargo test -p forge-session --test step_events` (new `step_started_index_is_monotonic_one_based_per_turn` + `step_started_total_is_unknown_during_turn` plus all preexisting step invariants)
- [x] `cargo test --workspace`
- [x] `just check-rust` (fmt, clippy `-D warnings`, rustdoc `-D warnings`)
- [x] `just check-web` (typecheck + token drift gate)
- [x] `pnpm -r test` (1112 web tests including AgentMonitor.test.tsx)
- [ ] Manual sanity once frontend wires `ev['index']` into the live chip (UI work is downstream of this PR)

## Backwards-compat

- Wire shape for the common `total: None` path adds exactly one new key (`index`) versus pre-F-606. The TS `StepStarted` adapter in `web/packages/app/src/routes/AgentMonitor.tsx` reads fields via `ev['key']` (no shape pinning) so nothing breaks.
- Replay test added asserting that an event log written before this change still deserializes (legacy → `index: 0`, `total: None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)