### PR TITLE
[F-698] Export typography tokens and migrate dashboard CSS to var(--type-*)

### DIFF
--- a/docs/design/token-reference.md
+++ b/docs/design/token-reference.md
@@ -98,6 +98,13 @@ These tokens should be defined at `:root` and used throughout. Never use raw val
   --font-body:    'Barlow', sans-serif;
   --font-mono:    'Fira Code', monospace;
 
+  /* Type scale — exported sizes from docs/design/typography.md.
+   * Use these in component CSS instead of bare `font-size: Npx`. */
+  --type-body-sm: 12px;
+  --type-mono-md: 13px;
+  --type-mono-sm: 11px;
+  --type-mono-xs: 9px;
+
   /* Provider accent colors */
   --color-provider-anthropic: #ff4a12;
   --color-provider-openai:    #ffaa33;

--- a/web/packages/app/src/components/dashboard/ContainersSection.css
+++ b/web/packages/app/src/components/dashboard/ContainersSection.css
@@ -29,7 +29,7 @@
 
 .containers-section__hint {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--type-mono-md);
   color: var(--color-text-secondary);
   line-height: 1.5;
 }
@@ -41,7 +41,7 @@
   border-left: 3px solid var(--color-error);
   border-radius: var(--r-sm);
   color: var(--color-text-primary);
-  font-size: 13px;
+  font-size: var(--type-mono-md);
 }
 
 .containers-section__list {
@@ -78,12 +78,12 @@
 
 .containers-section__id {
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--type-mono-md);
   color: var(--color-text-primary);
 }
 
 .containers-section__image {
-  font-size: 13px;
+  font-size: var(--type-mono-md);
   color: var(--color-text-secondary);
 }
 
@@ -103,7 +103,7 @@
   display: flex;
   gap: var(--sp-3);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-tertiary);
 }
 
@@ -169,7 +169,7 @@
   border-radius: var(--r-sm);
   padding: var(--sp-3);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   color: var(--color-text-secondary);
   line-height: 1.5;
   white-space: pre;
@@ -232,14 +232,14 @@
 
 .containers-banner__headline {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--type-mono-md);
   font-weight: 600;
   color: var(--color-text-primary);
 }
 
 .containers-banner__detail {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   color: var(--color-text-secondary);
   line-height: 1.5;
 }

--- a/web/packages/app/src/components/dashboard/CredentialsSection.css
+++ b/web/packages/app/src/components/dashboard/CredentialsSection.css
@@ -63,7 +63,7 @@
   height: var(--sp-5);
   border-radius: 50%;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   flex-shrink: 0;
 }
 
@@ -90,7 +90,7 @@
 
 .credentials-section__env-hint {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-tertiary);
   margin-left: auto;
 }
@@ -113,7 +113,7 @@
 .credentials-section__input {
   flex: 1;
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--type-mono-md);
   background: var(--color-bg);
   color: var(--color-text-primary);
   border: 1px solid var(--color-border-2);
@@ -138,7 +138,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   padding: var(--sp-2) var(--sp-4);
   background: transparent;
   color: var(--color-text-primary);
@@ -179,7 +179,7 @@
   border-left: 3px solid var(--color-ember-400);
   border-radius: var(--r-sm);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   color: var(--color-ember-300);
 }
 
@@ -266,7 +266,7 @@
 
 .credentials-banner__text {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--type-mono-md);
   color: var(--color-text-secondary);
   line-height: 1.5;
 }

--- a/web/packages/app/src/components/dashboard/MemorySection.css
+++ b/web/packages/app/src/components/dashboard/MemorySection.css
@@ -29,7 +29,7 @@
 
 .memory-section__warn {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   letter-spacing: 0.05em;
   color: var(--color-warning);
   background: var(--color-warning-bg);
@@ -75,13 +75,13 @@
 
 .memory-section__meta {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-tertiary);
 }
 
 .memory-section__path {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-tertiary);
   word-break: break-all;
 }
@@ -102,7 +102,7 @@
 
 .memory-section__toggle-label {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--color-text-secondary);
@@ -110,13 +110,13 @@
 
 .memory-section__error {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-danger, var(--color-warning));
 }
 
 .memory-section__empty {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-tertiary);
   font-style: italic;
 }
