### PR TITLE
[F-684] Replace plain-text loading copy with skeletons in 4 dashboard sections

### DIFF
--- a/docs/ui-specs/dashboard.md
+++ b/docs/ui-specs/dashboard.md
@@ -66,6 +66,27 @@ The Dashboard itself has no global loading or error state — it always renders 
 - **Sessions panel — empty (archived tab):** `// archive is empty`.
 - **Sessions panel — fetch failure:** visible error block with heading `SESSIONS UNAVAILABLE`, the verbatim error detail (preserved exactly per `voice-terminology.md` §8 "show technical identifiers verbatim"), and a `RETRY` button that re-invokes `session_list`. The error state is distinct from empty — the `session_list` rejection must not collapse to `// no active sessions`.
 
+### D.5.1 Loading-state primitives (F-684)
+
+Per `docs/design/ai-patterns.md` §"Interaction states", every fetching
+surface paints a **skeleton or the streaming cursor — never plain "loading…"
+text, never a spinner**. The dashboard sections all surface multi-row /
+grid layouts, so they use skeletons (the streaming cursor is reserved for
+inline assistant output in `ChatPane`).
+
+| Section            | Choice    | Shape                                                  |
+|--------------------|-----------|--------------------------------------------------------|
+| Providers          | skeleton  | 4 card-shaped placeholders on the live `auto-fill, minmax(220px, 1fr)` grid |
+| Containers         | skeleton  | 3 row-shaped block placeholders matching the row gap   |
+| Catalog (per tab)  | skeleton  | 4 row-shaped block placeholders inside the active tab  |
+| Usage              | skeleton  | 1 chart placeholder + 3 table-row placeholders         |
+
+The shared `<Skeleton>` primitive lives in `@forge/design` (`variant`:
+`block` / `text` / `card`; `count` for stacked rows). It carries
+`role="status"` + `aria-busy="true"` + `aria-live="polite"` so screen
+readers register the load without spamming on every paint, and respects
+`prefers-reduced-motion` by suppressing the shimmer.
+
 ### D.6 Cross-spec references
 
 - `session-roster.md` *(deferred post-Phase-2)* — forward-looking spec for an in-session roster of loaded assets. No component or hosting sidebar exists in Phase 2; the Dashboard's session cards still open sessions, but those sessions do not render a roster today.

--- a/web/packages/app/src/components/catalog/CatalogPane.css
+++ b/web/packages/app/src/components/catalog/CatalogPane.css
@@ -77,13 +77,10 @@
   gap: var(--sp-4);
 }
 
