### PR TITLE
[F-608 step 7] Crash-dump writer + observability glue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,6 +1405,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "dirs 6.0.0",
  "forge-core",
  "forge-ipc",
  "serde_json",

--- a/crates/forge-agent-host/Cargo.toml
+++ b/crates/forge-agent-host/Cargo.toml
@@ -34,6 +34,12 @@ anyhow = "1"
 # closure (architecture doc Open Questions §1).
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+# F-608 step 7: panic-hook crash-dump writer needs `$HOME` to fall back
+# to `~/.local/share/forge/crashes` when neither `$FORGE_CRASH_DIR` nor
+# `$XDG_DATA_HOME` is set. `dirs` is already pulled by other workspace
+# crates (`forge-session`, `forge-mcp`); pinning the same major matches
+# the workspace's existing convention.
+dirs = "6"
 forge-core = { path = "../forge-core" }
 forge-ipc = { path = "../forge-ipc" }
 serde_json = "1"

--- a/crates/forge-agent-host/src/lib.rs
+++ b/crates/forge-agent-host/src/lib.rs
@@ -46,7 +46,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use forge_core::{Event, EventSink, MessageId, ProviderId};
 use forge_ipc::sidecar::{
-    SidecarAgentDef, SidecarCrashed, SidecarEvent, SidecarHeartbeat, SidecarHelloAck,
+    CrashDump, SidecarAgentDef, SidecarCrashed, SidecarEvent, SidecarHeartbeat, SidecarHelloAck,
     SidecarMessage, SidecarProviderSpec, SidecarRunTurn, SIDECAR_SCHEMA_VERSION,
 };
 use tokio::io::{ReadHalf, WriteHalf};
