### PR TITLE
[F-704] Tighten agent-sidecar.md + add forge-agent-host README

### DIFF
--- a/crates/forge-agent-host/README.md
+++ b/crates/forge-agent-host/README.md
@@ -1,0 +1,49 @@
+# forge-agent-host
+
+The per-instance sidecar host: the `forged-agent` binary the daemon spawns under the F-608 sidecar architecture, plus the library half (`forge_agent_host`) that owns the IPC plumbing — handshake, heartbeat, panic-hook crash dump, dispatch loop, and the `IpcEventSink` adapter that lets the orchestrator's run loop emit events out the per-instance Unix domain socket. Intentionally thin: persistence, MCP, and the IPC server stay in `forge-session` so the sidecar's compile graph stays small (the architecture doc Open Questions §1 calls this out as the rationale for a separate crate).
+
+## Role in the workspace
+
+- Ships the `forged-agent` binary the daemon supervises one-per-`AgentInstanceId`. Resolved at runtime by `forge_shell::ipc::resolve_forged_agent_path` (sibling of the shell exe, falling back to `$PATH`).
+- Depended on by: `forge-session` (test-only — the supervisor's integration tests spawn the real binary).
+- Depends on: `forge-core`, `forge-ipc`, `secrecy`, `dirs`, `tokio`, `tracing-subscriber`. Pointedly does **not** depend on `forge-session`.
+
+## Public API
+
+- `AgentArgs` — the parsed CLI shape (`--socket <path> --instance-id <id> [--session-id <sess>]`). Hand-rolled parser; the architecture doc §1 calls out the time-to-first-token rationale for skipping `clap`.
+- `run(args: AgentArgs) -> Result<()>` — drive one full sidecar lifecycle: connect → handshake → loop → exit. The library entry the binary's `main` calls; the integration tests call it directly without forking.
+- `init_tracing()` — install the JSON-lines `tracing-subscriber` on stderr (architecture doc §10). Idempotent.
+- `install_panic_hook(identity)` — install the panic hook that (1) writes a `CrashDump` JSON file under `<XDG_DATA_HOME or ~/.local/share>/forge/crashes/<session-id>/<instance-id>-<unix-ts>.json` (mode `0o700`) and (2) queues a `SidecarMessage::Crashed` frame for the dispatch loop to flush on shutdown. Best-effort — a hard segfault never produces either.
+- `IpcEventSink` — `forge_core::EventSink` impl that frames every emit as `SidecarMessage::Event { seq, event }` and writes it on the daemon-facing UDS. Same trait the in-process `forge_session::orchestrator::run_turn` consumes; the orchestrator body is transport-agnostic.
+- `CredentialStash` — per-sidecar `SecretString` map keyed by `provider_id`. `Credentials` frames inbound from the daemon land here; `Debug` is custom-redacted so a stray `tracing::debug!` cannot reveal cached identifiers.
+- `DaemonHelloState` — single-slot store for the daemon-side `Hello` payload (agent definition, allowed paths, workspace, provider spec, sandbox level). First write wins; duplicates log at `warn` and are dropped.
+- `EventSeq` — monotonic per-process sequence allocator threaded through both the heartbeat task and the run-turn handler so every outbound frame is totally ordered. Starts at 1 (0 is reserved as a "never emitted" sentinel).
+- `build_hello_ack(daemon_pid)` — convenience constructor used by tests acting as the daemon side of the handshake.
+
+## Integration with `SidecarSupervisor`
+
+The supervisor lives in `forge_session::sidecar` and owns the socket bind, fork, restart, and tear-down. It interacts with this crate over the wire only — there is no Rust-level dependency edge from `forge-session` to `forge-agent-host` (that would re-introduce the compile-graph cost we wrote the binary to avoid). The contract:
+
+1. Supervisor binds `<socket_dir>/<instance-id>.sock` (anti-TOCTOU, mode `0o700`); see `crates/forge-session/src/sidecar/mod.rs`.
+2. Supervisor forks `forged-agent --socket <path> --instance-id <id> --session-id <sess>`.
+3. Sidecar connects, sends `Hello`, awaits `HelloAck` (10 s deadline; supervisor enforces its own outer handshake deadline).
+4. Heartbeat: 1 Hz `Heartbeat` frame; supervisor times out at 5 s and recycles the child.
+5. `RunTurn` / `Credentials` / `ToolCallApproved|Rejected` / `CompactTranscript` / a daemon-side follow-up `Hello` flow daemon → sidecar; `Event` / `Heartbeat` / `Crashed` / `ToolCallApprovalRequest` flow sidecar → daemon.
+6. `Shutdown { grace_ms }` triggers a clean half-close after a flush; absent that the supervisor falls back to SIGTERM-then-SIGKILL on `Drop`.
+
+The full state diagram and restart policy are in [`docs/architecture/agent-sidecar.md`](../../docs/architecture/agent-sidecar.md) §3.
+
+## Testing
+
+- **Unit tests** (`cargo test -p forge-agent-host --lib`) — argv parsing, `EventSeq` monotonicity, `CredentialStash` `Debug` redaction. No network, no fork.
+- **`forged_agent_lifecycle`** integration test — drives a real `forged-agent` child against a test-side UDS that acts as the daemon. Asserts handshake (`Hello` + `HelloAck`), heartbeat cadence, the stub `RunTurn` event sequence (`StepStarted` → `AssistantMessage { text: "[stub]" }` → `StepFinished`), and a clean shutdown drain.
+- **`forged_agent_credentials`** integration test — pushes a `Credentials` frame under `FORGE_LOG=trace` and audits the captured stderr to confirm the credential value never appears at any tracing level (architecture doc §5 audit policy).
+- **`FORGE_TEST_PANIC_ON_RUNTURN`** — undocumented test-only env var that drives the panic hook → on-disk crash-dump path end-to-end. Used by `forge-session`'s `sidecar_crash_dump` integration test; not a public contract.
+
+Run the suite standalone with `cargo test -p forge-agent-host`. The supervisor side is exercised separately under `forge-session` (`tests/sidecar_supervisor.rs`, `tests/bg_agents_sidecar.rs`).
+
+## Further reading
+
+- [Agent sidecar architecture](../../docs/architecture/agent-sidecar.md) — the F-608 design doc, including the 9-step rollout, restart policy, and known security limitations.
+- [IPC contracts](../../docs/architecture/ipc-contracts.md) — sidecar `SidecarMessage` shapes and the inline-vs-event rule (§4.0).
+- [Crate architecture](../../docs/architecture/crate-architecture.md) — workspace dependency map.

--- a/docs/architecture/agent-sidecar.md
+++ b/docs/architecture/agent-sidecar.md
@@ -59,7 +59,7 @@ forge-shell ◀──UDS──┤             forged              │
 
 ### 2. IPC Transport
 
-**Decision.** Per-instance Unix domain socket using the same length-prefixed JSON framing (`forge_ipc::write_frame` / `read_frame` at `crates/forge-ipc/src/lib.rs:247`) the daemon ↔ shell wire already uses. The daemon binds the socket before spawning the sidecar; the sidecar receives the path via `--socket /run/user/$uid/forge/<session>/<instance-id>.sock` and connects on startup.
+**Decision.** Per-instance Unix domain socket using the same length-prefixed JSON framing (`forge_ipc::write_frame` / `read_frame` at `crates/forge-ipc/src/lib.rs:247`) the daemon ↔ shell wire already uses. The daemon binds the socket before spawning the sidecar; the sidecar receives the path via `--socket ${XDG_RUNTIME_DIR:-$TMPDIR}/forge/sidecars/<session-id>/<instance-id>.sock` and connects on startup. The supervisor creates the per-session directory at mode `0o700` lazily on the first spawn (see `ensure_socket_dir` in `crates/forge-session/src/sidecar/mod.rs`); the production wiring is in `forge_shell::ipc::sidecar_socket_dir` (`crates/forge-shell/src/ipc.rs:2355`).
 
 **Rationale.**
 - Reusing `forge-ipc`'s framing pattern (same `[u32 BE length][JSON body]` shape, same 4 MiB cap, same `serde(tag = "t")` discriminated union) means zero new framing code and one mental model for IPC throughout Forge.
@@ -235,6 +235,30 @@ self.monitor.track(id.clone(), handle.pid).await;
 **Metrics surfaced via existing channels.**
 - `Event::ResourceSample` (already on the wire): real per-sidecar CPU/RSS/FD pills land in the AgentMonitor automatically once §9 wires the PID.
 - New event variant — **deliberately deferred**. F-608 does not introduce sidecar-lifecycle wire events; the existing `BackgroundAgentStarted` / `BackgroundAgentCompleted` / `AgentEvent::Failed` cover the three transitions the UI needs. The supervisor's restarts are invisible to the shell.
+
+---
+
+### 11. `provider:changed` Integration (F-640)
+
+**Decision.** A `provider:changed` swap takes effect on the **next** `RunTurn`. Any chat stream already in flight when the swap arrives continues against the previous provider until it terminates.
+
+**Mechanism.** The dashboard / settings flow emits a `provider:changed` Tauri event (`crates/forge-shell/src/providers_ipc.rs:314`). Each open session window forwards it to its session daemon over the existing UDS as `IpcMessage::ProviderChanged { provider_id }` (`crates/forge-ipc/src/lib.rs:108`). The daemon's connection arm calls `SwappableProvider::swap` (`crates/forge-providers/src/runtime.rs:128`), which atomically replaces the inner `RuntimeProvider` behind an `Arc<RwLock<_>>`.
+
+**In-flight semantics.** `SwappableProvider::chat` clones the inner `RuntimeProvider` (an `Arc` clone) under a brief read lock and drops the guard before awaiting the upstream stream. The cloned snapshot owns the in-flight chat for the rest of the turn — see `runtime.rs:144-152`. Result: the swap is invisible to any frame still being streamed. The next `chat` call (the next turn) re-reads the lock and picks up the new inner.
+
+**Sidecar protocol impact.** None. The sidecar wire protocol does not carry provider-swap frames; the daemon owns the `SwappableProvider` and the sidecar consumes whatever provider the daemon hands it via `Hello` / `Credentials` at the moment a `RunTurn` is dispatched. Operators reading event logs should therefore expect: a `provider:changed` event followed by an in-flight turn that finishes against the old provider, and only the *subsequent* turn's `Event::AssistantMessage { provider, .. }` reflects the new id.
+
+---
+
+## Known Security Limitations
+
+The architecture has open security findings that operators should be aware of. The supervisor / sidecar protocol is sufficient for trusted single-user workstations (Forge's current deployment model) but does not yet defend against a hostile process on the same host. Tracking issues:
+
+- **[SEC-11 / F-651](https://github.com/forge-ide/forge/issues/687)** — sidecar UDS `accept` does not verify peer credentials. Any process on the host that can `connect(2)` the supervisor's socket can impersonate a sidecar. Mitigation under design: `SO_PEERCRED` check against the spawned child's pid before completing the handshake.
+- **[SEC-12 / F-652](https://github.com/forge-ide/forge/issues/688)** — `forge_ipc::read_frame` / `read_frame_into` lack a mandatory deadline; the deadline-bearing variant `read_frame_into_with_deadline` exists (`crates/forge-ipc/src/lib.rs:437`) but is not used on every read site. A peer that opens a connection and writes one byte per minute holds the supervisor's read task indefinitely (slowloris). Mitigation under design: make a per-connection idle deadline mandatory at the framing layer.
+- **[SEC-19 / F-659](https://github.com/forge-ide/forge/issues/695)** — `SecretBytes` in the sidecar `Credentials` frame zeroizes only on the receive side (the sidecar wraps the bytes in `SecretString` straight out of the wire — see `crates/forge-agent-host/src/lib.rs:662`). The cleartext copy on the *sender* side, and any intermediate `Vec<u8>` produced by `serde_json::to_vec`, is not zeroized. A heap inspector with code-execution on the daemon could observe a recently-pushed credential before allocator reuse overwrites the buffer.
+
+These are tracked, intentionally not blocking F-608 rollout, and will close as their owning issues land. New findings should be added here with the same `SEC-NN / F-NNN` shape.
 
 ---
 


### PR DESCRIPTION
Closes #740.

## Summary

Doc-only follow-up to F-608 / F-640. Closes the four gaps the issue called out:

1. **§2 socket path** — replaced the pre-soak `/run/user/$uid/forge/<session>/<instance-id>.sock` placeholder with the shipped path: `${XDG_RUNTIME_DIR:-$TMPDIR}/forge/sidecars/<session-id>/<instance-id>.sock`. Pointed at `forge_shell::ipc::sidecar_socket_dir` and the supervisor's `ensure_socket_dir` for the `0o700` enforcement.
2. **§11 `provider:changed` integration (F-640)** — new section. Swap takes effect on the next `RunTurn`; the in-flight chat keeps its `Arc`-cloned `RuntimeProvider` snapshot through to stream end (per `SwappableProvider::chat`'s explicit "drop the read guard before await" contract). Sidecar wire protocol unchanged.
3. **Known Security Limitations** — new top-level section linking SEC-11 / SEC-12 / SEC-19 (issues #687, #688, #695) so operators reading the design doc see the open findings honestly disclosed.
4. **`crates/forge-agent-host/README.md`** — new file. Was the only crate without one. Covers purpose, public API (`AgentArgs`, `run`, `IpcEventSink`, `CredentialStash`, `DaemonHelloState`, `install_panic_hook`, `EventSeq`), supervisor integration contract, and how to run the crate's own tests.

## Test plan

- [x] `just check-rust` — clippy + rustdoc with `-D warnings` clean (forge-agent-host's README is rendered via `cargo doc`'s crate-level page; no doctest impact).
- [x] No code changes; existing `cargo test` suite is unchanged.
- [x] DoD checklist from #740 walked end-to-end (socket path / provider:changed / security limitations / README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)