### PR TITLE
[F-675] Unify MAX_PROVIDER_ID_BYTES to single canonical 128-byte cap

### DIFF
--- a/crates/forge-shell/src/credentials_ipc.rs
+++ b/crates/forge-shell/src/credentials_ipc.rs
@@ -47,9 +47,10 @@ pub const CREDENTIALS_OWNER_LABEL: &str = "dashboard";
 /// `login_provider` calls.
 pub const MAX_API_KEY_BYTES: usize = 8 * 1024;
 
-/// Per-field byte cap on `provider_id`. Provider IDs are short, lowercase
-/// ASCII slugs.
-pub const MAX_PROVIDER_ID_BYTES: usize = 64;
+// F-675: `MAX_PROVIDER_ID_BYTES` is defined canonically in `crate::ipc` so
+// the credentials and providers IPC surfaces share one cap. Re-import here
+// rather than redeclaring.
+use crate::ipc::MAX_PROVIDER_ID_BYTES;
 
 /// Tauri-managed handle to the credential store. Held as an
 /// `Arc<dyn Credentials>` so the same state can wrap any `Credentials`

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -124,6 +124,15 @@ pub(crate) const MAX_REJECT_REASON_BYTES: usize = 1024;
 /// without permitting unbounded growth if a compromised webview lies.
 pub(crate) const MAX_MESSAGE_ID_BYTES: usize = 64;
 
+/// F-675: canonical cap on every `provider_id` accepted by an IPC command.
+/// Slugs are short ASCII (`anthropic`, `openai`, `ollama`); 128 bytes is the
+/// generous upper bound that still admits the longest realistic
+/// `custom_openai:<name>` form while rejecting hostile renderers driving
+/// megabyte calls. Defined here — and only here — so the credentials and
+/// providers IPC surfaces share one cap and a slug accepted by one command
+/// is never silently rejected by another.
+pub(crate) const MAX_PROVIDER_ID_BYTES: usize = 128;
+
 /// F-036 / F-068 (L4 / T7): caps on untyped-string inputs to the persistent
 /// approval commands. `workspace_root` is an absolute filesystem path — 4096
 /// bytes covers PATH_MAX on every target platform (Linux 4096, macOS 1024,
@@ -3387,9 +3396,6 @@ fn validate_roster_scope(scope: &forge_core::RosterScope) -> Result<(), String> 
         }
     }
 }
-
-// Reuse the F-587 cap for embedded id payloads.
-use crate::credentials_ipc::MAX_PROVIDER_ID_BYTES;
 
 /// F-591: load every workspace + user-home skill and tag each as a session-
 /// wide roster entry.

--- a/crates/forge-shell/src/providers_ipc.rs
+++ b/crates/forge-shell/src/providers_ipc.rs
@@ -218,10 +218,10 @@ pub fn is_known_provider_id(settings: &forge_core::settings::AppSettings, id: &s
     false
 }
 
-/// Per-field byte cap on the inbound `provider_id` argument. Slugs are
-/// short; 128 bytes is a generous upper bound that still rejects a
-/// hostile renderer driving megabyte calls.
-pub const MAX_PROVIDER_ID_BYTES: usize = 128;
+// F-675: `MAX_PROVIDER_ID_BYTES` is defined canonically in `crate::ipc` so
+// the credentials and providers IPC surfaces share one cap. Re-import here
+// rather than redeclaring.
+use crate::ipc::MAX_PROVIDER_ID_BYTES;
 
 /// Pure validation helper exposed for unit tests.
 pub fn validate_provider_id(provider_id: &str) -> Result<(), String> {


### PR DESCRIPTION
## Summary

- Two IPC modules each defined `MAX_PROVIDER_ID_BYTES` locally with mismatched limits (`credentials_ipc.rs`: 64, `providers_ipc.rs`: 128). A slug accepted by `set_active_provider` could be silently rejected by `login_provider`.
- Consolidate the constant in `crates/forge-shell/src/ipc.rs` at **128 bytes** — the more generous of the two, accommodating `custom_openai:<long_name>` — and re-import from both consumers.
- Per-file definitions removed; both call sites and existing oversize tests now resolve the constant from `ipc.rs`.

## Definition of Done

- [x] Single canonical `MAX_PROVIDER_ID_BYTES` in `ipc.rs`
- [x] Both former definitions removed; both consumers import from `ipc.rs`
- [x] Tests pass in CI

## Test plan

- [x] `just check-rust` clean (fmt + clippy + rustdoc)
- [x] `cargo test -p forge-shell --lib provider_id` — 8/8 pass, including `validate_login_inputs_rejects_oversize_provider_id` and `validate_provider_id_rejects_oversize`
- [ ] CI green on PR

Closes #711