@@ -64,10 +64,17 @@ pub struct AgentArgs {
     /// Logical instance identifier the daemon assigned. Round-tripped
     /// through tracing fields and the `Hello` frame.
     pub instance_id: String,
+    /// Session id the spawning daemon belongs to. Used for the on-disk
+    /// crash-dump path
+    /// (`<XDG_DATA_HOME or ~/.local/share>/forge/crashes/<session-id>/...`).
+    /// Optional for back-compat — older supervisors that never pass
+    /// `--session-id` get crash dumps under a `default` bucket. F-608
+    /// step 7 lands the flag; step 5+ supervisors will start passing it.
+    pub session_id: String,
 }
 
 impl AgentArgs {
-    /// Parse `forged-agent --socket <path> --instance-id <id>`.
+    /// Parse `forged-agent --socket <path> --instance-id <id> [--session-id <sess>]`.
     ///
     /// Hand-rolled rather than `clap` because the sidecar boots on the
     /// time-to-first-token path; the architecture doc §1 calls out the
@@ -79,6 +86,7 @@ impl AgentArgs {
     {
         let mut socket: Option<PathBuf> = None;
         let mut instance_id: Option<String> = None;
+        let mut session_id: Option<String> = None;
         let mut iter = args.into_iter().map(Into::into);
         // Skip argv[0] (program name) — `std::env::args` includes it.
         let _ = iter.next();
@@ -92,6 +100,9 @@ impl AgentArgs {
                 "--instance-id" => {
                     instance_id = Some(iter.next().context("--instance-id requires a value")?);
                 }
+                "--session-id" => {
+                    session_id = Some(iter.next().context("--session-id requires a value")?);
+                }
                 other => {
                     anyhow::bail!("unknown argument: {other}");
                 }
@@ -100,6 +111,7 @@ impl AgentArgs {
         Ok(Self {
             socket: socket.context("--socket is required")?,
             instance_id: instance_id.context("--instance-id is required")?,
+            session_id: session_id.unwrap_or_else(|| "default".to_string()),
         })
     }
 }
@@ -114,19 +126,37 @@ type CrashSink = Arc<Mutex<Option<Vec<u8>>>>;
 
 static CRASH_SINK: OnceLock<CrashSink> = OnceLock::new();
 
+/// Identity carried into the panic hook so the on-disk dump can be
+/// attributed to the right session + instance. Populated by
+/// [`install_panic_hook`].
+#[derive(Debug, Clone)]
+pub struct CrashIdentity {
+    pub instance_id: String,
+    pub session_id: String,
+}
+
 /// Install the panic hook. Idempotent — the underlying `OnceLock` only
 /// stores the first sink, so the integration test (which spawns the
 /// binary fresh per-test) gets a clean install every process.
 ///
-/// The hook serializes a [`SidecarMessage::Crashed`] payload into the
-/// shared sink. The main loop's shutdown path drains the sink onto the
-/// wire before exit. We deliberately do **not** write to the socket from
-/// inside the hook itself: the hook may run on any thread (including
-/// blocking ones with no tokio runtime context), and a blocking write
-/// inside `panic` invites deadlocks. Best-effort delivery is fine — the
-/// supervisor falls back to EOF + non-zero exit detection per
-/// architecture doc §10.
-pub fn install_panic_hook() -> CrashSink {
+/// Two side-effects per panic:
+///   1. **Defensive (file-on-disk).** Persist a [`CrashDump`] to
+///      `<XDG_DATA_HOME or $HOME/.local/share>/forge/crashes/<session-id>/<instance-id>-<unix-ts>.json`,
+///      mode-`0o700` directory, written from inside the hook with
+///      `std::fs` (no tokio dependency). Survives even when the IPC
+///      pipe to the daemon is broken.
+///   2. **Cooperative (IPC).** Serialize a [`SidecarMessage::Crashed`]
+///      payload into the shared sink. The main loop's shutdown path
+///      drains the sink onto the wire before exit. We deliberately do
+///      **not** write to the socket from inside the hook itself: the
+///      hook may run on any thread (including blocking ones with no
+///      tokio runtime context), and a blocking write inside `panic`
+///      invites deadlocks.
+///
+/// Both paths are best-effort — a hard segfault never produces either
+/// frame. The supervisor falls back to EOF + non-zero exit detection
+/// per architecture doc §10.
+pub fn install_panic_hook(identity: CrashIdentity) -> CrashSink {
     let sink: CrashSink = CRASH_SINK
         .get_or_init(|| Arc::new(Mutex::new(None)))
         .clone();
@@ -149,6 +179,26 @@ pub fn install_panic_hook() -> CrashSink {
             std::backtrace::BacktraceStatus::Captured => Some(backtrace.to_string()),
             _ => None,
         };
+
+        // 1. Defensive: persist the dump to the crashes dir. Best-
+        //    effort — a write failure here only loses the file path,
+        //    not the IPC path below.
+        let captured_at = Utc::now();
+        let dump = CrashDump {
+            instance_id: identity.instance_id.clone(),
+            session_id: identity.session_id.clone(),
+            panic_message: panic_message.clone(),
+            backtrace: backtrace_str.clone(),
+            captured_at,
+        };
+        if let Err(e) = write_crash_dump_to_disk(&dump) {
+            // Use eprintln (not tracing) — the panic hook may run with
+            // no tracing subscriber attached and we still want CI logs
+            // to surface the failure.
+            eprintln!("forged-agent: failed to persist crash dump: {e}");
+        }
+
+        // 2. Cooperative: queue the IPC frame for drain-on-shutdown.
         let frame = SidecarMessage::Crashed(SidecarCrashed {
             panic_message,
             backtrace: backtrace_str,
@@ -165,6 +215,62 @@ pub fn install_panic_hook() -> CrashSink {
         prev(info);
     }));
     sink
+}
+
+/// Resolve the crash-dump base directory, honoring (in priority order)
+/// `$FORGE_CRASH_DIR`, `$XDG_DATA_HOME/forge/crashes`, then
+/// `$HOME/.local/share/forge/crashes`. Mirrors
+/// `forge_session::sidecar::crashes::crash_dir_with` — kept inline here
+/// so the sidecar doesn't pull `forge-session` (with its persistence /
+/// MCP graph) into its compile closure.
+fn crash_base_dir() -> Result<PathBuf> {
+    let forge_override = std::env::var("FORGE_CRASH_DIR").ok();
+    if let Some(s) = forge_override.filter(|s| !s.is_empty()) {
+        return Ok(PathBuf::from(s));
+    }
+    let xdg = std::env::var("XDG_DATA_HOME").ok();
+    if let Some(s) = xdg.filter(|s| !s.is_empty()) {
+        return Ok(PathBuf::from(s).join("forge").join("crashes"));
+    }
+    let home = dirs::home_dir().ok_or_else(|| {
+        anyhow::anyhow!(
+            "cannot resolve crash directory: $FORGE_CRASH_DIR / $XDG_DATA_HOME / $HOME all unset"
+        )
+    })?;
+    Ok(home.join(".local/share/forge/crashes"))
+}
+
+/// Write `dump` to disk under the resolved crash dir. Synchronous —
+/// this runs from inside the panic hook on any thread, with no tokio
+/// runtime guaranteed to be available.
+fn write_crash_dump_to_disk(dump: &CrashDump) -> Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    let base = crash_base_dir()?;
+    let dir = base.join(&dump.session_id);
+    // 0o700 on every component we have to create. An existing parent
+    // we leave untouched — a shared `~/.local/share` is a normal user
+    // setup and we don't want to fight the operator's umask.
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(&dir)
+        .with_context(|| format!("creating crash dir {}", dir.display()))?;
+    // Defensive: re-tighten the leaf dir we just created in case it
+    // pre-existed with a looser mode (DirBuilder.recursive doesn't
+    // chmod existing components).
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+
+    // Filename: `<instance-id>-<unix-ts>.json`. The architecture doc
+    // §"Step 7" calls out instance_id + timestamp as the collision-
+    // proof discriminator.
+    let ts = dump.captured_at.timestamp();
+    let path = dir.join(format!("{}-{}.json", dump.instance_id, ts));
+    let bytes = serde_json::to_vec_pretty(dump).context("serialize crash dump")?;
+    std::fs::write(&path, &bytes)
+        .with_context(|| format!("writing crash dump {}", path.display()))?;
+    Ok(())
 }
 
 /// Drain any queued crash payload into a single [`SidecarMessage::Crashed`]
@@ -394,6 +500,16 @@ fn spawn_heartbeat(
 async fn handle_run_turn_stub(events: &dyn EventSink, turn: SidecarRunTurn) -> Result<()> {
     use forge_core::{StepId, StepKind, StepOutcome};
 
+    // F-608 step 7: test-only panic injection. The acceptance test
+    // sets `FORGE_TEST_PANIC_ON_RUNTURN=<msg>` to drive the panic
+    // hook → on-disk crash-dump path end-to-end. The variable is
+    // undocumented for end users; only the test harness uses it.
+    if let Ok(msg) = std::env::var("FORGE_TEST_PANIC_ON_RUNTURN") {
+        if !msg.is_empty() {
+            panic!("{msg}");
+        }
+    }
+
     let now = Utc::now();
     let assistant_id = MessageId::new();
     let step_id = StepId::new();
@@ -541,9 +657,13 @@ async fn dispatch_loop(
 /// Library-level entry so the integration test can drive the same body
 /// without spawning the binary.
 pub async fn run(args: AgentArgs) -> Result<()> {
-    let crash_sink = install_panic_hook();
+    let crash_sink = install_panic_hook(CrashIdentity {
+        instance_id: args.instance_id.clone(),
+        session_id: args.session_id.clone(),
+    });
     info!(
         instance_id = %args.instance_id,
+        session_id = %args.session_id,
         socket = %args.socket.display(),
         "forged-agent starting"
     );
@@ -682,6 +802,23 @@ mod tests {
         .unwrap();
         assert_eq!(parsed.socket, PathBuf::from("/tmp/foo.sock"));
         assert_eq!(parsed.instance_id, "inst-1");
+        // F-608 step 7: omitted --session-id falls back to "default".
+        assert_eq!(parsed.session_id, "default");
+    }
+
+    #[test]
+    fn parse_args_with_session_id() {
+        let parsed = AgentArgs::parse_from([
+            "forged-agent",
+            "--socket",
+            "/tmp/foo.sock",
+            "--instance-id",
+            "inst-1",
+            "--session-id",
+            "sess-xyz",
+        ])
+        .unwrap();
+        assert_eq!(parsed.session_id, "sess-xyz");
     }
 
     #[test]

--- a/crates/forge-ipc/src/sidecar.rs
+++ b/crates/forge-ipc/src/sidecar.rs
@@ -258,6 +258,36 @@ pub struct SidecarCrashed {
     pub backtrace: Option<String>,
 }
 
+/// On-disk crash dump persisted by the sidecar's panic hook before
+/// exit. Mirrors [`SidecarCrashed`] but includes the identifiers needed
+/// for the daemon-side reader to attribute the dump to a session +
+/// instance. Persisted at
+/// `<XDG_DATA_HOME or $HOME/.local/share>/forge/crashes/<session-id>/<instance-id>-<unix-ts>.json`
+/// per `docs/architecture/agent-sidecar.md` §"Step 7".
+///
+/// Independent of the cooperative `SidecarMessage::Crashed` IPC frame:
+/// the IPC path is the cooperative case (drained on shutdown), the
+/// file-on-disk path is the defensive case — covers situations where
+/// the IPC plumbing itself failed and the supervisor never received the
+/// in-band frame.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CrashDump {
+    /// Logical instance id assigned by the daemon at spawn time.
+    pub instance_id: String,
+    /// Session the instance belonged to. Lifts the dump out of an
+    /// anonymous flat dir so a stuck session's history is grep-able.
+    pub session_id: String,
+    /// Stringified panic payload (per the `std::panic::PanicInfo`
+    /// downcast discipline used by the standard library's default
+    /// hook).
+    pub panic_message: String,
+    /// Captured backtrace if `RUST_BACKTRACE=1` was set; otherwise
+    /// `None`.
+    pub backtrace: Option<String>,
+    /// RFC 3339 UTC timestamp of the panic. Captured at hook fire time.
+    pub captured_at: DateTime<Utc>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -380,6 +410,35 @@ mod tests {
             let sent_json = serde_json::to_string(&sent).unwrap();
             let got_json = serde_json::to_string(&got).unwrap();
             assert_eq!(sent_json, got_json, "round-trip mismatch");
+        }
+    }
+
+    /// `CrashDump` is the on-disk dump shape persisted by the sidecar's
+    /// panic hook before exit. The shape is consumed by the daemon-side
+    /// crash reader, so a silent rename here would break post-mortem
+    /// triage. Pin the round-trip + canonical JSON keys.
+    #[test]
+    fn crash_dump_roundtrip_and_keys() {
+        let captured_at = Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap();
+        let dump = CrashDump {
+            instance_id: "inst-1".into(),
+            session_id: "sess-1".into(),
+            panic_message: "index out of bounds".into(),
+            backtrace: Some("frame 0: foo".into()),
+            captured_at,
+        };
+        let bytes = serde_json::to_vec(&dump).expect("serialize");
+        let got: CrashDump = serde_json::from_slice(&bytes).expect("deserialize");
+        assert_eq!(got, dump);
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        for key in [
+            "instance_id",
+            "session_id",
+            "panic_message",
+            "backtrace",
+            "captured_at",
+        ] {
+            assert!(value.get(key).is_some(), "missing key {key}: {value}");
         }
     }
 

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -190,3 +190,10 @@ path = "tests/sidecar_supervisor.rs"
 [[test]]
 name = "bg_agents_sidecar"
 path = "tests/bg_agents_sidecar.rs"
+
+# F-608 step 7: panic-hook crash-dump writer + reader. Drives the
+# `forged-agent` binary into a panic and asserts the on-disk dump
+# lands at the architected path with the panic message intact.
+[[test]]
+name = "sidecar_crash_dump"
+path = "tests/sidecar_crash_dump.rs"

--- a/crates/forge-session/src/sidecar/crashes.rs
+++ b/crates/forge-session/src/sidecar/crashes.rs
@@ -1,0 +1,253 @@
+//! F-608 step 7: daemon-side crash-dump reader.
+//!
+//! The sidecar binary (`forged-agent`) installs a panic hook that
+//! persists a [`CrashDump`] to
+//! `<XDG_DATA_HOME or $HOME/.local/share>/forge/crashes/<session-id>/<instance-id>-<unix-ts>.json`
+//! before exiting. The supervisor side observes the EOF and recycles
+//! the child; this module exposes the post-mortem half — given a
+//! session id, enumerate every dump on disk so triage UIs and tests
+//! can assert what the sidecar actually crashed on.
+//!
+//! The on-disk JSON shape lives in [`forge_ipc::sidecar::CrashDump`] so
+//! the writer (sidecar process) and reader (daemon process) share a
+//! single source of truth without forcing the sidecar to depend on
+//! `forge-session`.
+//!
+//! ## Crash-dir resolution
+//!
+//! The base directory is, in priority order:
+//!   1. `$FORGE_CRASH_DIR` — explicit override, used by tests so the
+//!      writer and reader don't pollute the user's real data dir.
+//!   2. `$XDG_DATA_HOME/forge/crashes` — the XDG base-dir spec data
+//!      home.
+//!   3. `$HOME/.local/share/forge/crashes` — the XDG default when
+//!      `XDG_DATA_HOME` is unset.
+//!
+//! The reader does **not** create the directory on read — a missing
+//! base dir is treated as "no crashes" and returns an empty list.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+pub use forge_ipc::sidecar::CrashDump;
+
+/// Resolve the absolute path of the crash-dir for a given `session_id`.
+///
+/// Reads `$FORGE_CRASH_DIR`, `$XDG_DATA_HOME`, and `$HOME` from the
+/// environment. The returned path may not exist — callers that need
+/// the directory present must `create_dir_all` it themselves with
+/// mode 0o700 (the sidecar writer does this; the reader does not).
+pub fn crash_dir_for_session(session_id: &str) -> Result<PathBuf> {
+    crash_dir_with(
+        std::env::var("FORGE_CRASH_DIR").ok().as_deref(),
+        std::env::var("XDG_DATA_HOME").ok().as_deref(),
+        dirs::home_dir().as_deref(),
+        session_id,
+    )
+}
+
+/// DI variant of [`crash_dir_for_session`]. Takes the env-derived
+/// inputs explicitly so tests can drive every branch with tempdirs
+/// instead of mutating process-global env.
+pub fn crash_dir_with(
+    forge_crash_dir: Option<&str>,
+    xdg_data_home: Option<&str>,
+    home: Option<&Path>,
+    session_id: &str,
+) -> Result<PathBuf> {
+    let base = resolve_crash_base(forge_crash_dir, xdg_data_home, home)?;
+    Ok(base.join(session_id))
+}
+
+/// Resolve the *base* crashes directory — the parent of every per-
+/// session subdir.
+fn resolve_crash_base(
+    forge_crash_dir: Option<&str>,
+    xdg_data_home: Option<&str>,
+    home: Option<&Path>,
+) -> Result<PathBuf> {
+    if let Some(s) = forge_crash_dir.filter(|s| !s.is_empty()) {
+        return Ok(PathBuf::from(s));
+    }
+    if let Some(s) = xdg_data_home.filter(|s| !s.is_empty()) {
+        return Ok(PathBuf::from(s).join("forge").join("crashes"));
+    }
+    let home = home.ok_or_else(|| {
+        anyhow::anyhow!(
+            "cannot resolve crash directory: $FORGE_CRASH_DIR / $XDG_DATA_HOME / $HOME all unset"
+        )
+    })?;
+    Ok(home.join(".local/share/forge/crashes"))
+}
+
+/// Enumerate every [`CrashDump`] persisted under the given session.
+///
+/// Returns the dumps sorted by `captured_at` (oldest first) so the
+/// caller can render them in the order the panics happened. Files
+/// that fail to parse are skipped with a warning rather than aborting
+/// the whole enumeration — a single corrupt dump must not hide the
+/// rest. A missing base directory returns an empty `Vec` (the
+/// supervisor may have spawned no children yet, or the entire
+/// session may have been crash-free).
+pub fn collect_crashes_for_session(session_id: &str) -> Result<Vec<CrashDump>> {
+    let dir = crash_dir_for_session(session_id)?;
+    collect_crashes_in_dir(&dir)
+}
+
+/// Collect every `*.json` crash-dump file in `dir`. Used by both
+/// [`collect_crashes_for_session`] and the integration test (which
+/// passes its tempdir override directly to skip the env-var dance).
+pub fn collect_crashes_in_dir(dir: &Path) -> Result<Vec<CrashDump>> {
+    let read = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(e).with_context(|| format!("read_dir {}", dir.display()));
+        }
+    };
+    let mut out = Vec::new();
+    for entry in read {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(error = %e, dir = %dir.display(), "skipping unreadable dir entry");
+                continue;
+            }
+        };
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        match read_dump_file(&path) {
+            Ok(dump) => out.push(dump),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "skipping unparseable crash dump"
+                );
+            }
+        }
+    }
+    out.sort_by_key(|d| d.captured_at);
+    Ok(out)
+}
+
+fn read_dump_file(path: &Path) -> Result<CrashDump> {
+    let bytes =
+        std::fs::read(path).with_context(|| format!("reading crash dump {}", path.display()))?;
+    let dump: CrashDump = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing crash dump {}", path.display()))?;
+    Ok(dump)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use std::os::unix::fs::DirBuilderExt;
+
+    #[test]
+    fn forge_crash_dir_overrides_xdg_and_home() {
+        let dir = crash_dir_with(
+            Some("/tmp/forge-test-crashes"),
+            Some("/should/be/ignored"),
+            Some(Path::new("/home/x")),
+            "sess-1",
+        )
+        .expect("ok");
+        assert_eq!(dir, PathBuf::from("/tmp/forge-test-crashes/sess-1"));
+    }
+
+    #[test]
+    fn xdg_data_home_overrides_home() {
+        let dir = crash_dir_with(
+            None,
+            Some("/var/lib/forge"),
+            Some(Path::new("/home/x")),
+            "sess-2",
+        )
+        .expect("ok");
+        assert_eq!(
+            dir,
+            PathBuf::from("/var/lib/forge/forge/crashes/sess-2"),
+            "XDG path must be `<XDG_DATA_HOME>/forge/crashes/<session-id>`"
+        );
+    }
+
+    #[test]
+    fn home_fallback_uses_local_share() {
+        let dir = crash_dir_with(None, None, Some(Path::new("/home/x")), "sess-3").expect("ok");
+        assert_eq!(
+            dir,
+            PathBuf::from("/home/x/.local/share/forge/crashes/sess-3")
+        );
+    }
+
+    #[test]
+    fn empty_overrides_treated_as_unset() {
+        // `std::env::var` returns Ok("") for `KEY=`, which must fall
+        // through to the next priority — otherwise an operator who
+        // accidentally exports `XDG_DATA_HOME=` would silently land
+        // crashes in `/forge/crashes/<sess>` (the literal joined
+        // path) instead of under `$HOME`.
+        let dir = crash_dir_with(Some(""), Some(""), Some(Path::new("/home/x")), "s").expect("ok");
+        assert_eq!(dir, PathBuf::from("/home/x/.local/share/forge/crashes/s"));
+    }
+
+    #[test]
+    fn missing_dir_returns_empty_vec() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("does-not-exist");
+        let got = collect_crashes_in_dir(&missing).expect("ok");
+        assert!(got.is_empty(), "missing dir must yield empty vec");
+    }
+
+    #[test]
+    fn collect_returns_sorted_dumps() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().to_path_buf();
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&dir)
+            .expect("mkdir");
+
+        let earlier = CrashDump {
+            instance_id: "inst-a".into(),
+            session_id: "sess-x".into(),
+            panic_message: "first".into(),
+            backtrace: None,
+            captured_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        };
+        let later = CrashDump {
+            instance_id: "inst-b".into(),
+            session_id: "sess-x".into(),
+            panic_message: "second".into(),
+            backtrace: Some("trace".into()),
+            captured_at: Utc.with_ymd_and_hms(2026, 1, 2, 0, 0, 0).unwrap(),
+        };
+        // Write files out of order to confirm the sort actually runs
+        // (not just file-system ordering).
+        std::fs::write(
+            dir.join("inst-b-200.json"),
+            serde_json::to_vec(&later).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("inst-a-100.json"),
+            serde_json::to_vec(&earlier).unwrap(),
+        )
+        .unwrap();
+        // Drop a non-json file to confirm the extension filter.
+        std::fs::write(dir.join("README.txt"), b"not a dump").unwrap();
+        // Drop an unparseable .json file to confirm the warn-and-skip
+        // path doesn't break enumeration.
+        std::fs::write(dir.join("garbage.json"), b"not json").unwrap();
+
+        let got = collect_crashes_in_dir(&dir).expect("collect");
+        assert_eq!(got.len(), 2, "got {got:?}");
+        assert_eq!(got[0].panic_message, "first");
+        assert_eq!(got[1].panic_message, "second");
+    }
+}

