### PR TITLE
[F-679] Extract duplicated utilities across Anthropic and OpenAI providers

### DIFF
--- a/crates/forge-providers/src/anthropic/mod.rs
+++ b/crates/forge-providers/src/anthropic/mod.rs
@@ -10,12 +10,11 @@
 //! per-line byte cap, inter-event idle timeout, and overall wall-clock budget.
 //! Any of these terminates the stream with a typed [`ChatChunk::Error`] —
 //! the SSE adapter ([`crate::sse`]) yields a typed [`crate::sse::SseError`]
-//! that this module maps onto [`StreamErrorKind`] one-for-one.
+//! that this module maps onto [`crate::StreamErrorKind`] one-for-one.
 
-use std::time::Duration;
-
+use crate::http_util::{self, HttpClientConfig};
 use crate::sse::{self, SseError, SseEvent};
-use crate::{ChatChunk, ChatRequest, Provider, StreamErrorKind};
+use crate::{ChatChunk, ChatRequest, Provider};
 use bytes::Bytes;
 use forge_core::Result;
 use futures::stream::{BoxStream, StreamExt};
@@ -27,41 +26,6 @@ pub const ANTHROPIC_VERSION: &str = "2023-06-01";
 
 pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 pub const DEFAULT_MAX_TOKENS: u32 = 4096;
-
-pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-pub const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
-pub const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(30);
-
-/// HTTP-layer timeouts applied at `reqwest::ClientBuilder` construction.
-#[derive(Debug, Clone, Copy)]
-pub struct ClientConfig {
-    pub connect_timeout: Duration,
-    pub read_timeout: Duration,
-    pub tcp_keepalive: Duration,
-}
-
-impl ClientConfig {
-    pub const DEFAULT: ClientConfig = ClientConfig {
-        connect_timeout: DEFAULT_CONNECT_TIMEOUT,
-        read_timeout: DEFAULT_READ_TIMEOUT,
-        tcp_keepalive: DEFAULT_TCP_KEEPALIVE,
-    };
-}
-
-impl Default for ClientConfig {
-    fn default() -> Self {
-        Self::DEFAULT
-    }
-}
-
-fn build_stream_client(cfg: &ClientConfig) -> reqwest::Client {
-    reqwest::Client::builder()
-        .connect_timeout(cfg.connect_timeout)
-        .read_timeout(cfg.read_timeout)
-        .tcp_keepalive(Some(cfg.tcp_keepalive))
-        .build()
-        .expect("reqwest stream client builder — only fails if no TLS backend is available")
-}
 
 pub struct AnthropicProvider {
     base_url: String,
@@ -84,7 +48,7 @@ impl AnthropicProvider {
             api_key: api_key.into(),
             model: model.into(),
             max_tokens,
-            stream_client: build_stream_client(&ClientConfig::DEFAULT),
+            stream_client: http_util::build_stream_client(&HttpClientConfig::DEFAULT),
             stream_cfg: sse::StreamConfig::DEFAULT,
         }
     }
@@ -132,7 +96,7 @@ impl Provider for AnthropicProvider {
                 let body = resp.text().await.unwrap_or_default();
                 return Err(anyhow::anyhow!(
                     "anthropic chat HTTP {status}: {}",
-                    truncate(&body, 500)
+                    http_util::truncate(&body, 500)
                 )
                 .into());
             }
@@ -170,37 +134,13 @@ where
         let chunks = match item {
             Ok(ev) => acc.consume(&ev),
             Err(e) => vec![ChatChunk::Error {
-                kind: map_sse_error(&e),
+                kind: http_util::map_sse_error(&e),
                 message: e.to_string(),
             }],
         };
         futures::stream::iter(chunks)
     });
     Box::pin(stream.fuse())
-}
-
-fn map_sse_error(e: &SseError) -> StreamErrorKind {
-    match e {
-        SseError::LineTooLong => StreamErrorKind::LineTooLong,
-        SseError::IdleTimeout => StreamErrorKind::IdleTimeout,
-        SseError::WallClockTimeout => StreamErrorKind::WallClockTimeout,
-        SseError::Transport(_) => StreamErrorKind::Transport,
-    }
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        // Walk char boundaries so we never split a multi-byte codepoint.
-        let cut = s
-            .char_indices()
-            .take_while(|(i, _)| *i < max)
-            .last()
-            .map(|(i, c)| i + c.len_utf8())
-            .unwrap_or(0);
-        format!("{}…", &s[..cut])
-    }
 }
 
 #[cfg(test)]
