### PR TITLE
[F-608 step 1] Define sidecar wire protocol in forge-ipc

### DIFF
--- a/crates/forge-cli/src/main.rs
+++ b/crates/forge-cli/src/main.rs
@@ -279,7 +279,7 @@ async fn session_tail(id: &str) -> Result<()> {
         }),
     )
     .await?;
-    let _ack = read_frame(&mut stream).await?;
+    let _ack: IpcMessage = read_frame(&mut stream).await?;
 
     write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 })).await?;
 
@@ -378,7 +378,7 @@ async fn run_agent(name: &str, input_source: &str) -> Result<()> {
         }),
     )
     .await?;
-    read_frame(&mut stream)
+    let _ack: IpcMessage = read_frame(&mut stream)
         .await
         .map_err(|e| anyhow::anyhow!("handshake failed: {e}"))?;
 

--- a/crates/forge-ipc/Cargo.toml
+++ b/crates/forge-ipc/Cargo.toml
@@ -6,6 +6,11 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
+# F-608: `SidecarMessage::HelloAck.started_at` and `Heartbeat.at` carry
+# `chrono::DateTime<Utc>` so the daemon-side supervisor can stamp restart
+# windows with the same wallclock the sidecar reports. Promoted from
+# dev-deps where the bench already pinned the same version.
+chrono = { version = "0.4", features = ["serde"] }
 forge-core = { path = "../forge-core" }
 # F-155: `IpcMessage::McpServersList` and `McpState` event carry
 # `forge_mcp::McpServerInfo` / `McpStateEvent` / `ServerState` values so the

