### PR TITLE
[F-694] Catalog provider color discipline

### DIFF
--- a/web/packages/app/src/components/catalog/CatalogPane.css
+++ b/web/packages/app/src/components/catalog/CatalogPane.css
@@ -158,6 +158,35 @@
   gap: var(--sp-2);
 }
 
+/* F-694: provider color discipline. Provider-scoped groups inherit the
+ * accent color of the provider that owns the rows; matches the convention
+ * the dashboard ProvidersSection enforces (see docs/design/ai-patterns.md
+ * §"Provider identity"). The accent paints a left border on the group and
+ * tints the group label to keep the visual identity consistent across the
+ * pane and the dashboard.
+ */
+.catalog__group[data-provider] {
+  padding-left: var(--sp-3);
+  border-left: 3px solid var(--color-provider-accent, var(--color-border-2));
+}
+
+.catalog__group[data-provider='anthropic'] {
+  --color-provider-accent: var(--color-provider-anthropic);
+}
+.catalog__group[data-provider='openai'] {
+  --color-provider-accent: var(--color-provider-openai);
+}
+.catalog__group[data-provider='local'] {
+  --color-provider-accent: var(--color-provider-local);
+}
+.catalog__group[data-provider='custom'] {
+  --color-provider-accent: var(--color-provider-custom);
+}
+
+.catalog__group[data-provider] .catalog__group-label {
+  color: var(--color-provider-accent);
+}
+
 .catalog__group-label {
   margin: 0;
   font-family: var(--font-mono);
@@ -208,6 +237,38 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* F-694: Provider-typed rows carry a 6px dot ahead of the name, painted in
+ * the provider's accent color. This is the per-row equivalent of the group
+ * border applied to provider-scoped buckets.
+ */
+.catalog-row[data-provider] {
+  --color-provider-accent: var(--color-border-2);
+}
+.catalog-row[data-provider='anthropic'] {
+  --color-provider-accent: var(--color-provider-anthropic);
+}
+.catalog-row[data-provider='openai'] {
+  --color-provider-accent: var(--color-provider-openai);
+}
+.catalog-row[data-provider='local'] {
+  --color-provider-accent: var(--color-provider-local);
+}
+.catalog-row[data-provider='custom'] {
+  --color-provider-accent: var(--color-provider-custom);
+}
+
+.catalog-row[data-provider] .catalog-row__name::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-provider-accent);
+  margin-right: var(--sp-2);
+  vertical-align: middle;
+  flex-shrink: 0;
 }
 
 .catalog-row__meta {

--- a/web/packages/app/src/components/catalog/CatalogPane.test.tsx
+++ b/web/packages/app/src/components/catalog/CatalogPane.test.tsx
@@ -305,3 +305,96 @@ describe('<CatalogPane> (F-592)', () => {
     expect(await findByText(/set_setting failed: invalid value/)).toBeTruthy();
   });
 });
+
+// F-694: Provider color discipline — every catalog surface that names a
+// provider must carry a `data-provider="<color-id>"` attribute that maps to a
+// `--color-provider-*` token. Two surfaces qualify: (1) provider-scoped group
+// headers (rows grouped under a `Provider · <id>` label), and (2) Provider-
+// typed roster rows themselves. The mapping collapses runtime ids onto the
+// four design tokens — `anthropic`, `openai`, `ollama`→`local`, anything else
+// (including `custom_openai:*`) → `custom`.
+describe('<CatalogPane> provider color discipline (F-694)', () => {
+  const skillIn = (
+    skillId: string,
+    providerScopeId: string,
+  ): ScopedRosterEntry => ({
+    entry: { type: 'Skill', id: skillId },
+    scope: { type: 'Provider', id: providerScopeId },
+  });
+
+  it('tags provider-scoped group headers with data-provider mapped to a color token id', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      switch (cmd) {
+        case 'list_skills':
+          return Promise.resolve([
+            skillIn('claude-skill', 'anthropic'),
+            skillIn('gpt-skill', 'openai'),
+            skillIn('llama-skill', 'ollama'),
+            skillIn('byo-skill', 'custom_openai:acme'),
+          ]);
+        case 'list_mcp_servers':
+        case 'list_agents':
+          return Promise.resolve([]);
+        default:
+          return Promise.resolve(undefined);
+      }
+    });
+
+    const { container } = render(() => <CatalogPane workspaceRoot="/ws" />);
+    await flush();
+
+    const groups = container.querySelectorAll('.catalog__group[data-provider]');
+    const seen = new Set<string>();
+    for (const g of Array.from(groups)) {
+      seen.add(g.getAttribute('data-provider')!);
+    }
+    expect(seen.has('anthropic')).toBe(true);
+    expect(seen.has('openai')).toBe(true);
+    expect(seen.has('local')).toBe(true); // ollama → local
+    expect(seen.has('custom')).toBe(true); // custom_openai:* → custom
+  });
+
+  it('tags Provider-typed rows with data-provider matching the entry id', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      switch (cmd) {
+        case 'list_skills':
+          return Promise.resolve([
+            {
+              entry: { type: 'Provider', id: 'anthropic', model: 'claude-sonnet-4' },
+              scope: { type: 'SessionWide' },
+            } satisfies ScopedRosterEntry,
+            {
+              entry: { type: 'Provider', id: 'ollama', model: 'llama3.1' },
+              scope: { type: 'SessionWide' },
+            } satisfies ScopedRosterEntry,
+          ]);
+        case 'list_mcp_servers':
+        case 'list_agents':
+          return Promise.resolve([]);
+        default:
+          return Promise.resolve(undefined);
+      }
+    });
+
+    const { container } = render(() => <CatalogPane workspaceRoot="/ws" />);
+    await flush();
+
+    const rows = container.querySelectorAll('.catalog-row[data-kind="skills"][data-provider]');
+    const colorIds = Array.from(rows).map((r) => r.getAttribute('data-provider'));
+    expect(colorIds).toContain('anthropic');
+    expect(colorIds).toContain('local');
+  });
+
+  it('non-provider rows and session-wide groups do not carry a data-provider tag', async () => {
+    setupInvoke({
+      skills: [skill('typescript-review')],
+    });
+    const { container } = render(() => <CatalogPane workspaceRoot="/ws" />);
+    await flush();
+
+    const taggedGroups = container.querySelectorAll('.catalog__group[data-provider]');
+    expect(taggedGroups.length).toBe(0);
+    const taggedRows = container.querySelectorAll('.catalog-row[data-provider]');
+    expect(taggedRows.length).toBe(0);
+  });
+});

