### PR TITLE
[F-695] Fix SubAgentBanner beyond-max-depth button copy

### DIFF
--- a/web/packages/app/src/components/SubAgentBanner.test.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.test.tsx
@@ -145,7 +145,7 @@ describe('SubAgentBanner — nested rendering for sub-of-sub', () => {
     expect(nestedHeader).toHaveTextContent('deep-helper');
   });
 
-  it('replaces nested inline children with an "OPEN MONITOR" button past max depth (3)', () => {
+  it('replaces nested inline children with an "OPEN IN NEW WINDOW" button past max depth (3)', () => {
     const grandchild: Extract<ChatTurn, { type: 'sub_agent_banner' }> = {
       type: 'sub_agent_banner',
       child_instance_id: 'too-deep-1',
@@ -222,7 +222,7 @@ describe('SubAgentBanner — double-click to Agent Monitor (F-140)', () => {
     expect(open).toHaveBeenCalledWith('child-1');
   });
 
-  it('invokes the "OPEN MONITOR" button when depth exceeds the inline cap', () => {
+  it('invokes the "OPEN IN NEW WINDOW" button when depth exceeds the inline cap', () => {
     const open = vi.fn();
     const grandchild: Extract<ChatTurn, { type: 'sub_agent_banner' }> = {
       type: 'sub_agent_banner',
@@ -241,10 +241,11 @@ describe('SubAgentBanner — double-click to Agent Monitor (F-140)', () => {
     ));
     fireEvent.click(getByTestId('sub-agent-banner-header-child-1'));
     const openBtn = getByTestId('sub-agent-banner-open-monitor-child-1');
-    // F-411: button label must be the sanctioned verb+noun display-caps form
-    // (voice-terminology.md §8).
-    expect(openBtn).toHaveTextContent('OPEN MONITOR');
-    expect(openBtn.textContent).not.toMatch(/Open in new window/);
+    // F-695: spec (`sub-agent-banner.md` §6) is authoritative — the button
+    // copy must be the verbatim phrase the spec sanctions, rendered in
+    // voice-terminology.md §8 display caps.
+    expect(openBtn).toHaveTextContent('OPEN IN NEW WINDOW');
+    expect(openBtn.textContent).not.toMatch(/OPEN MONITOR/);
     fireEvent.click(openBtn);
     expect(open).toHaveBeenCalledWith('child-1');
   });

--- a/web/packages/app/src/components/SubAgentBanner.tsx
+++ b/web/packages/app/src/components/SubAgentBanner.tsx
@@ -238,7 +238,7 @@ export const SubAgentBanner: Component<SubAgentBannerProps> = (props) => {
                 data-testid={`sub-agent-banner-open-monitor-${props.turn.child_instance_id}`}
                 onClick={openInMonitor}
               >
-                OPEN MONITOR
+                OPEN IN NEW WINDOW
               </Button>
             }
           >


### PR DESCRIPTION
Closes #731.

## Summary

`SubAgentBanner` rendered `OPEN MONITOR` for the beyond-MAX_INLINE_DEPTH affordance, drifting from the authoritative spec at `docs/ui-specs/sub-agent-banner.md` §6 ("…and **\"Open in new window\"** appears."). The spec wins; component now renders the spec phrase verbatim in voice-terminology.md §8 display caps:

```tsx
<Button>OPEN IN NEW WINDOW</Button>
```

Two existing tests were already pinning the (drifted) `OPEN MONITOR` label and explicitly asserting the new-window phrasing was *not* used. Both are flipped to assert the spec wording, with a comment noting `sub-agent-banner.md` §6 as the source of truth.

## Definition of Done

- [x] Component text updated to match the spec (no spec edit needed)
- [x] File changed is the one named in the DoD (`web/packages/app/src/components/SubAgentBanner.tsx`)
- [x] Tests pass in CI

## Test plan

- [x] `pnpm typecheck` clean
- [x] `vitest run SubAgentBanner` — 32/32 pass
- [x] `vitest run` (app package) — 1209/1209 pass
- [x] `pnpm check-tokens` — clean
- [ ] CI green