### PR TITLE
[F-680] Abstract ContainerRuntime trait off podman semantics

### DIFF
--- a/crates/forge-oci/src/lib.rs
+++ b/crates/forge-oci/src/lib.rs
@@ -279,21 +279,32 @@ pub trait ContainerLogs: Send + Sync {
 }
 
 /// Container lifecycle surface. See module docs.
+///
+/// Implementations are runtime-specific (`PodmanRuntime`, future
+/// `DockerRuntime`, etc.). The trait is shaped for argv-only invocation —
+/// every method takes structured slices, never shell strings.
 #[async_trait]
 pub trait ContainerRuntime: Send + Sync {
+    /// Probe the host: confirm the runtime binary is present, functional, and
+    /// configured for rootless operation. Each implementation classifies its
+    /// own probe failures into the canonical `OciError` variants
+    /// ([`OciError::RuntimeMissing`], [`OciError::RuntimeBroken`],
+    /// [`OciError::RootlessUnavailable`]) so callers can switch on the variant
+    /// without knowing which runtime is underneath.
+    async fn detect(&self) -> Result<(), OciError>;
+
     /// Pull the image into the local runtime store. Idempotent.
     async fn pull(&self, image: &ImageRef) -> Result<(), OciError>;
 
     /// Create a container from `image` with `argv` as the command. The
     /// container is created but not started; call [`Self::start`] separately.
-    async fn create(&self, image: &ImageRef, argv: &[String]) -> Result<ContainerHandle, OciError>;
+    async fn create(&self, image: &ImageRef, argv: &[&str]) -> Result<ContainerHandle, OciError>;
 
     /// Start a created container.
     async fn start(&self, handle: &ContainerHandle) -> Result<(), OciError>;
 
     /// Run `argv` inside an already-started container and capture its output.
-    async fn exec(&self, handle: &ContainerHandle, argv: &[String])
-        -> Result<ExecResult, OciError>;
+    async fn exec(&self, handle: &ContainerHandle, argv: &[&str]) -> Result<ExecResult, OciError>;
 
     /// Stop a running container (graceful — runtime sends SIGTERM, then
     /// SIGKILL after its grace period).
@@ -304,6 +315,19 @@ pub trait ContainerRuntime: Send + Sync {
 
     /// Capture a single resource snapshot.
     async fn stats(&self, handle: &ContainerHandle) -> Result<Stats, OciError>;
+
+    /// Parse a runtime-specific stats payload into the common [`Stats`]
+    /// shape. Each runtime emits its own JSON schema and unit conventions
+    /// (podman: `cpu_percent`/`mem_usage`/`pids`; docker would differ);
+    /// pinning the parser at the trait surface keeps that schema-shape
+    /// knowledge localized to the implementation while letting callers
+    /// drive parsing through a single seam.
+    ///
+    /// Implementations should be tolerant of partial/missing fields — return
+    /// `Stats { ..: None }` for fields the payload does not carry rather
+    /// than failing the whole call. Hard parse failures (e.g. malformed
+    /// JSON envelope) should surface as [`OciError::InvalidJson`].
+    fn parse_stats(&self, raw: &[u8]) -> Result<Stats, OciError>;
 }
 
 #[cfg(test)]
@@ -393,13 +417,16 @@ mod tests {
 
     #[async_trait]
     impl ContainerRuntime for MockRuntime {
+        async fn detect(&self) -> Result<(), OciError> {
+            Ok(())
+        }
         async fn pull(&self, _image: &ImageRef) -> Result<(), OciError> {
             Ok(())
         }
         async fn create(
             &self,
             _image: &ImageRef,
-            _argv: &[String],
+            _argv: &[&str],
         ) -> Result<ContainerHandle, OciError> {
             Ok(ContainerHandle::new("mock"))
         }
@@ -409,7 +436,7 @@ mod tests {
         async fn exec(
             &self,
             _handle: &ContainerHandle,
-            _argv: &[String],
+            _argv: &[&str],
         ) -> Result<ExecResult, OciError> {
             Ok(ExecResult {
                 exit_code: Some(0),
@@ -430,22 +457,57 @@ mod tests {
                 pids: None,
             })
         }
+        fn parse_stats(&self, _raw: &[u8]) -> Result<Stats, OciError> {
+            Ok(Stats {
+                cpu_percent: None,
+                memory_bytes: None,
+                pids: None,
+            })
+        }
     }
 
     #[tokio::test]
     async fn mock_runtime_satisfies_trait() {
         let rt: &dyn ContainerRuntime = &MockRuntime;
+        rt.detect().await.unwrap();
         let img = ImageRef::parse("alpine:3.19").unwrap();
         rt.pull(&img).await.unwrap();
-        let h = rt
-            .create(&img, &["echo".into(), "hi".into()])
-            .await
-            .unwrap();
+        // `create`/`exec` accept caller-borrowed `&str` slices directly —
+        // no `.into()` allocation required.
+        let h = rt.create(&img, &["echo", "hi"]).await.unwrap();
         rt.start(&h).await.unwrap();
-        let res = rt.exec(&h, &["true".into()]).await.unwrap();
+        let res = rt.exec(&h, &["true"]).await.unwrap();
         assert_eq!(res.exit_code, Some(0));
         rt.stop(&h).await.unwrap();
         rt.remove(&h).await.unwrap();
         let _ = rt.stats(&h).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn detect_is_callable_through_dyn_trait() {
+        // F-680: `detect` is part of the trait surface so callers can
+        // probe any runtime without knowing the concrete type.
+        let rt: &dyn ContainerRuntime = &MockRuntime;
+        rt.detect().await.unwrap();
+    }
+
+    #[test]
+    fn parse_stats_is_callable_through_dyn_trait() {
+        // F-680: parsing a runtime-specific stats payload is a trait
+        // method, so each runtime owns its own schema interpretation
+        // while callers drive parsing through a single seam.
+        let rt: &dyn ContainerRuntime = &MockRuntime;
+        let _ = rt.parse_stats(b"ignored").unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_and_exec_accept_borrowed_str_slices() {
+        // F-680: argv parameters are `&[&str]` so callers with borrowed
+        // string slices can call directly without allocating a Vec<String>.
+        let rt: &dyn ContainerRuntime = &MockRuntime;
+        let img = ImageRef::parse("alpine:3.19").unwrap();
+        let argv: [&str; 2] = ["echo", "hi"];
+        let _ = rt.create(&img, &argv).await.unwrap();
+        let _ = rt.exec(&ContainerHandle::new("x"), &argv).await.unwrap();
     }
 }

--- a/crates/forge-oci/src/podman.rs
+++ b/crates/forge-oci/src/podman.rs
@@ -33,6 +33,35 @@ impl PodmanRuntime {
         Self { runner }
     }
 
+    async fn run_or_fail(&self, args: &[&str]) -> Result<CommandOutcome, OciError> {
+        let outcome = self
+            .runner
+            .run(PODMAN, args)
+            .await
+            .map_err(|source| OciError::Io {
+                tool: PODMAN,
+                source,
+            })?;
+        if !outcome.success() {
+            return Err(OciError::CommandFailed {
+                tool: PODMAN,
+                args: args.iter().map(|s| s.to_string()).collect(),
+                exit_code: outcome.exit_code,
+                stderr: String::from_utf8_lossy(&outcome.stderr).to_string(),
+            });
+        }
+        Ok(outcome)
+    }
+}
+
+impl Default for PodmanRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ContainerRuntime for PodmanRuntime {
     /// Probe the host: confirm `podman --version` works AND `podman info`
     /// reports rootless mode is available.
     ///
@@ -46,7 +75,7 @@ impl PodmanRuntime {
     /// - [`OciError::RootlessUnavailable`] if `podman info` JSON parsed and
     ///   explicitly reports `host.security.rootless = false`.
     /// - [`OciError::InvalidJson`] if `podman info` JSON didn't parse.
-    pub async fn detect(&self) -> Result<(), OciError> {
+    async fn detect(&self) -> Result<(), OciError> {
         let version = self
             .runner
             .run(PODMAN, &["--version"])
@@ -99,42 +128,13 @@ impl PodmanRuntime {
         Ok(())
     }
 
-    async fn run_or_fail(&self, args: &[&str]) -> Result<CommandOutcome, OciError> {
-        let outcome = self
-            .runner
-            .run(PODMAN, args)
-            .await
-            .map_err(|source| OciError::Io {
-                tool: PODMAN,
-                source,
-            })?;
-        if !outcome.success() {
-            return Err(OciError::CommandFailed {
-                tool: PODMAN,
-                args: args.iter().map(|s| s.to_string()).collect(),
-                exit_code: outcome.exit_code,
-                stderr: String::from_utf8_lossy(&outcome.stderr).to_string(),
-            });
-        }
-        Ok(outcome)
-    }
-}
-
-impl Default for PodmanRuntime {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[async_trait]
-impl ContainerRuntime for PodmanRuntime {
     async fn pull(&self, image: &ImageRef) -> Result<(), OciError> {
         let img = image.to_image_string();
         self.run_or_fail(&["pull", &img]).await?;
         Ok(())
     }
 
-    async fn create(&self, image: &ImageRef, argv: &[String]) -> Result<ContainerHandle, OciError> {
+    async fn create(&self, image: &ImageRef, argv: &[&str]) -> Result<ContainerHandle, OciError> {
         let img = image.to_image_string();
         // `podman create [options] IMAGE [COMMAND [ARG...]]` — podman's
         // argument grammar terminates flag parsing at the IMAGE positional, so
@@ -146,7 +146,7 @@ impl ContainerRuntime for PodmanRuntime {
         // test in this module pins that behaviour by feeding `--privileged`
         // through and asserting podman does not apply it as a runtime flag.
         let mut args: Vec<&str> = vec!["create", &img];
-        args.extend(argv.iter().map(String::as_str));
+        args.extend_from_slice(argv);
         let outcome = self.run_or_fail(&args).await?;
         let id = String::from_utf8_lossy(&outcome.stdout).trim().to_string();
         if id.is_empty() {
@@ -165,11 +165,7 @@ impl ContainerRuntime for PodmanRuntime {
         Ok(())
     }
 
-    async fn exec(
-        &self,
-        handle: &ContainerHandle,
-        argv: &[String],
-    ) -> Result<ExecResult, OciError> {
+    async fn exec(&self, handle: &ContainerHandle, argv: &[&str]) -> Result<ExecResult, OciError> {
         // `podman exec [options] CONTAINER COMMAND [ARG...]` — same positional
         // grammar as `create`: podman stops parsing flags at the CONTAINER
         // positional, so caller-supplied argv elements that begin with `--`
@@ -178,7 +174,7 @@ impl ContainerRuntime for PodmanRuntime {
         // it would be passed verbatim to crun as the command. The
         // flag-injection regression test pins this.
         let mut args: Vec<&str> = vec!["exec", &handle.id];
-        args.extend(argv.iter().map(String::as_str));
+        args.extend_from_slice(argv);
         // exec captures the inner program's stdout/stderr/exit even on a
         // non-zero exit — that's a meaningful signal, not a runtime failure.
         // So we go around `run_or_fail` here.
@@ -212,8 +208,26 @@ impl ContainerRuntime for PodmanRuntime {
         let outcome = self
             .run_or_fail(&["stats", "--no-stream", "--format", "json", &handle.id])
             .await?;
+        // Delegate parsing to the trait method so the podman-specific JSON
+        // schema (`cpu_percent`, `mem_usage`, `pids`) is not baked into the
+        // lifecycle code. A future runtime emitting different field names or
+        // unit conventions would supply its own `parse_stats`; the lifecycle
+        // shape (run command → parse blob) stays the same.
+        self.parse_stats(&outcome.stdout)
+    }
+
+    fn parse_stats(&self, raw: &[u8]) -> Result<Stats, OciError> {
+        // Podman emits a JSON array; the first entry is the requested
+        // container. Field names and unit conventions are podman's:
+        //   - `cpu_percent`: string like `"1.35%"`
+        //   - `mem_usage`: string like `"178.3MB / 67.31GB"` (we surface only
+        //     the first number)
+        //   - `pids`: string or integer
+        // Missing/transitional fields are surfaced as `None` rather than
+        // failing the call — see `parse_size_first` for the `"-- / --"`
+        // placeholder podman emits while a container is mid-state.
         let parsed: serde_json::Value =
-            serde_json::from_slice(&outcome.stdout).map_err(|source| OciError::InvalidJson {
+            serde_json::from_slice(raw).map_err(|source| OciError::InvalidJson {
                 tool: PODMAN,
                 subcommand: "stats",
                 source,
@@ -377,6 +391,10 @@ mod tests {
         PodmanRuntime::with_runner(Box::new(runner))
     }
 
+    // `ContainerRuntime` is already in scope via `use super::*;` — tests
+    // call detect/create/exec/parse_stats through that trait surface so any
+    // accidental migration back to inherent methods would fail to link.
+
     #[tokio::test]
     async fn detect_succeeds_when_version_and_rootless_ok() {
         let runner = RecordingRunner::new();
@@ -467,10 +485,7 @@ mod tests {
 
         let runtime = rt(runner);
         let img = ImageRef::parse("alpine:3.19").unwrap();
-        let h = runtime
-            .create(&img, &["echo".into(), "hi".into()])
-            .await
-            .unwrap();
+        let h = runtime.create(&img, &["echo", "hi"]).await.unwrap();
         assert_eq!(h.id, "abc1234deadbeef");
 
         let calls = calls.lock().unwrap();
@@ -493,10 +508,7 @@ mod tests {
 
         let runtime = rt(runner);
         let img = ImageRef::parse("alpine:3.19").unwrap();
-        runtime
-            .create(&img, &["--privileged".into(), "sh".into()])
-            .await
-            .unwrap();
+        runtime.create(&img, &["--privileged", "sh"]).await.unwrap();
 
         let argv = calls.lock().unwrap()[0].1.clone();
         let image_idx = argv
@@ -528,7 +540,8 @@ mod tests {
         runner.push(StubResponse::ok_stdout(b"".to_vec()));
         let runtime = rt(runner);
         let img = ImageRef::parse("alpine:3.19").unwrap();
-        let err = runtime.create(&img, &[]).await.unwrap_err();
+        let argv: [&str; 0] = [];
+        let err = runtime.create(&img, &argv).await.unwrap_err();
         assert!(matches!(err, OciError::CommandFailed { .. }));
     }
 
@@ -559,10 +572,7 @@ mod tests {
 
         let runtime = rt(runner);
         let res = runtime
-            .exec(
-                &ContainerHandle::new("xyz"),
-                &["echo".into(), "hello".into()],
-            )
+            .exec(&ContainerHandle::new("xyz"), &["echo", "hello"])
             .await
             .unwrap();
         assert_eq!(res.stdout, "hello\n");
@@ -595,10 +605,7 @@ mod tests {
 
         let runtime = rt(runner);
         runtime
-            .exec(
-                &ContainerHandle::new("xyz"),
-                &["--user".into(), "root".into(), "id".into()],
-            )
+            .exec(&ContainerHandle::new("xyz"), &["--user", "root", "id"])
             .await
             .unwrap();
 
@@ -637,7 +644,7 @@ mod tests {
         });
 
         let res = rt(runner)
-            .exec(&ContainerHandle::new("xyz"), &["false".into()])
+            .exec(&ContainerHandle::new("xyz"), &["false"])
             .await
             .unwrap();
         assert_eq!(res.exit_code, Some(2));
@@ -706,6 +713,58 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, OciError::InvalidJson { .. }));
+    }
+
+    // ── F-680: trait-level stats parsing ─────────────────────────────
+
+    #[test]
+    fn parse_stats_handles_podman_json_payload() {
+        // F-680: `parse_stats` is a trait method — the podman-specific
+        // schema (`cpu_percent`, `mem_usage`, `pids` plus their string
+        // formats) is owned by `PodmanRuntime`'s impl, not by free
+        // helpers in the lifecycle path. Future runtimes will supply
+        // their own `parse_stats` translating their own JSON shape into
+        // the same `Stats` struct.
+        let runtime = PodmanRuntime::new();
+        let json = br#"[{"id":"xyz","cpu_percent":"2.5%","mem_usage":"64MB / 1GB","pids":"7"}]"#;
+        let stats = runtime.parse_stats(json).unwrap();
+        assert_eq!(stats.cpu_percent, Some(2.5));
+        assert_eq!(stats.memory_bytes, Some(64_000_000));
+        assert_eq!(stats.pids, Some(7));
+    }
+
+    #[test]
+    fn parse_stats_callable_through_trait_object() {
+        // Pinning the dyn-trait callability separately so a future
+        // refactor cannot accidentally make `parse_stats` an inherent
+        // method — that would defeat the whole abstraction.
+        let runtime: Box<dyn ContainerRuntime> = Box::new(PodmanRuntime::new());
+        let json = br#"[{"id":"x"}]"#;
+        let stats = runtime.parse_stats(json).unwrap();
+        assert!(stats.cpu_percent.is_none());
+    }
+
+    #[test]
+    fn parse_stats_surfaces_invalid_json_as_typed_error() {
+        let runtime = PodmanRuntime::new();
+        let err = runtime.parse_stats(b"not json").unwrap_err();
+        assert!(matches!(err, OciError::InvalidJson { tool: "podman", .. }));
+    }
+
+    // ── F-680: detect on the trait surface ───────────────────────────
+
+    #[tokio::test]
+    async fn detect_callable_through_trait_object() {
+        // F-680: `detect` is part of the trait. Callers that want to
+        // probe a runtime without knowing the concrete type call it
+        // through `&dyn ContainerRuntime`.
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"podman version 5.0\n".to_vec()));
+        runner.push(StubResponse::ok_stdout(
+            br#"{"host":{"security":{"rootless":true}}}"#.to_vec(),
+        ));
+        let runtime: Box<dyn ContainerRuntime> = Box::new(rt(runner));
+        runtime.detect().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/forge-oci/tests/podman_integration.rs
+++ b/crates/forge-oci/tests/podman_integration.rs
@@ -43,15 +43,7 @@ async fn create_does_not_apply_caller_flags_as_runtime_flags() {
     // as its own `--privileged` flag, the resulting container would have
     // `HostConfig.Privileged = true`, which we explicitly check against.
     let handle = runtime
-        .create(
-            &image,
-            &[
-                "--privileged".into(),
-                "sh".into(),
-                "-c".into(),
-                "true".into(),
-            ],
-        )
+        .create(&image, &["--privileged", "sh", "-c", "true"])
         .await
         .expect("create container");
 
@@ -102,13 +94,13 @@ async fn exec_does_not_apply_caller_flags_as_runtime_flags() {
     runtime.pull(&image).await.expect("pull alpine");
 
     let handle = runtime
-        .create(&image, &["sleep".into(), "30".into()])
+        .create(&image, &["sleep", "30"])
         .await
         .expect("create container");
     runtime.start(&handle).await.expect("start container");
 
     let result = runtime
-        .exec(&handle, &["--user".into(), "root".into(), "id".into()])
+        .exec(&handle, &["--user", "root", "id"])
         .await
         .expect("exec returns even when in-container command fails");
 
@@ -145,14 +137,14 @@ async fn podman_full_lifecycle_against_alpine() {
     // Long-lived foreground process so `exec` has something to attach to.
     // `sleep 60` is plenty for the test to do its work and tear down.
     let handle = runtime
-        .create(&image, &["sleep".into(), "60".into()])
+        .create(&image, &["sleep", "60"])
         .await
         .expect("create container");
 
     runtime.start(&handle).await.expect("start container");
 
     let result = runtime
-        .exec(&handle, &["echo".into(), "hello".into()])
+        .exec(&handle, &["echo", "hello"])
         .await
         .expect("exec echo");
     assert_eq!(result.stdout, "hello\n");

--- a/crates/forge-session/src/sandbox.rs
+++ b/crates/forge-session/src/sandbox.rs
@@ -719,14 +719,18 @@ mod imp {
                 SandboxLevel::Level1 => execute_level1(self).await,
                 SandboxLevel::Level2 { session } => {
                     let session = session.clone();
+                    // Materialize each argv element as an owned `String` so
+                    // the borrowed `&[&str]` slice we hand to `exec_step`
+                    // points into stable storage that outlives the call.
                     let argv: Vec<String> = self
                         .argv
                         .iter()
                         .map(|s| s.to_string_lossy().into_owned())
                         .collect();
                     drop(self); // we own no spawn-side state for Level 2.
+                    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
                     session
-                        .exec_step(&argv)
+                        .exec_step(&argv_refs)
                         .await
                         .map_err(|e| io::Error::other(format!("level 2 exec: {e}")))
                 }
@@ -1464,6 +1468,10 @@ mod tests {
 
     #[async_trait]
     impl ContainerRuntime for LoggingRuntime {
+        async fn detect(&self) -> Result<(), OciError> {
+            self.record("detect");
+            Ok(())
+        }
         async fn pull(&self, _image: &OciImageRef) -> Result<(), OciError> {
             self.record("pull");
             Ok(())
@@ -1471,7 +1479,7 @@ mod tests {
         async fn create(
             &self,
             _image: &OciImageRef,
-            _argv: &[String],
+            _argv: &[&str],
         ) -> Result<OciContainerHandle, OciError> {
             self.record("create");
             Ok(OciContainerHandle::new("c-id"))
@@ -1483,7 +1491,7 @@ mod tests {
         async fn exec(
             &self,
             _h: &OciContainerHandle,
-            _argv: &[String],
+            _argv: &[&str],
         ) -> Result<ExecResult, OciError> {
             self.record("exec");
             Ok(self.exec.clone())
@@ -1497,6 +1505,13 @@ mod tests {
             Ok(())
         }
         async fn stats(&self, _h: &OciContainerHandle) -> Result<Stats, OciError> {
+            Ok(Stats {
+                cpu_percent: None,
+                memory_bytes: None,
+                pids: None,
+            })
+        }
+        fn parse_stats(&self, _raw: &[u8]) -> Result<Stats, OciError> {
             Ok(Stats {
                 cpu_percent: None,
                 memory_bytes: None,

--- a/crates/forge-session/src/sandbox/level2.rs
+++ b/crates/forge-session/src/sandbox/level2.rs
@@ -201,7 +201,7 @@ impl Level2Session {
         limits: ContainerLimits,
     ) -> Result<Self, OciError> {
         runtime.pull(&image).await?;
-        let handle = runtime.create(&image, &Self::default_init_argv()).await?;
+        let handle = runtime.create(&image, Self::default_init_argv()).await?;
         runtime.start(&handle).await?;
         // Operator-facing notice when limits are configured but not
         // yet enforced. Until follow-up #631 lands, the container
@@ -232,14 +232,14 @@ impl Level2Session {
     /// The init argv used by [`Self::create`]. `sleep infinity` is the
     /// idiom — minimal binary surface inside the image, no daemon
     /// behaviour, exits cleanly on `podman stop`.
-    pub fn default_init_argv() -> Vec<String> {
-        vec!["sleep".to_string(), "infinity".to_string()]
+    pub fn default_init_argv() -> &'static [&'static str] {
+        &["sleep", "infinity"]
     }
 
     /// Run a single step inside the pre-warmed container and capture
     /// its result. Mirrors [`ContainerRuntime::exec`] — non-zero exits
     /// are surfaced via [`StepOutcome::exit_code`], not `Err`.
-    pub async fn exec_step(&self, argv: &[String]) -> Result<StepOutcome, OciError> {
+    pub async fn exec_step(&self, argv: &[&str]) -> Result<StepOutcome, OciError> {
         let res = self.runtime.exec(&self.handle, argv).await?;
         Ok(StepOutcome {
             exit_code: res.exit_code,
@@ -466,6 +466,10 @@ mod tests {
 
     #[async_trait]
     impl ContainerRuntime for MockRuntime {
+        async fn detect(&self) -> Result<(), OciError> {
+            self.record("detect");
+            Ok(())
+        }
         async fn pull(&self, _image: &ImageRef) -> Result<(), OciError> {
             self.record("pull");
             Ok(())
@@ -473,7 +477,7 @@ mod tests {
         async fn create(
             &self,
             _image: &ImageRef,
-            _argv: &[String],
+            _argv: &[&str],
         ) -> Result<ContainerHandle, OciError> {
             self.record("create");
             Ok(ContainerHandle::new("mock-container"))
@@ -485,7 +489,7 @@ mod tests {
         async fn exec(
             &self,
             _handle: &ContainerHandle,
-            _argv: &[String],
+            _argv: &[&str],
         ) -> Result<ExecResult, OciError> {
             self.record("exec");
             Ok(self
@@ -509,6 +513,13 @@ mod tests {
         }
         async fn stats(&self, _handle: &ContainerHandle) -> Result<Stats, OciError> {
             self.record("stats");
+            Ok(Stats {
+                cpu_percent: None,
+                memory_bytes: None,
+                pids: None,
+            })
+        }
+        fn parse_stats(&self, _raw: &[u8]) -> Result<Stats, OciError> {
             Ok(Stats {
                 cpu_percent: None,
                 memory_bytes: None,
@@ -555,10 +566,7 @@ mod tests {
             .await
             .unwrap();
         session.disable_drop_cleanup();
-        let outcome = session
-            .exec_step(&["echo".into(), "hi".into()])
-            .await
-            .unwrap();
+        let outcome = session.exec_step(&["echo", "hi"]).await.unwrap();
         assert_eq!(outcome.exit_code, Some(2));
         assert_eq!(outcome.stdout, "out\n");
         assert_eq!(outcome.stderr, "err\n");
@@ -577,7 +585,7 @@ mod tests {
             .await
             .unwrap();
         for _ in 0..3 {
-            session.exec_step(&["true".into()]).await.unwrap();
+            session.exec_step(&["true"]).await.unwrap();
         }
         session.teardown().await.unwrap();
         assert_eq!(
@@ -848,10 +856,7 @@ mod tests {
         let session = Level2Session::create(runtime, alpine(), ContainerLimits::default())
             .await
             .unwrap();
-        let outcome = session
-            .exec_step(&["echo".into(), "hello".into()])
-            .await
-            .unwrap();
+        let outcome = session.exec_step(&["echo", "hello"]).await.unwrap();
         assert_eq!(outcome.stdout, "hello\n");
         assert_eq!(outcome.exit_code, Some(0));
         session.teardown().await.unwrap();

--- a/crates/forge-shell/src/containers_ipc.rs
+++ b/crates/forge-shell/src/containers_ipc.rs
@@ -57,7 +57,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use forge_oci::{ContainerHandle, ContainerLogs, LogLine, OciError, PodmanRuntime};
+use forge_oci::{
+    ContainerHandle, ContainerLogs, ContainerRuntime, LogLine, OciError, PodmanRuntime,
+};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "webview")]
 use tauri::{AppHandle, Emitter, Manager, Runtime, State, Webview};
@@ -315,7 +317,6 @@ pub async fn stop_container<R: Runtime>(
 
     let runtime = PodmanRuntime::new();
     let handle = ContainerHandle::new(&container_id);
-    use forge_oci::ContainerRuntime;
     runtime.stop(&handle).await.map_err(|e| e.to_string())?;
     registry.mark_stopped(&container_id).await;
     let _ = app.emit(CONTAINERS_CHANGED_EVENT, &container_id);
@@ -335,7 +336,6 @@ pub async fn remove_container<R: Runtime>(
 
     let runtime = PodmanRuntime::new();
     let handle = ContainerHandle::new(&container_id);
-    use forge_oci::ContainerRuntime;
     runtime.remove(&handle).await.map_err(|e| e.to_string())?;
     registry.unregister(&container_id).await;
     let _ = app.emit(CONTAINERS_CHANGED_EVENT, &container_id);

--- a/docs/architecture/isolation-model.md
+++ b/docs/architecture/isolation-model.md
@@ -92,7 +92,27 @@ Implementation:
 
 Implemented in `crates/forge-session/src/sandbox/level2.rs` (F-596),
 backed by the `forge_oci::ContainerRuntime` trait shipped in F-595
-(today: `PodmanRuntime`).
+and broadened in F-680 to host more than one runtime
+(today: `PodmanRuntime`; future: `DockerRuntime` etc.).
+
+#### Trait surface
+
+`ContainerRuntime` is a runtime-agnostic lifecycle contract:
+
+| Method | Role |
+|---|---|
+| `detect()` | Probe the host and classify failure into one of the canonical `OciError` variants (`RuntimeMissing`, `RuntimeBroken`, `RootlessUnavailable`). |
+| `pull(image)` | Idempotent image fetch into the local store. |
+| `create(image, argv: &[&str])` | Create a container with the given in-container command. Argv is borrowed `&str` slices so callers don't have to allocate. |
+| `start(handle)` / `stop(handle)` / `remove(handle)` | Lifecycle transitions. |
+| `exec(handle, argv: &[&str])` | Run a command inside a started container. |
+| `stats(handle)` | Snapshot resource usage. Implementations call `parse_stats` after fetching the runtime's stats blob. |
+| `parse_stats(raw)` | Runtime-specific JSON-shape parser. Each runtime owns its own field-name and unit conventions (podman emits `cpu_percent`/`mem_usage`/`pids`; docker would emit different shapes). The trait pins the seam so callers drive parsing through a single method. |
+
+The seam matters most around `detect` and `parse_stats`: both are
+shapes that vary across runtimes, and putting them on the trait
+means a future `DockerRuntime` can ship without callers learning
+the runtime-specific schema.
 
 #### Lifecycle (pre-warm + reuse)
 


### PR DESCRIPTION
Closes forge-ide/forge#716

## Summary

Three sub-fixes that prepare `ContainerRuntime` for a second runtime impl, addressing each DoD checkbox:

- **Stats parsing is runtime-specific via the trait.** Added `parse_stats(raw: &[u8]) -> Result<Stats, OciError>`. `PodmanRuntime::stats()` now fetches the raw `podman stats` blob and delegates to its own `parse_stats`, which owns the podman-specific field names (`cpu_percent`, `mem_usage`, `pids`) and unit formats. A future `DockerRuntime` supplies its own parser without touching the lifecycle path.
- **`detect()` is part of the trait surface.** Lifted from an inherent method on `PodmanRuntime` to a trait method, so callers can probe any runtime through `&dyn ContainerRuntime`. The three documented "container unavailable" `OciError` variants (`RuntimeMissing`, `RuntimeBroken`, `RootlessUnavailable`) remain the cross-impl classification contract.
- **`create`/`exec` accept `&[&str]`.** Symmetric with `CommandRunner::run`; callers with borrowed string slices no longer need to allocate a `Vec<String>` before calling the trait. `Level2Session::default_init_argv` now returns `&'static [&'static str]`; `SandboxedCommand::execute`'s Level 2 path materializes its borrowed slice into stable storage before the call.

Also updates the architecture doc (`docs/architecture/isolation-model.md` §8.3) to describe the new trait surface, and adds tests pinning each behavioural change through the dyn-trait surface so a future refactor cannot accidentally regress to inherent methods.

## Test plan

- `cargo test --workspace` passes (43 tests in `forge-oci` covering the new `parse_stats` / trait-`detect` / `&[&str]` argv assertions)
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `just check-rust` passes (fmt + check + clippy + RUSTDOCFLAGS=-D warnings cargo doc)
- Integration tests in `crates/forge-oci/tests/podman_integration.rs` (require `--ignored`, skipped on CI) still drive a real podman through the full lifecycle.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)