@@ -219,38 +159,5 @@ mod tests {
     #[test]
     fn anthropic_version_pinned() {
         assert_eq!(ANTHROPIC_VERSION, "2023-06-01");
-    }
-
-    #[test]
-    fn truncate_does_not_panic_on_utf8_boundary() {
-        // 'é' is two UTF-8 bytes; byte index 2 falls inside the codepoint, so a
-        // naive `&s[..2]` slice panics. Should produce a valid prefix.
-        let s = "héllo";
-        let _ = truncate(s, 2);
-    }
-
-    #[test]
-    fn truncate_short_input_returns_as_is() {
-        assert_eq!(truncate("hi", 100), "hi");
-    }
-
-    #[test]
-    fn map_sse_error_covers_all_variants() {
-        assert_eq!(
-            map_sse_error(&SseError::LineTooLong),
-            StreamErrorKind::LineTooLong
-        );
-        assert_eq!(
-            map_sse_error(&SseError::IdleTimeout),
-            StreamErrorKind::IdleTimeout
-        );
-        assert_eq!(
-            map_sse_error(&SseError::WallClockTimeout),
-            StreamErrorKind::WallClockTimeout
-        );
-        assert_eq!(
-            map_sse_error(&SseError::Transport("x".into())),
-            StreamErrorKind::Transport
-        );
     }
 }

--- a/crates/forge-providers/src/http_util.rs
+++ b/crates/forge-providers/src/http_util.rs
@@ -1,0 +1,144 @@
+//! Shared HTTP / SSE helpers used by the Anthropic and OpenAI providers.
+//!
+//! Both providers run an identical streaming-HTTP posture (per-line cap,
+//! inter-event idle timeout, wall-clock budget) and produce identical
+//! [`crate::StreamErrorKind`] envelopes when the SSE adapter aborts. F-583
+//! and F-584 shipped near-identical helpers in parallel; this module is the
+//! single home those helpers consolidate into.
+//!
+//! Ollama keeps its own [`crate::ollama::ClientConfig`] and helpers — its
+//! public-API surface (used by integration tests) and second `request_client`
+//! both diverge from the SSE-streaming providers and were intentionally left
+//! untouched by the F-679 refactor.
+
+use std::time::Duration;
+
+use crate::sse::SseError;
+use crate::StreamErrorKind;
+
+pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+
+/// HTTP-layer timeouts applied at `reqwest::ClientBuilder` construction for
+/// SSE-streaming providers (Anthropic, OpenAI, OpenAI-compatible custom).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HttpClientConfig {
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+    pub tcp_keepalive: Duration,
+}
+
+impl HttpClientConfig {
+    pub const DEFAULT: HttpClientConfig = HttpClientConfig {
+        connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+        read_timeout: DEFAULT_READ_TIMEOUT,
+        tcp_keepalive: DEFAULT_TCP_KEEPALIVE,
+    };
+}
+
+impl Default for HttpClientConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Build a streaming `reqwest::Client` with the SSE provider hardening
+/// posture (per-connect / per-read / TCP keepalive timeouts).
+pub(crate) fn build_stream_client(cfg: &HttpClientConfig) -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(cfg.connect_timeout)
+        .read_timeout(cfg.read_timeout)
+        .tcp_keepalive(Some(cfg.tcp_keepalive))
+        .build()
+        .expect("reqwest stream client builder — only fails if no TLS backend is available")
+}
+
+/// Map a transport-layer SSE error onto the public terminal-stream classifier
+/// surfaced through [`crate::ChatChunk::Error`].
+pub(crate) fn map_sse_error(e: &SseError) -> StreamErrorKind {
+    match e {
+        SseError::LineTooLong => StreamErrorKind::LineTooLong,
+        SseError::IdleTimeout => StreamErrorKind::IdleTimeout,
+        SseError::WallClockTimeout => StreamErrorKind::WallClockTimeout,
+        SseError::Transport(_) => StreamErrorKind::Transport,
+    }
+}
+
+/// UTF-8-safe prefix truncation for HTTP error-body logging. Walks character
+/// boundaries so a multi-byte codepoint is never split (a naive `&s[..max]`
+/// would panic on input like `"héllo"` when `max == 2`).
+pub(crate) fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let cut = s
+            .char_indices()
+            .take_while(|(i, _)| *i < max)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+        format!("{}…", &s[..cut])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_client_config_default_matches_constants() {
+        let cfg = HttpClientConfig::default();
+        assert_eq!(cfg.connect_timeout, DEFAULT_CONNECT_TIMEOUT);
+        assert_eq!(cfg.read_timeout, DEFAULT_READ_TIMEOUT);
+        assert_eq!(cfg.tcp_keepalive, DEFAULT_TCP_KEEPALIVE);
+    }
+
+    #[test]
+    fn build_stream_client_succeeds_with_default_config() {
+        // Smoke test — the only failure mode is "no TLS backend available",
+        // which would already break every other test in the workspace.
+        let _ = build_stream_client(&HttpClientConfig::DEFAULT);
+    }
+
+    #[test]
+    fn truncate_short_input_returns_as_is() {
+        assert_eq!(truncate("hi", 100), "hi");
+    }
+
+    #[test]
+    fn truncate_does_not_panic_on_utf8_boundary() {
+        // 'é' is two UTF-8 bytes; byte index 2 falls inside the codepoint, so
+        // a naive `&s[..2]` slice panics. The helper must produce a valid
+        // prefix instead.
+        let s = "héllo";
+        let _ = truncate(s, 2);
+    }
+
+    #[test]
+    fn truncate_appends_ellipsis_when_cut() {
+        let out = truncate("abcdefgh", 3);
+        assert!(out.ends_with('…'));
+        assert!(out.starts_with("abc"));
+    }
+
+    #[test]
+    fn map_sse_error_covers_all_variants() {
+        assert_eq!(
+            map_sse_error(&SseError::LineTooLong),
+            StreamErrorKind::LineTooLong
+        );
+        assert_eq!(
+            map_sse_error(&SseError::IdleTimeout),
+            StreamErrorKind::IdleTimeout
+        );
+        assert_eq!(
+            map_sse_error(&SseError::WallClockTimeout),
+            StreamErrorKind::WallClockTimeout
+        );
+        assert_eq!(
+            map_sse_error(&SseError::Transport("x".into())),
+            StreamErrorKind::Transport
+        );
+    }
+}

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -12,6 +12,9 @@ use parking_lot::Mutex;
 use serde::Deserialize;
 
 pub mod anthropic;
