### PR TITLE
[F-696] A11y attribute audit: aria-expanded, aria-label, role=log, popover focus

### DIFF
--- a/web/packages/app/src/components/SubAgentBanner.test.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.test.tsx
@@ -92,6 +92,18 @@ describe('SubAgentBanner — expand/collapse', () => {
     );
   });
 
+  // F-696: header is a `role="button"` disclosure — must announce its
+  // collapsed/expanded state via aria-expanded for assistive tech.
+  it('header reports aria-expanded=false when collapsed and true when expanded', () => {
+    const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    const header = getByTestId('sub-agent-banner-header-child-1');
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(header);
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(header);
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+  });
+
   it('expands when Enter is pressed on the focused header', () => {
     const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
     const header = getByTestId('sub-agent-banner-header-child-1');
@@ -365,6 +377,16 @@ describe('SubAgentBanner — state-chip popover (F-448 Phase 3)', () => {
     expect(getByTestId('sub-agent-banner-popover-child-1')).toBeInTheDocument();
     fireEvent.mouseDown(getByTestId('outside'));
     expect(queryByTestId('sub-agent-banner-popover-child-1')).not.toBeInTheDocument();
+  });
+
+  // F-696: APG menu pattern — opening the popover must move focus into it
+  // (first interactive descendant) so AT can announce its contents and Tab
+  // navigates the popover instead of skipping it.
+  it('moves focus into the popover (first interactive child) on open', () => {
+    const { getByTestId } = render(() => <SubAgentBanner turn={makeTurn()} />);
+    fireEvent.click(getByTestId('sub-agent-banner-state-child-1'));
+    const monitorBtn = getByTestId('sub-agent-banner-popover-monitor-child-1');
+    expect(document.activeElement).toBe(monitorBtn);
   });
 
   it('"Open in Agent Monitor" link inside the popover calls onOpenInMonitor', () => {

--- a/web/packages/app/src/components/SubAgentBanner.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.tsx
@@ -131,6 +131,7 @@ export const SubAgentBanner: Component<SubAgentBannerProps> = (props) => {
         onDblClick={openInMonitor}
         role="button"
         tabIndex={0}
+        aria-expanded={expanded()}
         onKeyDown={(e: KeyboardEvent) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();

--- a/web/packages/app/src/components/SubAgentDetailsPopover.tsx
+++ b/web/packages/app/src/components/SubAgentDetailsPopover.tsx
@@ -1,4 +1,4 @@
-import { type Component, Show } from 'solid-js';
+import { type Component, Show, onMount } from 'solid-js';
 import { useFocusTrap } from '../lib/useFocusTrap';
 import type { SubAgentStatus } from '../stores/messages';
 import './SubAgentDetailsPopover.css';
@@ -32,11 +32,17 @@ function formatStartedAt(ms: number): string {
 }
 
 export const SubAgentDetailsPopover: Component<SubAgentDetailsPopoverProps> = (props) => {
-  // Menu-mode focus trap: Escape + outside-click dismissal without moving
-  // focus into the popover (the state-chip button retains focus so Tab flow
-  // stays predictable).
+  // Menu-mode focus trap: Escape + outside-click dismissal. F-696: per APG
+  // menu pattern, focus moves to the first interactive descendant on open so
+  // assistive tech can announce popover contents and Tab navigates within it.
   let rootRef: HTMLDivElement | undefined;
   useFocusTrap(() => rootRef, { trap: false, onDismiss: () => props.onDismiss() });
+  onMount(() => {
+    const first = rootRef?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    first?.focus();
+  });
 
   return (
     <div

--- a/web/packages/app/src/components/dashboard/ContainersSection.test.tsx
+++ b/web/packages/app/src/components/dashboard/ContainersSection.test.tsx
@@ -175,6 +175,37 @@ describe('ContainersSection (F-597)', () => {
       expect(first.tail).not.toBeNull();
     });
   });
+
+  // F-696: the log pane sits inside a `useFocusTrap` modal flyout. A
+  // `tabIndex={0}` on `<pre>` made it a Tab stop *inside* the trap, and
+  // Tab from there exited the modal. The pane must instead expose itself
+  // as `role="log"` (live region) without entering the focus order.
+  it('log pane is a live region (role=log) and is not a Tab stop', async () => {
+    const { fn } = makeBackend({
+      containers: [
+        {
+          container_id: 'cid-1',
+          session_id: 'sess-1',
+          image: 'alpine:3.19',
+          started_at: new Date().toISOString(),
+          stopped: false,
+        },
+      ],
+      logs: [{ stream: 'stdout', line: 'tick', timestamp: null }],
+    });
+    setInvokeForTesting(fn as never);
+
+    const { findByTestId, container } = render(() => <ContainersSection />);
+    const logsBtn = (await findByTestId('container-logs-btn-cid-1')) as HTMLButtonElement;
+    fireEvent.click(logsBtn);
+    await findByTestId('container-logs-flyout');
+    const pane = container.querySelector('.containers-section__log-pane') as HTMLElement | null;
+    expect(pane).not.toBeNull();
+    expect(pane!.getAttribute('role')).toBe('log');
+    expect(pane!.hasAttribute('tabindex')).toBe(false);
+    expect(pane!.getAttribute('aria-live')).toBe('polite');
+    expect(pane!.getAttribute('aria-label')).toMatch(/logs/i);
+  });
 });
 
 describe('ContainerRuntimeBanner (F-597)', () => {

--- a/web/packages/app/src/components/dashboard/ContainersSection.tsx
+++ b/web/packages/app/src/components/dashboard/ContainersSection.tsx
@@ -362,7 +362,12 @@ const LogsFlyout: Component<LogsFlyoutProps> = (props) => {
             </p>
           )}
         </Show>
-        <pre class="containers-section__log-pane" tabIndex={0}>
+        <pre
+          class="containers-section__log-pane"
+          role="log"
+          aria-live="polite"
+          aria-label={`Container ${props.containerId.slice(0, 12)} logs`}
+        >
           <For each={lines()}>
             {(l) => (
               <div

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -2270,6 +2270,29 @@ describe('ToolCallCard Phase 3 — parallel-reads grouping (F-447 §5.1)', () =>
     expect(getByTestId('tool-call-card-tc-xp-2')).toBeInTheDocument();
   });
 
+  // F-696: header is `role="button"` with summary text only — assistive tech
+  // benefits from an explicit aria-label that names the count and aggregate
+  // status so the full context announces alongside the role.
+  it('aggregate header carries an aria-label with count + aggregate status', () => {
+    for (const id of ['tc-lbl-1', 'tc-lbl-2', 'tc-lbl-3']) {
+      pushEvent(SID, {
+        kind: 'ToolCallStarted',
+        tool_call_id: id,
+        tool_name: 'fs.read',
+        args_json: JSON.stringify({ path: `${id}.txt` }),
+        batch_id: 'lbl',
+      });
+    }
+    const { getByTestId } = render(() => <ChatPane />);
+    const row = getByTestId('tool-call-group-row-lbl');
+    const label = row.getAttribute('aria-label');
+    expect(label).toBeTruthy();
+    expect(label).toMatch(/parallel reads/i);
+    expect(label).toMatch(/3 calls/);
+    // Aggregate status is in-progress while no children have completed.
+    expect(label).toMatch(/in-progress/i);
+  });
+
   it('renders a single call with batch_id as a standalone card (no group chrome)', () => {
     pushEvent(SID, {
       kind: 'ToolCallStarted',

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -649,6 +649,7 @@ const ParallelReadsGroup: Component<{
         tabIndex={0}
         aria-expanded={expanded()}
         aria-controls={`tool-call-group-body-${props.batchId}`}
+        aria-label={`parallel reads — ${props.calls.length} ${props.calls.length === 1 ? 'call' : 'calls'} (${aggregateStatus()})`}
         onClick={() => setExpanded((v) => !v)}
         onKeyDown={handleKeyDown}
       >


### PR DESCRIPTION
## Summary

Closes #732. Bundles four small WCAG/APG attribute fixes from the Phase 3 frontend review:

- **SubAgentBanner header** — adds `aria-expanded={expanded()}` so the `role="button"` disclosure announces its state.
- **SubAgentDetailsPopover** — moves focus to the first interactive descendant on open (APG menu pattern); Escape + outside-click dismissal preserved via menu-mode `useFocusTrap`.
- **ContainersSection log pane** — drops `tabIndex={0}` (Tab from there exited the surrounding focus-trap modal); replaces with `role="log"` + `aria-live="polite"` + descriptive `aria-label`.
- **ChatPane ParallelReadsGroup row** — adds `aria-label` naming the call count and aggregate status so the full context announces with `role="button"`.

Items 4 (`AgentMonitor` `IconButton` close labels at lines 1167/1263) and 6 (`AgentMonitor` `Tab` `aria-selected`) from the issue were already correct via design-system primitives — `IconButton.label` forwards to `aria-label`; `Tab.selected` maps to `aria-selected`. Both are already covered by existing tests (`getByLabelText(/Close step detail/i)`, AgentMonitor F-416 tablist suite).

Reused existing `useFocusTrap` from `@forge/design`-adjacent `app/lib/useFocusTrap.ts` per scope; no new hook.

## Test plan

- [x] `pnpm -r typecheck` clean
- [x] `pnpm check-tokens` clean (no token drift)
- [x] `pnpm test` — 1213 app tests + 35 design tests + others all green
- [x] New regression tests added per fix:
  - `SubAgentBanner.test.tsx` — aria-expanded toggles with collapse state
  - `SubAgentBanner.test.tsx` — popover open moves focus to first interactive child
  - `ContainersSection.test.tsx` — log pane is `role="log"`, no `tabindex`, has `aria-live` + `aria-label`
  - `ChatPane.test.tsx` — parallel-reads aggregate row carries an `aria-label` with count + status

🤖 Generated with [Claude Code](https://claude.com/claude-code)