### PR TITLE
[F-672] Add tracing to containers, memory, and usage IPC commands

### DIFF
--- a/crates/forge-shell/src/containers_ipc.rs
+++ b/crates/forge-shell/src/containers_ipc.rs
@@ -64,8 +64,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "webview")]
 use tauri::{AppHandle, Emitter, Manager, Runtime, State, Webview};
 use tokio::sync::RwLock;
-#[allow(unused_imports)]
-use tracing;
 
 /// Per-field byte cap on the inbound `container_id` argument. Podman
 /// container IDs are 64 hex chars; 256 bytes is a generous cap that
@@ -304,7 +302,20 @@ pub async fn detect_container_runtime<R: Runtime>(
 ) -> Result<RuntimeStatus, String> {
     crate::ipc::require_window_label(&webview, CONTAINERS_OWNER_LABEL, "detect_container_runtime")?;
     let runtime = PodmanRuntime::new();
-    Ok(classify_runtime_status(runtime.detect().await))
+    let status = classify_runtime_status(runtime.detect().await);
+    if status.is_unavailable() {
+        tracing::warn!(
+            target: "forge_shell::containers",
+            status = ?status,
+            "detect_container_runtime reported runtime unavailable",
+        );
+    } else {
+        tracing::trace!(
+            target: "forge_shell::containers",
+            "detect_container_runtime probed runtime available",
+        );
+    }
+    Ok(status)
 }
 
 #[cfg(feature = "webview")]
@@ -330,9 +341,22 @@ pub async fn stop_container<R: Runtime>(
 
     let runtime = PodmanRuntime::new();
     let handle = ContainerHandle::new(&container_id);
-    runtime.stop(&handle).await.map_err(|e| e.to_string())?;
+    runtime.stop(&handle).await.map_err(|e| {
+        tracing::warn!(
+            target: "forge_shell::containers",
+            container_id = %container_id,
+            error = %e,
+            "stop_container failed",
+        );
+        e.to_string()
+    })?;
     registry.mark_stopped(&container_id).await;
     let _ = app.emit(CONTAINERS_CHANGED_EVENT, &container_id);
+    tracing::trace!(
+        target: "forge_shell::containers",
+        container_id = %container_id,
+        "stop_container ok",
+    );
     Ok(())
 }
 
@@ -349,9 +373,22 @@ pub async fn remove_container<R: Runtime>(
 
     let runtime = PodmanRuntime::new();
     let handle = ContainerHandle::new(&container_id);
-    runtime.remove(&handle).await.map_err(|e| e.to_string())?;
+    runtime.remove(&handle).await.map_err(|e| {
+        tracing::warn!(
+            target: "forge_shell::containers",
+            container_id = %container_id,
+            error = %e,
+            "remove_container failed",
+        );
+        e.to_string()
+    })?;
     registry.unregister(&container_id).await;
     let _ = app.emit(CONTAINERS_CHANGED_EVENT, &container_id);
+    tracing::trace!(
+        target: "forge_shell::containers",
+        container_id = %container_id,
+        "remove_container ok",
+    );
     Ok(())
 }
 