-.catalog__loading {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--color-text-secondary);
-  letter-spacing: 0.2em;
-  margin: 0;
-  text-transform: uppercase;
+/* F-684: catalog tab loading state — list-shaped skeleton matching the
+ * `.catalog__rows` layout the resource resolves into. */
+.catalog__skeleton.forge-skeleton-group {
+  gap: var(--sp-2);
 }
 
 .catalog__error {

--- a/web/packages/app/src/components/catalog/CatalogPane.test.tsx
+++ b/web/packages/app/src/components/catalog/CatalogPane.test.tsx
@@ -67,6 +67,20 @@ afterEach(() => {
 });
 
 describe('<CatalogPane> (F-592)', () => {
+  it('renders a skeleton loading state per active tab during the fetch (F-684)', async () => {
+    invokeMock.mockImplementation(() => new Promise(() => undefined));
+    const { findByTestId, queryByText } = render(() => (
+      <CatalogPane workspaceRoot="/ws" />
+    ));
+    // Default active tab is `skills`; only that tabpanel paints its skeleton
+    // because each kind's resource is gated behind its own panel `<Show>`.
+    const skeleton = await findByTestId('catalog-loading-skills');
+    expect(skeleton.getAttribute('role')).toBe('status');
+    expect(skeleton.getAttribute('aria-busy')).toBe('true');
+    // Plain-text "Skills · loading" copy must be gone.
+    expect(queryByText(/Skills · loading/i)).toBeFalsy();
+  });
+
   it('renders three tabs (Skills / MCP / Agents)', async () => {
     setupInvoke();
     const { findAllByRole } = render(() => <CatalogPane workspaceRoot="/ws" />);

--- a/web/packages/app/src/components/catalog/CatalogPane.tsx
+++ b/web/packages/app/src/components/catalog/CatalogPane.tsx
@@ -17,7 +17,7 @@ import {
   Show,
   type Component,
 } from 'solid-js';
-import { Tab, Tabs } from '@forge/design';
+import { Skeleton, Tab, Tabs } from '@forge/design';
 import type { RosterEntry, ScopedRosterEntry } from '@forge/ipc';
 import {
   listAgents,
@@ -297,7 +297,13 @@ export const CatalogPane: Component<CatalogPaneProps> = (props) => {
                 aria-labelledby={`catalog-tab-${kind.id}`}
               >
                 <Show when={resource.loading}>
-                  <p class="catalog__loading">{kind.label} · loading</p>
+                  <Skeleton
+                    variant="block"
+                    count={4}
+                    label={`Loading ${kind.label.toLowerCase()}`}
+                    class="catalog__skeleton"
+                    data-testid={`catalog-loading-${kind.id}`}
+                  />
                 </Show>
 
                 <Show when={errorDetail()}>

--- a/web/packages/app/src/components/dashboard/ContainersSection.css
+++ b/web/packages/app/src/components/dashboard/ContainersSection.css
@@ -34,6 +34,13 @@
   line-height: 1.5;
 }
 
+/* F-684: row-shaped loading state. The skeleton group's gap matches the
+ * gap between live `.containers-section__row` entries so the surface does
+ * not re-layout when the resource resolves. */
+.containers-section__skeleton.forge-skeleton-group {
+  gap: var(--sp-4);
+}
+
 .containers-section__error {
   margin: 0;
   padding: var(--sp-3) var(--sp-4);

--- a/web/packages/app/src/components/dashboard/ContainersSection.test.tsx
+++ b/web/packages/app/src/components/dashboard/ContainersSection.test.tsx
@@ -80,6 +80,22 @@ describe('ContainersSection (F-597)', () => {
     expect(await findByTestId('containers-empty')).toBeTruthy();
   });
 
+  it('renders a skeleton loading state during the IPC fetch (F-684)', async () => {
+    const fn = vi.fn(async (cmd: string) => {
+      if (cmd === 'list_active_containers') {
+        return new Promise(() => undefined);
+      }
+      return undefined;
+    });
+    setInvokeForTesting(fn as never);
+    const { findByTestId, queryByText } = render(() => <ContainersSection />);
+    const skeleton = await findByTestId('containers-loading');
+    expect(skeleton.getAttribute('role')).toBe('status');
+    expect(skeleton.getAttribute('aria-busy')).toBe('true');
+    // Plain-text "containers · loading" copy must be gone.
+    expect(queryByText(/containers · loading/i)).toBeFalsy();
+  });
+
   it('renders one row per registered container', async () => {
     const { fn } = makeBackend({
       containers: [

--- a/web/packages/app/src/components/dashboard/ContainersSection.tsx
+++ b/web/packages/app/src/components/dashboard/ContainersSection.tsx
@@ -30,7 +30,7 @@ import {
   onMount,
   Show,
 } from 'solid-js';
-import { Button } from '@forge/design';
+import { Button, Skeleton } from '@forge/design';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import {
   CONTAINERS_CHANGED_EVENT,
@@ -148,7 +148,13 @@ export const ContainersSection: Component = () => {
       </header>
 
       <Show when={containers.loading}>
-        <p class="containers-section__hint">containers · loading</p>
+        <Skeleton
+          variant="block"
+          count={3}
+          label="Loading containers"
+          class="containers-section__skeleton"
+          data-testid="containers-loading"
+        />
       </Show>
 
       <Show when={!containers.loading && (containers() ?? []).length === 0}>

--- a/web/packages/app/src/components/dashboard/ProvidersSection.css
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.css
@@ -33,12 +33,16 @@
   text-transform: uppercase;
 }
 
-.providers__loading {
-  font-family: var(--font-mono);
-  font-size: var(--type-mono-sm);
-  color: var(--color-text-secondary);
-  letter-spacing: 0.2em;
-  margin: 0;
+/* F-684: provider-grid loading state.
+ *
+ * The skeleton group lays out 4 card-shaped placeholders on the same
+ * `auto-fill, minmax(220px, 1fr)` track that the live `.providers__grid` uses
+ * so the surface does not jump when the resource resolves.
+ */
+.providers__skeleton.forge-skeleton-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--sp-3);
 }
 
 .providers__error,

--- a/web/packages/app/src/components/dashboard/ProvidersSection.test.tsx
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.test.tsx
@@ -85,6 +85,22 @@ afterEach(() => {
 });
 
 describe('ProvidersSection (F-586)', () => {
+  it('renders a skeleton loading state during the IPC fetch (F-684)', async () => {
+    // Pending forever — the resource never settles, so the snapshot stays in
+    // its `loading` branch.
+    invokeMock.mockImplementation(() => new Promise(() => undefined));
+    const { findByTestId, queryByText } = render(() => <ProvidersSection />);
+
+    const skeleton = await findByTestId('providers-loading');
+    expect(skeleton.getAttribute('role')).toBe('status');
+    expect(skeleton.getAttribute('aria-busy')).toBe('true');
+    // Plain-text "providers · probing" copy must be gone — replaced by
+    // a card-shaped skeleton matching the live grid layout.
+    expect(queryByText(/providers · probing/i)).toBeFalsy();
+    // The skeleton renders one placeholder per expected card slot.
+    expect(skeleton.querySelectorAll('.forge-skeleton--card').length).toBe(4);
+  });
+
   it('renders a card per provider returned by list_providers', async () => {
     setupInvokeMock();
     const { findAllByRole } = render(() => <ProvidersSection />);

--- a/web/packages/app/src/components/dashboard/ProvidersSection.tsx
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.tsx
@@ -1,5 +1,5 @@
 import { createResource, createSignal, For, Show, type Component } from 'solid-js';
-import { Tab, Tabs } from '@forge/design';
+import { Skeleton, Tab, Tabs } from '@forge/design';
 import {
   getActiveProvider,
   listProviders,
@@ -78,7 +78,13 @@ export const ProvidersSection: Component = () => {
       </header>
 
       <Show when={snapshot.loading}>
-        <p class="providers__loading">providers · probing</p>
+        <Skeleton
+          variant="card"
+          count={4}
+          label="Loading providers"
+          class="providers__skeleton"
+          data-testid="providers-loading"
+        />
       </Show>
 
       <Show when={errorDetail()}>

--- a/web/packages/app/src/components/usage/UsagePane.css
+++ b/web/packages/app/src/components/usage/UsagePane.css
@@ -104,13 +104,28 @@
  * State copy
  * ------------------------------------------------------------------------ */
 
-.usage-pane__loading,
 .usage-pane__empty {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--color-text-secondary);
   letter-spacing: 0.2em;
   margin: 0;
+}
+
+/* F-684: usage loading state — chart-then-rows skeleton matching the
+ * post-resolve layout (chart card on top, three table rows beneath). */
+.usage-pane__skeletons {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+
+.usage-pane__skeleton-chart .forge-skeleton {
+  height: var(--sp-12);
+}
+
+.usage-pane__skeleton-rows .forge-skeleton {
+  height: var(--sp-6);
 }
 
 .usage-pane__error {

--- a/web/packages/app/src/components/usage/UsagePane.test.tsx
+++ b/web/packages/app/src/components/usage/UsagePane.test.tsx
@@ -131,12 +131,21 @@ describe('UsagePane helpers', () => {
 // ---------------------------------------------------------------------------
 
 describe('<UsagePane>', () => {
-  it('renders the loading state during the IPC fetch', async () => {
+  it('renders a skeleton loading state during the IPC fetch (F-684)', async () => {
     invokeMock.mockImplementation(() => new Promise(() => undefined));
-    const { findByText } = render(() => (
+    const { findByTestId, queryByText } = render(() => (
       <UsagePane workspaceRoot="/ws/a" />
     ));
-    expect(await findByText(/usage · probing/i)).toBeTruthy();
+    const skeletonHost = await findByTestId('usage-loading');
+    // Skeleton primitive carries `role="status"` + `aria-busy="true"`; one
+    // for the chart, one for the table rows.
+    const statuses = skeletonHost.querySelectorAll('[role="status"]');
+    expect(statuses.length).toBe(2);
+    for (const s of Array.from(statuses)) {
+      expect(s.getAttribute('aria-busy')).toBe('true');
+    }
+    // Plain-text loading copy must be gone — F-684 replaces it with skeletons.
+    expect(queryByText(/usage · probing/i)).toBeFalsy();
   });
 
   it('renders the empty state when no usage exists in range', async () => {

--- a/web/packages/app/src/components/usage/UsagePane.tsx
+++ b/web/packages/app/src/components/usage/UsagePane.tsx
@@ -16,6 +16,7 @@ import {
   type Component,
 } from 'solid-js';
 import type { GroupBy, UsageRange } from '@forge/ipc';
+import { Skeleton } from '@forge/design';
 import {
   fetchUsageSummary,
   type UsageBreakdownView,
@@ -173,7 +174,20 @@ export const UsagePane: Component<UsagePaneProps> = (props) => {
       </header>
 
       <Show when={data.loading}>
-        <p class="usage-pane__loading">usage · probing</p>
+        <div class="usage-pane__skeletons" data-testid="usage-loading">
+          <Skeleton
+            variant="block"
+            count={1}
+            label="Loading usage chart"
+            class="usage-pane__skeleton-chart"
+          />
+          <Skeleton
+            variant="block"
+            count={3}
+            label="Loading usage tables"
+            class="usage-pane__skeleton-rows"
+          />
+        </div>
       </Show>
 
       <Show when={errorDetail()}>

--- a/web/packages/design/src/components/Skeleton.test.tsx
+++ b/web/packages/design/src/components/Skeleton.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { cleanup, render } from '@solidjs/testing-library';
+import { Skeleton } from './Skeleton';
+
+describe('Skeleton', () => {
+  it('renders a status region with aria-busy=true', () => {
+    const { getByRole } = render(() => <Skeleton />);
+    const status = getByRole('status');
+    expect(status.getAttribute('aria-busy')).toBe('true');
+    expect(status.getAttribute('aria-live')).toBe('polite');
+    cleanup();
+  });
+
+  it('uses a default Loading label and forwards a custom one', () => {
+    const { getByRole, unmount } = render(() => <Skeleton />);
+    expect(getByRole('status').getAttribute('aria-label')).toBe('Loading');
+    unmount();
+    const custom = render(() => <Skeleton label="Loading providers" />);
+    expect(custom.getByRole('status').getAttribute('aria-label')).toBe(
+      'Loading providers',
+    );
+    custom.unmount();
+  });
+
+  it('applies the block variant by default', () => {
+    const { getByRole } = render(() => <Skeleton />);
+    const status = getByRole('status');
+    const items = status.querySelectorAll('.forge-skeleton');
+    expect(items.length).toBe(1);
+    expect(items[0]?.classList.contains('forge-skeleton--block')).toBe(true);
+    cleanup();
+  });
+
+  it.each(['block', 'text', 'card'] as const)(
+    'wires variant=%s to a class modifier',
+    (variant) => {
+      const { getByRole } = render(() => <Skeleton variant={variant} />);
+      const item = getByRole('status').querySelector('.forge-skeleton');
+      expect(item?.classList.contains(`forge-skeleton--${variant}`)).toBe(true);
+      cleanup();
+    },
+  );
+
+  it('renders `count` items when count > 1', () => {
+    const { getByRole } = render(() => <Skeleton count={3} variant="card" />);
+    const items = getByRole('status').querySelectorAll('.forge-skeleton');
+    expect(items.length).toBe(3);
+    for (const item of Array.from(items)) {
+      expect(item.classList.contains('forge-skeleton--card')).toBe(true);
+    }
+    cleanup();
+  });
+
+  it('clamps non-positive counts to 1', () => {
+    const { getByRole } = render(() => <Skeleton count={0} />);
+    expect(getByRole('status').querySelectorAll('.forge-skeleton').length).toBe(1);
+    cleanup();
+  });
+
+  it('forwards extra attributes (class, data-*) to the wrapper', () => {
+    const { getByRole } = render(() => (
+      <Skeleton class="extra" data-testid="sk" />
+    ));
+    const status = getByRole('status');
+    expect(status.classList.contains('forge-skeleton-group')).toBe(true);
+    expect(status.getAttribute('data-testid')).toBe('sk');
+    // The custom class is merged into each item, not the wrapper, so the
+    // group still carries its baseline class.
+    const items = status.querySelectorAll('.forge-skeleton');
+    expect(items[0]?.classList.contains('extra')).toBe(true);
+    cleanup();
+  });
+});

--- a/web/packages/design/src/components/Skeleton.tsx
+++ b/web/packages/design/src/components/Skeleton.tsx
@@ -1,0 +1,59 @@
+import { type Component, type JSX, splitProps, For } from 'solid-js';
+
+/** Visual variant. `block` is the default rectangle; `text` renders a shorter,
+ *  text-line shape (~1em height); `card` matches the multi-row card silhouette
+ *  the dashboard uses for its grid surfaces. */
+export type SkeletonVariant = 'block' | 'text' | 'card';
+
+export interface SkeletonProps
+  extends Omit<JSX.HTMLAttributes<HTMLDivElement>, 'role' | 'aria-busy'> {
+  /** Visual treatment. Defaults to `'block'`. */
+  variant?: SkeletonVariant;
+  /** Optional row count for list/grid placeholders. Renders `count` siblings.
+   *  Defaults to `1` (the wrapping element is the only placeholder). */
+  count?: number;
+  /**
+   * Accessible label announced to assistive tech once. Defaults to `'Loading'`.
+   * The placeholder group itself carries `role="status"` + `aria-live="polite"`
+   * so screen readers register the load without spamming on every paint.
+   */
+  label?: string;
+}
+
+/**
+ * Forge skeleton primitive (F-684). Shape-matched placeholder for loading
+ * surfaces that resolve into grids, lists, or cards. Replaces plain-text
+ * "loading…" copy per `docs/design/ai-patterns.md` §"Interaction states".
+ *
+ * Use `count > 1` to render multiple stacked rows for list / grid surfaces.
+ * The wrapper sets `role="status"` + `aria-busy="true"` so the placeholder
+ * pattern is announced as a load state, not an empty region.
+ */
+export const Skeleton: Component<SkeletonProps> = (props) => {
+  const [own, rest] = splitProps(props, ['variant', 'count', 'label', 'class']);
+
+  const variant = (): SkeletonVariant => own.variant ?? 'block';
+  const count = (): number => Math.max(1, own.count ?? 1);
+  const label = (): string => own.label ?? 'Loading';
+
+  const itemClass = (): string => {
+    const parts = ['forge-skeleton', `forge-skeleton--${variant()}`];
+    if (own.class) parts.push(own.class);
+    return parts.join(' ');
+  };
+
+  return (
+    <div
+      class="forge-skeleton-group"
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label={label()}
+      {...rest}
+    >
+      <For each={Array.from({ length: count() })}>
+        {() => <div class={itemClass()} aria-hidden="true" />}
+      </For>
+    </div>
+  );
+};

--- a/web/packages/design/src/components/forge-button.css
+++ b/web/packages/design/src/components/forge-button.css
@@ -320,3 +320,63 @@
   line-height: 1.4;
   margin-left: var(--sp-2);
 }
+
+/* =============================================================================
+ * Skeleton (F-684)
+ *
+ * Shape-matched loading placeholder. Per `docs/design/ai-patterns.md`
+ * §"Interaction states", every fetching surface paints a skeleton (or the
+ * streaming cursor) — never a spinner, never plain "loading…" text.
+ *
+ * The wrapper carries the ARIA. Each child rectangle is `aria-hidden`; the
+ * shimmer is decorative. Reduced-motion users see a static surface-3 fill
+ * instead of the keyframe sweep.
+ * ============================================================================= */
+
+@keyframes forge-skeleton-shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.forge-skeleton-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  width: 100%;
+}
+
+.forge-skeleton {
+  display: block;
+  border-radius: var(--r-sm);
+  background-color: var(--color-surface-2);
+  background-image: linear-gradient(
+    90deg,
+    var(--color-surface-2) 0%,
+    var(--color-surface-3) 50%,
+    var(--color-surface-2) 100%
+  );
+  background-size: 200% 100%;
+  animation: forge-skeleton-shimmer 1.4s linear infinite;
+}
+
+.forge-skeleton--block {
+  height: var(--sp-12);
+}
+
+.forge-skeleton--text {
+  height: var(--sp-4);
+  max-width: 60%;
+}
+
+.forge-skeleton--card {
+  height: 72px;
+  border: 1px solid var(--color-border-2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .forge-skeleton {
+    background-image: none;
+    animation: none;
+    background-color: var(--color-surface-3);
+  }
+}

--- a/web/packages/design/src/components/index.ts
+++ b/web/packages/design/src/components/index.ts
@@ -18,3 +18,8 @@ export {
   type TabsVariant,
 } from './Tab';
 export { MenuItem, type MenuItemProps, type MenuItemVariant } from './MenuItem';
+export {
+  Skeleton,
+  type SkeletonProps,
+  type SkeletonVariant,
+} from './Skeleton';


### PR DESCRIPTION
Closes #720

## Summary

Per `docs/design/ai-patterns.md` §"Interaction states", every fetching surface should paint a skeleton or the streaming cursor — never plain-text "loading…" copy. Four dashboard surfaces (Providers, Containers, Catalog, Usage) shipped with plain-text labels; this PR replaces them with shape-matched skeleton placeholders.

- New shared `<Skeleton>` primitive in `@forge/design` — `variant: block | text | card`, `count` for stacked rows, `role="status"` + `aria-busy` + `aria-live="polite"` so screen readers announce the load once. Respects `prefers-reduced-motion` (suppresses the shimmer keyframe).
- `ProvidersSection`: 4 card-shaped placeholders on the live `auto-fill, minmax(220px, 1fr)` grid so the surface does not jump on resolve.
- `ContainersSection`: 3 row-shaped block placeholders matching the row gap.
- `CatalogPane` (per active tab): 4 row-shaped block placeholders inside the active tabpanel.
- `UsagePane`: 1 chart placeholder + 3 table-row placeholders matching the post-resolve layout.
- Documented the per-section choice in `docs/ui-specs/dashboard.md §D.5.1`.

## Test plan

- [x] `pnpm -r typecheck` clean (all 4 workspace projects)
- [x] `node scripts/check-tokens.mjs` clean (59 tokens match)
- [x] `pnpm -r test` clean — 1270 tests pass (44 design incl. 9 new Skeleton tests; 1212 app incl. 4 new F-684 loading-state tests; 14 monaco-host)
- [x] `cargo fmt --check && cargo check --workspace` clean (no Rust changes touched, but verified)
- [ ] Visual verification in dev server — not run (no GUI environment in worktree); the test suite asserts the structure (`role="status"`, `aria-busy="true"`, `forge-skeleton--*` modifiers, correct `count`) and the CSS file owns the shape.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context per the forge-finish-task handoff protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)