+// F-679: shared HTTP / SSE helpers used by Anthropic and the OpenAI family.
+// Crate-private — the only consumers are sibling provider modules.
+pub(crate) mod http_util;
 pub mod ollama;
 pub mod openai;
 // F-593: static price-table parser + cost calculator. The committed

--- a/crates/forge-providers/src/openai/mod.rs
+++ b/crates/forge-providers/src/openai/mod.rs
@@ -11,12 +11,11 @@
 //! per-line byte cap, inter-event idle timeout, and overall wall-clock budget.
 //! Any of these terminates the stream with a typed [`ChatChunk::Error`] —
 //! the SSE adapter ([`crate::sse`]) yields a typed [`crate::sse::SseError`]
-//! that this module maps onto [`StreamErrorKind`] one-for-one.
+//! that this module maps onto [`crate::StreamErrorKind`] one-for-one.
 
-use std::time::Duration;
-
+use crate::http_util::{self, HttpClientConfig};
 use crate::sse::{self, SseError, SseEvent};
-use crate::{ChatChunk, ChatRequest, Provider, StreamErrorKind};
+use crate::{ChatChunk, ChatRequest, Provider};
 use bytes::Bytes;
 use forge_core::Result;
 use futures::stream::{BoxStream, StreamExt};
@@ -27,41 +26,6 @@ pub mod translate;
 pub use custom::{AuthShape, CustomOpenAiProvider};
 
 pub const DEFAULT_BASE_URL: &str = "https://api.openai.com";
-
-pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-pub const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
-pub const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(30);
-
-/// HTTP-layer timeouts applied at `reqwest::ClientBuilder` construction.
-#[derive(Debug, Clone, Copy)]
-pub struct ClientConfig {
-    pub connect_timeout: Duration,
-    pub read_timeout: Duration,
-    pub tcp_keepalive: Duration,
-}
-
-impl ClientConfig {
-    pub const DEFAULT: ClientConfig = ClientConfig {
-        connect_timeout: DEFAULT_CONNECT_TIMEOUT,
-        read_timeout: DEFAULT_READ_TIMEOUT,
-        tcp_keepalive: DEFAULT_TCP_KEEPALIVE,
-    };
-}
-
-impl Default for ClientConfig {
-    fn default() -> Self {
-        Self::DEFAULT
-    }
-}
-
-fn build_stream_client(cfg: &ClientConfig) -> reqwest::Client {
-    reqwest::Client::builder()
-        .connect_timeout(cfg.connect_timeout)
-        .read_timeout(cfg.read_timeout)
-        .tcp_keepalive(Some(cfg.tcp_keepalive))
-        .build()
-        .expect("reqwest stream client builder — only fails if no TLS backend is available")
-}
 
 pub struct OpenAiProvider {
     base_url: String,
@@ -85,7 +49,7 @@ impl OpenAiProvider {
             api_key: api_key.into(),
             model: model.into(),
             max_tokens: None,
-            stream_client: build_stream_client(&ClientConfig::DEFAULT),
+            stream_client: http_util::build_stream_client(&HttpClientConfig::DEFAULT),
             stream_cfg: sse::StreamConfig::DEFAULT,
         }
     }
