### PR TITLE
[F-608 step 6] Plumb credential push from daemon to sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
  "dirs 6.0.0",
  "forge-core",
  "forge-ipc",
+ "secrecy",
  "serde_json",
  "tempfile",
  "tokio",

--- a/crates/forge-agent-host/Cargo.toml
+++ b/crates/forge-agent-host/Cargo.toml
@@ -42,6 +42,11 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 forge-core = { path = "../forge-core" }
 forge-ipc = { path = "../forge-ipc" }
+# F-608 step 6: sidecar-side credential stash. Inbound `Credentials`
+# frames are unwrapped from `SecretBytes` straight into `SecretString`
+# (zeroize-on-drop, redacted `Debug`) so the credential value never
+# exists in a cleartext-debug-printable form past the receive boundary.
+secrecy = "0.10"
 serde_json = "1"
 tokio = { version = "1", features = ["net", "io-util", "rt-multi-thread", "macros", "sync", "time", "signal"] }
 tracing = "0.1"
@@ -56,3 +61,11 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time",
 [[test]]
 name = "forged_agent_lifecycle"
 path = "tests/forged_agent_lifecycle.rs"
+
+# F-608 step 6: receive `Credentials`, stash in `SecretString`, no log
+# leakage at any tracing level. Drives a real `forged-agent` child
+# under `FORGE_LOG=trace` and audits captured stderr for the test
+# secret.
+[[test]]
+name = "forged_agent_credentials"
+path = "tests/forged_agent_credentials.rs"

--- a/crates/forge-agent-host/src/lib.rs
+++ b/crates/forge-agent-host/src/lib.rs
@@ -36,6 +36,7 @@
 //! 4+ swaps the stub body for a call into the refactored
 //! orchestrator, passing the same sink as `&dyn EventSink`.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -46,9 +47,10 @@ use async_trait::async_trait;
 use chrono::Utc;
 use forge_core::{Event, EventSink, MessageId, ProviderId};
 use forge_ipc::sidecar::{
-    CrashDump, SidecarAgentDef, SidecarCrashed, SidecarEvent, SidecarHeartbeat, SidecarHelloAck,
-    SidecarMessage, SidecarProviderSpec, SidecarRunTurn, SIDECAR_SCHEMA_VERSION,
+    CrashDump, SidecarAgentDef, SidecarCrashed, SidecarCredentials, SidecarEvent, SidecarHeartbeat,
+    SidecarHelloAck, SidecarMessage, SidecarProviderSpec, SidecarRunTurn, SIDECAR_SCHEMA_VERSION,
 };
+use secrecy::SecretString;
 use tokio::io::{ReadHalf, WriteHalf};
 use tokio::net::UnixStream;
 use tokio::sync::Mutex as AsyncMutex;
@@ -383,6 +385,91 @@ impl DaemonHelloState {
     }
 }
 