@@ -159,7 +159,7 @@
 
 .memory-editor__path {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-tertiary);
   word-break: break-all;
   flex: 1;
@@ -175,7 +175,7 @@
   border-bottom: 1px solid var(--color-warning-border);
   padding: var(--sp-2) var(--sp-4);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
 }
 
 .memory-editor__body {
@@ -195,7 +195,7 @@
   background: var(--color-bg-1);
   color: var(--color-text-primary);
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--type-mono-md);
   line-height: 1.5;
   outline: 0;
 }
@@ -218,7 +218,7 @@
 
 .memory-editor__status {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-tertiary);
 }
 
@@ -234,7 +234,7 @@
   padding: var(--sp-2) var(--sp-4);
   border-bottom: 1px solid var(--color-border-1);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
 }
 
 .memory-editor--small {

--- a/web/packages/app/src/components/dashboard/ProvidersSection.css
+++ b/web/packages/app/src/components/dashboard/ProvidersSection.css
@@ -35,7 +35,7 @@
 
 .providers__loading {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-secondary);
   letter-spacing: 0.2em;
   margin: 0;
@@ -52,7 +52,7 @@
   border-radius: var(--r-sm);
   margin: 0;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   color: var(--color-ember-300);
 }
 
@@ -62,13 +62,13 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   color: var(--color-ember-300);
 }
 
 .providers__error-detail {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--type-mono-md);
   color: var(--color-text-secondary);
 }
 
@@ -96,7 +96,7 @@
   text-transform: none;
   letter-spacing: 0;
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--type-mono-md);
   font-weight: 400;
   border: 1px solid var(--color-border-2);
   background: var(--color-surface-2);
@@ -143,7 +143,7 @@
 
 .provider-card__row--meta {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-secondary);
 }
 
@@ -167,7 +167,7 @@
 
 .provider-card__hint {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   color: var(--color-text-secondary);
   white-space: nowrap;
   overflow: hidden;
@@ -183,7 +183,7 @@
 
 .provider-card__cred {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--type-mono-sm);
   padding: 0 var(--sp-1);
   flex-shrink: 0;
 }

--- a/web/packages/design/src/tokens.css
+++ b/web/packages/design/src/tokens.css
@@ -86,6 +86,13 @@
   --font-body:    'Barlow', sans-serif;
   --font-mono:    'Fira Code', monospace;
 
+  /* Type scale — exported sizes from docs/design/typography.md.
+   * Use these in component CSS instead of bare `font-size: Npx`. */
+  --type-body-sm: 12px;
+  --type-mono-md: 13px;
+  --type-mono-sm: 11px;
+  --type-mono-xs: 9px;
+
   /* Provider accent colors */
   --color-provider-anthropic: #ff4a12;
   --color-provider-openai:    #ffaa33;


### PR DESCRIPTION
## Summary

- Adds the documented type scale (`--type-body-sm`, `--type-mono-md`, `--type-mono-sm`, `--type-mono-xs`) as CSS custom properties in `web/packages/design/src/tokens.css` and `docs/design/token-reference.md`.
- Migrates matching hardcoded `font-size: Npx` values (9/11/12/13px) in the four Phase 3 dashboard section CSS files (`CredentialsSection`, `ProvidersSection`, `MemorySection`, `ContainersSection`) to `var(--type-*)`.
- Layered cleanly on top of F-692's `--color-overlay` / `--shadow-modal` additions.

## Out of scope

The issue's remediation lists exactly the four tokens above. The dashboard CSS still contains a handful of bare sizes that don't correspond to any documented type-scale token: `10px` (5x), `14px` (2x), `16px` (2x), `1rem` (2x), `1.125rem` (1x). These are left untouched — picking tokens for them would invent scope beyond the issue.

## Definition of Done

- [x] Typography tokens exported from `tokens.css` and listed in `token-reference.md`
- [x] Phase 3 dashboard CSS uses `var(--type-*)` for every size that has a matching token (12px → body-sm, 11px → mono-sm, 13px → mono-md, 9px → mono-xs)
- [x] `node scripts/check-tokens.mjs` clean
- [x] `pnpm typecheck` clean

## Test plan

- [x] `node scripts/check-tokens.mjs` → ok: 63 tokens match
- [x] `pnpm typecheck` → all 4 workspace projects pass
- [x] `vitest run src/components/dashboard` → 52/52 pass

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)