### PR TITLE
[F-608 step 3] EventSink trait + IpcEventSink in forged-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ name = "forge-agent-host"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "forge-core",
  "forge-ipc",

--- a/crates/forge-agent-host/Cargo.toml
+++ b/crates/forge-agent-host/Cargo.toml
@@ -27,6 +27,12 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+# F-608 step 3: `IpcEventSink` implements the `forge_core::EventSink`
+# trait via `#[async_trait]`. The trait is intentionally hosted in
+# forge-core (not forge-session) so the sidecar can satisfy it without
+# pulling the daemon's persistence / MCP / OCI graph into its compile
+# closure (architecture doc Open Questions §1).
+async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 forge-core = { path = "../forge-core" }
 forge-ipc = { path = "../forge-ipc" }

--- a/crates/forge-agent-host/src/lib.rs
+++ b/crates/forge-agent-host/src/lib.rs
@@ -1,11 +1,11 @@
-//! F-608 step 2: `forged-agent` sidecar host.
+//! F-608 sidecar host: `forged-agent`.
 //!
-//! This crate ships the per-instance sidecar binary that the daemon spawns
-//! when `FORGE_AGENT_SIDECAR=1`. It owns the IPC plumbing — handshake,
-//! heartbeat, panic-hook crash dump, dispatch loop — and nothing else.
-//! The actual `run_turn` body lives in `forge-session`; step 3 refactors
-//! it behind an `EventSink` trait so the same body can run in-process or
-//! through this crate's outbound frame writer.
+//! This crate ships the per-instance sidecar binary that the daemon
+//! spawns when `FORGE_AGENT_SIDECAR=1`. It owns the IPC plumbing —
+//! handshake, heartbeat, panic-hook crash dump, dispatch loop — plus
+//! the [`IpcEventSink`] adapter that lets the orchestrator's run loop
+//! emit events out the per-instance Unix domain socket as
+//! [`SidecarMessage::Event`] frames.
 //!
 //! ## Wire flow
 //!
@@ -18,19 +18,23 @@
 //!     │ HelloAck { pid, started_at }   ──────▶│
 //!     │                                ◀──────│ Heartbeat (1 Hz, forever)
 //!     │ RunTurn { … }                  ──────▶│
+//!     │                                ◀──────│ Event::StepStarted       (stub)
 //!     │                                ◀──────│ Event::AssistantMessage  (stub)
 //!     │                                ◀──────│ Event::StepFinished      (stub)
 //!     │ Shutdown { grace_ms }          ──────▶│
 //!     │                                       │ drain → exit(0)
 //! ```
 //!
-//! ## Stub handlers
+//! ## Stub handlers — F-608 step 3
 //!
