### PR TITLE
[F-676] Split overloaded Hello frame into dedicated DaemonHello variant

### DIFF
--- a/crates/forge-agent-host/src/lib.rs
+++ b/crates/forge-agent-host/src/lib.rs
@@ -48,7 +48,8 @@ use chrono::Utc;
 use forge_core::{Event, EventSink, MessageId, ProviderId};
 use forge_ipc::sidecar::{
     CrashDump, SidecarAgentDef, SidecarCrashed, SidecarCredentials, SidecarEvent, SidecarHeartbeat,
-    SidecarHelloAck, SidecarMessage, SidecarProviderSpec, SidecarRunTurn, SIDECAR_SCHEMA_VERSION,
+    SidecarHelloAck, SidecarMessage, SidecarProviderSpec, SidecarRunTurn, SIDECAR_PROTO_VERSION,
+    SIDECAR_SCHEMA_VERSION,
 };
 use secrecy::SecretString;
 use tokio::io::{ReadHalf, WriteHalf};
@@ -769,21 +770,49 @@ async fn dispatch_loop(
                     grace_ms: s.grace_ms,
                 });
             }
-            // F-608 step 5: the supervisor forwards the daemon-side
-            // `Hello` payload as a follow-up frame after the
-            // handshake. Capture the agent_def / provider_spec /
-            // workspace path so the (still-stub) RunTurn handler — and
-            // step 6's real provider body — can seed itself from the
-            // metadata the daemon already had on hand. Validate the
-            // `instance_id` against argv to catch a confused supervisor
-            // wiring two children to the same socket; the error is
-            // non-fatal (we drop the frame and continue) so the
-            // sidecar does not take itself down on a peer mistake.
-            SidecarMessage::Hello(h) => {
+            // F-608 step 5 / F-676: the supervisor forwards the
+            // daemon-side metadata payload as a dedicated `DaemonHello`
+            // frame after the handshake (split from the original
+            // overloaded `Hello` discriminator in F-676). Capture the
+            // agent_def / provider_spec / workspace path so the
+            // (still-stub) RunTurn handler — and step 6's real provider
+            // body — can seed itself from the metadata the daemon
+            // already had on hand. Re-validate `proto` and
+            // `instance_id` against the values established at handshake
+            // time; the errors are non-fatal (we drop the frame and
+            // continue) so the sidecar does not take itself down on a
+            // peer mistake.
+            SidecarMessage::DaemonHello(h) => {
+                if h.proto != SIDECAR_PROTO_VERSION {
+                    warn!(
+                        instance_id = %h.instance_id,
+                        proto = h.proto,
+                        expected = SIDECAR_PROTO_VERSION,
+                        "DaemonHello proto mismatch; dropping frame"
+                    );
+                    continue;
+                }
+                if h.instance_id.to_string() != instance_id {
+                    warn!(
+                        received = %h.instance_id,
+                        expected = %instance_id,
+                        "DaemonHello instance_id mismatch; dropping frame"
+                    );
+                    continue;
+                }
+                // F-678: surface daemon↔sidecar schema-version skew on
+                // the DaemonHello metadata frame too (the same check
+                // that fires on `HelloAck`). Soft warn — drift is not
+                // fatal here, the discriminator change is what matters.
+                forge_ipc::warn_if_schema_mismatch(
+                    "daemon",
+                    h.schema_version,
+                    SIDECAR_SCHEMA_VERSION,
+                );
                 info!(
                     instance_id = %h.instance_id,
                     proto = h.proto,
-                    "received daemon Hello payload"
+                    "received DaemonHello payload"
                 );
                 daemon_hello.set(DaemonHelloPayload {
                     agent_def: h.agent_def,
@@ -794,11 +823,13 @@ async fn dispatch_loop(
                     telemetry_endpoint: h.telemetry_endpoint,
                 });
             }
-            // Sidecar → daemon variants on the daemon → sidecar half are
-            // a protocol violation; warn and continue rather than crash
-            // (we don't want the sidecar to take itself down on a
-            // confused supervisor).
-            SidecarMessage::HelloAck(_)
+            // The sidecar → daemon `Hello` handshake variant should
+            // never arrive on this side after the initial handshake.
+            // Treat as a protocol violation; warn and continue rather
+            // than crash (we don't want the sidecar to take itself
+            // down on a confused supervisor).
+            SidecarMessage::Hello(_)
+            | SidecarMessage::HelloAck(_)
             | SidecarMessage::Event(_)
             | SidecarMessage::ToolCallApprovalRequest(_)
             | SidecarMessage::Heartbeat(_)

--- a/crates/forge-ipc/src/sidecar.rs
+++ b/crates/forge-ipc/src/sidecar.rs
@@ -118,7 +118,13 @@ pub const SIDECAR_PROTO_VERSION: u32 = 1;
 /// * `2` — F-608 step 6: `Credentials.secret_handle: String` →
 ///   `Credentials.secret: SecretBytes` (`Vec<u8>` opaque, redacted
 ///   `Debug`/`Display`).
-pub const SIDECAR_SCHEMA_VERSION: u32 = 2;
+/// * `3` — F-676: split the overloaded `Hello` discriminator into
+///   `Hello` (sidecar → daemon handshake) and `DaemonHello` (daemon →
+///   sidecar metadata follow-up). The daemon and sidecar binaries ship
+///   together, so this is a co-deployed bump; mixing a pre-`3`
+///   supervisor with a `3`-aware sidecar (or vice versa) is unsupported
+///   and surfaces as a deserialization error on the unknown variant.
+pub const SIDECAR_SCHEMA_VERSION: u32 = 3;
 
 /// Bidirectional message exchanged between `forged` and `forged-agent`.
 ///
@@ -129,10 +135,17 @@ pub const SIDECAR_SCHEMA_VERSION: u32 = 2;
 #[serde(tag = "t")]
 pub enum SidecarMessage {
     // ── daemon → sidecar ──────────────────────────────────────────────────
-    /// First frame after the sidecar connects. Carries everything the
-    /// child needs to initialize its provider loop without re-reading
-    /// daemon-owned state from disk.
-    Hello(SidecarHello),
+    /// Daemon → sidecar metadata frame sent immediately after the
+    /// supervisor's [`SidecarMessage::HelloAck`]. Carries the agent
+    /// definition, allowed paths, workspace path, provider spec,
+    /// sandbox level, and telemetry endpoint the run-turn body needs to
+    /// initialize without re-reading daemon-owned state from disk.
+    ///
+    /// Split from [`SidecarMessage::Hello`] in F-676 (schema_version 3)
+    /// so the discriminator no longer encodes two semantically distinct
+    /// frames. The receive side validates `proto` and `instance_id`
+    /// against the values established at handshake time.
+    DaemonHello(SidecarHello),
 
     /// Run one turn of the request loop. The sidecar streams events back
     /// as [`SidecarMessage::Event`] frames and emits no reply; the
@@ -164,7 +177,15 @@ pub enum SidecarMessage {
     Shutdown(SidecarShutdown),
 
     // ── sidecar → daemon ──────────────────────────────────────────────────
-    /// Acknowledges [`SidecarMessage::Hello`] and reports the child's
+    /// Initial handshake frame the *child* sends on connect to advertise
+    /// its `instance_id` and `proto` version. The supervisor validates
+    /// both before responding with [`SidecarMessage::HelloAck`]. The
+    /// daemon-initiated metadata follow-up is
+    /// [`SidecarMessage::DaemonHello`]; F-676 split the two so this
+    /// discriminator carries the handshake direction unambiguously.
+    Hello(SidecarHello),
+
+    /// Acknowledges [`SidecarMessage::Hello`] and reports the daemon's
     /// PID. The supervisor pins this `pid` into `ResourceMonitor::track`
     /// (closing F-451) and uses `started_at` to time-stamp restart
     /// counters.
@@ -195,8 +216,11 @@ pub enum SidecarMessage {
 
 // ── daemon → sidecar payloads ────────────────────────────────────────────
 
-/// Initial sidecar → daemon handshake payload (and, in step-4 of F-608,
-/// the daemon → sidecar follow-up that forwards the spawn parameters).
+/// Handshake / metadata payload shared by [`SidecarMessage::Hello`]
+/// (sidecar → daemon, on connect) and [`SidecarMessage::DaemonHello`]
+/// (daemon → sidecar, after `HelloAck`). The runtime fields are
+/// identical; F-676 splits the *discriminator* so call sites can tell
+/// the two flows apart without inspecting context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SidecarHello {
     pub proto: u32,
@@ -452,6 +476,28 @@ mod tests {
                 telemetry_endpoint: Some("http://otel:4317".into()),
                 schema_version: SIDECAR_SCHEMA_VERSION,
             }),
+            SidecarMessage::DaemonHello(SidecarHello {
+                proto: SIDECAR_PROTO_VERSION,
+                instance_id: AgentInstanceId::from_string("inst-3".into()),
+                agent_def: SidecarAgentDef {
+                    name: "daemon-payload".into(),
+                    description: Some("daemon → sidecar metadata".into()),
+                    body: "## Prompt".into(),
+                    allowed_paths: vec!["/workspace".into()],
+                    isolation: "process".into(),
+                    memory_enabled: true,
+                },
+                allowed_paths: vec!["/workspace".into()],
+                workspace_path: "/workspace".into(),
+                provider_spec: SidecarProviderSpec {
+                    kind: "ollama".into(),
+                    model: "llama3.1:8b".into(),
+                    base_url: None,
+                },
+                sandbox_level: SidecarSandboxLevel::Level1,
+                telemetry_endpoint: Some("http://otel:4317".into()),
+                schema_version: SIDECAR_SCHEMA_VERSION,
+            }),
             SidecarMessage::RunTurn(SidecarRunTurn {
                 turn_id: "turn-1".into(),
                 msg_id: MessageId::from_string("msg-1".into()),
@@ -516,6 +562,59 @@ mod tests {
             let got_json = serde_json::to_string(&got).unwrap();
             assert_eq!(sent_json, got_json, "round-trip mismatch");
         }
+    }
+
+    /// F-676: `Hello` and `DaemonHello` carry the same payload shape
+    /// but must serialize with distinct `t` tags so the receive side can
+    /// disambiguate the handshake-direction frame from the daemon-side
+    /// metadata follow-up. Pin both tags here so a future enum-rename
+    /// surfaces in CI.
+    #[test]
+    fn hello_and_daemon_hello_use_distinct_wire_tags() {
+        let payload = SidecarHello {
+            proto: SIDECAR_PROTO_VERSION,
+            instance_id: AgentInstanceId::from_string("inst-x".into()),
+            agent_def: SidecarAgentDef {
+                name: "n".into(),
+                description: None,
+                body: String::new(),
+                allowed_paths: vec![],
+                isolation: "process".into(),
+                memory_enabled: false,
+            },
+            allowed_paths: vec![],
+            workspace_path: "/workspace".into(),
+            provider_spec: SidecarProviderSpec {
+                kind: "ollama".into(),
+                model: "llama3.1:8b".into(),
+                base_url: None,
+            },
+            sandbox_level: SidecarSandboxLevel::Level1,
+            telemetry_endpoint: None,
+            schema_version: SIDECAR_SCHEMA_VERSION,
+        };
+
+        let hello_v: serde_json::Value = serde_json::from_slice(
+            &serde_json::to_vec(&SidecarMessage::Hello(payload.clone())).unwrap(),
+        )
+        .unwrap();
+        let daemon_v: serde_json::Value = serde_json::from_slice(
+            &serde_json::to_vec(&SidecarMessage::DaemonHello(payload.clone())).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(hello_v.get("t").and_then(|v| v.as_str()), Some("Hello"));
+        assert_eq!(
+            daemon_v.get("t").and_then(|v| v.as_str()),
+            Some("DaemonHello")
+        );
+
+        // Round-trip back to the typed enum: the `t` tag must drive the
+        // arm, not the payload shape.
+        let hello_back: SidecarMessage = serde_json::from_value(hello_v).unwrap();
+        let daemon_back: SidecarMessage = serde_json::from_value(daemon_v).unwrap();
+        assert!(matches!(hello_back, SidecarMessage::Hello(_)));
+        assert!(matches!(daemon_back, SidecarMessage::DaemonHello(_)));
     }
 
     /// `CrashDump` is the on-disk dump shape persisted by the sidecar's

--- a/crates/forge-session/src/sidecar/mod.rs
+++ b/crates/forge-session/src/sidecar/mod.rs
@@ -534,23 +534,22 @@ impl SidecarSupervisor {
             "sidecar handshake complete",
         );
 
-        // Optionally pass the original daemon → child Hello payload
-        // forward as a follow-up frame. Step 1's protocol shape is
-        // child-initiated; the supervisor still needs to deliver
-        // `agent_def`, `provider_spec`, etc. to the child for the
-        // run-turn body to consume in step 5. We send the payload as a
-        // second `Hello` frame so the child can pick it up via the
-        // same dispatch loop. The current step-3 stub binary ignores
-        // it as a "non-RunTurn daemon message" — wiring step 5 will
-        // teach the child to consume it.
-        let daemon_hello = SidecarMessage::Hello(hello.clone());
+        // Pass the daemon-side metadata payload forward as a follow-up
+        // frame. Step 1's handshake shape is child-initiated; the
+        // supervisor still needs to deliver `agent_def`,
+        // `provider_spec`, etc. to the child for the run-turn body to
+        // consume in step 5. F-676: this travels as a dedicated
+        // `DaemonHello` variant rather than a second `Hello`, so the
+        // discriminator no longer encodes two semantically distinct
+        // frames and the receiver can pattern-match the daemon-side
+        // payload distinctly from the handshake.
+        let daemon_hello = SidecarMessage::DaemonHello(hello.clone());
         if let Err(e) = forge_ipc::write_frame(&mut writer, &daemon_hello).await {
-            // Non-fatal in step 4: the child stub ignores the frame. A
-            // failure here implies the connection broke between ack and
-            // first command — fold it into the restart loop by treating
-            // it as a fresh crash.
+            // A failure here implies the connection broke between ack
+            // and first command — fold it into the restart loop by
+            // treating it as a fresh crash.
             let _ = child.kill().await;
-            return Err(e.context("forward daemon Hello to forged-agent"));
+            return Err(e.context("forward DaemonHello to forged-agent"));
         }
 
         Ok(LiveSidecar {
@@ -964,7 +963,9 @@ impl SupervisorTask {
                 c.panic_message,
                 c.backtrace.unwrap_or_default()
             )),
-            SidecarMessage::HelloAck(_) | SidecarMessage::Hello(_) => {
+            SidecarMessage::HelloAck(_)
+            | SidecarMessage::Hello(_)
+            | SidecarMessage::DaemonHello(_) => {
                 warn!(
                     target: "forge_session::sidecar",
                     instance_id = %self.instance_id,

--- a/docs/architecture/agent-sidecar.md
+++ b/docs/architecture/agent-sidecar.md
@@ -71,8 +71,9 @@ forge-shell ◀──UDS──┤             forged              │
 
 | Direction | Variant | Payload |
 |---|---|---|
-| daemon → sidecar | `Hello` | `{ proto: u32, instance_id, agent_def, allowed_paths, workspace_path, provider_spec, sandbox_level, telemetry_endpoint }` |
-| sidecar → daemon | `HelloAck` | `{ pid, started_at, schema_version }` |
+| sidecar → daemon | `Hello` | `{ proto: u32, instance_id, agent_def, allowed_paths, workspace_path, provider_spec, sandbox_level, telemetry_endpoint }` (handshake; supervisor validates `proto` and `instance_id` before completing the handshake) |
+| daemon → sidecar | `HelloAck` | `{ pid, started_at, schema_version }` |
+| daemon → sidecar | `DaemonHello` | `{ proto: u32, instance_id, agent_def, allowed_paths, workspace_path, provider_spec, sandbox_level, telemetry_endpoint }` (F-676: dedicated metadata follow-up sent immediately after `HelloAck`; sidecar re-validates `proto` and `instance_id` against handshake state) |
 | daemon → sidecar | `RunTurn` | `{ turn_id, msg_id, text, agents_md, branch_parent, branch_variant_index, byte_budget }` |
 | daemon → sidecar | `Credentials` | `{ provider_id, secret_handle }` (push model — see §5) |
 | daemon → sidecar | `ToolCallApproved` / `ToolCallRejected` | mirrors `crates/forge-ipc/src/lib.rs:191` |


### PR DESCRIPTION
## Summary

The sidecar protocol previously reused `SidecarMessage::Hello` for two semantically distinct purposes: the sidecar→daemon handshake on connect and the daemon→sidecar metadata follow-up after `HelloAck`. Reading either site required call-site inspection, and the receive side never re-validated `proto`/`instance_id` on the second frame, so a corrupted metadata frame slipped through silently.

## Changes

- **`crates/forge-ipc/src/sidecar.rs`** — Add `SidecarMessage::DaemonHello(SidecarHello)`. Bump `SIDECAR_SCHEMA_VERSION` to `3`. Re-document `Hello` as the sidecar→daemon handshake variant and `DaemonHello` as the daemon→sidecar metadata follow-up; update the shared `SidecarHello` payload doc to match.
- **`crates/forge-session/src/sidecar/mod.rs`** — Supervisor emits `DaemonHello` immediately after `HelloAck` instead of a second `Hello`. Outbound-side handler also accepts `DaemonHello` in the “unexpected handshake frame after handshake complete” warn path.
- **`crates/forge-agent-host/src/lib.rs`** — Dispatch loop pattern-matches `DaemonHello`. Re-validates `h.proto == SIDECAR_PROTO_VERSION` and `h.instance_id == argv.instance_id`; logs `warn` and drops the frame on mismatch (non-fatal). The `Hello` variant moves to the protocol-violation list since it should never arrive on the daemon→sidecar leg post-handshake. Pulls `SIDECAR_PROTO_VERSION` into the file-level imports.
- **`docs/architecture/agent-sidecar.md`** — Update the §2 protocol table to list both `Hello` (with the corrected sidecar→daemon direction) and `DaemonHello` with their distinct semantics.

## Tests

- `sidecar_message_roundtrip` now includes a `DaemonHello` case alongside the existing `Hello` cases (full serde round-trip with all payload fields exercised).
- New `hello_and_daemon_hello_use_distinct_wire_tags` pins the `t`-tag distinction (`"Hello"` vs `"DaemonHello"`) and round-trips through `serde_json::Value` to prove the discriminator drives the arm, not the payload shape.
- Full workspace `cargo test` and `just check-rust` (fmt + clippy + RUSTDOCFLAGS=-D warnings cargo doc) pass locally.

## Definition of Done

- [x] `DaemonHello` variant exists and the supervisor uses it
- [x] Round-trip serde tests for the new shape (`sidecar_message_roundtrip` + `hello_and_daemon_hello_use_distinct_wire_tags`)
- [x] Receive side re-validates `proto` + `instance_id` on the daemon-side frame (additional belt-and-braces beyond the variant split)
- [x] Tests pass in CI (pending — local `just check-rust` clean)

Closes #712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)