+/// F-608 step 6: per-sidecar credential stash.
+///
+/// `Credentials` frames inbound from the daemon land here, keyed by
+/// `provider_id`. The bytes are wrapped in [`SecretString`] (zeroize-on-
+/// drop, redacted `Debug`) the moment the dispatch loop hands them in,
+/// so the only cleartext copy of the credential past the receive
+/// boundary lives inside the secrecy crate's RAII guard. The (still-
+/// stub) RunTurn handler — and step 6+'s real provider body — pulls the
+/// value out via [`Self::take`] / [`Self::get`] only at the network
+/// boundary, never logging the result.
+///
+/// Phase-1 Ollama is keyless, so the stash is observed but unused; the
+/// slot is here so Anthropic/OpenAI providers can hook in without a
+/// further protocol revision when they ship.
+#[derive(Clone, Default)]
+pub struct CredentialStash {
+    inner: Arc<Mutex<HashMap<String, SecretString>>>,
+}
+
+impl std::fmt::Debug for CredentialStash {
+    /// Custom `Debug` so a stray `tracing::debug!("{:?}", stash)` cannot
+    /// even hint at provider IDs that have credentials cached. The byte
+    /// count is fine — credential identifiers are non-secret — but the
+    /// SecretString Debug already redacts, so this is belt-and-braces.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.inner.lock().map(|g| g.len()).unwrap_or(0);
+        f.debug_struct("CredentialStash")
+            .field("entries", &len)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CredentialStash {
+    /// Replace any existing entry for `provider_id` with `secret`. The
+    /// daemon side resolves a single active provider per session today,
+    /// but the storage shape allows a future multi-provider workflow to
+    /// stage credentials for several providers without reconnecting.
+    pub fn put(&self, provider_id: String, secret: SecretString) {
+        match self.inner.lock() {
+            Ok(mut guard) => {
+                guard.insert(provider_id, secret);
+            }
+            Err(_) => {
+                // Poisoned mutex — an earlier panic with the lock held
+                // already routed through the panic hook's crash dump.
+                // Don't overwrite; the supervisor will recycle this
+                // sidecar shortly via the EOF-on-exit detection.
+            }
+        }
+    }
+
+    /// Snapshot the credential for `provider_id`, or `None` when no
+    /// frame has yet been pushed for it. Returns a clone of the
+    /// `SecretString` (cheap — `secrecy::SecretBox` is `Arc`-shaped)
+    /// so the caller can hand the value to a provider auth shape
+    /// without touching the stash again.
+    pub fn get(&self, provider_id: &str) -> Option<SecretString> {
+        self.inner
+            .lock()
+            .ok()
+            .and_then(|g| g.get(provider_id).cloned())
+    }
+
+    /// Remove and return the credential for `provider_id`. Use this on
+    /// a one-shot auth path so the stash drops the secret as soon as
+    /// the provider has consumed it.
+    pub fn take(&self, provider_id: &str) -> Option<SecretString> {
+        self.inner
+            .lock()
+            .ok()
+            .and_then(|mut g| g.remove(provider_id))
+    }
+
+    /// Number of currently-staged credentials. Diagnostic-only — never
+    /// reveals identifiers or values.
+    pub fn len(&self) -> usize {
+        self.inner.lock().map(|g| g.len()).unwrap_or(0)
+    }
+
+    /// Predicate mirror of [`Self::len`].
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
 /// Per-instance event sequence number. Threaded through the heartbeat
 /// task and the run-turn handler so every outbound `Event` frame is
 /// totally ordered. Starts at 1 (0 is reserved as a "never emitted"
@@ -557,6 +644,46 @@ enum LoopExit {
     PeerClosed,
 }
 
+/// F-608 step 6: stash an inbound `Credentials` frame.
+///
+/// The bytes are unwrapped from [`forge_ipc::sidecar::SecretBytes`] —
+/// itself redacted at `Debug` / `Display` — and re-wrapped into a
+/// `SecretString` via `String::from_utf8`. Credential values are ASCII
+/// API keys today; a future binary-secret provider would swap this for
+/// `SecretBox<Vec<u8>>`. On UTF-8 failure the frame is rejected with a
+/// non-leaking warning rather than panicked through — a malformed
+/// credential should not take the sidecar down on a confused peer.
+///
+/// The trace emission is deliberately bare: `provider_id` only, never
+/// the byte count of the credential and never the value. The byte
+/// count would let a side-channel observer correlate "small key"
+/// vs. "long bearer token"; the security audit policy in the
+/// architecture doc §5 forbids it.
+fn stash_credential(stash: &CredentialStash, instance_id: &str, cred: SidecarCredentials) {
+    let provider_id = cred.provider_id.to_string();
+    let bytes = cred.secret.into_bytes();
+    let as_string = match String::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => {
+            warn!(
+                target: "forge_agent_host::credentials",
+                instance_id = %instance_id,
+                provider_id = %provider_id,
+                "rejecting non-utf8 credential payload",
+            );
+            return;
+        }
+    };
+    let secret = SecretString::from(as_string);
+    stash.put(provider_id.clone(), secret);
+    tracing::trace!(
+        target: "forge_agent_host::credentials",
+        instance_id = %instance_id,
+        provider_id = %provider_id,
+        "stashed credential",
+    );
+}
+
 /// Read loop: dispatch incoming daemon → sidecar messages until a
 /// `Shutdown` frame or EOF. Uses a hoisted buffer so the streaming-token
 /// path stays allocation-free per frame (mirrors `forge-ipc`'s
@@ -567,6 +694,8 @@ async fn dispatch_loop(
     seq: EventSeq,
     pending_turns: Arc<AtomicU64>,
     daemon_hello: DaemonHelloState,
+    credentials: CredentialStash,
+    instance_id: &str,
 ) -> Result<LoopExit> {
     // F-608 step 3: build the sink once and reuse across turns. Cheap
     // to clone (two `Arc`s); cloning per RunTurn would be equally
@@ -596,15 +725,24 @@ async fn dispatch_loop(
                     error!(error = %e, "run_turn stub failed");
                 }
             }
+            SidecarMessage::Credentials(cred) => {
+                // F-608 step 6: stash the credential keyed by
+                // `provider_id`. Phase-1 OllamaProvider is keyless so
+                // the (still-stub) RunTurn handler ignores the stash;
+                // the slot is here so Anthropic / OpenAI auth shapes
+                // can hook in without a further protocol revision.
+                // `stash_credential` redacts on every log emission —
+                // see its module-doc.
+                stash_credential(&credentials, instance_id, cred);
+            }
             SidecarMessage::ToolCallApproved(_)
             | SidecarMessage::ToolCallRejected(_)
-            | SidecarMessage::Credentials(_)
             | SidecarMessage::CompactTranscript(_) => {
                 // Steps 4+ wire these to the refactored orchestrator
-                // (approval queue, credential push, compaction
-                // proxy). Step 3 only swaps the run_turn emission
-                // path onto the EventSink trait — these stay no-ops
-                // until the orchestrator body lands here.
+                // (approval queue, compaction proxy). Step 3 only
+                // swaps the run_turn emission path onto the EventSink
+                // trait — these stay no-ops until the orchestrator
+                // body lands here.
                 debug!("ignoring non-RunTurn daemon message in stub handler");
             }
             SidecarMessage::Shutdown(s) => {
@@ -713,6 +851,7 @@ pub async fn run(args: AgentArgs) -> Result<()> {
     let pending_turns = Arc::new(AtomicU64::new(0));
     let seq = EventSeq::default();
     let daemon_hello = DaemonHelloState::default();
+    let credentials = CredentialStash::default();
     let hb_handle = spawn_heartbeat(writer.clone(), pending_turns.clone());
 
     // Main dispatch loop.
@@ -722,6 +861,8 @@ pub async fn run(args: AgentArgs) -> Result<()> {
         seq,
         pending_turns,
         daemon_hello,
+        credentials,
+        &args.instance_id,
     )
     .await?;
 

--- a/crates/forge-agent-host/tests/forged_agent_credentials.rs
+++ b/crates/forge-agent-host/tests/forged_agent_credentials.rs
@@ -1,0 +1,149 @@
+//! F-608 step 6 sidecar-side: receive `Credentials` frame, stash, no
+//! log leakage.
+//!
+//! The integration test in [`forged_agent_lifecycle.rs`] already proves
+//! handshake / heartbeat / stub-RunTurn / shutdown end-to-end. This file
+//! adds a second pass that:
+//!
+//! 1. drives a real `forged-agent` child through handshake,
+//! 2. pushes a [`SidecarMessage::Credentials`] frame onto the daemon →
+//!    sidecar leg with a known test secret,
+//! 3. shuts the child down cleanly,
+//! 4. captures the child's stderr (a JSON-lines `tracing` stream when
+//!    `FORGE_LOG=trace`) and asserts the secret value never appears at
+//!    any log level — even with the trace-grade filter the architecture
+//!    doc §10 specifies.
+//!
+//! Captured stderr stays in the test output on failure so triage
+//! doesn't have to reproduce locally.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use forge_core::ProviderId;
+use forge_ipc::sidecar::{
+    SecretBytes, SidecarCredentials, SidecarHelloAck, SidecarMessage, SidecarShutdown,
+    SIDECAR_SCHEMA_VERSION,
+};
+use tempfile::TempDir;
+use tokio::io::AsyncReadExt;
+use tokio::net::{UnixListener, UnixStream};
+
+const TEST_SECRET_VALUE: &str = "sk-ant-step6-sidecar-leakcanary-XYZZY";
+
+fn forged_agent_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_forged-agent"))
+}
+
+async fn read_one(s: &mut UnixStream) -> SidecarMessage {
+    forge_ipc::read_frame_with_deadline::<_, SidecarMessage>(s, Duration::from_secs(10))
+        .await
+        .expect("read frame")
+}
+
+#[tokio::test]
+async fn credentials_frame_stashed_without_log_leakage() {
+    let tmp = TempDir::new().expect("tmp");
+    let socket = tmp.path().join("agent.sock");
+    let listener = UnixListener::bind(&socket).expect("bind uds");
+
+    // Crank the sidecar's tracing layer to `trace` so the credential
+    // stash emission hits stderr — that's the path we want to audit.
+    let mut child = tokio::process::Command::new(forged_agent_path())
+        .arg("--socket")
+        .arg(&socket)
+        .arg("--instance-id")
+        .arg("inst-cred-test")
+        .env("FORGE_LOG", "trace")
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn forged-agent");
+
+    let stderr = child.stderr.take().expect("captured stderr");
+
+    let (mut conn, _) = tokio::time::timeout(Duration::from_secs(10), listener.accept())
+        .await
+        .expect("accept timeout")
+        .expect("accept failed");
+
+    // Hello → HelloAck handshake. The sidecar bails on a missing ack
+    // so we have to drive both sides.
+    let hello = read_one(&mut conn).await;
+    match hello {
+        SidecarMessage::Hello(h) => {
+            assert_eq!(h.instance_id.to_string(), "inst-cred-test");
+        }
+        other => panic!("expected Hello, got {other:?}"),
+    }
+    let ack = SidecarMessage::HelloAck(SidecarHelloAck {
+        pid: std::process::id(),
+        started_at: chrono::Utc::now(),
+        schema_version: SIDECAR_SCHEMA_VERSION,
+    });
+    forge_ipc::write_frame(&mut conn, &ack)
+        .await
+        .expect("write ack");
+
+    // Push the credential frame the daemon side would emit before
+    // `RunTurn`. Phase-1 OllamaProvider is keyless so the sidecar's
+    // run loop never reads the stash; this test is purely about the
+    // receive + stash + no-leak guarantee.
+    let cred = SidecarMessage::Credentials(SidecarCredentials {
+        provider_id: ProviderId::from_string("anthropic".into()),
+        secret: SecretBytes::new(TEST_SECRET_VALUE.as_bytes().to_vec()),
+    });
+    forge_ipc::write_frame(&mut conn, &cred)
+        .await
+        .expect("write Credentials");
+
+    // Give the sidecar a beat to dispatch the frame and emit any
+    // tracing line it would produce. 250 ms is comfortably more than
+    // the dispatch loop's per-frame cost (single-digit microseconds on
+    // tokio UDS).
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    // Cooperative shutdown — drains and exits clean.
+    let shutdown = SidecarMessage::Shutdown(SidecarShutdown { grace_ms: 1000 });
+    forge_ipc::write_frame(&mut conn, &shutdown)
+        .await
+        .expect("write shutdown");
+
+    let status = tokio::time::timeout(Duration::from_secs(15), child.wait())
+        .await
+        .expect("child did not exit within 15s of Shutdown")
+        .expect("wait failed");
+    assert!(
+        status.success(),
+        "forged-agent exited with non-zero status: {status:?}"
+    );
+
+    // Drain the captured stderr to a single buffer and audit it.
+    let mut stderr_buf = Vec::new();
+    let mut reader = tokio::io::BufReader::new(stderr);
+    let _ = tokio::time::timeout(Duration::from_secs(5), reader.read_to_end(&mut stderr_buf))
+        .await
+        .expect("read stderr");
+    let stderr_text = String::from_utf8_lossy(&stderr_buf);
+
+    // The hardline assertion — the secret value must not appear in
+    // any captured log line, at any level. Print the captured text
+    // on failure so triage has the smoking gun.
+    assert!(
+        !stderr_text.contains(TEST_SECRET_VALUE),
+        "credential value leaked into sidecar stderr:\n{stderr_text}"
+    );
+
+    // Belt-and-braces: the architecture-doc-mandated trace line MUST
+    // appear, since its presence proves the stash code path actually
+    // ran (the negative assertion above can't be vacuously satisfied
+    // by a no-op match arm).
+    assert!(
+        stderr_text.contains("stashed credential"),
+        "expected 'stashed credential' trace emission to appear; \
+         absence implies the stash arm didn't run:\n{stderr_text}"
+    );
+    assert!(
+        stderr_text.contains("anthropic"),
+        "non-secret provider_id should appear in trace output:\n{stderr_text}"
+    );
+}

--- a/crates/forge-ipc/src/sidecar.rs
+++ b/crates/forge-ipc/src/sidecar.rs
@@ -16,6 +16,77 @@ use chrono::{DateTime, Utc};
 use forge_core::{AgentInstanceId, Event, MessageId, ProviderId};
 use serde::{Deserialize, Serialize};
 
+/// Opaque byte container for [`SidecarCredentials::secret`].
+///
+/// F-608 step 6 swaps the step-1 placeholder `secret_handle: String` for
+/// real credential bytes pushed daemon → sidecar. The wire shape is just
+/// a JSON byte array (serde transparent), but `Debug` and `Display` are
+/// overridden to redact the contents — so a stray `tracing::debug!("{:?}",
+/// frame)` anywhere in the supervisor / sidecar stack cannot leak the
+/// secret bytes into logs. The sidecar wraps the inner `Vec<u8>` into a
+/// `secrecy::SecretString` immediately on receive, so the only place the
+/// raw bytes ever appear in cleartext is on the wire and inside the
+/// receive-side conversion — both narrow, audited paths.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SecretBytes(Vec<u8>);
+
+impl SecretBytes {
+    /// Construct from a raw byte buffer. Callers should typically have a
+    /// `SecretString` in hand and call `from_secret` instead — this
+    /// constructor exists for the deserialize / round-trip / test paths.
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Length of the inner buffer. Non-secret — only the byte count is
+    /// exposed, never the payload itself.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Predicate mirror of [`Self::len`].
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Consume the wrapper and return the inner bytes.
+    ///
+    /// The receive side uses this to hand the bytes straight into a
+    /// `secrecy::SecretString` (which zeroes-on-drop) without any
+    /// intermediate clone. The original `SecretBytes` is dropped by the
+    /// move; no intermediate `String` ever exists at trace level.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    /// Borrow the inner bytes. Reserved for narrow audited call sites
+    /// (e.g. immediate conversion into `SecretString` on receive). Do
+    /// not pass the slice to anything that may log or stringify it.
+    pub fn expose_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SecretBytes {
+    /// Redact the payload. The byte count is included so log lines remain
+    /// useful for triage (e.g. confirming a non-empty credential was
+    /// pushed) without leaking the value.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SecretBytes([REDACTED {} bytes])", self.0.len())
+    }
+}
+
+impl std::fmt::Display for SecretBytes {
+    /// `Display` mirrors `Debug` so a `format!("{}", bytes)` cannot leak
+    /// the credential. There is no legitimate caller for stringifying
+    /// secret bytes — every consumer should be unwrapping into a
+    /// `SecretString` and exposing only at the network boundary.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[REDACTED {} bytes]", self.0.len())
+    }
+}
+
 /// Wire protocol version negotiated in [`SidecarMessage::Hello`].
 ///
 /// Bumped when the discriminator set or any payload field changes shape.
@@ -31,7 +102,13 @@ pub const SIDECAR_PROTO_VERSION: u32 = 1;
 /// serialization changes (renames, type widening, etc.). The supervisor
 /// logs the value but does not gate startup on it today; that becomes a
 /// hard check once we ship a non-`1` schema.
-pub const SIDECAR_SCHEMA_VERSION: u32 = 1;
+///
+/// History:
+/// * `1` — initial F-608 step 1 protocol.
+/// * `2` — F-608 step 6: `Credentials.secret_handle: String` →
+///   `Credentials.secret: SecretBytes` (`Vec<u8>` opaque, redacted
+///   `Debug`/`Display`).
+pub const SIDECAR_SCHEMA_VERSION: u32 = 2;
 
 /// Bidirectional message exchanged between `forged` and `forged-agent`.
 ///
@@ -54,9 +131,11 @@ pub enum SidecarMessage {
     RunTurn(SidecarRunTurn),
 
     /// Push a per-provider credential to the sidecar (§5: daemon owns
-    /// the keyring; sidecar receives just-in-time). `secret_handle` is
-    /// an opaque string for step 1 — real `secrecy::SecretString`
-    /// plumbing lands with step 6.
+    /// the keyring; sidecar receives just-in-time). The bytes ride
+    /// inside [`SecretBytes`], whose `Debug` / `Display` impls redact —
+    /// so a stray `format!("{:?}", frame)` anywhere in the supervisor
+    /// or sidecar code path cannot leak the credential. The receive
+    /// side immediately wraps into `secrecy::SecretString`.
     Credentials(SidecarCredentials),
 
     /// Approve a pending tool call. Mirrors [`crate::ToolCallApproved`]
@@ -180,13 +259,16 @@ pub struct SidecarRunTurn {
     pub byte_budget: u64,
 }
 
-/// Push a credential for `provider_id`. Step 1 stores it as an opaque
-/// string handle; step 6 swaps in `Vec<u8>` + `secrecy::SecretString`
-/// and adds the zeroize-on-drop discipline.
+/// Push a credential for `provider_id`. F-608 step 6: the secret rides
+/// inside a [`SecretBytes`] wrapper whose `Debug` / `Display` redact, so
+/// nothing in the daemon / supervisor / sidecar stack can leak the value
+/// through a tracing emission. The sidecar wraps the inner bytes into
+/// `secrecy::SecretString` (zeroize-on-drop) the moment the frame is
+/// dispatched.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SidecarCredentials {
     pub provider_id: ProviderId,
-    pub secret_handle: String,
+    pub secret: SecretBytes,
 }
 
 /// Approve a pending tool call (mirrors [`crate::ToolCallApproved`]).
@@ -358,7 +440,7 @@ mod tests {
             }),
             SidecarMessage::Credentials(SidecarCredentials {
                 provider_id: ProviderId::from_string("prov-1".into()),
-                secret_handle: "handle-abc".into(),
+                secret: SecretBytes::new(b"handle-abc".to_vec()),
             }),
             SidecarMessage::ToolCallApproved(SidecarToolCallApproved {
                 id: "tool-1".into(),
@@ -439,6 +521,72 @@ mod tests {
             "captured_at",
         ] {
             assert!(value.get(key).is_some(), "missing key {key}: {value}");
+        }
+    }
+
+    /// F-608 step 6: `SecretBytes::Debug` must redact the payload so a
+    /// stray `tracing::debug!("{:?}", frame)` can never leak credential
+    /// bytes — even if the surrounding `SidecarCredentials` derives
+    /// `Debug`. Pinned here because the redaction guarantee is the
+    /// security contract the architecture doc §5 calls out by name.
+    #[test]
+    fn secret_bytes_debug_redacts_payload() {
+        let secret = SecretBytes::new(b"sk-ant-leaked-key".to_vec());
+        let dbg = format!("{secret:?}");
+        let display = format!("{secret}");
+        assert!(
+            !dbg.contains("sk-ant-leaked-key"),
+            "Debug must not leak secret bytes: {dbg}"
+        );
+        assert!(
+            !display.contains("sk-ant-leaked-key"),
+            "Display must not leak secret bytes: {display}"
+        );
+        assert!(dbg.contains("REDACTED"), "Debug should mark redaction");
+        // The payload's byte count is non-secret — handy for triage.
+        assert!(dbg.contains("17"), "Debug should report byte count");
+    }
+
+    /// F-608 step 6: even the variant's derived `Debug` must not leak
+    /// the credential — `SidecarCredentials` derives `Debug`, but the
+    /// inner `secret: SecretBytes` field overrides its own `Debug` to
+    /// redact. This test pins both layers.
+    #[test]
+    fn sidecar_credentials_debug_redacts_payload() {
+        let frame = SidecarMessage::Credentials(SidecarCredentials {
+            provider_id: ProviderId::from_string("anthropic".into()),
+            secret: SecretBytes::new(b"sk-ant-leaked-key".to_vec()),
+        });
+        let dbg = format!("{frame:?}");
+        assert!(
+            !dbg.contains("sk-ant-leaked-key"),
+            "outer Debug must not leak the secret bytes: {dbg}"
+        );
+        assert!(
+            dbg.contains("anthropic"),
+            "non-secret provider_id should remain visible: {dbg}"
+        );
+    }
+
+    /// F-608 step 6: the wire format *does* carry the secret bytes
+    /// (that's the frame's job) — only `Debug` / `Display` redact. Pin
+    /// the round-trip so the receive side recovers the exact bytes the
+    /// daemon pushed.
+    #[test]
+    fn sidecar_credentials_round_trip_preserves_bytes() {
+        let original = SidecarCredentials {
+            provider_id: ProviderId::from_string("anthropic".into()),
+            secret: SecretBytes::new(b"sk-ant-secret".to_vec()),
+        };
+        let frame = SidecarMessage::Credentials(original);
+        let bytes = serde_json::to_vec(&frame).unwrap();
+        let recovered: SidecarMessage = serde_json::from_slice(&bytes).unwrap();
+        match recovered {
+            SidecarMessage::Credentials(c) => {
+                assert_eq!(c.provider_id.to_string(), "anthropic");
+                assert_eq!(c.secret.expose_bytes(), b"sk-ant-secret");
+            }
+            other => panic!("expected Credentials, got {other:?}"),
         }
     }
 

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -172,6 +172,13 @@ path = "tests/eprintln_audit.rs"
 name = "credentials_pull"
 path = "tests/credentials_pull.rs"
 
+# F-608 step 6: orchestrator-side sidecar credential push contract +
+# log-leak audit. Asserts the credential value never appears in
+# captured tracing output at any level.
+[[test]]
+name = "credentials_sidecar_push"
+path = "tests/credentials_sidecar_push.rs"
+
 [[test]]
 name = "provider_swap"
 path = "tests/provider_swap.rs"

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -7,13 +7,15 @@ use chrono::Utc;
 use forge_core::{
     apply_superseded,
     credentials::Credentials,
-    ids::{MessageId, ProviderId, StepId, ToolCallId},
+    ids::{AgentInstanceId, MessageId, ProviderId, StepId, ToolCallId},
     read_since, ApprovalScope, ApprovalSource, Event, EventSink, RerunVariant, StepKind,
     StepOutcome,
 };
+use forge_ipc::sidecar::{SecretBytes, SidecarCredentials, SidecarMessage};
 use forge_providers::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider};
 use futures::StreamExt;