-//! Step 2 intentionally keeps the message handlers as stubs. `RunTurn`
-//! emits a deterministic placeholder event sequence so an integration
-//! test can verify the IPC plumbing end-to-end without depending on a
-//! real provider. Step 3 replaces the stub with the refactored
-//! `run_turn` body.
+//! `RunTurn` still emits a deterministic placeholder event sequence
+//! (so the integration test can verify the IPC plumbing end-to-end
+//! without depending on a real provider). What changed in step 3:
+//! every emit routes through [`forge_core::EventSink`] via
+//! [`IpcEventSink`], the same trait
+//! `forge_session::orchestrator::run_turn` consumes in-process. Step
+//! 4+ swaps the stub body for a call into the refactored
+//! orchestrator, passing the same sink as `&dyn EventSink`.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -38,8 +42,9 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use chrono::Utc;
-use forge_core::{MessageId, ProviderId};
+use forge_core::{Event, EventSink, MessageId, ProviderId};
 use forge_ipc::sidecar::{
     SidecarCrashed, SidecarEvent, SidecarHeartbeat, SidecarHelloAck, SidecarMessage,
     SidecarRunTurn, SIDECAR_SCHEMA_VERSION,
@@ -232,6 +237,61 @@ impl EventSeq {
 /// shutdown drain), so the half lives behind a tokio mutex.
 pub type SharedWriter = Arc<AsyncMutex<WriteHalf<UnixStream>>>;
 
+/// F-608 step 3: sidecar-side [`EventSink`] implementation.
+///
+/// The orchestrator's run loop (in `forge-session`) emits every
+/// `forge_core::Event` through the trait. In the daemon those land in
+/// the on-disk event log and IPC broadcast; in this crate, every emit
+/// is framed as a [`SidecarMessage::Event`] carrying a monotonic
+/// per-sidecar `seq` and written on the daemon-facing UDS — the daemon
+/// writes the event to the session log on the receiving end (§2 of
+/// `docs/architecture/agent-sidecar.md`).
+///
+/// Cloning is cheap (two `Arc`s) so the supervisor wiring in step 5
+/// can hand a clone to whatever loop drives the sidecar's run-turn
+/// body without juggling lifetimes.
+#[derive(Clone)]
+pub struct IpcEventSink {
+    writer: SharedWriter,
+    seq: EventSeq,
+}
+
+impl IpcEventSink {
+    /// Bind a sink to the sidecar's outbound writer half + per-process
+    /// event-sequence allocator. The same `EventSeq` instance must be
+    /// shared with the heartbeat task so a future ordering-aware
+    /// daemon can correlate heartbeat gaps against missing event
+    /// numbers.
+    pub fn new(writer: SharedWriter, seq: EventSeq) -> Self {
+        Self { writer, seq }
+    }
+}
+
+#[async_trait]
+impl EventSink for IpcEventSink {
+    /// Frame `event` as `SidecarMessage::Event { seq, event }` and
+    /// write it on the UDS. The lock on `writer` is held only across
+    /// the single `write_frame` call so concurrent emitters (e.g. a
+    /// future tool-approval request raised inside a turn) interleave
+    /// at frame granularity rather than blocking on each other for
+    /// the duration of a turn.
+    ///
+    /// Write failures propagate. The supervisor observes the EOF on
+    /// the daemon side and recycles the sidecar — letting the
+    /// orchestrator silently drop events on a broken pipe would
+    /// leave half-bracketed step windows in the daemon's session
+    /// log.
+    async fn emit(&self, event: Event) -> anyhow::Result<()> {
+        let frame = SidecarMessage::Event(SidecarEvent {
+            seq: self.seq.next(),
+            event,
+        });
+        let mut w = self.writer.lock().await;
+        forge_ipc::write_frame(&mut *w, &frame).await?;
+        Ok(())
+    }
+}
+
 /// Spawn the 1 Hz heartbeat task. Returns the join handle so the
 /// shutdown path can abort it before draining the writer for a clean
 /// last-frame ordering.
@@ -263,53 +323,54 @@ fn spawn_heartbeat(
 }
 
 /// Stub `RunTurn` handler. Emits a deterministic event sequence:
-/// `AssistantMessage { text: "[stub]" }` then `StepFinished`. Step 3
-/// replaces this with the refactored `run_turn` body.
-async fn handle_run_turn_stub(
-    writer: &SharedWriter,
-    seq: &EventSeq,
-    turn: SidecarRunTurn,
-) -> Result<()> {
-    use forge_core::{Event, StepId, StepKind, StepOutcome};
+/// `StepStarted`, `AssistantMessage { text: "[stub]" }`, `StepFinished`.
+///
+/// F-608 step 3: emissions now route through the
+/// [`EventSink`](forge_core::EventSink) trait via [`IpcEventSink`] —
+/// the same trait `forge-session::orchestrator::run_turn` consumes
+/// in-process. The on-the-wire bytes are unchanged from step 2; what
+/// changed is that the sidecar no longer hand-rolls
+/// `SidecarMessage::Event` framing inline. Step 4+ replaces the stub
+/// body entirely with a call into the refactored orchestrator,
+/// passing this same `IpcEventSink` as `&dyn EventSink`.
+async fn handle_run_turn_stub(events: &dyn EventSink, turn: SidecarRunTurn) -> Result<()> {
+    use forge_core::{StepId, StepKind, StepOutcome};
 
     let now = Utc::now();
     let assistant_id = MessageId::new();
     let step_id = StepId::new();
 
     // Step started so the UI sees a step boundary even from the stub.
-    let step_started = Event::StepStarted {
-        step_id: step_id.clone(),
-        instance_id: None,
-        kind: StepKind::Model,
-        started_at: now,
-        index: 1,
-        total: Some(1),
-    };
-    let assistant = Event::AssistantMessage {
-        id: assistant_id,
-        provider: ProviderId::from_string("stub".to_string()),
-        model: "stub".to_string(),
-        at: now,
-        stream_finalised: true,
-        text: std::sync::Arc::from("[stub]"),
-        branch_parent: turn.branch_parent.clone(),
-        branch_variant_index: turn.branch_variant_index.unwrap_or(0),
-    };
-    let step_finished = Event::StepFinished {
-        step_id,
-        outcome: StepOutcome::Ok,
-        duration_ms: 0,
-        token_usage: None,
-    };
-
-    for ev in [step_started, assistant, step_finished] {
-        let frame = SidecarMessage::Event(SidecarEvent {
-            seq: seq.next(),
-            event: ev,
-        });
-        let mut w = writer.lock().await;
-        forge_ipc::write_frame(&mut *w, &frame).await?;
-    }
+    events
+        .emit(Event::StepStarted {
+            step_id: step_id.clone(),
+            instance_id: None,
+            kind: StepKind::Model,
+            started_at: now,
+            index: 1,
+            total: Some(1),
+        })
+        .await?;
+    events
+        .emit(Event::AssistantMessage {
+            id: assistant_id,
+            provider: ProviderId::from_string("stub".to_string()),
+            model: "stub".to_string(),
+            at: now,
+            stream_finalised: true,
+            text: std::sync::Arc::from("[stub]"),
+            branch_parent: turn.branch_parent.clone(),
+            branch_variant_index: turn.branch_variant_index.unwrap_or(0),
+        })
+        .await?;
+    events
+        .emit(Event::StepFinished {
+            step_id,
+            outcome: StepOutcome::Ok,
+            duration_ms: 0,
+            token_usage: None,
+        })
+        .await?;
     Ok(())
 }
 
@@ -332,6 +393,13 @@ async fn dispatch_loop(
     seq: EventSeq,
     pending_turns: Arc<AtomicU64>,
 ) -> Result<LoopExit> {
+    // F-608 step 3: build the sink once and reuse across turns. Cheap
+    // to clone (two `Arc`s); cloning per RunTurn would be equally
+    // correct but pointless. The heartbeat task holds a separate
+    // clone of the underlying writer, so frame ordering between
+    // heartbeats and `Event` frames stays serialized through the
+    // tokio mutex.
+    let event_sink = IpcEventSink::new(writer.clone(), seq.clone());
     let mut buf = Vec::new();
     loop {
         let frame: SidecarMessage = match forge_ipc::read_frame_into(reader, &mut buf).await {
@@ -347,7 +415,7 @@ async fn dispatch_loop(
         match frame {
             SidecarMessage::RunTurn(turn) => {
                 pending_turns.fetch_add(1, Ordering::Relaxed);
-                let res = handle_run_turn_stub(&writer, &seq, turn).await;
+                let res = handle_run_turn_stub(&event_sink, turn).await;
                 pending_turns.fetch_sub(1, Ordering::Relaxed);
                 if let Err(e) = res {
                     error!(error = %e, "run_turn stub failed");
@@ -357,9 +425,12 @@ async fn dispatch_loop(
             | SidecarMessage::ToolCallRejected(_)
             | SidecarMessage::Credentials(_)
             | SidecarMessage::CompactTranscript(_) => {
-                // Step 2 leaves these as no-ops; step 3 wires them to
-                // the refactored run_turn.
-                debug!("ignoring non-RunTurn daemon message in step-2 stub handler");
+                // Steps 4+ wire these to the refactored orchestrator
+                // (approval queue, credential push, compaction
+                // proxy). Step 3 only swaps the run_turn emission
+                // path onto the EventSink trait — these stay no-ops
+                // until the orchestrator body lands here.
+                debug!("ignoring non-RunTurn daemon message in stub handler");
             }
             SidecarMessage::Shutdown(s) => {
                 info!(grace_ms = s.grace_ms, "received shutdown");

--- a/crates/forge-core/src/event_sink.rs
+++ b/crates/forge-core/src/event_sink.rs
@@ -1,0 +1,57 @@
+//! F-608 step 3: transport-agnostic event emission seam.
+//!
+//! `run_turn` and `run_request_loop` (in `forge-session`) historically
+//! held a concrete `Arc<Session>` and called `session.emit(Event)` on
+//! every event. With the agent sidecar landing in F-608, the same
+//! orchestrator body needs to run in two contexts:
+//!
+//! * **In-process (daemon)** — events flow into the local
+//!   `forge_session::session::Session`'s durable event log + broadcast.
+//! * **Sidecar (`forged-agent`)** — events leave the process as
+//!   `SidecarMessage::Event(SidecarEvent { seq, event })` frames over
+//!   the per-instance Unix domain socket; the daemon writes them to the
+//!   session log on the receiving end.
+//!
+//! [`EventSink`] is the single trait every emitter sees. The trait
+//! lives in `forge-core` (rather than `forge-session`) so the sidecar
+//! crate can implement it without taking a dependency on the daemon's
+//! persistence / IPC server / MCP machinery — the architecture doc
+//! Open Questions §1 calls out keeping the sidecar's compile graph
+//! minimal as the explicit non-goal that motivates this placement.
+
+use async_trait::async_trait;
+
+use crate::event::Event;
+
+/// One-way emission surface for an [`Event`].
+///
+/// Implementors are responsible for whatever durability + fan-out their
+/// transport requires:
+///
+/// * The daemon's `Session` flushes the event to its on-disk
+///   `EventLog` and broadcasts it to subscribed IPC clients.
+/// * The sidecar's `IpcEventSink` allocates a monotonic `seq`, frames
+///   the event as a `SidecarMessage::Event`, and writes it on the UDS.
+///
+/// `Send + Sync` is required because both the orchestrator's stream
+/// loop and the parallel-tool dispatch path hand sinks across `tokio`
+/// task boundaries (`Arc<dyn EventSink>` clones into spawned tasks).
+///
+/// The error type is [`anyhow::Error`] to match the orchestrator's
+/// existing error-propagation shape: today every `session.emit(...)?`
+/// flows through `anyhow::Result<()>`. Concrete sink implementations
+/// may map their internal typed errors (e.g.
+/// `forge_session::SessionError`, `tokio::io::Error`) into
+/// `anyhow::Error` at the boundary.
+#[async_trait]
+pub trait EventSink: Send + Sync {
+    /// Append `event` to whatever durable channel this sink represents.
+    ///
+    /// Failures are surfaced to the caller — the orchestrator
+    /// propagates them out of `run_turn` so a misbehaving sink does
+    /// not silently lose events. The IPC sink in `forged-agent`
+    /// converts a write failure into a hard turn error so the
+    /// supervisor can observe the connection drop and recycle the
+    /// sidecar.
+    async fn emit(&self, event: Event) -> anyhow::Result<()>;
+}

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod credentials;
 mod error;
 mod event;
 mod event_log;
+mod event_sink;
 pub mod ids;
 pub mod mcp_state;
 pub mod meta;
@@ -25,6 +26,7 @@ pub use credentials::{Credentials, EnvFallbackStore, LayeredStore, MemoryStore};
 pub use error::{ForgeError, Result};
 pub use event::{ApprovalPreview, ApprovalSource, ContextRef, EndReason, Event};
 pub use event_log::{read_since, EventLog, MAX_LINE_BYTES};
+pub use event_sink::EventSink;
 pub use ids::{
     AgentId, AgentInstanceId, MessageId, ProviderId, SessionId, StepId, TerminalId, ToolCallId,
     WorkspaceId,

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -8,7 +8,8 @@ use forge_core::{
     apply_superseded,
     credentials::Credentials,
     ids::{MessageId, ProviderId, StepId, ToolCallId},
-    read_since, ApprovalScope, ApprovalSource, Event, RerunVariant, StepKind, StepOutcome,
+    read_since, ApprovalScope, ApprovalSource, Event, EventSink, RerunVariant, StepKind,
+    StepOutcome,
 };
 use forge_providers::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider};
 use futures::StreamExt;
@@ -164,6 +165,16 @@ fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
 #[allow(clippy::too_many_arguments)]
 pub async fn run_turn<P: Provider>(
     session: Arc<Session>,
+    // F-608 step 3: transport-agnostic event emission. Session-side
+    // operations (pause/interrupt flags, parallel-group counter, byte
+    // budget, compaction guard) still flow through `Arc<Session>`
+    // above, but every `Event` this turn produces is routed through
+    // `events.emit(...)` so the same body runs unchanged in the
+    // sidecar (where `events` is an `IpcEventSink` writing
+    // `SidecarMessage::Event` frames). In-process callers pass
+    // `session.as_ref()` here — `Session: EventSink` delegates to
+    // its existing durable-log + broadcast emit.
+    events: &dyn EventSink,
     provider: Arc<P>,
     text: String,
     pending_approvals: PendingApprovals,
@@ -246,7 +257,7 @@ pub async fn run_turn<P: Provider>(
 
     let msg_id = MessageId::new();
 
-    session
+    events
         .emit(Event::UserMessage {
             id: msg_id.clone(),
             at: Utc::now(),
@@ -327,6 +338,7 @@ pub async fn run_turn<P: Provider>(
 
     run_request_loop(
         session,
+        events,
         provider,
         initial_req,
         msg_id,
@@ -398,6 +410,14 @@ async fn build_legacy_dispatcher(mcp: Option<&Arc<McpManager>>) -> ToolDispatche
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_request_loop<P: Provider>(
     session: Arc<Session>,
+    // F-608 step 3: every event emitted from inside the request loop
+    // routes through this sink. Session-state primitives (pause flag,
+    // interrupt flag + capture publish, parallel-group allocator) still
+    // come off `session` because they're inherently coupled to the
+    // in-process daemon — the sidecar variant of the loop will receive
+    // these as IPC frames in step 5 (BackgroundAgentRegistry wiring) so
+    // we deliberately do NOT widen `EventSink` to include them here.
+    events: &dyn EventSink,
     provider: Arc<P>,
     mut req: ChatRequest,
     msg_id: MessageId,
@@ -452,7 +472,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
         let model_step_id = StepId::new();
         let model_step_started = Instant::now();
         step_index += 1;
-        session
+        events
             .emit(Event::StepStarted {
                 step_id: model_step_id.clone(),
                 instance_id: instance_id.clone(),
@@ -465,7 +485,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
 
         // Emit AssistantMessage(open) before any chunks arrive — ensures the
         // event is present even when the first chunk is a tool call (not text).
-        session
+        events
             .emit(Event::AssistantMessage {
                 id: msg_id.clone(),
                 provider: provider_id.clone(),
@@ -505,7 +525,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
             match chunk {
                 ChatChunk::TextDelta(delta) => {
                     assistant_text.push_str(&delta);
-                    session
+                    events
                         .emit(Event::AssistantDelta {
                             id: msg_id.clone(),
                             at: Utc::now(),
@@ -541,7 +561,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
                     // Drop any buffered tool calls — they never reached
                     // the dispatcher and emitting partial Tool* events
                     // would leave a half-bracketed step window.
-                    session
+                    events
                         .emit(Event::AssistantMessage {
                             id: msg_id.clone(),
                             provider: provider_id.clone(),
@@ -557,7 +577,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
                     // F-139: close the Model step with an Error outcome
                     // so late-joining subscribers see a well-formed
                     // step window even on provider abort.
-                    session
+                    events
                         .emit(Event::StepFinished {
                             step_id: model_step_id.clone(),
                             outcome: StepOutcome::Error {
@@ -619,7 +639,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
         // stays alive, the next `SendUserMessage` continues normally.
         if interrupted {
             let partial_arc: Arc<str> = Arc::from(assistant_text.as_str());
-            session
+            events
                 .emit(Event::AssistantMessage {
                     id: msg_id.clone(),
                     provider: provider_id.clone(),
@@ -631,7 +651,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
                     branch_variant_index,
                 })
                 .await?;
-            session
+            events
                 .emit(Event::SessionInterrupted {
                     at: Utc::now(),
                     partial_text: Arc::clone(&partial_arc),
@@ -639,7 +659,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
                     captured_at_msg_id: msg_id.clone(),
                 })
                 .await?;
-            session
+            events
                 .emit(Event::StepFinished {
                     step_id: model_step_id.clone(),
                     outcome: StepOutcome::Error {
@@ -670,6 +690,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
             rejected,
         } = dispatch_tool_calls(
             &session,
+            events,
             std::mem::take(&mut pending_calls),
             &msg_id,
             &instance_id,
@@ -687,7 +708,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
         // exit shape the pre-F-599 code did so the LIFO step invariant
         // holds for embedders that pin on it.
         if rejected {
-            session
+            events
                 .emit(Event::AssistantMessage {
                     id: msg_id.clone(),
                     provider: provider_id.clone(),
@@ -699,7 +720,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
                     branch_variant_index,
                 })
                 .await?;
-            session
+            events
                 .emit(Event::StepFinished {
                     step_id: model_step_id.clone(),
                     outcome: StepOutcome::Ok,
@@ -712,7 +733,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
 
         // Always finalise the assistant message — whether or not tool
         // calls fired this turn.
-        session
+        events
             .emit(Event::AssistantMessage {
                 id: msg_id.clone(),
                 provider: provider_id.clone(),
@@ -724,7 +745,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
                 branch_variant_index,
             })
             .await?;
-        session
+        events
             .emit(Event::StepFinished {
                 step_id: model_step_id.clone(),
                 outcome: StepOutcome::Ok,
@@ -859,6 +880,12 @@ fn group_tool_calls(read_only_flags: &[Option<bool>]) -> Vec<ToolBatch> {
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_tool_calls(
     session: &Arc<Session>,
+    // F-608 step 3: route every Tool* / Step* event through the
+    // injected sink. `session` is still kept on hand for the
+    // session-state primitive `next_parallel_group()` (which the
+    // sidecar will receive as an IPC frame in step 5, so we hold the
+    // line on what `EventSink` carries).
+    events: &dyn EventSink,
     pending: Vec<PendingToolCall>,
     msg_id: &MessageId,
     instance_id: &Option<forge_core::ids::AgentInstanceId>,
@@ -916,7 +943,7 @@ async fn dispatch_tool_calls(
                 let started = Instant::now();
                 tool_steps[idx] = Some((tool_step_id.clone(), started));
                 *step_index += 1;
-                session
+                events
                     .emit(Event::StepStarted {
                         step_id: tool_step_id.clone(),
                         instance_id: instance_id.clone(),
@@ -926,7 +953,7 @@ async fn dispatch_tool_calls(
                         total: None,
                     })
                     .await?;
-                session
+                events
                     .emit(Event::ToolCallStarted {
                         id: pc.call_id.clone(),
                         msg: msg_id.clone(),
@@ -945,7 +972,7 @@ async fn dispatch_tool_calls(
             // here: read-only tools never raise a user prompt today.
             for &idx in &batch.indices {
                 let pc = &pending[idx];
-                session
+                events
                     .emit(Event::ToolCallApproved {
                         id: pc.call_id.clone(),
                         by: ApprovalSource::Auto,
@@ -961,7 +988,7 @@ async fn dispatch_tool_calls(
             for &idx in &batch.indices {
                 let pc = &pending[idx];
                 let (tool_step_id, _) = tool_steps[idx].as_ref().expect("tool step opened");
-                session
+                events
                     .emit(Event::ToolInvoked {
                         step_id: tool_step_id.clone(),
                         tool_call_id: pc.call_id.clone(),
@@ -1061,7 +1088,7 @@ async fn dispatch_tool_calls(
                 let result_ok = result.get("error").is_none();
                 let duration_ms = started.elapsed().as_millis() as u64;
 
-                session
+                events
                     .emit(Event::ToolReturned {
                         step_id: tool_step_id.clone(),
                         tool_call_id: pc.call_id.clone(),
@@ -1069,7 +1096,7 @@ async fn dispatch_tool_calls(
                         bytes_out: result_bytes,
                     })
                     .await?;
-                session
+                events
                     .emit(Event::ToolCallCompleted {
                         id: pc.call_id.clone(),
                         result: result.clone(),
@@ -1077,7 +1104,7 @@ async fn dispatch_tool_calls(
                         at: Utc::now(),
                     })
                     .await?;
-                session
+                events
                     .emit(Event::StepFinished {
                         step_id: tool_step_id.clone(),
                         outcome: if result_ok {
@@ -1116,7 +1143,7 @@ async fn dispatch_tool_calls(
                 let tool_step_id = StepId::new();
                 let tool_step_started = Instant::now();
                 *step_index += 1;
-                session
+                events
                     .emit(Event::StepStarted {
                         step_id: tool_step_id.clone(),
                         instance_id: instance_id.clone(),
@@ -1126,7 +1153,7 @@ async fn dispatch_tool_calls(
                         total: None,
                     })
                     .await?;
-                session
+                events
                     .emit(Event::ToolCallStarted {
                         id: pc.call_id.clone(),
                         msg: msg_id.clone(),
@@ -1143,7 +1170,7 @@ async fn dispatch_tool_calls(
                 let result = match tool_lookup {
                     Ok(tool) => {
                         if auto_approve || tool.read_only() {
-                            session
+                            events
                                 .emit(Event::ToolCallApproved {
                                     id: pc.call_id.clone(),
                                     by: ApprovalSource::Auto,
@@ -1157,7 +1184,7 @@ async fn dispatch_tool_calls(
                                 .lock()
                                 .await
                                 .insert(pc.call_id.to_string(), tx);
-                            session
+                            events
                                 .emit(Event::ToolCallApprovalRequested {
                                     id: pc.call_id.clone(),
                                     preview: tool.approval_preview(&pc.args),
@@ -1167,13 +1194,13 @@ async fn dispatch_tool_calls(
                             let scope = match decision {
                                 ApprovalDecision::Approved(scope) => scope,
                                 ApprovalDecision::Rejected => {
-                                    session
+                                    events
                                         .emit(Event::ToolCallRejected {
                                             id: pc.call_id.clone(),
                                             reason: Some("rejected by client".to_string()),
                                         })
                                         .await?;
-                                    session
+                                    events
                                         .emit(Event::StepFinished {
                                             step_id: tool_step_id.clone(),
                                             outcome: StepOutcome::Error {
@@ -1191,7 +1218,7 @@ async fn dispatch_tool_calls(
                                     });
                                 }
                             };
-                            session
+                            events
                                 .emit(Event::ToolCallApproved {
                                     id: pc.call_id.clone(),
                                     by: ApprovalSource::User,
@@ -1201,7 +1228,7 @@ async fn dispatch_tool_calls(
                                 .await?;
                         }
 
-                        session
+                        events
                             .emit(Event::ToolInvoked {
                                 step_id: tool_step_id.clone(),
                                 tool_call_id: pc.call_id.clone(),
@@ -1218,7 +1245,7 @@ async fn dispatch_tool_calls(
                         crate::tools::invoke_with_budget(tool, &pc.args, ctx).await
                     }
                     Err(ToolError::UnknownTool(n)) => {
-                        session
+                        events
                             .emit(Event::ToolInvoked {
                                 step_id: tool_step_id.clone(),
                                 tool_call_id: pc.call_id.clone(),
@@ -1229,7 +1256,7 @@ async fn dispatch_tool_calls(
                         serde_json::json!({ "error": format!("unknown tool '{n}'") })
                     }
                     Err(e) => {
-                        session
+                        events
                             .emit(Event::ToolInvoked {
                                 step_id: tool_step_id.clone(),
                                 tool_call_id: pc.call_id.clone(),
@@ -1246,7 +1273,7 @@ async fn dispatch_tool_calls(
                     .map(|s| s.len() as u64)
                     .unwrap_or(0);
                 let result_ok = result.get("error").is_none();
-                session
+                events
                     .emit(Event::ToolReturned {
                         step_id: tool_step_id.clone(),
                         tool_call_id: pc.call_id.clone(),
@@ -1254,7 +1281,7 @@ async fn dispatch_tool_calls(
                         bytes_out: result_bytes,
                     })
                     .await?;
-                session
+                events
                     .emit(Event::ToolCallCompleted {
                         id: pc.call_id.clone(),
                         result: result.clone(),
@@ -1262,7 +1289,7 @@ async fn dispatch_tool_calls(
                         at: Utc::now(),
                     })
                     .await?;
-                session
+                events
                     .emit(Event::StepFinished {
                         step_id: tool_step_id.clone(),
                         outcome: if result_ok {
@@ -1497,8 +1524,13 @@ impl Orchestrator {
             mcp: None,
         };
 
+        // F-608 step 3: rerun is in-process — `Session` IS the
+        // `EventSink`, so we pass the same `Arc<Session>` for both
+        // session-state ops and event emission.
+        let events: &dyn EventSink = session.as_ref();
         run_request_loop(
             Arc::clone(&session),
+            events,
             provider,
             req,
             new_id.clone(),
@@ -1624,8 +1656,11 @@ impl Orchestrator {
             mcp: None,
         };
 
+        // F-608 step 3: see `rerun_replace` — Session is the sink.
+        let events: &dyn EventSink = session.as_ref();
         run_request_loop(
             Arc::clone(&session),
+            events,
             provider,
             req,
             new_id.clone(),
@@ -1734,8 +1769,11 @@ impl Orchestrator {
             mcp: None,
         };
 
+        // F-608 step 3: see `rerun_replace` — Session is the sink.
+        let events: &dyn EventSink = session.as_ref();
         run_request_loop(
             Arc::clone(&session),
+            events,
             provider,
             req,
             new_id.clone(),
@@ -2130,6 +2168,7 @@ mod tests {
 
         run_turn(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             "first turn".to_string(),
             Arc::clone(&pending),
@@ -2155,6 +2194,7 @@ mod tests {
 
         run_turn(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             "second turn".to_string(),
             pending,
@@ -2215,8 +2255,10 @@ mod tests {
                 .expect("construct mock"),
         );
 
+        let events_session = Arc::clone(&session);
         run_turn(
             session,
+            events_session.as_ref(),
             Arc::clone(&provider),
             "hello".to_string(),
             Arc::new(Mutex::new(HashMap::new())),
@@ -2416,6 +2458,7 @@ mod tests {
 
         run_turn(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             "fresh prompt".to_string(),
             pending,
@@ -2480,6 +2523,7 @@ mod tests {
 
         run_turn(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             "below threshold".to_string(),
             pending,
@@ -2692,6 +2736,7 @@ mod tests {
             let started = std::time::Instant::now();
             run_request_loop(
                 Arc::clone(&session),
+                session.as_ref(),
                 Arc::clone(&provider),
                 req,
                 MessageId::new(),
@@ -2786,6 +2831,7 @@ mod tests {
 
         run_request_loop(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             req,
             MessageId::new(),
@@ -2894,6 +2940,7 @@ mod tests {
 
         run_request_loop(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             ChatRequest {
                 system: None,
@@ -2975,6 +3022,7 @@ mod tests {
 
         run_request_loop(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             ChatRequest {
                 system: None,
@@ -3074,6 +3122,7 @@ mod tests {
 
         run_request_loop(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             ChatRequest {
                 system: None,
@@ -3192,6 +3241,7 @@ mod tests {
 
         run_request_loop(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             ChatRequest {
                 system: None,
@@ -3228,6 +3278,7 @@ mod tests {
         let mut rx = session.event_tx.subscribe();
         run_request_loop(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             ChatRequest {
                 system: None,
@@ -3341,6 +3392,7 @@ mod tests {
 
         run_request_loop(
             Arc::clone(&session),
+            session.as_ref(),
             Arc::clone(&provider),
             ChatRequest {
                 system: None,

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -1286,6 +1286,10 @@ async fn handle_connection<P: Provider + 'static>(
                         tokio::spawn(async move {
                             let result = run_turn(
                                 Arc::clone(&session),
+                                // F-608 step 3: in-process turn — `Session`
+                                // implements `EventSink`, so the same Arc
+                                // doubles as the emission target.
+                                session.as_ref(),
                                 provider,
                                 m.text,
                                 approvals,

--- a/crates/forge-session/src/session.rs
+++ b/crates/forge-session/src/session.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 
-use forge_core::{Event, EventLog};
+use async_trait::async_trait;
+use forge_core::{Event, EventLog, EventSink};
 use tokio::sync::{broadcast, Mutex, Notify};
 
 use crate::error::SessionError;
@@ -324,6 +325,18 @@ impl Session {
 
     pub async fn current_seq(&self) -> u64 {
         *self.seq.lock().await
+    }
+}
+
+/// F-608 step 3: route the in-process orchestrator's event emissions
+/// through the [`EventSink`] trait. Delegates to the existing
+/// [`Session::emit`] body and re-wraps the typed [`SessionError`] into
+/// `anyhow::Error` at the trait boundary so the orchestrator's
+/// `anyhow::Result<()>` propagation shape is preserved.
+#[async_trait]
+impl EventSink for Session {
+    async fn emit(&self, event: Event) -> anyhow::Result<()> {
+        Session::emit(self, event).await.map_err(Into::into)
     }
 }
 

--- a/crates/forge-session/tests/agent_spawn_live.rs
+++ b/crates/forge-session/tests/agent_spawn_live.rs
@@ -89,6 +89,7 @@ async fn agent_spawn_from_live_turn_registers_child_and_emits_sub_agent_spawned(
 
     run_turn(
         Arc::clone(&session),
+        session.as_ref(),
         provider,
         "go".to_string(),
         pending_approvals,

--- a/crates/forge-session/tests/credentials_pull.rs
+++ b/crates/forge-session/tests/credentials_pull.rs
@@ -103,6 +103,7 @@ async fn run_turn_pulls_credential_when_context_supplied() {
 
     run_turn(
         Arc::clone(&session),
+        session.as_ref(),
         Arc::clone(&provider),
         "hello".to_string(),
         pending,
@@ -153,6 +154,7 @@ async fn run_turn_proceeds_when_credential_is_missing() {
 
     run_turn(
         Arc::clone(&session),
+        session.as_ref(),
         Arc::clone(&provider),
         "hello".to_string(),
         Arc::new(Mutex::new(HashMap::new())),
@@ -188,8 +190,10 @@ async fn run_turn_fails_when_credential_backend_errors() {
             .expect("construct mock"),
     );
 
+    let events_session = Arc::clone(&session);
     let err = run_turn(
         session,
+        events_session.as_ref(),
         provider,
         "hello".to_string(),
         Arc::new(Mutex::new(HashMap::new())),
@@ -233,8 +237,10 @@ async fn run_turn_skips_pull_when_no_context_supplied() {
             .expect("construct mock"),
     );
 
+    let events_session = Arc::clone(&session);
     run_turn(
         session,
+        events_session.as_ref(),
         provider,
         "hello".to_string(),
         Arc::new(Mutex::new(HashMap::new())),


### PR DESCRIPTION
Closes #654.

## Summary

- Introduces `forge_core::EventSink` — a transport-agnostic, async, one-way emission trait for `Event`. The orchestrator's run loop in `forge-session` (`run_turn` / `run_request_loop` / `dispatch_tool_calls`) now emits every event through `&dyn EventSink` instead of `Arc<Session>::emit`.
- `Session` implements `EventSink`, delegating to its existing durable-log + broadcast emit; in-process callers pass `session.as_ref()` and the wire shape stays identical (verified by `step_events.rs` and the full session test suite).
- New `IpcEventSink` in `forge-agent-host` frames each event as `SidecarMessage::Event(SidecarEvent { seq, event })` with a monotonic per-sidecar `seq` and writes it on the daemon-facing UDS. The stub `RunTurn` handler is rewired through it — wire bytes unchanged from step 2.

## Where the trait lives — and why

`forge_core::event_sink::EventSink`, not `forge_session::event_sink`.

Hosting in `forge-session` would have forced `forge-agent-host` to add `forge-session` to its compile graph (and transitively `forge-mcp`, `forge-oci`, the keyring backends, the IPC server, persistence). The architecture doc Open Questions §1 explicitly calls out keeping the sidecar's compile closure minimal as the rationale for `forge-agent-host` being its own crate; pulling `forge-session` back in would defeat that. `forge-core` already owns `Event`, already has `async-trait`, and is a workspace dep of both crates — it's the architecturally correct layer.

## Design choice for non-emit Session operations — split, not widened

`run_request_loop` still takes `Arc<Session>` alongside `&dyn EventSink`. Reasons:

* `Session::wait_if_paused()` (F-603), `is_interrupt_requested()` / `publish_interrupt_capture()` (F-604), `next_parallel_group()` (F-599), `is_compacting()` (F-598) are all in-memory primitives that the *daemon* owns. The sidecar will receive their counterparts as IPC frames in step 5 (`BackgroundAgentRegistry`) — not by widening `EventSink`.
* Keeping `EventSink` narrow (one method, one direction) means `IpcEventSink` is a 30-line implementation. Widening it would have meant either stubbing every method on the sidecar side or duplicating control-plane semantics across two transport implementations — both bad.
* Compaction (`compact()`) and the rerun paths still take `Arc<Session>` because they touch the on-disk event log (`session.log_path`, `read_since`) and session-only state. Those paths are inherently in-process; the rerun functions create the sink locally with `let events: &dyn EventSink = session.as_ref();` and pass it down.

## Out of scope (deferred to later F-608 steps per the architecture doc)

- `SidecarSupervisor` and the daemon-side spawn / lifecycle management (step 4).
- `BackgroundAgentRegistry` wiring (step 5).
- Replacing the `forge-agent-host` `handle_run_turn_stub` body with a real call into `run_turn` (step 4+). The stub keeps step 2's deterministic 3-event sequence; the only delta in step 3 is that those emissions now route through the trait.
- Cross-process credential push, tool-call approval round-trip, `CompactTranscript` proxying — all called out in the dispatch-loop's no-op arm with explicit comments pointing at step 4+.

## DoD per the task

- [x] `pub trait EventSink` defined (`crates/forge-core/src/event_sink.rs`)
- [x] `Session: EventSink` implemented (`crates/forge-session/src/session.rs`)
- [x] `IpcEventSink` in `forge-agent-host` writes `SidecarMessage::Event { seq, event }` frames over the existing socket plumbing
- [x] `run_turn` and `run_request_loop` signatures updated to take `&dyn EventSink`
- [x] `forge-agent-host` stub `RunTurn` handler routes through the new trait
- [x] `crates/forge-session/tests/step_events.rs` still passes (verifies in-process Session sink)
- [x] `cargo test -p forge-session` green
- [x] `cargo test -p forge-agent-host` green (lifecycle integration test exercises `IpcEventSink` end-to-end)
- [x] `cargo build --workspace` green
- [x] No new transport, no supervisor, no spawning logic

## Test plan

- [x] `cargo test -p forge-session` — 300+ tests pass, including `step_events`, `pause_resume`, `interrupt_refine`, `credentials_pull`, `agent_spawn_live`, all orchestrator inline tests.
- [x] `cargo test -p forge-agent-host` — `forged_agent_lifecycle::full_lifecycle_handshake_run_turn_shutdown` passes (verifies the new `IpcEventSink` produces the same on-the-wire sequence the inline framing did).
- [x] `cargo test --workspace` — clean run, no failures.
- [x] `just check-rust` — `cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)