--- a/crates/forge-session/src/sidecar/mod.rs
+++ b/crates/forge-session/src/sidecar/mod.rs
@@ -22,6 +22,13 @@
 //! [`crate::bg_agents::BackgroundAgentRegistry`]; that integration lands
 //! in step 5 behind the `FORGE_AGENT_SIDECAR` flag.
 //!
+//! ## Sub-modules
+//!
+//! - [`crashes`] — daemon-side crash-dump reader. The sidecar binary
+//!   writes a `<XDG_DATA_HOME or ~/.local/share>/forge/crashes/<session-id>/<instance-id>-<unix-ts>.json`
+//!   from its panic hook (F-608 step 7); this submodule enumerates and
+//!   parses those dumps for the daemon-side observability path.
+//!
 //! # Layout
 //!
 //! ```text
@@ -43,6 +50,8 @@
 //!                │ forged-agent child  │  IpcEventSink → SidecarMessage::Event
 //!                └─────────────────────┘
 //! ```
+
+pub mod crashes;
 
 use std::collections::VecDeque;
 use std::io::ErrorKind;
@@ -215,6 +224,14 @@ struct ShutdownRequest {
 pub struct SidecarSupervisor {
     socket_dir: Arc<PathBuf>,
     forged_agent_path: Arc<PathBuf>,
+    /// F-608 step 7: session id forwarded to the child as
+    /// `--session-id`. The child's panic hook uses this to disambiguate
+    /// crash dumps under
+    /// `<XDG_DATA_HOME or ~/.local/share>/forge/crashes/<session-id>/`.
+    /// Default is `"default"` so step-5 callers that haven't been
+    /// updated yet still spawn — their crashes simply land under a
+    /// `default` bucket until the wiring catches up.
+    session_id: Arc<String>,
 }
 
 impl SidecarSupervisor {
@@ -231,7 +248,18 @@ impl SidecarSupervisor {
         Self {
             socket_dir: Arc::new(socket_dir),
             forged_agent_path: Arc::new(forged_agent_path),
+            session_id: Arc::new("default".to_string()),
         }
+    }
+
+    /// F-608 step 7: bind a session id forwarded to every spawned
+    /// child as `--session-id`. The child's panic hook uses it to
+    /// place crash dumps in the right per-session bucket so the
+    /// daemon-side reader (see [`crate::sidecar::crashes`]) can
+    /// enumerate them.
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Arc::new(session_id.into());
+        self
     }
 
     /// Path to the directory the supervisor binds sidecar sockets in.
@@ -292,6 +320,7 @@ impl SidecarSupervisor {
         let supervisor = SupervisorTask {
             socket_dir: self.socket_dir.clone(),
             forged_agent_path: self.forged_agent_path.clone(),
+            session_id: self.session_id.clone(),
             socket_path: socket_path.clone(),
             instance_id: instance_id.clone(),
             params,
@@ -353,6 +382,8 @@ impl SidecarSupervisor {
             .arg(socket_path)
             .arg("--instance-id")
             .arg(instance_id.to_string())
+            .arg("--session-id")
+            .arg(self.session_id.as_str())
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -482,6 +513,7 @@ impl SidecarSupervisor {
 struct SupervisorTask {
     socket_dir: Arc<PathBuf>,
     forged_agent_path: Arc<PathBuf>,
+    session_id: Arc<String>,
     socket_path: PathBuf,
     instance_id: AgentInstanceId,
     params: SpawnParams,
@@ -567,6 +599,7 @@ impl SupervisorTask {
                     let supervisor_view = SidecarSupervisor {
                         socket_dir: self.socket_dir.clone(),
                         forged_agent_path: self.forged_agent_path.clone(),
+                        session_id: self.session_id.clone(),
                     };
                     match supervisor_view
                         .launch_and_handshake(

--- a/crates/forge-session/tests/sidecar_crash_dump.rs
+++ b/crates/forge-session/tests/sidecar_crash_dump.rs
@@ -1,0 +1,270 @@
+//! F-608 step 7 acceptance test: panic-hook crash-dump writer.
+//!
+//! Drives the `forged-agent` binary into a panic via the
+//! `FORGE_TEST_PANIC_ON_RUNTURN` test knob, then asserts:
+//!   - the on-disk dump appears under the architected path
+//!     (`<crash dir>/<session-id>/<instance-id>-<unix-ts>.json`)
+//!   - the dump's `panic_message` matches the injected payload
+//!   - the daemon-side reader (`crashes::collect_crashes_in_dir`) can
+//!     parse it
+//!
+//! The test sets `FORGE_CRASH_DIR` to a tempdir on the supervisor
+//! side; the supervisor spawns the child with that env inherited so
+//! the writer in the sidecar honors the override too. We never
+//! pollute the user's real `~/.local/share/forge/crashes`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use forge_core::{AgentInstanceId, Event, EventSink};
+use forge_ipc::sidecar::{
+    SidecarAgentDef, SidecarHello, SidecarMessage, SidecarProviderSpec, SidecarRunTurn,
+    SidecarSandboxLevel, SIDECAR_PROTO_VERSION,
+};
+use forge_session::sidecar::{
+    crashes::{collect_crashes_in_dir, CrashDump},
+    SidecarSupervisor, SpawnParams,
+};
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+
+/// Resolve the freshly-built `forged-agent` binary, mirroring the
+/// pattern in `sidecar_supervisor.rs`. cargo doesn't set
+/// `CARGO_BIN_EXE_<name>` for binaries outside the package under test,
+/// so we walk up from the test exe to `target/<profile>/forged-agent`.
+fn forged_agent_path() -> PathBuf {
+    let exe = std::env::current_exe().expect("current_exe");
+    let dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("target/<profile> dir")
+        .to_path_buf();
+    let candidate = dir.join("forged-agent");
+    if !candidate.exists() {
+        let status = std::process::Command::new(env!("CARGO"))
+            .args(["build", "-p", "forge-agent-host", "--bin", "forged-agent"])
+            .status()
+            .expect("invoke cargo build for forge-agent-host");
+        assert!(
+            status.success(),
+            "cargo build -p forge-agent-host --bin forged-agent failed"
+        );
+    }
+    assert!(
+        candidate.exists(),
+        "forged-agent binary missing at {} after build attempt",
+        candidate.display()
+    );
+    candidate
+}
+
+#[derive(Debug, Default)]
+struct CapturingSink {
+    events: Mutex<Vec<Event>>,
+}
+
+impl CapturingSink {
+    fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+}
+
+#[async_trait]
+impl EventSink for CapturingSink {
+    async fn emit(&self, event: Event) -> Result<()> {
+        self.events.lock().await.push(event);
+        Ok(())
+    }
+}
+
+fn fixture_hello(instance_id: &AgentInstanceId) -> SidecarHello {
+    SidecarHello {
+        proto: SIDECAR_PROTO_VERSION,
+        instance_id: instance_id.clone(),
+        agent_def: SidecarAgentDef {
+            name: "test".into(),
+            description: None,
+            body: String::new(),
+            allowed_paths: vec![],
+            isolation: "process".into(),
+            memory_enabled: false,
+        },
+        allowed_paths: vec![],
+        workspace_path: "/tmp".into(),
+        provider_spec: SidecarProviderSpec {
+            kind: "stub".into(),
+            model: "stub".into(),
+            base_url: None,
+        },
+        sandbox_level: SidecarSandboxLevel::Level1,
+        telemetry_endpoint: None,
+    }
+}
+
+/// Acceptance: the sidecar's panic hook writes a dump to disk that
+/// the daemon-side reader can parse, with the injected panic message
+/// intact.
+///
+/// The test deliberately uses `FORGE_CRASH_DIR` to redirect the
+/// writer to a tempdir. The supervisor inherits its full env to the
+/// child, so the redirect propagates without any extra plumbing.
+///
+/// We use `#[tokio::test(flavor = "current_thread")]` so the env-var
+/// mutation below is serialized against any other test in this file
+/// that might also touch process-global env. Today there is only one
+/// test, but pinning the flavor leaves the door open.
+#[tokio::test]
+async fn panic_hook_writes_crash_dump_to_disk() {
+    // Tempdir for the on-disk dumps. Held across the whole test so
+    // we can read its contents post-mortem.
+    let crash_tmp = TempDir::new().expect("crash tempdir");
+    let socket_tmp = TempDir::new().expect("socket tempdir");
+
+    // Process-global env knobs. These must survive into the spawned
+    // `forged-agent` child. SAFETY: tokio::process::Command snapshots
+    // env at spawn time; setting before `spawn()` is sufficient.
+    //
+    // We rely on cargo's per-test process isolation only for the
+    // FORGE_TEST_PANIC_ON_RUNTURN signal — the dispatch test in
+    // `sidecar_supervisor.rs` would also panic if it inherited this
+    // var, so we unset on test exit via RAII.
+    struct EnvGuard(&'static [&'static str]);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for k in self.0 {
+                std::env::remove_var(k);
+            }
+        }
+    }
+    let panic_msg = "F-608 step 7 injected panic";
+    std::env::set_var("FORGE_CRASH_DIR", crash_tmp.path());
+    std::env::set_var("FORGE_TEST_PANIC_ON_RUNTURN", panic_msg);
+    // Also enable backtrace capture so the dump's `backtrace` field
+    // is populated — the assertion below is permissive (it must be
+    // present *or* explicitly None), but a real-user panic dump
+    // should carry a trace.
+    std::env::set_var("RUST_BACKTRACE", "1");
+    let _env = EnvGuard(&[
+        "FORGE_CRASH_DIR",
+        "FORGE_TEST_PANIC_ON_RUNTURN",
+        "RUST_BACKTRACE",
+    ]);
+
+    let session_id = "sess-step7-acceptance";
+    let supervisor = SidecarSupervisor::new(socket_tmp.path().to_path_buf(), forged_agent_path())
+        .with_session_id(session_id);
+
+    let id = AgentInstanceId::from_string("inst-crash".into());
+    let sink = CapturingSink::new();
+    let handle = supervisor
+        .spawn(
+            id.clone(),
+            SpawnParams {
+                hello: fixture_hello(&id),
+            },
+            sink.clone(),
+        )
+        .await
+        .expect("spawn");
+
+    // Drive the child into the panic by sending a RunTurn frame.
+    // The stub run-turn handler reads FORGE_TEST_PANIC_ON_RUNTURN and
+    // panics; the panic hook persists the dump before the process
+    // exits.
+    let turn = SidecarMessage::RunTurn(SidecarRunTurn {
+        turn_id: "turn-crash".into(),
+        msg_id: forge_core::MessageId::new(),
+        text: "anything".into(),
+        agents_md: String::new(),
+        branch_parent: None,
+        branch_variant_index: None,
+        byte_budget: 4096,
+    });
+    handle
+        .command_tx
+        .send(turn)
+        .await
+        .expect("queue RunTurn frame");
+
+    // Poll the per-session crash dir until a dump appears or the
+    // deadline elapses. The supervisor's restart loop will also try
+    // to re-fork (the panicking child counts as a crash); we don't
+    // care about that — we only care that *at least one* dump
+    // landed on disk before the supervisor wound everything up.
+    let session_dir = crash_tmp.path().join(session_id);
+    let mut dumps: Vec<CrashDump> = Vec::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    while std::time::Instant::now() < deadline {
+        if session_dir.exists() {
+            dumps = collect_crashes_in_dir(&session_dir).expect("collect");
+            if !dumps.is_empty() {
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Stop the supervisor (best effort — the supervisor may have
+    // already escalated past its retry budget). Drop is enough; we
+    // don't await shutdown because the supervisor may have already
+    // exited on retry exhaustion, in which case `shutdown()` returns
+    // an error we'd have to swallow anyway.
+    drop(handle);
+
+    assert!(
+        !dumps.is_empty(),
+        "expected at least one crash dump under {} after panicking RunTurn",
+        session_dir.display()
+    );
+
+    let dump = &dumps[0];
+    assert_eq!(
+        dump.session_id, session_id,
+        "dump must carry the spawning session id"
+    );
+    assert_eq!(
+        dump.instance_id,
+        id.to_string(),
+        "dump must carry the spawning instance id"
+    );
+    assert!(
+        dump.panic_message.contains(panic_msg),
+        "panic message must survive the hook → disk roundtrip; got {:?}",
+        dump.panic_message
+    );
+
+    // The dir we just enumerated must exist (the writer's
+    // create_dir_all path) and the per-session dir must be 0o700 per
+    // the architecture-doc contract.
+    let mode = std::fs::metadata(&session_dir)
+        .expect("metadata for session dir")
+        .permissions();
+    use std::os::unix::fs::PermissionsExt;
+    let bits = mode.mode() & 0o777;
+    assert_eq!(
+        bits,
+        0o700,
+        "session dir at {} must be 0o700 per F-608 step 7 contract; got 0o{:o}",
+        session_dir.display(),
+        bits
+    );
+
+    // Filename collision invariant: the writer uses
+    // `<instance-id>-<unix-ts>.json` and the per-spawn instance id is
+    // unique, so the dump file name must include the instance id.
+    let entries: Vec<String> = std::fs::read_dir(&session_dir)
+        .expect("read session dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        entries.iter().any(|n| n.starts_with(&id.to_string())),
+        "expected a dump filename starting with {} under {}; got {:?}",
+        id,
+        session_dir.display(),
+        entries
+    );
+}


### PR DESCRIPTION
## Summary

- New defensive crash path for the F-608 sidecar: on panic, `forged-agent` persists a `CrashDump` JSON to `<XDG_DATA_HOME or ~/.local/share>/forge/crashes/<session-id>/<instance-id>-<unix-ts>.json` in addition to the existing best-effort `Crashed` IPC frame. The on-disk path covers the case where the IPC pipe to the daemon failed before the panic.
- Daemon-side reader at `forge_session::sidecar::crashes` enumerates dumps for a session; the per-session subdir is created mode 0o700; filename collisions are impossible (instance id + unix timestamp).
- `SidecarSupervisor::with_session_id` plumbs the active session id through to the child as `--session-id`. New flag is optional with a `default` fallback so already-merged step-5 callers still spawn correctly.
- Acceptance test injects a panic via a `FORGE_TEST_PANIC_ON_RUNTURN` test knob and asserts the dump appears with the panic message intact.

## File layout

- `crates/forge-ipc/src/sidecar.rs` — new `CrashDump` shared schema (writer + reader).
- `crates/forge-session/src/sidecar.rs` → `sidecar/mod.rs`; new `sidecar/crashes.rs` houses the daemon-side reader.
- `crates/forge-agent-host/src/lib.rs` — panic-hook now writes the file synchronously via `std::fs` (no tokio runtime guaranteed inside a hook); coexists with the IPC frame queued for drain-on-shutdown.

## Test plan

- [x] `cargo test -p forge-ipc` — `CrashDump` round-trip + canonical-key pin
- [x] `cargo test -p forge-agent-host` — CLI flag parsing + lifecycle
- [x] `cargo test -p forge-session` — new `sidecar_crash_dump` test exercises the writer end-to-end; existing `sidecar_supervisor` tests remain green
- [x] `cargo build --workspace`
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)