--- a/crates/forge-ipc/benches/frame.rs
+++ b/crates/forge-ipc/benches/frame.rs
@@ -247,7 +247,7 @@ fn report_alloc_reduction(rt: &Runtime) {
             let n_before = alloc_count();
             let b_before = alloc_bytes();
             for _ in 0..N {
-                let _ = read_frame(&mut srv).await.expect("read_frame");
+                let _: IpcMessage = read_frame(&mut srv).await.expect("read_frame");
             }
             let n_after = alloc_count();
             let b_after = alloc_bytes();
@@ -269,7 +269,7 @@ fn report_alloc_reduction(rt: &Runtime) {
             let n_before = alloc_count();
             let b_before = alloc_bytes();
             for _ in 0..N {
-                let _ = read_frame_into(&mut srv, &mut buf)
+                let _: IpcMessage = read_frame_into(&mut srv, &mut buf)
                     .await
                     .expect("read_frame_into");
             }
@@ -337,7 +337,7 @@ fn bench_read_paths(c: &mut Criterion) {
                         });
                         let before = alloc_count();
                         for _ in 0..n {
-                            let frame = read_frame(&mut srv).await.expect("read_frame");
+                            let frame: IpcMessage = read_frame(&mut srv).await.expect("read_frame");
                             black_box(frame);
                         }
                         let allocs = alloc_count() - before;
@@ -366,7 +366,7 @@ fn bench_read_paths(c: &mut Criterion) {
                         let mut buf: Vec<u8> = Vec::with_capacity(4096);
                         let before = alloc_count();
                         for _ in 0..n {
-                            let frame = read_frame_into(&mut srv, &mut buf)
+                            let frame: IpcMessage = read_frame_into(&mut srv, &mut buf)
                                 .await
                                 .expect("read_frame_into");
                             black_box(frame);

--- a/crates/forge-ipc/src/lib.rs
+++ b/crates/forge-ipc/src/lib.rs
@@ -5,9 +5,15 @@ pub use forge_core::RerunVariant;
 // IPC import path.
 pub use forge_core::{McpStateEvent, ServerState};
 pub use forge_mcp::McpServerInfo;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+// F-608: sibling tagged-union for the daemon ↔ `forged-agent` wire. Lives
+// alongside `IpcMessage` (different shape, same framing) per
+// `docs/architecture/agent-sidecar.md` §2.
+pub mod sidecar;
 
 pub const PROTO_VERSION: u32 = 1;
 pub const SCHEMA_VERSION: u32 = 1;
@@ -244,10 +250,19 @@ pub struct HelloAck {
     pub schema_version: u32,
 }
 
-pub async fn write_frame<W: AsyncWrite + Unpin>(
-    writer: &mut W,
-    msg: &IpcMessage,
-) -> anyhow::Result<()> {
+/// Write one length-prefixed JSON frame.
+///
+/// F-608: generic over `T: Serialize` so this helper services both the
+/// daemon ↔ shell wire ([`IpcMessage`]) and the daemon ↔ sidecar wire
+/// ([`sidecar::SidecarMessage`]). Body shape, length-prefix encoding,
+/// and the 4 MiB frame cap are unchanged from the pre-F-608
+/// `&IpcMessage`-typed signature; existing callers compile without
+/// modification because `T` is inferred from the call site.
+pub async fn write_frame<W, T>(writer: &mut W, msg: &T) -> anyhow::Result<()>
+where
+    W: AsyncWrite + Unpin,
+    T: Serialize + ?Sized,
+{
     let body = serde_json::to_vec(msg)?;
     if body.len() > MAX_FRAME_SIZE {
         bail!("frame too large: {} bytes", body.len());
@@ -264,7 +279,16 @@ pub async fn write_frame<W: AsyncWrite + Unpin>(
 /// negligible. Hot pumping loops (assistant-token streaming) should
 /// hoist a `Vec<u8>` outside the loop and call [`read_frame_into`]
 /// directly to amortize the allocation across frames (F-565).
-pub async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> anyhow::Result<IpcMessage> {
+///
+/// F-608: generic over the decoded message type — the call site picks
+/// the type via turbofish (`read_frame::<IpcMessage>(&mut r)`) or via
+/// the surrounding bind annotation. Same JSON-decoded body, same
+/// length-prefix shape.
+pub async fn read_frame<R, T>(reader: &mut R) -> anyhow::Result<T>
+where
+    R: AsyncRead + Unpin,
+    T: DeserializeOwned,
+{
     let mut buf = Vec::new();
     read_frame_into(reader, &mut buf).await
 }
@@ -272,15 +296,20 @@ pub async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> anyhow::Result<
 /// F-565: read a single IPC frame into the caller-owned `buf`, reusing
 /// its capacity across calls. The buffer is resized (without zero-fill
 /// of already-allocated capacity) to the frame body length, then filled
-/// with `read_exact`. Decoded `IpcMessage` borrows nothing from `buf`,
-/// so the caller may immediately reuse it for the next frame.
+/// with `read_exact`. The decoded message borrows nothing from `buf`
+/// (because of the `DeserializeOwned` bound), so the caller may
+/// immediately reuse it for the next frame.
 ///
 /// Replaces a `vec![0u8; len]` per call — at streaming-token rates that
 /// is one heap alloc + one zero-fill per token, both removed here.
-pub async fn read_frame_into<R: AsyncRead + Unpin>(
-    reader: &mut R,
-    buf: &mut Vec<u8>,
-) -> anyhow::Result<IpcMessage> {
+///
+/// F-608: generic so the framing helpers serve both `IpcMessage` and
+/// the new [`sidecar::SidecarMessage`] without duplicating the body.
+pub async fn read_frame_into<R, T>(reader: &mut R, buf: &mut Vec<u8>) -> anyhow::Result<T>
+where
+    R: AsyncRead + Unpin,
+    T: DeserializeOwned,
+{
     let len = reader.read_u32().await? as usize;
     if len > MAX_FRAME_SIZE {
         bail!("frame too large: {} bytes", len);
@@ -303,22 +332,29 @@ pub async fn read_frame_into<R: AsyncRead + Unpin>(
 /// prefix or the frame body is fully read. The underlying reader is
 /// left in an indeterminate state; callers should drop the connection
 /// on error rather than retrying.
-pub async fn read_frame_with_deadline<R: AsyncRead + Unpin>(
-    reader: &mut R,
-    deadline: Duration,
-) -> anyhow::Result<IpcMessage> {
+///
+/// F-608: generic over the decoded message type — see [`read_frame`].
+pub async fn read_frame_with_deadline<R, T>(reader: &mut R, deadline: Duration) -> anyhow::Result<T>
+where
+    R: AsyncRead + Unpin,
+    T: DeserializeOwned,
+{
     let mut buf = Vec::new();
     read_frame_into_with_deadline(reader, &mut buf, deadline).await
 }
 
 /// F-565: deadline-bounded variant of [`read_frame_into`]. See
 /// [`read_frame_with_deadline`] for the deadline semantics.
-pub async fn read_frame_into_with_deadline<R: AsyncRead + Unpin>(
+pub async fn read_frame_into_with_deadline<R, T>(
     reader: &mut R,
     buf: &mut Vec<u8>,
     deadline: Duration,
-) -> anyhow::Result<IpcMessage> {
-    match tokio::time::timeout(deadline, read_frame_into(reader, buf)).await {
+) -> anyhow::Result<T>
+where
+    R: AsyncRead + Unpin,
+    T: DeserializeOwned,
+{
+    match tokio::time::timeout(deadline, read_frame_into::<R, T>(reader, buf)).await {
         Ok(inner) => inner,
         Err(_) => bail!("ipc read timed out after {:?}", deadline),
     }
@@ -356,7 +392,7 @@ mod tests {
 
         let sent = hello_msg();
         write_frame(&mut a, &sent).await.unwrap();
-        let got = read_frame(&mut b).await.unwrap();
+        let got: IpcMessage = read_frame(&mut b).await.unwrap();
 
         let sent_json = serde_json::to_string(&sent).unwrap();
         let got_json = serde_json::to_string(&got).unwrap();
@@ -369,7 +405,7 @@ mod tests {
 
         let sent = hello_ack_msg();
         write_frame(&mut a, &sent).await.unwrap();
-        let got = read_frame(&mut b).await.unwrap();
+        let got: IpcMessage = read_frame(&mut b).await.unwrap();
 
         let sent_json = serde_json::to_string(&sent).unwrap();
         let got_json = serde_json::to_string(&got).unwrap();
@@ -385,7 +421,9 @@ mod tests {
         let mut reader = a;
 
         let started = std::time::Instant::now();
-        let result = read_frame_with_deadline(&mut reader, Duration::from_millis(100)).await;
+        let result =
+            read_frame_with_deadline::<_, IpcMessage>(&mut reader, Duration::from_millis(100))
+                .await;
         let elapsed = started.elapsed();
 
         assert!(result.is_err(), "expected deadline error, got {:?}", result);
@@ -406,7 +444,7 @@ mod tests {
             write_frame(&mut a, &sent).await.unwrap();
         });
 
-        let got = read_frame_with_deadline(&mut b, Duration::from_secs(5))
+        let got: IpcMessage = read_frame_with_deadline(&mut b, Duration::from_secs(5))
             .await
             .expect("frame should arrive before deadline");
         matches!(got, IpcMessage::Hello(_));

--- a/crates/forge-ipc/src/sidecar.rs
+++ b/crates/forge-ipc/src/sidecar.rs
@@ -1,0 +1,419 @@
+//! F-608: sidecar wire protocol.
+//!
+//! `forged` (the daemon) and `forged-agent` (the per-instance sidecar process)
+//! exchange [`SidecarMessage`] frames over a per-instance Unix domain socket.
+//! Framing reuses the existing length-prefixed JSON helpers in this crate
+//! ([`crate::write_frame`] / [`crate::read_frame_into`]) — same `[u32 BE
+//! length][JSON body]` shape, same 4 MiB cap, same `serde(tag = "t")`
+//! discrimination — so the daemon ↔ shell wire and the daemon ↔ sidecar wire
+//! share one mental model and one piece of framing code.
+//!
+//! Variants follow `docs/architecture/agent-sidecar.md` §2. This module
+//! defines the types only: transport, supervisor, and spawning land in
+//! later F-608 steps.
+
+use chrono::{DateTime, Utc};
+use forge_core::{AgentInstanceId, Event, MessageId, ProviderId};
+use serde::{Deserialize, Serialize};
+
+/// Wire protocol version negotiated in [`SidecarMessage::Hello`].
+///
+/// Bumped when the discriminator set or any payload field changes shape.
+/// The sidecar refuses a `Hello` whose `proto` it does not recognize and
+/// exits non-zero so the supervisor's restart-then-escalate path can
+/// surface the mismatch as a `SessionFailed`.
+pub const SIDECAR_PROTO_VERSION: u32 = 1;
+
+/// Schema version reported by the sidecar in [`SidecarMessage::HelloAck`].
+///
+/// Tracks the same shape contract as [`crate::SCHEMA_VERSION`] does for
+/// the daemon ↔ shell wire — bumped whenever an existing field's
+/// serialization changes (renames, type widening, etc.). The supervisor
+/// logs the value but does not gate startup on it today; that becomes a
+/// hard check once we ship a non-`1` schema.
+pub const SIDECAR_SCHEMA_VERSION: u32 = 1;
+
+/// Bidirectional message exchanged between `forged` and `forged-agent`.
+///
+/// The discriminator is `t` (matching [`crate::IpcMessage`]) so the wire
+/// format stays uniform across Forge IPC. Daemon → sidecar variants are
+/// commands; sidecar → daemon variants are events / replies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "t")]
+pub enum SidecarMessage {
+    // ── daemon → sidecar ──────────────────────────────────────────────────
+    /// First frame after the sidecar connects. Carries everything the
+    /// child needs to initialize its provider loop without re-reading
+    /// daemon-owned state from disk.
+    Hello(SidecarHello),
+
+    /// Run one turn of the request loop. The sidecar streams events back
+    /// as [`SidecarMessage::Event`] frames and emits no reply; the
+    /// daemon observes turn completion via the `Event::TurnCompleted`
+    /// payload.
+    RunTurn(SidecarRunTurn),
+
+    /// Push a per-provider credential to the sidecar (§5: daemon owns
+    /// the keyring; sidecar receives just-in-time). `secret_handle` is
+    /// an opaque string for step 1 — real `secrecy::SecretString`
+    /// plumbing lands with step 6.
+    Credentials(SidecarCredentials),
+
+    /// Approve a pending tool call. Mirrors [`crate::ToolCallApproved`]
+    /// shape so the sidecar can hand it through unchanged.
+    ToolCallApproved(SidecarToolCallApproved),
+
+    /// Reject a pending tool call. Mirrors [`crate::ToolCallRejected`].
+    ToolCallRejected(SidecarToolCallRejected),
+
+    /// Proxied from the shell (F-598): compact the active transcript.
+    CompactTranscript(SidecarCompactTranscript),
+
+    /// Cooperative shutdown signal. The sidecar drains its outbox,
+    /// closes the write half, and exits within `grace_ms` or the
+    /// supervisor escalates to SIGTERM.
+    Shutdown(SidecarShutdown),
+
+    // ── sidecar → daemon ──────────────────────────────────────────────────
+    /// Acknowledges [`SidecarMessage::Hello`] and reports the child's
+    /// PID. The supervisor pins this `pid` into `ResourceMonitor::track`
+    /// (closing F-451) and uses `started_at` to time-stamp restart
+    /// counters.
+    HelloAck(SidecarHelloAck),
+
+    /// One `forge_core::Event` produced inside the sidecar's run loop.
+    /// `seq` is monotonic per sidecar process; the daemon writes the
+    /// `event` payload to the session event log unchanged. No
+    /// translation layer (§2: same wire shape on both legs).
+    Event(SidecarEvent),
+
+    /// The provider loop hit a tool call that needs human approval. The
+    /// daemon forwards it to the shell and replies with
+    /// [`SidecarMessage::ToolCallApproved`] or
+    /// [`SidecarMessage::ToolCallRejected`].
+    ToolCallApprovalRequest(SidecarToolCallApprovalRequest),
+
+    /// 1 Hz liveness ping. The supervisor's heartbeat watchdog times
+    /// out at 5 s of silence and escalates to a restart (§3).
+    Heartbeat(SidecarHeartbeat),
+
+    /// Best-effort panic dump written from the sidecar's panic hook
+    /// before the process exits. May be lost on a hard segfault — the
+    /// supervisor falls back to EOF + non-zero exit detection in that
+    /// case.
+    Crashed(SidecarCrashed),
+}
+
+// ── daemon → sidecar payloads ────────────────────────────────────────────
+
+/// Initial daemon → sidecar handshake payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarHello {
+    pub proto: u32,
+    pub instance_id: AgentInstanceId,
+    pub agent_def: SidecarAgentDef,
+    pub allowed_paths: Vec<String>,
+    pub workspace_path: String,
+    pub provider_spec: SidecarProviderSpec,
+    pub sandbox_level: SidecarSandboxLevel,
+    /// Optional OTLP / tracing collector endpoint. `None` skips export.
+    pub telemetry_endpoint: Option<String>,
+}
+
+/// Wire-friendly subset of `forge_agents::AgentDef` carried over the
+/// sidecar handshake. The full type is not `Serialize` (it owns parser
+/// state); the sidecar only needs the post-parse fields the run loop
+/// reads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarAgentDef {
+    pub name: String,
+    pub description: Option<String>,
+    pub body: String,
+    pub allowed_paths: Vec<String>,
+    pub isolation: String,
+    pub memory_enabled: bool,
+}
+
+/// Wire-friendly description of which provider the sidecar should
+/// instantiate for this turn loop. Step 1 keeps the shape opaque (a
+/// `kind` discriminator + a `model` hint); step 3+ swaps in a richer
+/// type once the provider crate exposes a serializable spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarProviderSpec {
+    /// Provider identifier — e.g. `"ollama"`, `"anthropic"`, `"openai"`.
+    pub kind: String,
+    /// Model id passed to the provider. Free-form; provider-specific.
+    pub model: String,
+    /// Optional base URL override (e.g. self-hosted Ollama).
+    pub base_url: Option<String>,
+}
+
+/// Wire-friendly mirror of `forge_session::sandbox::SandboxLevel`. The
+/// host type carries `Arc<dyn ContainerRuntime>` for `Level2` and is
+/// not serializable; the sidecar runs *outside* the L2 container (§6)
+/// so it only needs to know which mode the daemon is in.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "level", rename_all = "snake_case")]
+pub enum SidecarSandboxLevel {
+    Level1,
+    Level2 {
+        /// Container image reference the daemon's `Level2Session` is
+        /// running. Informational on the sidecar side.
+        image: String,
+    },
+}
+
+/// `RunTurn` payload — see `crates/forge-session/src/orchestrator.rs:165`
+/// for the field-level mapping to today's in-process `run_turn`
+/// arguments.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarRunTurn {
+    pub turn_id: String,
+    pub msg_id: MessageId,
+    pub text: String,
+    /// Concatenated `AGENTS.md` / agent body / memory the daemon
+    /// assembled.
+    pub agents_md: String,
+    pub branch_parent: Option<MessageId>,
+    pub branch_variant_index: Option<u32>,
+    /// Soft cap for the assembled prompt + tool transcript, in bytes.
+    pub byte_budget: u64,
+}
+
+/// Push a credential for `provider_id`. Step 1 stores it as an opaque
+/// string handle; step 6 swaps in `Vec<u8>` + `secrecy::SecretString`
+/// and adds the zeroize-on-drop discipline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarCredentials {
+    pub provider_id: ProviderId,
+    pub secret_handle: String,
+}
+
+/// Approve a pending tool call (mirrors [`crate::ToolCallApproved`]).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarToolCallApproved {
+    pub id: String,
+    pub scope: String,
+}
+
+/// Reject a pending tool call (mirrors [`crate::ToolCallRejected`]).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarToolCallRejected {
+    pub id: String,
+    pub reason: Option<String>,
+}
+
+/// F-598: compact the active transcript. Empty payload — proxied
+/// straight from [`crate::CompactTranscript`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SidecarCompactTranscript {}
+
+/// Cooperative shutdown grace window before the supervisor escalates
+/// to SIGTERM. See §3 lifecycle diagram.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarShutdown {
+    pub grace_ms: u64,
+}
+
+// ── sidecar → daemon payloads ────────────────────────────────────────────
+
+/// `HelloAck` reply. `pid` closes F-451 (real PID into
+/// `ResourceMonitor`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarHelloAck {
+    pub pid: u32,
+    pub started_at: DateTime<Utc>,
+    pub schema_version: u32,
+}
+
+/// One `forge_core::Event` lifted out of the sidecar's run loop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarEvent {
+    pub seq: u64,
+    pub event: Event,
+}
+
+/// Tool-call approval request raised from inside the sidecar. The
+/// daemon forwards `name` + `args` to the shell unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarToolCallApprovalRequest {
+    pub id: String,
+    pub name: String,
+    pub args: serde_json::Value,
+}
+
+/// 1 Hz liveness ping. `pending_turns` lets the supervisor see whether
+/// silence is "idle" (0) or "stuck mid-turn" (>0) for triage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarHeartbeat {
+    pub at: DateTime<Utc>,
+    pub pending_turns: u32,
+}
+
+/// Panic dump emitted by the sidecar's panic hook before exit. Best-
+/// effort: a hard segfault never produces this frame.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarCrashed {
+    pub panic_message: String,
+    pub backtrace: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use forge_core::{AgentInstanceId, MessageId, ProviderId};
+
+    /// Round-trip every variant through `serde_json::to_vec` /
+    /// `from_slice` and assert the shape is preserved. The acceptance
+    /// criterion in `docs/architecture/agent-sidecar.md` Step 1 calls
+    /// this out by name as `sidecar_message_roundtrip`.
+    #[test]
+    fn sidecar_message_roundtrip() {
+        let at = Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap();
+
+        let cases = vec![
+            SidecarMessage::Hello(SidecarHello {
+                proto: SIDECAR_PROTO_VERSION,
+                instance_id: AgentInstanceId::from_string("inst-1".into()),
+                agent_def: SidecarAgentDef {
+                    name: "researcher".into(),
+                    description: Some("does research".into()),
+                    body: "## Prompt\nbe helpful".into(),
+                    allowed_paths: vec!["/workspace".into()],
+                    isolation: "process".into(),
+                    memory_enabled: false,
+                },
+                allowed_paths: vec!["/workspace".into(), "/tmp/forge".into()],
+                workspace_path: "/workspace".into(),
+                provider_spec: SidecarProviderSpec {
+                    kind: "ollama".into(),
+                    model: "llama3.1:8b".into(),
+                    base_url: Some("http://localhost:11434".into()),
+                },
+                sandbox_level: SidecarSandboxLevel::Level1,
+                telemetry_endpoint: None,
+            }),
+            SidecarMessage::Hello(SidecarHello {
+                proto: SIDECAR_PROTO_VERSION,
+                instance_id: AgentInstanceId::from_string("inst-2".into()),
+                agent_def: SidecarAgentDef {
+                    name: "builder".into(),
+                    description: None,
+                    body: String::new(),
+                    allowed_paths: vec![],
+                    isolation: "trusted".into(),
+                    memory_enabled: true,
+                },
+                allowed_paths: vec![],
+                workspace_path: "/workspace".into(),
+                provider_spec: SidecarProviderSpec {
+                    kind: "anthropic".into(),
+                    model: "claude-opus".into(),
+                    base_url: None,
+                },
+                sandbox_level: SidecarSandboxLevel::Level2 {
+                    image: "registry.example.com/forge/sandbox:1".into(),
+                },
+                telemetry_endpoint: Some("http://otel:4317".into()),
+            }),
+            SidecarMessage::RunTurn(SidecarRunTurn {
+                turn_id: "turn-1".into(),
+                msg_id: MessageId::from_string("msg-1".into()),
+                text: "hello".into(),
+                agents_md: "# Agents".into(),
+                branch_parent: Some(MessageId::from_string("msg-0".into())),
+                branch_variant_index: Some(2),
+                byte_budget: 65_536,
+            }),
+            SidecarMessage::Credentials(SidecarCredentials {
+                provider_id: ProviderId::from_string("prov-1".into()),
+                secret_handle: "handle-abc".into(),
+            }),
+            SidecarMessage::ToolCallApproved(SidecarToolCallApproved {
+                id: "tool-1".into(),
+                scope: "Once".into(),
+            }),
+            SidecarMessage::ToolCallRejected(SidecarToolCallRejected {
+                id: "tool-2".into(),
+                reason: Some("denied by user".into()),
+            }),
+            SidecarMessage::CompactTranscript(SidecarCompactTranscript::default()),
+            SidecarMessage::Shutdown(SidecarShutdown { grace_ms: 2000 }),
+            SidecarMessage::HelloAck(SidecarHelloAck {
+                pid: 4242,
+                started_at: at,
+                schema_version: SIDECAR_SCHEMA_VERSION,
+            }),
+            SidecarMessage::Event(SidecarEvent {
+                seq: 7,
+                event: Event::SessionStarted {
+                    at,
+                    workspace: "/workspace".into(),
+                    agent: None,
+                    persistence: forge_core::types::SessionPersistence::Persist,
+                },
+            }),
+            SidecarMessage::ToolCallApprovalRequest(SidecarToolCallApprovalRequest {
+                id: "tool-3".into(),
+                name: "shell.exec".into(),
+                args: serde_json::json!({"cmd": "ls", "args": ["-la"]}),
+            }),
+            SidecarMessage::Heartbeat(SidecarHeartbeat {
+                at,
+                pending_turns: 1,
+            }),
+            SidecarMessage::Crashed(SidecarCrashed {
+                panic_message: "index out of bounds".into(),
+                backtrace: Some("frame 0: foo\nframe 1: bar".into()),
+            }),
+        ];
+
+        for sent in cases {
+            let bytes = serde_json::to_vec(&sent).expect("serialize");
+            let got: SidecarMessage = serde_json::from_slice(&bytes).expect("deserialize");
+            // `SidecarMessage` doesn't derive `PartialEq` (its payloads
+            // include `serde_json::Value` and `forge_core::Event` whose
+            // `PartialEq` surface we don't want to depend on here), so
+            // compare canonical JSON instead — same discipline used in
+            // [`crate`]'s `round_trips_hello_*` tests.
+            let sent_json = serde_json::to_string(&sent).unwrap();
+            let got_json = serde_json::to_string(&got).unwrap();
+            assert_eq!(sent_json, got_json, "round-trip mismatch");
+        }
+    }
+
+    /// The discriminator field is `t` so the sidecar wire is uniform
+    /// with [`crate::IpcMessage`]. Pin the on-wire shape so a future
+    /// rename cannot drift past CI silently.
+    #[test]
+    fn sidecar_message_uses_t_discriminator() {
+        let msg = SidecarMessage::Shutdown(SidecarShutdown { grace_ms: 500 });
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json.get("t").and_then(|v| v.as_str()), Some("Shutdown"));
+        assert_eq!(json.get("grace_ms").and_then(|v| v.as_u64()), Some(500));
+    }
+
+    /// Reuse of [`crate::write_frame`] / [`crate::read_frame_into`] is
+    /// the contract called out in the architecture doc Step 1. Drive a
+    /// `SidecarMessage` through the same helpers `IpcMessage` uses to
+    /// prove the framing helpers are message-type-agnostic.
+    #[tokio::test]
+    async fn sidecar_message_round_trips_over_unix_stream() {
+        use tokio::net::UnixStream;
+
+        let (mut a, mut b) = UnixStream::pair().unwrap();
+        let sent = SidecarMessage::Heartbeat(SidecarHeartbeat {
+            at: Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap(),
+            pending_turns: 0,
+        });
+
+        crate::write_frame(&mut a, &sent).await.unwrap();
+        let mut buf = Vec::new();
+        let got: SidecarMessage = crate::read_frame_into(&mut b, &mut buf).await.unwrap();
+
+        let sent_json = serde_json::to_string(&sent).unwrap();
+        let got_json = serde_json::to_string(&got).unwrap();
+        assert_eq!(sent_json, got_json);
+    }
+}

--- a/crates/forge-ipc/tests/frame_sizing.rs
+++ b/crates/forge-ipc/tests/frame_sizing.rs
@@ -35,7 +35,7 @@ async fn oversized_length_prefix_rejected_before_allocation() {
     // 4 MiB+1 buffer, the test would hang instead of erroring.
     client.shutdown().await.unwrap();
 
-    let err = read_frame(&mut server)
+    let err = read_frame::<_, IpcMessage>(&mut server)
         .await
         .expect_err("read_frame must reject oversized length prefix");
     let msg = format!("{err}");
@@ -58,7 +58,7 @@ async fn malformed_body_returns_decode_error_not_panic() {
     client.write_all(garbage).await.unwrap();
     client.shutdown().await.unwrap();
 
-    let err = read_frame(&mut server)
+    let err = read_frame::<_, IpcMessage>(&mut server)
         .await
         .expect_err("read_frame must surface a decode error for malformed JSON");
     // `serde_json::Error`'s `Display` starts with its error category; it
@@ -113,7 +113,7 @@ async fn exactly_at_cap_round_trips() {
             .expect("write_frame must accept a body of exactly MAX_FRAME_SIZE")
     });
 
-    let got = read_frame(&mut server)
+    let got: IpcMessage = read_frame(&mut server)
         .await
         .expect("read_frame must accept a body of exactly MAX_FRAME_SIZE");
     writer.await.unwrap();

--- a/crates/forge-session/tests/archive_shutdown.rs
+++ b/crates/forge-session/tests/archive_shutdown.rs
@@ -85,7 +85,7 @@ async fn ephemeral_shutdown_removes_session_dir_and_socket() {
     .await
     .unwrap();
 
-    let _ack = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let _ack: IpcMessage = forge_ipc::read_frame(&mut stream).await.unwrap();
 
     forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
         .await
@@ -192,7 +192,7 @@ async fn persistent_sigterm_archives_session_dir_and_meta() {
     )
     .await
     .unwrap();
-    let _ack = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let _ack: IpcMessage = forge_ipc::read_frame(&mut stream).await.unwrap();
     forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
         .await
         .unwrap();

--- a/crates/forge-session/tests/handshake.rs
+++ b/crates/forge-session/tests/handshake.rs
@@ -85,7 +85,7 @@ async fn unknown_proto_rejected() {
     });
     forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
 
-    let result = forge_ipc::read_frame(&mut stream).await;
+    let result: anyhow::Result<IpcMessage> = forge_ipc::read_frame(&mut stream).await;
     assert!(
         result.is_err(),
         "expected connection to be closed for unknown proto"
@@ -276,7 +276,7 @@ async fn handshake_deadline_disconnects_half_handshaked_peer() {
         },
     });
     forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
-    let _ack = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let _ack: IpcMessage = forge_ipc::read_frame(&mut stream).await.unwrap();
 
     // Now stall. The daemon should close us within the Subscribe deadline.
     let started = std::time::Instant::now();
@@ -328,7 +328,7 @@ async fn post_handshake_idle_timeout_disconnects_peer() {
         },
     });
     forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
-    let _ack = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let _ack: IpcMessage = forge_ipc::read_frame(&mut stream).await.unwrap();
 
     let subscribe = IpcMessage::Subscribe(forge_ipc::Subscribe { since: 0 });
     forge_ipc::write_frame(&mut stream, &subscribe)
@@ -404,7 +404,7 @@ async fn garbage_frame_rejected() {
         .await
         .unwrap();
 
-    let result = forge_ipc::read_frame(&mut stream).await;
+    let result: anyhow::Result<IpcMessage> = forge_ipc::read_frame(&mut stream).await;
     assert!(
         result.is_err(),
         "expected connection to be closed for garbage frame"

--- a/crates/forge-session/tests/pid_file_lifecycle.rs
+++ b/crates/forge-session/tests/pid_file_lifecycle.rs
@@ -67,7 +67,7 @@ async fn handshake(sock: &std::path::Path) {
     )
     .await
     .unwrap();
-    let _ack = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let _ack: IpcMessage = forge_ipc::read_frame(&mut stream).await.unwrap();
     forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
         .await
         .unwrap();

--- a/crates/forge-session/tests/provider_selection.rs
+++ b/crates/forge-session/tests/provider_selection.rs
@@ -59,7 +59,7 @@ async fn handshake(stream: &mut UnixStream) {
     )
     .await
     .unwrap();
-    let _ack = forge_ipc::read_frame(stream).await.unwrap();
+    let _ack: IpcMessage = forge_ipc::read_frame(stream).await.unwrap();
     forge_ipc::write_frame(stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

Step 1 of the agent sidecar architecture (#654; design merged in #656). Introduces the daemon ↔ `forged-agent` wire types in `forge-ipc` so the supervisor (step 4), the `forged-agent` binary (step 2), and the `run_turn` refactor (step 3) have a stable contract to build on.

- New `forge_ipc::sidecar` module with the `SidecarMessage` tagged-union (`#[serde(tag = "t")]`) covering every variant from §2 of `docs/architecture/agent-sidecar.md`:
  - daemon → sidecar: `Hello`, `RunTurn`, `Credentials`, `ToolCallApproved`, `ToolCallRejected`, `CompactTranscript`, `Shutdown`
  - sidecar → daemon: `HelloAck`, `Event`, `ToolCallApprovalRequest`, `Heartbeat`, `Crashed`
- Generalized `write_frame` / `read_frame` / `read_frame_into` (and the deadline variants) to `T: Serialize + DeserializeOwned` so both `IpcMessage` and `SidecarMessage` reuse the same length-prefixed JSON framing — same `[u32 BE length][JSON body]` shape, same 4 MiB cap. Zero new framing code; the contract called out in the architecture doc Step 1.
- Existing `IpcMessage` call sites get a type-inference hint (turbofish or annotated bind) where the surrounding pattern didn't already pin `T`. No behavioural change.
- Round-trip serde tests cover every variant: `sidecar_message_roundtrip`, `sidecar_message_uses_t_discriminator`, and `sidecar_message_round_trips_over_unix_stream` (the last one drives a `SidecarMessage` through `crate::write_frame` / `crate::read_frame_into` to prove the framing helpers are message-type-agnostic).
- Promoted `chrono` from dev-deps to deps so `Heartbeat.at` / `HelloAck.started_at` can carry `DateTime<Utc>` per §2.

Step 1 is types-only — no transport, supervisor, or spawning code (those are steps 2–9).

### Placeholders called out in the architecture doc

- `SidecarCredentials.secret_handle` is an opaque `String`. Real `secrecy::SecretString` plumbing lands with step 6 (§5).
- `SidecarProviderSpec` is a small `kind`/`model`/`base_url` triple — `forge-providers` does not yet expose a serializable spec; step 3 swaps in the richer type once it does.
- `SidecarAgentDef` mirrors the post-parse fields of `forge_agents::AgentDef` (the host type owns parser state and is not `Serialize`).
- `SidecarSandboxLevel` carries the L2 image string only — the sidecar runs *outside* the L2 container per §6, so it just needs to know the daemon's mode.

## Test plan

- [x] `cargo test -p forge-ipc` — 7 unit tests (3 sidecar + 4 IpcMessage), 3 integration tests (frame_sizing).
- [x] `cargo check -p forge-session` — `forge_ipc::sidecar::*` is importable from downstream crates.
- [x] `cargo check --workspace --all-targets` — full workspace compiles.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo doc --no-deps -p forge-ipc` clean (no rustdoc warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)