### PR TITLE
[F-607] export_transcript IPC command

### DIFF
--- a/crates/forge-shell/src/dashboard_sessions.rs
+++ b/crates/forge-shell/src/dashboard_sessions.rs
@@ -266,9 +266,10 @@ pub fn default_workspaces_toml() -> PathBuf {
 #[cfg_attr(not(feature = "webview"), allow(dead_code))]
 pub(crate) const INVALID_SESSION_ID_ERROR: &str = "invalid session id";
 
-/// Strict gate over the `id` argument to `open_session`. Matches exactly
-/// the output of `forge_core::SessionId::new()` — 16 lowercase hex chars,
-/// no separators — and rejects everything else.
+/// Strict gate over the `id` argument to `open_session` (and reused by
+/// F-607's `export_transcript`). Matches exactly the output of
+/// `forge_core::SessionId::new()` — 16 lowercase hex chars, no separators —
+/// and rejects everything else.
 ///
 /// F-063 (M11 / T5): the window label `session-{id}` is consumed by
 /// Tauri's capability matcher (`session-*` glob in
@@ -284,7 +285,7 @@ pub(crate) const INVALID_SESSION_ID_ERROR: &str = "invalid session id";
 /// warning without hiding real unused-code regressions under
 /// `--features webview`.
 #[cfg_attr(not(feature = "webview"), allow(dead_code))]
-fn is_valid_session_id(id: &str) -> bool {
+pub(crate) fn is_valid_session_id(id: &str) -> bool {
     id.len() == 16 && id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
 }
 

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -601,6 +601,10 @@ pub fn build_invoke_handler<R: Runtime>() -> Box<dyn Fn(tauri::ipc::Invoke<R>) -
         crate::memory_ipc::read_agent_memory,
         crate::memory_ipc::save_agent_memory,
         crate::memory_ipc::clear_agent_memory,
+        // F-607: transcript export. Callable from the dashboard window
+        // (Inspector "Export transcript" button) or the matching
+        // `session-{id}` window; other session windows are rejected.
+        crate::transcript_ipc::export_transcript,
     ])
 }
 

--- a/crates/forge-shell/src/lib.rs
+++ b/crates/forge-shell/src/lib.rs
@@ -64,6 +64,11 @@ pub mod providers_ipc;
 // in-module under `#[cfg(test)]`.
 #[cfg(feature = "webview")]
 pub mod usage_ipc;
+// F-607: `export_transcript` Tauri command. Pure helpers
+// (`read_transcript_bytes`, `transcript_path`) are always compiled so
+// non-webview unit tests link without Tauri; the `#[tauri::command]` wrapper
+// is gated behind `webview`.
+pub mod transcript_ipc;
 pub mod window_spec;
 
 #[cfg(feature = "webview")]