--- a/web/packages/app/src/components/catalog/CatalogPane.tsx
+++ b/web/packages/app/src/components/catalog/CatalogPane.tsx
@@ -75,6 +75,23 @@ interface CatalogRow {
   /** Free-form metadata line: provider model, agent background flag, etc. */
   meta: string;
   scope: ScopedRosterEntry['scope'];
+  /** F-694: design-token color id when the row itself is a Provider entry. */
+  providerColor: ProviderColorId | null;
+}
+
+/**
+ * F-694: maps a runtime provider id onto one of the four `--color-provider-*`
+ * design tokens. Runtime ids (`anthropic`, `openai`, `ollama`,
+ * `custom_openai:<name>`) are richer than the four-color discipline; this
+ * collapses them onto the canonical token names per `docs/design/ai-patterns.md`.
+ */
+type ProviderColorId = 'anthropic' | 'openai' | 'local' | 'custom';
+
+function providerColorId(id: string): ProviderColorId {
+  if (id === 'anthropic') return 'anthropic';
+  if (id === 'openai') return 'openai';
+  if (id === 'ollama' || id === 'lm-studio' || id === 'local') return 'local';
+  return 'custom';
 }
 
 function rosterId(entry: RosterEntry): string {
@@ -109,6 +126,8 @@ function toRow(kind: CatalogKind, scoped: ScopedRosterEntry): CatalogRow {
     name: rosterId(scoped.entry),
     meta: rosterMeta(scoped.entry),
     scope: scoped.scope,
+    providerColor:
+      scoped.entry.type === 'Provider' ? providerColorId(scoped.entry.id) : null,
   };
 }
 
@@ -138,6 +157,8 @@ interface ScopeGroup {
   key: string;
   label: string;
   rows: CatalogRow[];
+  /** F-694: design-token color id for provider-scoped groups; null otherwise. */
+  providerColor: ProviderColorId | null;
 }
 
 function groupByScope(rows: CatalogRow[]): ScopeGroup[] {
@@ -146,7 +167,13 @@ function groupByScope(rows: CatalogRow[]): ScopeGroup[] {
     const key = scopeKey(row.scope);
     let group = groups.get(key);
     if (group === undefined) {
-      group = { key, label: scopeLabel(row.scope), rows: [] };
+      group = {
+        key,
+        label: scopeLabel(row.scope),
+        rows: [],
+        providerColor:
+          row.scope.type === 'Provider' ? providerColorId(row.scope.id) : null,
+      };
       groups.set(key, group);
     }
     group.rows.push(row);
@@ -341,7 +368,10 @@ export const CatalogPane: Component<CatalogPaneProps> = (props) => {
                       <ul class="catalog__groups">
                         <For each={groups()}>
                           {(group) => (
-                            <li class="catalog__group">
+                            <li
+                              class="catalog__group"
+                              data-provider={group.providerColor ?? undefined}
+                            >
                               <h3 class="catalog__group-label">{group.label}</h3>
                               <ul class="catalog__rows">
                                 <For each={group.rows}>
@@ -399,7 +429,12 @@ interface CatalogRowViewProps {
 const CatalogRowView: Component<CatalogRowViewProps> = (props) => {
   const id = `catalog-toggle-${props.row.kind}-${props.row.id}`;
   return (
-    <li class="catalog-row" data-kind={props.row.kind} data-id={props.row.id}>
+    <li
+      class="catalog-row"
+      data-kind={props.row.kind}
+      data-id={props.row.id}
+      data-provider={props.row.providerColor ?? undefined}
+    >
       <div class="catalog-row__body">
         <span class="catalog-row__name">{props.row.name}</span>
         <Show when={props.row.meta}>


### PR DESCRIPTION
Closes forge-ide/forge#730

## Summary
- Provider-scoped catalog groups (rows grouped under a `Provider · <id>` header) now carry a `data-provider` attribute and paint a left-border accent + tinted label using the `--color-provider-*` design tokens.
- Provider-typed roster rows themselves get a 6px provider-color dot ahead of the name.
- Runtime provider ids (`anthropic`, `openai`, `ollama`, `lm-studio`, `custom_openai:*`) collapse onto the four-color discipline from `docs/design/ai-patterns.md`. Mapping mirrors the existing `routes/Session/providerAccent.ts` helper.
- No token changes — `--color-provider-{anthropic,openai,local,custom}` already exist in `tokens.css` and `token-reference.md`.

## Test plan
- `pnpm --filter app test` — 1212 passed (84 files), 3 new tests in `CatalogPane.test.tsx` covering provider-scope groups, Provider-typed rows, and the negative case (no tag on session-wide / non-provider entries).
- `pnpm typecheck` clean across all packages.
- `node scripts/check-tokens.mjs` clean (59 tokens match reference).

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)