@@ -161,9 +125,11 @@ pub(crate) fn chat_request(
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(
-                anyhow::anyhow!("openai chat HTTP {status}: {}", truncate(&body, 500)).into(),
-            );
+            return Err(anyhow::anyhow!(
+                "openai chat HTTP {status}: {}",
+                http_util::truncate(&body, 500)
+            )
+            .into());
         }
 
         Ok(decode_openai_stream(resp.bytes_stream(), cfg))
@@ -174,7 +140,7 @@ pub(crate) fn chat_request(
 /// [`OpenAiProvider`]. Re-exported so [`CustomOpenAiProvider`] can build its
 /// own client with identical timeouts.
 pub(crate) fn build_stream_client_default() -> reqwest::Client {
-    build_stream_client(&ClientConfig::DEFAULT)
+    http_util::build_stream_client(&HttpClientConfig::DEFAULT)
 }
 
 /// Decode the raw `bytes` stream into a `ChatChunk` stream by piping through
@@ -205,37 +171,13 @@ where
         let chunks = match item {
             Ok(ev) => acc.consume(&ev),
             Err(e) => vec![ChatChunk::Error {
-                kind: map_sse_error(&e),
+                kind: http_util::map_sse_error(&e),
                 message: e.to_string(),
             }],
         };
         futures::stream::iter(chunks)
     });
     Box::pin(stream.fuse())
-}
-
-fn map_sse_error(e: &SseError) -> StreamErrorKind {
-    match e {
-        SseError::LineTooLong => StreamErrorKind::LineTooLong,
-        SseError::IdleTimeout => StreamErrorKind::IdleTimeout,
-        SseError::WallClockTimeout => StreamErrorKind::WallClockTimeout,
-        SseError::Transport(_) => StreamErrorKind::Transport,
-    }
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        // Walk char boundaries so we never split a multi-byte codepoint.
-        let cut = s
-            .char_indices()
-            .take_while(|(i, _)| *i < max)
-            .last()
-            .map(|(i, c)| i + c.len_utf8())
-            .unwrap_or(0);
-        format!("{}…", &s[..cut])
-    }
 }
 
 #[cfg(test)]
@@ -255,38 +197,5 @@ mod tests {
     fn with_max_tokens_sets_value() {
         let p = OpenAiProvider::new("https://x", "sk", "gpt-4o").with_max_tokens(2048);
         assert_eq!(p.max_tokens, Some(2048));
-    }
-
-    #[test]
-    fn truncate_does_not_panic_on_utf8_boundary() {
-        // 'é' is two UTF-8 bytes; byte index 2 falls inside the codepoint, so a
-        // naive `&s[..2]` slice panics. Should produce a valid prefix.
-        let s = "héllo";
-        let _ = truncate(s, 2);
-    }
-
-    #[test]
-    fn truncate_short_input_returns_as_is() {
-        assert_eq!(truncate("hi", 100), "hi");
-    }
-
-    #[test]
-    fn map_sse_error_covers_all_variants() {
-        assert_eq!(
-            map_sse_error(&SseError::LineTooLong),
-            StreamErrorKind::LineTooLong
-        );
-        assert_eq!(
-            map_sse_error(&SseError::IdleTimeout),
-            StreamErrorKind::IdleTimeout
-        );
-        assert_eq!(
-            map_sse_error(&SseError::WallClockTimeout),
-            StreamErrorKind::WallClockTimeout
-        );
-        assert_eq!(
-            map_sse_error(&SseError::Transport("x".into())),
-            StreamErrorKind::Transport
-        );
     }
 }


### PR DESCRIPTION
Closes forge-ide/forge#715

## Summary

F-583 (Anthropic) and F-584 (OpenAI) shipped three byte-identical helpers in parallel — `map_sse_error`, `truncate`, and `ClientConfig` (+ `Default` + `build_stream_client`). This PR extracts them into a single crate-private module `crates/forge-providers/src/http_util.rs` and routes both providers through it.

- `HttpClientConfig` + `build_stream_client` — streaming `reqwest::Client` posture (connect / read / TCP keepalive timeouts)
- `map_sse_error` — `SseError` → `StreamErrorKind` classifier
- `truncate` — UTF-8-safe prefix truncation for HTTP error logging

The OpenAI module retains its `pub(crate) build_stream_client_default` thunk so `CustomOpenAiProvider` continues to construct an identically-configured client without reaching across modules.

Ollama is intentionally **not** touched: its `ClientConfig` is part of the public API consumed by `tests/ollama.rs`, it ships an additional `build_request_client` for the non-streaming `/api/tags` path, and the issue scope is Anthropic + OpenAI only.

## Test plan
- `cargo test --workspace` passes (115 tests in `forge-providers` lib, all integration suites green)
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo fmt --check` passes
- `just check-rust` passes (rustdoc gate caught a stale intra-doc link to `StreamErrorKind`; fixed before push)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)