--- a/crates/forge-shell/src/transcript_ipc.rs
+++ b/crates/forge-shell/src/transcript_ipc.rs
@@ -1,0 +1,223 @@
+//! F-607: Tauri command surface for transcript export.
+//!
+//! Single command — [`export_transcript`] — that returns the raw
+//! `<workspace>/.forge/sessions/<session_id>/events.jsonl` bytes for a
+//! session. Wraps the existing on-disk event log so the AgentMonitor
+//! Inspector (F-449 §9.3 "Export transcript") can pull the transcript
+//! through IPC instead of reaching into the filesystem from the webview.
+//!
+//! # Authorization
+//!
+//! Callable from either the dashboard window or the matching
+//! `session-{id}` window. Other session windows are rejected — a
+//! session-A webview has no business reading session-B's transcript.
+//!
+//! # Path safety
+//!
+//! `session_id` is validated against the canonical
+//! [`forge_core::SessionId`] wire shape (16 lowercase hex chars). Any
+//! non-conforming input is rejected before the path is built, which
+//! eliminates path-traversal (`../`) and out-of-band characters from the
+//! `events.jsonl` lookup. The path itself is composed via
+//! [`forge_session::server::event_log_path`], the same resolver the
+//! daemon uses, so shell and daemon stay in lock-step on session layout.
+//!
+//! # Size cap
+//!
+//! Transcripts are buffered into a `Vec<u8>` and capped at 50 MiB
+//! ([`MAX_TRANSCRIPT_BYTES`]). A long-running session can exceed that
+//! cap — in which case the command errors instead of allocating
+//! unbounded memory or truncating silently. The webview can fall back
+//! to reading the file directly through `read_file` (which is sandboxed
+//! to the workspace) if it ever needs to stream a larger transcript.
+//!
+//! # Missing file
+//!
+//! A session that has not yet written any events (or one whose log was
+//! pruned) returns an empty byte vector with a `tracing::warn`. The
+//! Inspector can render "no events" instead of surfacing an error to
+//! the user.
+
+use std::path::PathBuf;
+
+#[cfg(feature = "webview")]
+use tauri::{Runtime, State, Webview};
+
+#[cfg(feature = "webview")]
+use crate::ipc::{require_size, BridgeState, LABEL_MISMATCH_ERROR, MAX_WORKSPACE_ROOT_BYTES};
+
+/// Maximum transcript size returned by [`export_transcript`]. Set at 50 MiB
+/// — well above any realistic session log (events are typically a few KiB
+/// each; a chatty multi-day session lands in the low single-digit MiB) but
+/// low enough to bound the Tauri-side allocation a compromised session
+/// window can trigger.
+pub const MAX_TRANSCRIPT_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Stable error tag returned when the on-disk transcript exceeds
+/// [`MAX_TRANSCRIPT_BYTES`]. Tests pin this prefix; preserve it when
+/// evolving the message.
+pub const TRANSCRIPT_TOO_LARGE_ERROR: &str = "transcript exceeds export cap";
+
+/// Stable error tag returned when reading the on-disk transcript fails for
+/// any reason other than "not found".
+pub const TRANSCRIPT_READ_ERROR: &str = "failed to read transcript";
+
+/// Pure helper. Reads `path` into a `Vec<u8>`, returning:
+///
+/// - `Ok(Vec::new())` when the file does not exist (newly-created session
+///   that has not yet written its first event).
+/// - `Err(_)` when the file's size exceeds `cap_bytes`.
+/// - `Err(_)` when any other I/O error occurs.
+///
+/// Extracted for unit testing without spinning up Tauri.
+pub fn read_transcript_bytes(path: &std::path::Path, cap_bytes: u64) -> Result<Vec<u8>, String> {
+    let metadata = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::warn!(
+                target: "forge_shell::transcript_ipc",
+                path = %path.display(),
+                "transcript file missing; returning empty bytes"
+            );
+            return Ok(Vec::new());
+        }
+        Err(e) => {
+            return Err(format!("{TRANSCRIPT_READ_ERROR}: {e}"));
+        }
+    };
+
+    if metadata.len() > cap_bytes {
+        return Err(format!(
+            "{TRANSCRIPT_TOO_LARGE_ERROR}: {} bytes exceeds {} byte cap",
+            metadata.len(),
+            cap_bytes
+        ));
+    }
+
+    std::fs::read(path).map_err(|e| format!("{TRANSCRIPT_READ_ERROR}: {e}"))
+}
+
+/// Resolve the absolute path to the events.jsonl for `session_id` under
+/// `workspace_root`. Mirrors the daemon's
+/// [`forge_session::server::event_log_path`] so shell and daemon stay
+/// in lock-step on session layout.
+pub fn transcript_path(session_id: &str, workspace_root: &std::path::Path) -> PathBuf {
+    forge_session::server::event_log_path(session_id, Some(workspace_root))
+}
+
+/// F-607: return the raw `events.jsonl` bytes for `session_id`.
+///
+/// **Authorization.** Callable from the dashboard window (Inspector use
+/// case) or the matching `session-{session_id}` window (in-session
+/// transcript export). Any other session window is rejected.
+///
+/// **Path safety.** `session_id` must match the canonical [`SessionId`]
+/// wire shape (16 lowercase hex chars). Path traversal is impossible:
+/// `../` / NUL / separator bytes fail validation before the path is
+/// built.
+///
+/// **Workspace resolution.** For a session caller the workspace is taken
+/// from the server-side cache populated at `session_hello`. For the
+/// dashboard the supplied `workspace_root` is validated against the
+/// workspaces registry — the same gate every other dashboard-callable
+/// IPC command uses.
+///
+/// [`SessionId`]: forge_core::SessionId
+#[cfg(feature = "webview")]
+#[tauri::command]
+pub async fn export_transcript<R: Runtime>(
+    session_id: String,
+    workspace_root: String,
+    webview: Webview<R>,
+    state: State<'_, BridgeState>,
+) -> Result<Vec<u8>, String> {
+    // Authorization: dashboard window OR exactly the matching session window.
+    // We deliberately do not delegate to `require_window_label_in` because
+    // that helper's `allow_session_prefix=true` mode lets *any* `session-*`
+    // label through — we need to bind the caller to the *specific*
+    // `session-{session_id}` it claims to export.
+    let caller_label = webview.label();
+    let session_label = format!("session-{session_id}");
+    if caller_label != "dashboard" && caller_label != session_label {
+        tracing::warn!(
+            target: "forge_shell::ipc::authz",
+            actual = caller_label,
+            expected_dashboard = "dashboard",
+            expected_session = %session_label,
+            command = "export_transcript",
+            "window label mismatch"
+        );
+        return Err(LABEL_MISMATCH_ERROR.to_string());
+    }
+
+    require_size("workspace_root", &workspace_root, MAX_WORKSPACE_ROOT_BYTES)?;
+
+    if !crate::dashboard_sessions::is_valid_session_id(&session_id) {
+        return Err(crate::dashboard_sessions::INVALID_SESSION_ID_ERROR.to_string());
+    }
+
+    // For a session caller `resolve_workspace_root_for_command` ignores the
+    // webview-supplied path and reads the cached value primed by
+    // `session_hello`. For the dashboard it canonicalizes the supplied
+    // path and verifies it lives in the workspaces registry. Either way
+    // the value we feed to `transcript_path` is server-trusted.
+    let workspace =
+        crate::ipc::resolve_workspace_root_for_command(caller_label, &workspace_root, &state)
+            .await?;
+    let path = transcript_path(&session_id, &workspace);
+    read_transcript_bytes(&path, MAX_TRANSCRIPT_BYTES)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[test]
+    fn read_returns_bytes_verbatim_for_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("events.jsonl");
+        let payload = b"{\"event\":\"hello\"}\n{\"event\":\"world\"}\n";
+        std::fs::write(&path, payload).unwrap();
+
+        let got = read_transcript_bytes(&path, MAX_TRANSCRIPT_BYTES).unwrap();
+        assert_eq!(got, payload.to_vec());
+    }
+
+    #[test]
+    fn read_returns_empty_when_file_missing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("does-not-exist.jsonl");
+        let got = read_transcript_bytes(&path, MAX_TRANSCRIPT_BYTES).unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn read_errors_when_file_exceeds_cap() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("events.jsonl");
+        let cap: u64 = 1024;
+        let mut f = std::fs::File::create(&path).unwrap();
+        // Write cap + 1 bytes.
+        let chunk = vec![b'x'; (cap as usize) + 1];
+        f.write_all(&chunk).unwrap();
+        drop(f);
+
+        let err = read_transcript_bytes(&path, cap).expect_err("expected oversize error");
+        assert!(
+            err.starts_with(TRANSCRIPT_TOO_LARGE_ERROR),
+            "got error: {err}"
+        );
+    }
+
+    #[test]
+    fn transcript_path_matches_daemon_layout() {
+        let workspace = std::path::Path::new("/tmp/ws");
+        let path = transcript_path("deadbeefcafebabe", workspace);
+        assert_eq!(
+            path,
+            std::path::Path::new("/tmp/ws/.forge/sessions/deadbeefcafebabe/events.jsonl")
+        );
+    }
+}

