### PR TITLE
[F-692] CredentialsSection.css: replace raw rgba with design tokens

### DIFF
--- a/docs/design/token-reference.md
+++ b/docs/design/token-reference.md
@@ -66,6 +66,10 @@ These tokens should be defined at `:root` and used throughout. Never use raw val
   --color-error-border:   rgba(255,74,18,0.22);
   --color-info-border:    rgba(122,170,255,0.22);
 
+  /* Overlays & elevation — modal scrims and elevated-surface shadows. */
+  --color-overlay: rgba(0, 0, 0, 0.55);
+  --shadow-modal: 0 8px 32px rgba(0, 0, 0, 0.5);
+
   /* Syntax */
   --color-syntax-kw:      #ff7a30;
   --color-syntax-fn:      #ffd166;

--- a/web/packages/app/src/components/dashboard/CredentialsSection.css
+++ b/web/packages/app/src/components/dashboard/CredentialsSection.css
@@ -190,7 +190,7 @@
 .credentials-section__modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.55);
+  background: var(--color-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -208,7 +208,7 @@
   gap: var(--sp-4);
   width: 100%;
   max-width: 420px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-modal);
 }
 
 .credentials-section__modal-head {

--- a/web/packages/design/src/tokens.css
+++ b/web/packages/design/src/tokens.css
@@ -54,6 +54,10 @@
   --color-error-border:   rgba(255,74,18,0.22);
   --color-info-border:    rgba(122,170,255,0.22);
 
+  /* Overlays & elevation — modal scrims and elevated-surface shadows. */
+  --color-overlay: rgba(0, 0, 0, 0.55);
+  --shadow-modal: 0 8px 32px rgba(0, 0, 0, 0.5);
+
   /* Syntax */
   --color-syntax-kw:      #ff7a30;
   --color-syntax-fn:      #ffd166;


### PR DESCRIPTION
## Summary
- Replace hard-coded `rgba(0,0,0,0.55)` modal backdrop and `0 8px 32px rgba(0,0,0,0.5)` shadow in `CredentialsSection.css` with `var(--color-overlay)` and `var(--shadow-modal)`.
- Add `--color-overlay` and `--shadow-modal` tokens to `tokens.css` and document them in `docs/design/token-reference.md`.

Closes #728.

## Definition of Done
- [x] CSS uses CSS custom properties for both values
- [x] New tokens (`--color-overlay`, `--shadow-modal`) appear in `tokens.css` and `token-reference.md`
- [x] `node scripts/check-tokens.mjs` clean (`ok: 61 tokens match`)
- [x] `pnpm typecheck` passes

## Test plan
- [x] `node scripts/check-tokens.mjs` — clean
- [x] `pnpm typecheck` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)