### PR TITLE
[F-691] Replace verbose empty-state copy with terse mono noun-phrase form

### DIFF
--- a/web/packages/app/src/components/dashboard/ContainersSection.css
+++ b/web/packages/app/src/components/dashboard/ContainersSection.css
@@ -41,6 +41,22 @@
   gap: var(--sp-4);
 }
 
+.containers-section__empty {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  letter-spacing: 0.05em;
+}
+
+.containers-section__empty-hint {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  opacity: 0.7;
+}
+
 .containers-section__error {
   margin: 0;
   padding: var(--sp-3) var(--sp-4);

--- a/web/packages/app/src/components/dashboard/ContainersSection.test.tsx
+++ b/web/packages/app/src/components/dashboard/ContainersSection.test.tsx
@@ -96,6 +96,16 @@ describe('ContainersSection (F-597)', () => {
     expect(queryByText(/containers · loading/i)).toBeFalsy();
   });
 
+  it('empty-state uses canonical mono noun-phrase copy with muted secondary hint (F-691)', async () => {
+    const { findByTestId, queryByTestId } = render(() => <ContainersSection />);
+    const empty = await findByTestId('containers-empty');
+    expect(empty.textContent).toBe('// no active containers');
+    // Educational hint moves to a separate, muted line.
+    const hint = queryByTestId('containers-empty-hint');
+    expect(hint).toBeTruthy();
+    expect(hint?.textContent).toMatch(/Level-2 isolation/);
+  });
+
   it('renders one row per registered container', async () => {
     const { fn } = makeBackend({
       containers: [

--- a/web/packages/app/src/components/dashboard/ContainersSection.tsx
+++ b/web/packages/app/src/components/dashboard/ContainersSection.tsx
@@ -158,9 +158,14 @@ export const ContainersSection: Component = () => {
       </Show>
 
       <Show when={!containers.loading && (containers() ?? []).length === 0}>
-        <p class="containers-section__hint" data-testid="containers-empty">
-          No active sandbox containers. They appear here when a session uses
-          Level-2 isolation.
+        <p class="containers-section__empty" data-testid="containers-empty">
+          // no active containers
+        </p>
+        <p
+          class="containers-section__empty-hint"
+          data-testid="containers-empty-hint"
+        >
+          Level-2 isolation populates this list.
         </p>
       </Show>
 

--- a/web/packages/app/src/components/dashboard/MemorySection.test.tsx
+++ b/web/packages/app/src/components/dashboard/MemorySection.test.tsx
@@ -119,6 +119,14 @@ describe('MemorySection (F-602)', () => {
     expect(await findByTestId('memory-section-empty')).toBeTruthy();
   });
 
+  it('empty-state uses canonical mono noun-phrase copy (F-691)', async () => {
+    const { fn } = buildMemoryInvoke({ entries: [], bodies: {} });
+    setInvokeForTesting(fn as never);
+    const { findByTestId } = render(() => <MemorySection workspaceRoot="/work" />);
+    const empty = await findByTestId('memory-section-empty');
+    expect(empty.textContent).toBe('// no agents');
+  });
+
   it('reflects the toggle state from settings_override', async () => {
     const { fn } = buildMemoryInvoke({
       entries: [

--- a/web/packages/app/src/components/dashboard/MemorySection.tsx
+++ b/web/packages/app/src/components/dashboard/MemorySection.tsx
@@ -145,7 +145,7 @@ export const MemorySection: Component<MemorySectionProps> = (props) => {
         when={(entries() ?? []).length > 0}
         fallback={
           <p class="memory-section__empty" data-testid="memory-section-empty">
-            No agent definitions loaded for this workspace.
+            // no agents
           </p>
         }
       >

--- a/web/packages/app/src/components/dashboard/ProvidersSection.css
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.css
@@ -45,6 +45,20 @@
   gap: var(--sp-3);
 }
 
+.providers__loading,
+.providers__empty {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.2em;
+  margin: 0;
+}
+
+.providers__empty {
+  color: var(--color-text-tertiary);
+  letter-spacing: 0.05em;
+}
+
 .providers__error,
 .providers__action-error {
   display: flex;

--- a/web/packages/app/src/components/dashboard/ProvidersSection.test.tsx
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.test.tsx
@@ -234,6 +234,14 @@ describe('ProvidersSection (F-586)', () => {
     expect(alert.textContent).toMatch(/keyring backend down/i);
   });
 
+  it('empty-state uses canonical mono noun-phrase copy when no providers configured (F-691)', async () => {
+    setupInvokeMock({ entries: [], active: null });
+    const { findByTestId } = render(() => <ProvidersSection />);
+    await waitForFetch();
+    const empty = await findByTestId('providers-empty');
+    expect(empty.textContent).toBe('// no providers configured');
+  });
+
   it('drops a second click while the first switch is in flight', async () => {
     // F-586 review: double-tap guard. The first `setActiveProvider` IPC
     // is still pending (its promise hasn't resolved), so a second click

--- a/web/packages/app/src/components/dashboard/ProvidersSection.tsx
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.tsx
@@ -106,25 +106,34 @@ export const ProvidersSection: Component = () => {
 
       <Show when={snapshot.state === 'ready' && snapshot()}>
         {(data) => (
-          <Tabs
-            variant="radio"
-            class="providers__grid"
-            aria-label="Active provider"
-            aria-busy={isSubmitting()}
-            ref={setGridRef as never}
+          <Show
+            when={(data().entries?.length ?? 0) > 0}
+            fallback={
+              <p class="providers__empty" data-testid="providers-empty">
+                // no providers configured
+              </p>
+            }
           >
-            <For each={data().entries}>
-              {(entry) => (
-                <ProviderCard
-                  entry={entry}
-                  active={data().active === entry.id}
-                  pending={pendingId() === entry.id}
-                  disabled={isSubmitting()}
-                  onSelect={handleSelect}
-                />
-              )}
-            </For>
-          </Tabs>
+            <Tabs
+              variant="radio"
+              class="providers__grid"
+              aria-label="Active provider"
+              aria-busy={isSubmitting()}
+              ref={setGridRef as never}
+            >
+              <For each={data().entries}>
+                {(entry) => (
+                  <ProviderCard
+                    entry={entry}
+                    active={data().active === entry.id}
+                    pending={pendingId() === entry.id}
+                    disabled={isSubmitting()}
+                    onSelect={handleSelect}
+                  />
+                )}
+              </For>
+            </Tabs>
+          </Show>
         )}
       </Show>
     </section>


### PR DESCRIPTION
Closes forge-ide/forge#727

## Summary
- MemorySection, ContainersSection, ProvidersSection now use canonical mono noun-phrase empty-state copy per `docs/design/voice-terminology.md` §8 (`// no agents`, `// no active containers`, `// no providers configured`).
- Educational copy on ContainersSection moves to a separate, muted line (`Level-2 isolation populates this list.`).
- ProvidersSection grows an explicit empty-state branch — previously it rendered an empty `<Tabs>` grid when no providers were configured.

## Test plan
- `pnpm --filter app exec vitest run` passes (1212 tests, 84 files, 0 errors)
- `just check-web` passes (typecheck + design-token gate)
- Targeted RED→GREEN tests added to all three section test files asserting the canonical copy verbatim

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>