--- a/crates/forge-shell/tests/ipc_transcript.rs
+++ b/crates/forge-shell/tests/ipc_transcript.rs
@@ -1,0 +1,267 @@
+//! F-607 transcript export IPC tests.
+//!
+//! Drives `export_transcript` end-to-end through Tauri's
+//! `tauri::test::get_ipc_response`. Mirrors the F-602 memory test harness:
+//! the user-config dir + workspaces registry are redirected via the
+//! `webview-test`-gated `BridgeState::with_test_*` constructors so tests
+//! never touch the real platform paths.
+
+#![cfg(feature = "webview-test")]
+
+use forge_core::workspaces::{write_workspaces, WorkspaceEntry};
+use forge_shell::bridge::SessionConnections;
+use forge_shell::ipc::{build_invoke_handler, BridgeState};
+use tauri::test::{mock_builder, mock_context, noop_assets, INVOKE_KEY};
+use tauri::Manager;
+use tempfile::TempDir;
+
+const VALID_SID: &str = "deadbeefcafebabe";
+
+/// Build a mock app with the workspaces registry seeded *and* the session
+/// connection's cached workspace primed. Lets a single app host both
+/// `dashboard` and `session-{id}` window flavors.
+async fn make_app(
+    workspace: &std::path::Path,
+    session_id: &str,
+) -> (tauri::App<tauri::test::MockRuntime>, TempDir) {
+    let registry_dir = TempDir::new().unwrap();
+    let toml_path = registry_dir.path().join("workspaces.toml");
+    let canonical = std::fs::canonicalize(workspace).expect("canonicalize workspace");
+    let entries = vec![WorkspaceEntry {
+        id: forge_core::WorkspaceId::new(),
+        path: canonical.clone(),
+        name: "ws".into(),
+        last_opened: chrono::Utc::now(),
+        pinned: false,
+    }];
+    write_workspaces(&toml_path, &entries)
+        .await
+        .expect("seed workspaces.toml");
+
+    let connections = SessionConnections::new();
+    connections
+        .prime_workspace_root_for_test(session_id.to_string(), canonical.clone())
+        .await;
+
+    let user_cfg_dir = TempDir::new().unwrap();
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::with_test_user_config_and_workspaces(
+        connections,
+        user_cfg_dir.path().to_path_buf(),
+        toml_path,
+    ));
+    // Hold user_cfg_dir for the lifetime of the test by leaking it into
+    // `forget`. The OS reclaims it at test exit; this just keeps the path
+    // alive past the function return without complicating the signature.
+    std::mem::forget(user_cfg_dir);
+    (app, registry_dir)
+}
+
+fn make_dashboard_window(
+    app: &tauri::App<tauri::test::MockRuntime>,
+) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
+    tauri::WebviewWindowBuilder::new(
+        app,
+        "dashboard",
+        tauri::WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("mock dashboard window")
+}
+
+fn make_session_window(
+    app: &tauri::App<tauri::test::MockRuntime>,
+    session_id: &str,
+) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
+    tauri::WebviewWindowBuilder::new(
+        app,
+        format!("session-{session_id}"),
+        tauri::WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("mock session window")
+}
+
+fn invoke_ok(
+    window: &tauri::WebviewWindow<tauri::test::MockRuntime>,
+    cmd: &str,
+    payload: serde_json::Value,
+) -> serde_json::Value {
+    let res = tauri::test::get_ipc_response(
+        window,
+        tauri::webview::InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+    res.expect("invoke returned Ok").deserialize().unwrap()
+}
+
+fn invoke_err(
+    window: &tauri::WebviewWindow<tauri::test::MockRuntime>,
+    cmd: &str,
+    payload: serde_json::Value,
+) -> String {
+    let res = tauri::test::get_ipc_response(
+        window,
+        tauri::webview::InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+    match res {
+        Ok(ok) => panic!("expected error, got Ok: {ok:?}"),
+        Err(serde_json::Value::String(s)) => s,
+        Err(other) => other.to_string(),
+    }
+}
+
+/// Seed `<workspace>/.forge/sessions/<sid>/events.jsonl` with `bytes`.
+fn seed_transcript(workspace: &std::path::Path, sid: &str, bytes: &[u8]) {
+    let dir = workspace.join(".forge").join("sessions").join(sid);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("events.jsonl"), bytes).unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn export_transcript_round_trips_session_events() {
+    let workspace = TempDir::new().unwrap();
+    let payload = b"{\"event\":\"hello\",\"seq\":1}\n{\"event\":\"world\",\"seq\":2}\n".to_vec();
+    seed_transcript(workspace.path(), VALID_SID, &payload);
+
+    let (app, _registry) = make_app(workspace.path(), VALID_SID).await;
+    let window = make_session_window(&app, VALID_SID);
+
+    let canonical_ws = std::fs::canonicalize(workspace.path()).unwrap();
+    let bytes = invoke_ok(
+        &window,
+        "export_transcript",
+        serde_json::json!({
+            "sessionId": VALID_SID,
+            "workspaceRoot": canonical_ws,
+        }),
+    );
+    let arr = bytes.as_array().expect("response is a byte array");
+    let got: Vec<u8> = arr
+        .iter()
+        .map(|v| v.as_u64().expect("byte") as u8)
+        .collect();
+    assert_eq!(got, payload, "transcript bytes must round-trip verbatim");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn export_transcript_round_trips_for_dashboard_caller() {
+    // The Inspector's "Export transcript" button is rendered in the
+    // dashboard window. Verify the dashboard label is accepted.
+    let workspace = TempDir::new().unwrap();
+    let payload = b"{\"event\":\"only\"}\n".to_vec();
+    seed_transcript(workspace.path(), VALID_SID, &payload);
+
+    let (app, _registry) = make_app(workspace.path(), VALID_SID).await;
+    let window = make_dashboard_window(&app);
+
+    let canonical_ws = std::fs::canonicalize(workspace.path()).unwrap();
+    let bytes = invoke_ok(
+        &window,
+        "export_transcript",
+        serde_json::json!({
+            "sessionId": VALID_SID,
+            "workspaceRoot": canonical_ws,
+        }),
+    );
+    let arr = bytes.as_array().unwrap();
+    let got: Vec<u8> = arr.iter().map(|v| v.as_u64().unwrap() as u8).collect();
+    assert_eq!(got, payload);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn export_transcript_rejects_invalid_session_id() {
+    let workspace = TempDir::new().unwrap();
+    let (app, _registry) = make_app(workspace.path(), VALID_SID).await;
+    let window = make_dashboard_window(&app);
+
+    let canonical_ws = std::fs::canonicalize(workspace.path()).unwrap();
+    for bad in [
+        "../etc/passwd",
+        "deadbeef cafebabe",
+        "DEADBEEFCAFEBABE",
+        "deadbeefcafebab",   // 15 chars
+        "deadbeefcafebabe0", // 17 chars
+        "zzzzzzzzzzzzzzzz",
+        "",
+    ] {
+        let err = invoke_err(
+            &window,
+            "export_transcript",
+            serde_json::json!({
+                "sessionId": bad,
+                "workspaceRoot": canonical_ws,
+            }),
+        );
+        assert!(
+            err.contains("invalid session id"),
+            "expected validation rejection for {bad:?}, got {err}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn export_transcript_rejects_session_window_for_other_session() {
+    // session-A must not be able to export session-B's transcript.
+    let workspace = TempDir::new().unwrap();
+    let other_sid = "0123456789abcdef";
+    seed_transcript(workspace.path(), other_sid, b"secret\n");
+
+    let (app, _registry) = make_app(workspace.path(), VALID_SID).await;
+    // Caller window is `session-deadbeefcafebabe`.
+    let window = make_session_window(&app, VALID_SID);
+
+    let canonical_ws = std::fs::canonicalize(workspace.path()).unwrap();
+    let err = invoke_err(
+        &window,
+        "export_transcript",
+        serde_json::json!({
+            "sessionId": other_sid,
+            "workspaceRoot": canonical_ws,
+        }),
+    );
+    assert!(
+        err.contains("forbidden") || err.contains("label mismatch"),
+        "expected authz rejection, got {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn export_transcript_handles_missing_file_gracefully() {
+    // Brand-new session that has not yet written its first event:
+    // the directory may not exist yet. Expect an empty byte vec, not an
+    // error — the Inspector renders "no events" instead of breaking.
+    let workspace = TempDir::new().unwrap();
+    let (app, _registry) = make_app(workspace.path(), VALID_SID).await;
+    let window = make_dashboard_window(&app);
+
+    let canonical_ws = std::fs::canonicalize(workspace.path()).unwrap();
+    let bytes = invoke_ok(
+        &window,
+        "export_transcript",
+        serde_json::json!({
+            "sessionId": VALID_SID,
+            "workspaceRoot": canonical_ws,
+        }),
+    );
+    let arr = bytes.as_array().expect("array even when empty");
+    assert!(arr.is_empty(), "expected empty transcript, got {arr:?}");
+}

--- a/docs/architecture/ipc-contracts.md
+++ b/docs/architecture/ipc-contracts.md
@@ -42,6 +42,7 @@ Registered in `crates/forge-shell/src/ipc.rs::build_invoke_handler`. Every comma
 |------|-------------|---------|
 | `session-{id}` | `require_window_label(&webview, "session-{session_id}")` | Only the exact session webview that owns the `session_id` may invoke |
 | `dashboard` | `require_window_label_in(&webview, &["dashboard"], false)` | Only the dashboard window may invoke |
+| `dashboard + session-{id}` | inline check against `"dashboard"` and `"session-{session_id}"` | Dashboard **or** the *specific* session's window may invoke; other `session-*` windows are rejected |
 | `dashboard + session-*` | `require_window_label_in(&webview, &["dashboard"], true)` | Dashboard **or** any `session-*` webview may invoke |
 | `any session-*` | `require_window_label_in(&webview, &[], true)` | Any `session-*` webview may invoke; dashboard is rejected |
 
@@ -143,6 +144,14 @@ Output bytes flow back via the `terminal:bytes` Tauri event (see §4.1 events).
 | `list_providers` | `workspace_root: String, scope: RosterScope` | `Vec<ScopedRosterEntry>` | `dashboard + session-*` |
 
 `RosterScope` is a tagged union: `{ type: "SessionWide" } | { type: "Agent", id: AgentId } | { type: "Provider", id: ProviderId }`. Filter semantics: `SessionWide` returns everything; `Agent(id)` narrows to entries bound to that agent (returns empty today for skills/agents/MCP since those surface as `SessionWide` until per-agent binding lands); `Provider(id)` narrows to that provider entry. Built-in providers (`anthropic`, `openai`, `ollama`) are hardcoded; `[providers.custom_openai.<name>]` entries from merged settings surface as `custom_openai:<name>`.
+
+**Transcript export** (F-607) — thin wrapper over the daemon's on-disk `events.jsonl` so the AgentMonitor Inspector (F-449 §9.3) can pull a session transcript through IPC instead of the filesystem.
+
+| Command | Args | Response | Authz |
+|---------|------|----------|-------|
+| `export_transcript` | `session_id: String, workspace_root: String` | `Vec<u8>` (raw `events.jsonl` bytes) | `dashboard + session-{id}` |
+
+`session_id` is validated against the canonical [`SessionId`](../../crates/forge-core/src/ids.rs) wire shape (16 lowercase hex chars) before the path is built, so path-traversal / NUL / separator inputs are rejected. The path is composed via `forge_session::server::event_log_path` — the same resolver the daemon writes through. A session that has not yet written its first event returns an empty `Vec<u8>` (with a `tracing::warn`); a transcript larger than 50 MiB returns `transcript exceeds export cap: …`.
 
 ---
 

--- a/web/packages/ipc/src/generated/AppSettings.ts
+++ b/web/packages/ipc/src/generated/AppSettings.ts
@@ -15,22 +15,22 @@ import type { WindowsSettings } from "./WindowsSettings";
  * refuse to load. This is the opposite of `ApprovalConfig`, where strict
  * validation protects the approval trust boundary.
  */
-export type AppSettings = { notifications: NotificationsSettings, windows: WindowsSettings,
+export type AppSettings = { notifications: NotificationsSettings, windows: WindowsSettings, 
 /**
  * Built-in provider connection details (F-585). Optional and
  * backwards-compatible: settings files without `[providers]` deserialize
  * to an empty map.
  */
-providers: ProvidersSettings,
+providers: ProvidersSettings, 
 /**
  * Catalog UI enable/disable flags (F-592). Open-shape map; absent =
  * enabled.
  */
-catalog: CatalogSettings,
+catalog: CatalogSettings, 
 /**
  * Dashboard UI preferences (F-597). Optional and backwards-compatible.
  */
-dashboard: DashboardSettings,
+dashboard: DashboardSettings, 
 /**
  * Per-agent cross-session memory toggles (F-602). Absent agents fall
  * back to the def-level `memory_enabled` frontmatter flag.


### PR DESCRIPTION
Closes forge-ide/forge#653

## Summary
- New `export_transcript(session_id, workspace_root) -> Vec<u8>` Tauri command in `crates/forge-shell/src/transcript_ipc.rs`. Reads `<workspace>/.forge/sessions/<id>/events.jsonl` via the daemon's `forge_session::server::event_log_path` so shell + daemon stay in lock-step on session layout.
- Authz binds the caller to the dashboard window or the *exact* matching `session-{id}` window; other session windows are rejected (enforced inline because `require_window_label_in(allow_session_prefix=true)` would let any `session-*` label through).
- SessionId is validated against the canonical 16-hex-char wire shape before the path is built — `is_valid_session_id` was lifted to `pub(crate)` in `dashboard_sessions` to avoid duplication. Path traversal / NUL / separator inputs are rejected before any I/O.
- Buffered (not streamed) with a 50 MiB cap; oversized transcripts return `transcript exceeds export cap: ...`. Missing file (newly-created session, log pruned) returns empty `Vec<u8>` with a tracing warn so the Inspector can render "no events" rather than break.
- `docs/architecture/ipc-contracts.md` updated with the new "dashboard + session-{id}" gate row and a Transcript export section.
- No frontend changes. No new dependencies.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy -p forge-shell --features webview-test --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `pnpm -r typecheck`
- [x] `pnpm check-tokens`
- [x] `pnpm -r test -- --run`
- [x] New unit tests in `crates/forge-shell/src/transcript_ipc.rs` (4): file-present round-trip, missing-file empty, oversize cap, daemon-layout path
- [x] New integration tests in `crates/forge-shell/tests/ipc_transcript.rs` (5): session caller round-trip, dashboard caller round-trip, invalid session id matrix, cross-session authz rejection, missing-file graceful empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)