@@ -369,10 +406,26 @@ pub async fn container_logs<R: Runtime>(
     let tail = tail.map(|n| n.min(MAX_LOG_TAIL));
     let runtime = PodmanRuntime::new();
     let handle = ContainerHandle::new(&container_id);
-    runtime
-        .logs(&handle, since.as_deref(), tail)
-        .await
-        .map_err(|e| e.to_string())
+    match runtime.logs(&handle, since.as_deref(), tail).await {
+        Ok(lines) => {
+            tracing::trace!(
+                target: "forge_shell::containers",
+                container_id = %container_id,
+                lines = lines.len(),
+                "container_logs ok",
+            );
+            Ok(lines)
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "forge_shell::containers",
+                container_id = %container_id,
+                error = %e,
+                "container_logs failed",
+            );
+            Err(e.to_string())
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/forge-shell/src/memory_ipc.rs
+++ b/crates/forge-shell/src/memory_ipc.rs
@@ -233,15 +233,27 @@ pub async fn list_agent_memory<R: Runtime>(
         crate::ipc::resolve_workspace_root_for_command(webview.label(), &workspace_root, &state)
             .await?;
     let user_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-    let defs = forge_agents::load_agents(&workspace_path, &user_home)
-        .map_err(|e| format!("load agents: {e}"))?;
+    let defs = forge_agents::load_agents(&workspace_path, &user_home).map_err(|e| {
+        tracing::warn!(
+            target: "forge_shell::memory",
+            error = %e,
+            "list_agent_memory failed loading agents",
+        );
+        format!("load agents: {e}")
+    })?;
 
     // Use the test-overridable user config dir so integration tests can
     // redirect the memory root the way ipc_settings.rs redirects settings.
     let user_dir = crate::ipc::resolve_user_config_dir(&state);
     let store = match user_dir.as_deref() {
         Some(dir) => MemoryStore::new(dir),
-        None => return Err("could not resolve user config directory".to_string()),
+        None => {
+            tracing::warn!(
+                target: "forge_shell::memory",
+                "list_agent_memory failed: could not resolve user config directory",
+            );
+            return Err("could not resolve user config directory".to_string());
+        }
     };
 
     // Settings overlay (F-602): the user's `[memory.enabled.<agent>]` map
@@ -249,10 +261,23 @@ pub async fn list_agent_memory<R: Runtime>(
     // when the settings file is absent or carries no `[memory]` section.
     let settings = forge_core::settings::load_merged_in(user_dir.as_deref(), &workspace_path)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| {
+            tracing::warn!(
+                target: "forge_shell::memory",
+                error = %e,
+                "list_agent_memory failed loading settings",
+            );
+            e.to_string()
+        })?;
     let overrides = settings.memory.enabled.clone();
 
-    Ok(build_agent_memory_entries(&store, &defs, &overrides))
+    let entries = build_agent_memory_entries(&store, &defs, &overrides);
+    tracing::trace!(
+        target: "forge_shell::memory",
+        count = entries.len(),
+        "list_agent_memory ok",
+    );
+    Ok(entries)
 }
 
 #[cfg(feature = "webview")]
@@ -268,13 +293,43 @@ pub async fn read_agent_memory<R: Runtime>(
     let user_dir = crate::ipc::resolve_user_config_dir(&state);
     let store = match user_dir.as_deref() {
         Some(dir) => MemoryStore::new(dir),
-        None => return Err("could not resolve user config directory".to_string()),
+        None => {
+            tracing::warn!(
+                target: "forge_shell::memory",
+                agent_id = %agent_id,
+                "read_agent_memory failed: could not resolve user config directory",
+            );
+            return Err("could not resolve user config directory".to_string());
+        }
     };
 
     match store.load(&agent_id) {
-        Ok(Some(memory)) => Ok(memory.body),
-        Ok(None) => Ok(String::new()),
-        Err(e) => Err(format!("read_agent_memory: {e}")),
+        Ok(Some(memory)) => {
+            tracing::trace!(
+                target: "forge_shell::memory",
+                agent_id = %agent_id,
+                bytes = memory.body.len(),
+                "read_agent_memory ok",
+            );
+            Ok(memory.body)
+        }
+        Ok(None) => {
+            tracing::trace!(
+                target: "forge_shell::memory",
+                agent_id = %agent_id,
+                "read_agent_memory ok (absent)",
+            );
+            Ok(String::new())
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "forge_shell::memory",
+                agent_id = %agent_id,
+                error = %e,
+                "read_agent_memory failed",
+            );
+            Err(format!("read_agent_memory: {e}"))
+        }
     }
 }
 
@@ -293,13 +348,35 @@ pub async fn save_agent_memory<R: Runtime>(
     let user_dir = crate::ipc::resolve_user_config_dir(&state);
     let store = match user_dir.as_deref() {
         Some(dir) => MemoryStore::new(dir),
-        None => return Err("could not resolve user config directory".to_string()),
+        None => {
+            tracing::warn!(
+                target: "forge_shell::memory",
+                agent_id = %agent_id,
+                "save_agent_memory failed: could not resolve user config directory",
+            );
+            return Err("could not resolve user config directory".to_string());
+        }
     };
 
     let memory = store
         .write(&agent_id, &body, WriteMode::Replace)
-        .map_err(|e| format!("save_agent_memory: {e}"))?;
+        .map_err(|e| {
+            tracing::warn!(
+                target: "forge_shell::memory",
+                agent_id = %agent_id,
+                error = %e,
+                "save_agent_memory failed",
+            );
+            format!("save_agent_memory: {e}")
+        })?;
 
+    tracing::trace!(
+        target: "forge_shell::memory",
+        agent_id = %agent_id,
+        version = memory.frontmatter.version,
+        bytes = body.len(),
+        "save_agent_memory ok",
+    );
     Ok(AgentMemorySavedDto {
         version: memory.frontmatter.version,
         updated_at: memory.frontmatter.updated_at,
@@ -319,7 +396,14 @@ pub async fn clear_agent_memory<R: Runtime>(
     let user_dir = crate::ipc::resolve_user_config_dir(&state);
     let store = match user_dir.as_deref() {
         Some(dir) => MemoryStore::new(dir),
-        None => return Err("could not resolve user config directory".to_string()),
+        None => {
+            tracing::warn!(
+                target: "forge_shell::memory",
+                agent_id = %agent_id,
+                "clear_agent_memory failed: could not resolve user config directory",
+            );
+            return Err("could not resolve user config directory".to_string());
+        }
     };
 
     // Idempotent: the file may not exist yet (the agent never wrote, the
@@ -328,7 +412,20 @@ pub async fn clear_agent_memory<R: Runtime>(
     // creates a fresh file.
     store
         .write(&agent_id, "", WriteMode::Replace)
-        .map_err(|e| format!("clear_agent_memory: {e}"))?;
+        .map_err(|e| {
+            tracing::warn!(
+                target: "forge_shell::memory",
+                agent_id = %agent_id,
+                error = %e,
+                "clear_agent_memory failed",
+            );
+            format!("clear_agent_memory: {e}")
+        })?;
+    tracing::trace!(
+        target: "forge_shell::memory",
+        agent_id = %agent_id,
+        "clear_agent_memory ok",
+    );
     Ok(())
 }
 

--- a/crates/forge-shell/src/usage_ipc.rs
+++ b/crates/forge-shell/src/usage_ipc.rs
@@ -83,7 +83,13 @@ pub async fn usage_summary<R: Runtime>(
     let usage_dir = match resolve_usage_dir() {
         Some(d) => d,
         // No platform config dir: return an empty summary rather than crash.
-        None => return Ok(summarize(&[], range, group_by, None, chrono::Utc::now())),
+        None => {
+            tracing::warn!(
+                target: "forge_shell::usage",
+                "usage_summary could not resolve usage dir; returning empty summary",
+            );
+            return Ok(summarize(&[], range, group_by, None, chrono::Utc::now()));
+        }
     };
 
     let monthly_files = read_all_monthly_files(&usage_dir).await;
@@ -94,13 +100,21 @@ pub async fn usage_summary<R: Runtime>(
         workspace_root.map(WorkspaceId::from_string)
     };
 
-    Ok(summarize(
+    let summary = summarize(
         &monthly_files,
         range,
         group_by,
         workspace_filter.as_ref(),
         chrono::Utc::now(),
-    ))
+    );
+    tracing::trace!(
+        target: "forge_shell::usage",
+        cross_workspace = cross_workspace,
+        files = monthly_files.len(),
+        breakdown_rows = summary.breakdown.len(),
+        "usage_summary ok",
+    );
+    Ok(summary)
 }
 
 #[cfg(test)]

--- a/crates/forge-shell/tests/ipc_dashboard_tracing.rs
+++ b/crates/forge-shell/tests/ipc_dashboard_tracing.rs
@@ -1,0 +1,127 @@
+//! F-672: tracing-emission pin for the dashboard-scoped IPC commands in
+//! `containers_ipc`, `memory_ipc`, and `usage_ipc`.
+//!
+//! Each module emits `tracing::trace!(target: "forge_shell::<module>", ...)`
+//! on the success path and `tracing::warn!` on the failure path. This
+//! suite drives a representative success path per module through the
+//! Tauri mock harness and asserts the structured fields a dashboard
+//! operator needs when triaging logs (target + principal field).
+//!
+//! Mirrors the F-371 `ipc_authz_tracing.rs` shape: install the global
+//! capture subscriber once, serialize tests on `capture_test_lock`, drain
+//! and grep.
+
+#![cfg(feature = "webview-test")]
+
+mod common;
+
+use forge_shell::bridge::SessionConnections;
+use forge_shell::ipc::{build_invoke_handler, BridgeState};
+use tauri::test::{mock_builder, mock_context, noop_assets, INVOKE_KEY};
+use tauri::Manager;
+use tempfile::TempDir;
+
+fn make_app(user_cfg_dir: &std::path::Path) -> tauri::App<tauri::test::MockRuntime> {
+    let connections = SessionConnections::new();
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::with_test_user_config_dir(
+        connections,
+        user_cfg_dir.to_path_buf(),
+    ));
+    app.manage(forge_shell::containers_ipc::ContainerRegistryState::new());
+    app
+}
+
+fn make_dashboard_window(
+    app: &tauri::App<tauri::test::MockRuntime>,
+) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
+    tauri::WebviewWindowBuilder::new(
+        app,
+        "dashboard",
+        tauri::WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("mock dashboard window")
+}
+
+fn invoke_ok(
+    window: &tauri::WebviewWindow<tauri::test::MockRuntime>,
+    cmd: &str,
+    payload: serde_json::Value,
+) -> serde_json::Value {
+    let res = tauri::test::get_ipc_response(
+        window,
+        tauri::webview::InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+    res.expect("invoke returned Ok").deserialize().unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn save_agent_memory_emits_trace_on_success() {
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let user_cfg_dir = TempDir::new().unwrap();
+    let app = make_app(user_cfg_dir.path());
+    let window = make_dashboard_window(&app);
+
+    let _ = invoke_ok(
+        &window,
+        "save_agent_memory",
+        serde_json::json!({ "agentId": "scribe", "body": "remember the milk" }),
+    );
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("forge_shell::memory"),
+        "expected memory target, got: {logs}"
+    );
+    assert!(
+        logs.contains("save_agent_memory ok"),
+        "expected success message, got: {logs}"
+    );
+    assert!(
+        logs.contains("agent_id=scribe"),
+        "expected agent_id field, got: {logs}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_active_containers_does_not_log_authz_warn_on_success() {
+    // The container commands trace on runtime calls (stop/remove/logs);
+    // their success-path tracing is exercised on the `detect` and `logs`
+    // paths which require a real podman binary. This guard pins the
+    // lower bar: the dashboard label *passes* the authz gate, so no
+    // forge_shell::ipc::authz warning should appear.
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let user_cfg_dir = TempDir::new().unwrap();
+    let app = make_app(user_cfg_dir.path());
+    let window = make_dashboard_window(&app);
+
+    let _ = invoke_ok(&window, "list_active_containers", serde_json::json!({}));
+
+    let logs = common::drain_capture();
+    assert!(
+        !logs.contains("forge_shell::ipc::authz"),
+        "dashboard label must pass authz silently, got: {logs}"
+    );
+}


### PR DESCRIPTION
## Summary

- Closes observability gap flagged by the Phase 3 milestone quality review on `containers_ipc.rs`, `memory_ipc.rs`, and `usage_ipc.rs` (issue #708).
- All 9 dashboard-scoped commands now emit `tracing::warn!` on `Err` (with `error = %e` plus the principal field — `container_id`, `agent_id`, etc.) and `tracing::trace!` on `Ok`, matching the `credentials_ipc` / `providers_ipc` template.
- New `tests/ipc_dashboard_tracing.rs` follows the F-371 `ipc_authz_tracing` pattern: drives `save_agent_memory` and `list_active_containers` through the Tauri mock harness, captures tracing output, and pins target + field shape.

## Definition of Done

- [x] All 9 commands emit tracing on success and failure
- [x] `just check-rust` passes locally
- [x] New tracing-emission test added

## Test plan

- [x] `cargo test -p forge-shell --features webview-test --test ipc_dashboard_tracing`
- [x] `cargo test -p forge-shell --features webview-test --test ipc_memory --test ipc_containers --test ipc_authz_tracing`
- [x] `just check-rust` (clippy + rustdoc gates)
- [ ] CI green

Closes #708

Generated with [Claude Code](https://claude.com/claude-code)