-use tokio::sync::{oneshot, Mutex};
+use secrecy::ExposeSecret;
+use tokio::sync::{mpsc, oneshot, Mutex};
 
 /// F-587: per-turn credential pull binding.
 ///
@@ -39,6 +41,44 @@ use tokio::sync::{oneshot, Mutex};
 pub struct CredentialContext {
     pub store: Arc<dyn Credentials>,
     pub provider_id: String,
+    /// F-608 step 6: optional daemon → sidecar credential push hook.
+    ///
+    /// When set, the orchestrator's per-turn pull frames the just-
+    /// pulled credential as a [`SidecarMessage::Credentials`] and
+    /// sends it on the supplied [`mpsc::Sender`] **before** the request
+    /// loop opens. The hook is wired by the supervisor / bg-agent glue
+    /// when `FORGE_AGENT_SIDECAR=1` is active; in-process callers
+    /// (today's default) leave it `None` and the function never frames
+    /// the secret onto a wire.
+    ///
+    /// Push errors are non-fatal: a closed channel means the supervisor
+    /// has wound the sidecar down, in which case the upcoming
+    /// `RunTurn` would also be discarded — we log at warn and continue
+    /// rather than fail the turn pre-emptively.
+    pub sidecar_push: Option<SidecarCredentialPush>,
+}
+
+/// F-608 step 6: handle for pushing a credential frame onto a per-
+/// instance sidecar.
+///
+/// Holds an `instance_id` (for the "pushed credential" trace emission)
+/// and the supervisor's outbound command channel. Cheap to clone; the
+/// channel is bounded, so a backpressured sidecar surfaces as `Err` from
+/// `try_send` in the push path rather than blocking the orchestrator.
+#[derive(Clone)]
+pub struct SidecarCredentialPush {
+    pub instance_id: AgentInstanceId,
+    pub command_tx: mpsc::Sender<SidecarMessage>,
+}
+
+impl std::fmt::Debug for SidecarCredentialPush {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Channel handle is uninteresting; the instance_id is the
+        // useful diagnostic field.
+        f.debug_struct("SidecarCredentialPush")
+            .field("instance_id", &self.instance_id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl std::fmt::Debug for CredentialContext {
@@ -48,6 +88,7 @@ impl std::fmt::Debug for CredentialContext {
         // by contract.
         f.debug_struct("CredentialContext")
             .field("provider_id", &self.provider_id)
+            .field("sidecar_push", &self.sidecar_push)
             .finish_non_exhaustive()
     }
 }
@@ -75,6 +116,52 @@ async fn pull_active_credential(ctx: &Option<CredentialContext>) -> Result<()> {
             hit = pulled.is_some(),
             "credential pull",
         );
+
+        // F-608 step 6: when a sidecar push hook is wired AND the
+        // credential pull hit, frame the value as a `Credentials` IPC
+        // message and forward it to the per-instance sidecar before the
+        // orchestrator's caller emits `RunTurn`. The provider's
+        // per-request auth shape on the sidecar side then has the value
+        // staged. We deliberately do NOT push on the miss path —
+        // staging an empty credential would teach the sidecar a bogus
+        // "I have a key" signal for a provider that's actually keyless.
+        //
+        // Security: `expose_secret()` is the only call site that
+        // touches the cleartext bytes; the result is moved straight
+        // into `SecretBytes` (whose `Debug`/`Display` redact) and never
+        // bound to a `&str` we could accidentally log. The trace
+        // emission below carries `provider_id` + `instance_id` only —
+        // never the byte count, never the value.
+        if let (Some(secret), Some(push)) = (pulled.as_ref(), ctx.sidecar_push.as_ref()) {
+            let frame = SidecarMessage::Credentials(SidecarCredentials {
+                provider_id: ProviderId::from_string(ctx.provider_id.clone()),
+                secret: SecretBytes::new(secret.expose_secret().as_bytes().to_vec()),
+            });
+            match push.command_tx.send(frame).await {
+                Ok(()) => {
+                    tracing::trace!(
+                        target: "forge_session::orchestrator::credentials",
+                        provider_id = %ctx.provider_id,
+                        instance_id = %push.instance_id,
+                        "pushed credential",
+                    );
+                }
+                Err(_) => {
+                    // Closed channel = supervisor has wound the sidecar
+                    // down. The pending `RunTurn` will land on the same
+                    // closed channel; surface here as a warn rather than
+                    // failing the turn pre-emptively so the caller's own
+                    // error path (if any) drives the lifecycle.
+                    tracing::warn!(
+                        target: "forge_session::orchestrator::credentials",
+                        provider_id = %ctx.provider_id,
+                        instance_id = %push.instance_id,
+                        "sidecar credential push: channel closed",
+                    );
+                }
+            }
+        }
+
         drop(pulled);
     }
     Ok(())

--- a/crates/forge-session/tests/credentials_pull.rs
+++ b/crates/forge-session/tests/credentials_pull.rs
@@ -119,6 +119,7 @@ async fn run_turn_pulls_credential_when_context_supplied() {
         Some(CredentialContext {
             store: cred_store,
             provider_id: "anthropic".to_string(),
+            sidecar_push: None,
         }),
     )
     .await
@@ -170,6 +171,7 @@ async fn run_turn_proceeds_when_credential_is_missing() {
         Some(CredentialContext {
             store: cred_store,
             provider_id: "anthropic".to_string(),
+            sidecar_push: None,
         }),
     )
     .await
@@ -209,6 +211,7 @@ async fn run_turn_fails_when_credential_backend_errors() {
         Some(CredentialContext {
             store,
             provider_id: "anthropic".to_string(),
+            sidecar_push: None,
         }),
     )
     .await
@@ -338,6 +341,7 @@ async fn rerun_replace_pulls_credential_when_context_supplied() {
             Some(CredentialContext {
                 store: cred_store,
                 provider_id: "anthropic".to_string(),
+                sidecar_push: None,
             }),
         )
         .await
@@ -384,6 +388,7 @@ async fn rerun_replace_fails_when_credential_backend_errors() {
             Some(CredentialContext {
                 store,
                 provider_id: "anthropic".to_string(),
+                sidecar_push: None,
             }),
         )
         .await
@@ -427,6 +432,7 @@ async fn rerun_branch_pulls_credential_when_context_supplied() {
             Some(CredentialContext {
                 store: cred_store,
                 provider_id: "anthropic".to_string(),
+                sidecar_push: None,
             }),
         )
         .await
@@ -471,6 +477,7 @@ async fn rerun_fresh_pulls_credential_when_context_supplied() {
             Some(CredentialContext {
                 store: cred_store,
                 provider_id: "anthropic".to_string(),
+                sidecar_push: None,
             }),
         )
         .await

--- a/crates/forge-session/tests/credentials_sidecar_push.rs
+++ b/crates/forge-session/tests/credentials_sidecar_push.rs
@@ -1,0 +1,397 @@
+//! F-608 step 6: orchestrator-side sidecar credential push.
+//!
+//! Pins three guarantees the architecture doc §5 calls out by name:
+//!
+//! 1. When `CredentialContext.sidecar_push` is `Some` AND the credential
+//!    pull hits, `run_turn` frames the value as a
+//!    [`SidecarMessage::Credentials`] and sends it on the supplied
+//!    channel **before** the orchestrator's caller would emit `RunTurn`.
+//! 2. When `sidecar_push` is `None` (in-process / `FORGE_AGENT_SIDECAR=0`
+//!    path), no frame is sent. Behavior is byte-for-byte identical to
+//!    the pre-step-6 keyless path.
+//! 3. The credential value never appears in any captured log line at any
+//!    level — even when the test injects a `tracing::trace`-grade
+//!    subscriber. The architecture doc explicitly forbids leaking the
+//!    secret bytes through the supervisor's tracing layer.
+//!
+//! Together these pin the seam Phase-3 `AnthropicProvider` /
+//! `OpenAIProvider` will plug into.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::Utc;
+use forge_core::{
+    ids::{AgentInstanceId, MessageId, ProviderId},
+    Credentials, Event, MemoryStore, RerunVariant,
+};
+use forge_ipc::sidecar::SidecarMessage;
+use forge_providers::MockProvider;
+use forge_session::orchestrator::{
+    run_turn, CredentialContext, Orchestrator, PendingApprovals, SidecarCredentialPush,
+};
+use forge_session::session::Session;
+use secrecy::SecretString;
+use tempfile::TempDir;
+use tokio::sync::{mpsc, Mutex as AsyncMutex};
+
+mod common;
+
+/// Test secret value — pinned here so the log-redaction assertion can
+/// scan captured output for it. Pick something distinctive enough that a
+/// false positive on an unrelated string is implausible.
+const TEST_SECRET_VALUE: &str = "sk-ant-step6-leakcanary-XYZZY";
+
+/// Construct a session, mock provider, and the boilerplate scaffolding
+/// `run_turn` needs. Centralized so each test stays focused on the seam.
+async fn fixtures() -> (Arc<Session>, Arc<MockProvider>, PendingApprovals, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(
+        MockProvider::from_responses(vec!["{\"done\":\"end_turn\"}\n".into()])
+            .expect("construct mock"),
+    );
+    let pending: PendingApprovals = Arc::new(AsyncMutex::new(HashMap::new()));
+    (session, provider, pending, dir)
+}
+
+/// Acceptance: `run_turn` pushes a `Credentials` frame on the supplied
+/// channel before opening the request loop, and the frame round-trips to
+/// the same secret bytes the keyring stored.
+#[tokio::test]
+async fn run_turn_pushes_credentials_frame_when_sidecar_hook_set() {
+    let (session, provider, pending, _dir) = fixtures().await;
+
+    let store: Arc<dyn Credentials> = {
+        let s = Arc::new(MemoryStore::new());
+        s.set("anthropic", SecretString::from(TEST_SECRET_VALUE))
+            .await
+            .unwrap();
+        s
+    };
+
+    let (tx, mut rx) = mpsc::channel::<SidecarMessage>(8);
+    let instance_id = AgentInstanceId::from_string("inst-push-1".into());
+
+    run_turn(
+        Arc::clone(&session),
+        session.as_ref(),
+        Arc::clone(&provider),
+        "hello".to_string(),
+        pending,
+        vec![],
+        true,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(CredentialContext {
+            store: Arc::clone(&store),
+            provider_id: "anthropic".to_string(),
+            sidecar_push: Some(SidecarCredentialPush {
+                instance_id: instance_id.clone(),
+                command_tx: tx,
+            }),
+        }),
+    )
+    .await
+    .expect("turn should complete");
+
+    // The push happens synchronously inside `pull_active_credential`,
+    // so a non-blocking `try_recv` is sufficient.
+    let frame = rx
+        .try_recv()
+        .expect("a Credentials frame must have been pushed");
+    match frame {
+        SidecarMessage::Credentials(c) => {
+            assert_eq!(c.provider_id.to_string(), "anthropic");
+            assert_eq!(
+                c.secret.expose_bytes(),
+                TEST_SECRET_VALUE.as_bytes(),
+                "wire frame must carry the exact secret bytes"
+            );
+        }
+        other => panic!("expected Credentials, got {other:?}"),
+    }
+
+    // No follow-up frames — the run-turn body is in-process for this
+    // test (no `FORGE_AGENT_SIDECAR` registry path), so only the
+    // credential push reaches the channel.
+    assert!(
+        rx.try_recv().is_err(),
+        "no further frames should be pushed by an in-process run_turn"
+    );
+}
+
+/// Acceptance: when the credential pull misses (`Ok(None)`), no frame is
+/// sent. Phase-1 keyless OllamaProvider relies on this — pushing an
+/// empty credential would teach the sidecar a bogus "I have a key"
+/// signal for a provider that's actually keyless.
+#[tokio::test]
+async fn run_turn_does_not_push_when_credential_miss() {
+    let (session, provider, pending, _dir) = fixtures().await;
+
+    // Empty store — `get` returns Ok(None).
+    let store: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+    let (tx, mut rx) = mpsc::channel::<SidecarMessage>(8);
+    let instance_id = AgentInstanceId::from_string("inst-miss".into());
+
+    run_turn(
+        Arc::clone(&session),
+        session.as_ref(),
+        Arc::clone(&provider),
+        "hello".to_string(),
+        pending,
+        vec![],
+        true,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(CredentialContext {
+            store,
+            provider_id: "anthropic".to_string(),
+            sidecar_push: Some(SidecarCredentialPush {
+                instance_id,
+                command_tx: tx,
+            }),
+        }),
+    )
+    .await
+    .expect("missing credential must remain a clean miss");
+
+    assert!(
+        rx.try_recv().is_err(),
+        "miss path must not push a Credentials frame"
+    );
+}
+
+/// Acceptance: when `sidecar_push` is `None`, the frame channel is never
+/// touched (there isn't one to touch). Pins the in-process /
+/// flag-unset path is byte-for-byte unchanged from pre-step-6.
+#[tokio::test]
+async fn run_turn_does_not_push_without_sidecar_hook() {
+    let (session, provider, pending, _dir) = fixtures().await;
+
+    let store: Arc<dyn Credentials> = {
+        let s = Arc::new(MemoryStore::new());
+        s.set("anthropic", SecretString::from(TEST_SECRET_VALUE))
+            .await
+            .unwrap();
+        s
+    };
+
+    // No channel → `sidecar_push: None`.
+    run_turn(
+        Arc::clone(&session),
+        session.as_ref(),
+        Arc::clone(&provider),
+        "hello".to_string(),
+        pending,
+        vec![],
+        true,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(CredentialContext {
+            store,
+            provider_id: "anthropic".to_string(),
+            sidecar_push: None,
+        }),
+    )
+    .await
+    .expect("turn should complete");
+    // Reaching this line at all is the assertion: the in-process path
+    // didn't touch a channel that wasn't there.
+}
+
+/// Acceptance (security DoD): the credential value `TEST_SECRET_VALUE`
+/// must never appear in captured tracing output, **at any level** —
+/// even with a `trace`-grade filter that catches the
+/// `forge_session::orchestrator::credentials::pushed credential` line
+/// and the sidecar's stash emission.
+///
+/// Drives the full daemon-side push path with a `sidecar_push` hook
+/// wired to a real channel, then scans the captured byte buffer for the
+/// distinctive secret value. Architecture doc §5 forbids any
+/// observation channel that exposes the bytes.
+///
+/// Uses the existing `tests/common/mod.rs` capture-subscriber pattern
+/// (mirrors `bg_agents_tracing.rs` and `forge-shell`'s test harness):
+/// install once globally, serialize tests via `capture_test_lock` so
+/// `drain_capture` reflects only this test's emissions.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn secret_value_never_appears_in_logs() {
+    let _serial = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _drain_initial = common::drain_capture();
+
+    let (session, provider, pending, _dir) = fixtures().await;
+
+    let store: Arc<dyn Credentials> = {
+        let s = Arc::new(MemoryStore::new());
+        s.set("anthropic", SecretString::from(TEST_SECRET_VALUE))
+            .await
+            .unwrap();
+        s
+    };
+
+    let (tx, mut rx) = mpsc::channel::<SidecarMessage>(8);
+    let instance_id = AgentInstanceId::from_string("inst-leak-test".into());
+
+    run_turn(
+        Arc::clone(&session),
+        session.as_ref(),
+        Arc::clone(&provider),
+        "hello".to_string(),
+        pending,
+        vec![],
+        true,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(CredentialContext {
+            store,
+            provider_id: "anthropic".to_string(),
+            sidecar_push: Some(SidecarCredentialPush {
+                instance_id,
+                command_tx: tx,
+            }),
+        }),
+    )
+    .await
+    .expect("turn should complete");
+
+    // Drain the channel so any `Debug`-leaking close-down log
+    // emission would also be captured.
+    let _ = rx.try_recv();
+    drop(rx);
+
+    let captured_text = common::drain_capture();
+
+    assert!(
+        !captured_text.contains(TEST_SECRET_VALUE),
+        "credential value leaked into captured logs:\n{captured_text}"
+    );
+
+    // Belt-and-braces: the architecture-doc-mandated trace line MUST
+    // appear, since its presence proves the push code path actually
+    // ran (i.e. the negative assertion above isn't vacuously satisfied
+    // by a no-op control flow).
+    assert!(
+        captured_text.contains("pushed credential"),
+        "expected the architecture-doc-mandated trace emission; \
+         absence implies the push path didn't run:\n{captured_text}"
+    );
+    assert!(
+        captured_text.contains("inst-leak-test"),
+        "instance_id should appear in trace output:\n{captured_text}"
+    );
+    assert!(
+        captured_text.contains("anthropic"),
+        "non-secret provider_id should appear in logs:\n{captured_text}"
+    );
+}
+
+/// Acceptance: the rerun paths honor the same push contract as the
+/// fresh-turn entry, identical to the existing
+/// `rerun_*_pulls_credential_when_context_supplied` tests in
+/// `credentials_pull.rs`. Without this the rerun path would
+/// regenerate a target message against a sidecar that hasn't been
+/// handed the active credential.
+#[tokio::test]
+async fn rerun_replace_pushes_credentials_frame() {
+    let (session, provider, _pending, _dir) = fixtures().await;
+
+    // Seed one user → assistant turn so the rerun has a target.
+    let user_id = MessageId::new();
+    session
+        .emit(Event::UserMessage {
+            id: user_id,
+            at: Utc::now(),
+            text: Arc::from("seed prompt"),
+            context: vec![],
+            branch_parent: None,
+        })
+        .await
+        .unwrap();
+    let assistant_id = MessageId::new();
+    session
+        .emit(Event::AssistantMessage {
+            id: assistant_id.clone(),
+            provider: ProviderId::new(),
+            model: "mock".into(),
+            at: Utc::now(),
+            stream_finalised: true,
+            text: Arc::from("seed response"),
+            branch_parent: None,
+            branch_variant_index: 0,
+        })
+        .await
+        .unwrap();
+
+    let store: Arc<dyn Credentials> = {
+        let s = Arc::new(MemoryStore::new());
+        s.set("anthropic", SecretString::from(TEST_SECRET_VALUE))
+            .await
+            .unwrap();
+        s
+    };
+
+    let (tx, mut rx) = mpsc::channel::<SidecarMessage>(8);
+    let instance_id = AgentInstanceId::from_string("inst-rerun".into());
+
+    Orchestrator::new()
+        .rerun_message(
+            Arc::clone(&session),
+            Arc::clone(&provider),
+            assistant_id,
+            RerunVariant::Replace,
+            Arc::new(AsyncMutex::new(HashMap::new())),
+            vec![],
+            true,
+            None,
+            None,
+            None,
+            None,
+            Some(CredentialContext {
+                store,
+                provider_id: "anthropic".to_string(),
+                sidecar_push: Some(SidecarCredentialPush {
+                    instance_id,
+                    command_tx: tx,
+                }),
+            }),
+        )
+        .await
+        .expect("rerun should complete");
+
+    let frame = rx
+        .try_recv()
+        .expect("rerun must push a Credentials frame at entry");
+    match frame {
+        SidecarMessage::Credentials(c) => {
+            assert_eq!(c.provider_id.to_string(), "anthropic");
+            assert_eq!(c.secret.expose_bytes(), TEST_SECRET_VALUE.as_bytes());
+        }
+        other => panic!("expected Credentials, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Closes the credential-push leg of F-608 (issue #654). When `CredentialContext` carries a `sidecar_push` hook, the orchestrator's per-turn pull frames the just-pulled value as `SidecarMessage::Credentials` and forwards it to the per-instance sidecar before the orchestrator opens the request loop. The flag-unset / in-process path is byte-for-byte unchanged.

- **Daemon side** (`crates/forge-session/src/orchestrator.rs`): `pull_active_credential` gains a push branch gated on `ctx.sidecar_push.is_some() && pulled.is_some()`. Closed-channel and miss paths are non-fatal.
- **Sidecar side** (`crates/forge-agent-host/src/lib.rs`): the dispatch loop's `Credentials` arm unwraps `SecretBytes` into a `secrecy::SecretString` (zeroize-on-drop) and stashes by `provider_id`. Phase-1 OllamaProvider is keyless so the stash is observed but unused — the slot is staged for Anthropic / OpenAI providers when they ship.
- **Wire shape** (`crates/forge-ipc/src/sidecar.rs`): `Credentials.secret_handle: String` → `secret: SecretBytes` (`Vec<u8>` opaque, redacted `Debug`/`Display`). `SIDECAR_SCHEMA_VERSION` bumped 1 → 2.

## Security posture

The `SecretBytes` wrapper redacts at `Debug` / `Display` so a stray `tracing::debug!("{:?}", frame)` anywhere in the supervisor / sidecar stack cannot leak the credential bytes. Two trace-level emissions ride this path:

- daemon: `forge_session::orchestrator::credentials: pushed credential provider_id=... instance_id=...`
- sidecar: `forge_agent_host::credentials: stashed credential instance_id=... provider_id=...`

Neither line carries the secret value, the byte count, or any other side-channel-leaking field. Both are pinned by the new test suite.

## Tests

- `forge-ipc`: `secret_bytes_debug_redacts_payload`, `sidecar_credentials_debug_redacts_payload`, `sidecar_credentials_round_trip_preserves_bytes` pin both redaction layers and the wire round-trip.
- `forge-session::credentials_sidecar_push` (new): pins the daemon-side push contract — frame sent before request loop opens, no frame on miss / no-hook / rerun paths — and the security DoD (test secret value never appears in captured tracing output at any level, even with a trace-grade global subscriber).
- `forge-agent-host::forged_agent_credentials` (new): drives a real `forged-agent` child under `FORGE_LOG=trace`, pushes a `Credentials` frame, audits captured stderr for the test secret.

## Test plan

- [x] `cargo test -p forge-ipc` green
- [x] `cargo test -p forge-session` green (214+5+9+... all passing)
- [x] `cargo test -p forge-agent-host` green
- [x] `cargo build --workspace` green
- [x] `cargo fmt --all -- --check` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)