### PR TITLE
[F-642] Apply security hardening flags to Level 2 sandbox

### DIFF
--- a/crates/forge-oci/src/lib.rs
+++ b/crates/forge-oci/src/lib.rs
@@ -240,6 +240,192 @@ pub enum OciError {
     },
 }
 
+/// Network policy applied at container create time.
+///
+/// Maps directly onto `podman create --network <value>`. The default for
+/// Level 2 sandboxes is [`NetworkPolicy::None`] — no inbound or outbound
+/// traffic — because containers ship without any tool-declared host
+/// allow-list today (CNI policy is future work, see
+/// `docs/architecture/isolation-model.md` §8.3).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NetworkPolicy {
+    /// `--network none` — no network namespace beyond loopback.
+    None,
+    /// Inherit the host network namespace (`--network host`). Reserved for
+    /// trusted callers; never the default for Level 2.
+    Host,
+    /// Use a named podman network. The string is passed verbatim to
+    /// `--network <name>`.
+    Named(String),
+}
+
+impl NetworkPolicy {
+    /// Render as the value passed after `--network`. Returns `None` when
+    /// the policy is "use the runtime default" — currently nothing maps to
+    /// this, but it leaves room for future variants without churning the
+    /// argv-shaping call sites.
+    pub fn as_arg(&self) -> Option<&str> {
+        match self {
+            NetworkPolicy::None => Some("none"),
+            NetworkPolicy::Host => Some("host"),
+            NetworkPolicy::Named(name) => Some(name.as_str()),
+        }
+    }
+}
+
+/// User-namespace policy applied at container create time.
+///
+/// `--userns keep-id` anchors the container's user namespace to the host
+/// uid/gid so file ownership round-trips cleanly between mounts. Without
+/// it, rootless podman applies its default mapping (uid 0 inside maps to
+/// the rootless uid outside) which makes workspace mounts hostile to read
+/// in either direction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum UserNsPolicy {
+    /// `--userns keep-id` — caller's uid/gid is preserved inside the
+    /// container.
+    KeepId,
+    /// Use the runtime default (rootless podman: nested mapping). No
+    /// `--userns` flag emitted.
+    Default,
+}
+
+/// Security hardening options applied at container create time.
+///
+/// Every field maps to a concrete `podman create` flag; the defaults are
+/// the strict "Level 2" preset documented in
+/// `docs/architecture/isolation-model.md` §8.3. Callers that need a
+/// permissive policy (tests, legacy code paths) should construct this
+/// explicitly with [`SecurityOpts::permissive`].
+///
+/// Threat model: rootless podman alone leaves `NoNewPrivs=0`, the default
+/// rootless capability set, an open network namespace, and a writable
+/// rootfs — every escape-class CVE in the kernel, podman, or runc that
+/// these flags would otherwise defeat is exploitable from inside the
+/// container.
+///
+/// Field ordering in [`SecurityOpts::to_create_flags`] is deterministic so
+/// argv assertions can pin the rendering.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SecurityOpts {
+    /// `--security-opt no-new-privileges` — once set, processes inside
+    /// the container cannot gain privileges via setuid binaries or file
+    /// capabilities. Default `true`.
+    pub no_new_privileges: bool,
+
+    /// Capabilities to drop. `["ALL"]` drops every capability and is the
+    /// hardened default; downstream issues that need specific
+    /// capabilities should add them to [`Self::cap_add`] rather than
+    /// shrinking this list.
+    pub cap_drop: Vec<String>,
+
+    /// Capabilities to add back after the cap-drop. The hardened default
+    /// is empty — the `sleep infinity` init process and the agent
+    /// commands run via `podman exec` need none.
+    pub cap_add: Vec<String>,
+
+    /// `--read-only` — rootfs is mounted read-only. Writable workspace
+    /// directories are surfaced as explicit tmpfs / volume mounts (future
+    /// work tracked alongside the F-642 follow-ups). Default `true`.
+    pub read_only_rootfs: bool,
+
+    /// Network policy. Default [`NetworkPolicy::None`] — the strictest
+    /// interpretation of the F-642 DoD "restricted network".
+    pub network: NetworkPolicy,
+
+    /// User-namespace policy. Default [`UserNsPolicy::KeepId`].
+    pub userns: UserNsPolicy,
+}
+
+impl SecurityOpts {
+    /// Strict Level-2 baseline: no-new-privileges, cap-drop ALL,
+    /// read-only rootfs, no network, keep-id user namespace.
+    ///
+    /// This is what [`crate::ContainerRuntime::create`] callers should
+    /// pass unless they have a specific reason to relax a flag — and
+    /// every relaxation should be documented at the call site.
+    pub fn hardened_default() -> Self {
+        Self {
+            no_new_privileges: true,
+            cap_drop: vec!["ALL".to_string()],
+            cap_add: Vec::new(),
+            read_only_rootfs: true,
+            network: NetworkPolicy::None,
+            userns: UserNsPolicy::KeepId,
+        }
+    }
+
+    /// Permissive preset — every hardening flag disabled. Reserved for
+    /// tests that need a baseline argv without security flags interleaved
+    /// in their assertions. Production callers must not use this.
+    pub fn permissive() -> Self {
+        Self {
+            no_new_privileges: false,
+            cap_drop: Vec::new(),
+            cap_add: Vec::new(),
+            read_only_rootfs: false,
+            network: NetworkPolicy::Named("default".to_string()), // inherit runtime default
+            userns: UserNsPolicy::Default,
+        }
+    }
+
+    /// Render into the canonical podman create flag list. The order is
+    /// pinned by tests so the exact argv is deterministic:
+    ///
+    /// 1. `--security-opt no-new-privileges` (if set)
+    /// 2. one `--cap-drop <CAP>` per entry in `cap_drop`, in input order
+    /// 3. one `--cap-add <CAP>` per entry in `cap_add`, in input order
+    /// 4. `--read-only` (if set)
+    /// 5. `--network <value>` (always emitted unless the variant maps to
+    ///    `None`, which currently never happens)
+    /// 6. `--userns keep-id` (if `KeepId`)
+    ///
+    /// The flags are inserted between `podman create` and the IMAGE
+    /// positional so podman parses them as runtime options. See
+    /// [`crate::ContainerRuntime::create`] docs for the positional grammar.
+    pub fn to_create_flags(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if self.no_new_privileges {
+            out.push("--security-opt".to_string());
+            out.push("no-new-privileges".to_string());
+        }
+        for cap in &self.cap_drop {
+            out.push("--cap-drop".to_string());
+            out.push(cap.clone());
+        }
+        for cap in &self.cap_add {
+            out.push("--cap-add".to_string());
+            out.push(cap.clone());
+        }
+        if self.read_only_rootfs {
+            out.push("--read-only".to_string());
+        }
+        if let Some(value) = self.network.as_arg() {
+            // SecurityOpts::permissive uses Named("default") as a sentinel
+            // for "do not pin --network" — emit nothing in that case so
+            // the runtime's default network namespace is inherited.
+            if !(matches!(self.network, NetworkPolicy::Named(ref n) if n == "default")) {
+                out.push("--network".to_string());
+                out.push(value.to_string());
+            }
+        }
+        if matches!(self.userns, UserNsPolicy::KeepId) {
+            out.push("--userns".to_string());
+            out.push("keep-id".to_string());
+        }
+        out
+    }
+}
+
+impl Default for SecurityOpts {
+    /// Defaults to the strict [`Self::hardened_default`]. Production
+    /// callers should never have to think about security defaults; opting
+    /// out is the explicit step.
+    fn default() -> Self {
+        Self::hardened_default()
+    }
+}
+
 /// One line of captured container output.
 ///
 /// Surfaced by [`ContainerLogs::logs`]. The runtime hands back stdout and
@@ -298,7 +484,21 @@ pub trait ContainerRuntime: Send + Sync {
 
     /// Create a container from `image` with `argv` as the command. The
     /// container is created but not started; call [`Self::start`] separately.
-    async fn create(&self, image: &ImageRef, argv: &[&str]) -> Result<ContainerHandle, OciError>;
+    ///
+    /// `opts` carries the security-hardening flags rendered between
+    /// `podman create` and the IMAGE positional. Production callers
+    /// should pass [`SecurityOpts::hardened_default`] (the strict Level-2
+    /// baseline); see `docs/architecture/isolation-model.md` §8.3 for the
+    /// documented allow-list. The argv-parsing grammar is unchanged:
+    /// caller-supplied `argv` still terminates flag parsing at the IMAGE
+    /// positional (the `--privileged` flag-injection regression test in
+    /// `crates/forge-oci/src/podman.rs` pins this).
+    async fn create(
+        &self,
+        image: &ImageRef,
+        argv: &[&str],
+        opts: &SecurityOpts,
+    ) -> Result<ContainerHandle, OciError>;
 
     /// Start a created container.
     async fn start(&self, handle: &ContainerHandle) -> Result<(), OciError>;
@@ -427,6 +627,7 @@ mod tests {
             &self,
             _image: &ImageRef,
             _argv: &[&str],
+            _opts: &SecurityOpts,
         ) -> Result<ContainerHandle, OciError> {
             Ok(ContainerHandle::new("mock"))
         }
@@ -474,7 +675,10 @@ mod tests {
         rt.pull(&img).await.unwrap();
         // `create`/`exec` accept caller-borrowed `&str` slices directly —
         // no `.into()` allocation required.
-        let h = rt.create(&img, &["echo", "hi"]).await.unwrap();
+        let h = rt
+            .create(&img, &["echo", "hi"], &SecurityOpts::hardened_default())
+            .await
+            .unwrap();
         rt.start(&h).await.unwrap();
         let res = rt.exec(&h, &["true"]).await.unwrap();
         assert_eq!(res.exit_code, Some(0));
@@ -507,7 +711,108 @@ mod tests {
         let rt: &dyn ContainerRuntime = &MockRuntime;
         let img = ImageRef::parse("alpine:3.19").unwrap();
         let argv: [&str; 2] = ["echo", "hi"];
-        let _ = rt.create(&img, &argv).await.unwrap();
+        let _ = rt
+            .create(&img, &argv, &SecurityOpts::hardened_default())
+            .await
+            .unwrap();
         let _ = rt.exec(&ContainerHandle::new("x"), &argv).await.unwrap();
+    }
+
+    // ── F-642: SecurityOpts hardening defaults ───────────────────────
+
+    #[test]
+    fn hardened_default_includes_every_dod_flag() {
+        // F-642: this is the load-bearing security invariant. If the
+        // hardened default ever silently relaxes one of these flags,
+        // the Level 2 sandbox loses an escape-class CVE mitigation.
+        // Every assertion is keyed off the issue's DoD checklist.
+        let opts = SecurityOpts::hardened_default();
+        assert!(
+            opts.no_new_privileges,
+            "no-new-privileges must be enabled by default"
+        );
+        assert_eq!(
+            opts.cap_drop,
+            vec!["ALL".to_string()],
+            "cap-drop must default to ALL"
+        );
+        assert!(
+            opts.cap_add.is_empty(),
+            "cap-add allow-list must default to empty (sleep-infinity init needs none)"
+        );
+        assert!(opts.read_only_rootfs, "rootfs must be read-only by default");
+        assert_eq!(
+            opts.network,
+            NetworkPolicy::None,
+            "network must be `none` by default"
+        );
+        assert!(
+            matches!(opts.userns, UserNsPolicy::KeepId),
+            "user namespace must default to keep-id"
+        );
+    }
+
+    #[test]
+    fn hardened_default_renders_canonical_flag_order() {
+        // The order is pinned because the integration test asserts the
+        // exact rendered argv. Any reorder is a breaking change to
+        // operators reading the audit trail.
+        let flags = SecurityOpts::hardened_default().to_create_flags();
+        assert_eq!(
+            flags,
+            vec![
+                "--security-opt".to_string(),
+                "no-new-privileges".to_string(),
+                "--cap-drop".to_string(),
+                "ALL".to_string(),
+                "--read-only".to_string(),
+                "--network".to_string(),
+                "none".to_string(),
+                "--userns".to_string(),
+                "keep-id".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn default_trait_returns_hardened() {
+        // Production callers that fall back to `Default` should get the
+        // strict policy, never a permissive accident. F-654 will extend
+        // this trait, not relax it.
+        assert_eq!(SecurityOpts::default(), SecurityOpts::hardened_default());
+    }
+
+    #[test]
+    fn permissive_emits_no_hardening_flags() {
+        // The permissive preset exists for tests that want a clean argv
+        // baseline. If any flag leaks through, those tests would silently
+        // start asserting against the hardening flags.
+        let flags = SecurityOpts::permissive().to_create_flags();
+        assert!(
+            flags.is_empty(),
+            "permissive preset must render zero flags, got {flags:?}"
+        );
+    }
+
+    #[test]
+    fn cap_add_entries_render_after_cap_drop() {
+        // Order matters: podman applies --cap-drop then --cap-add, so
+        // the rendered argv mirroring that order is what an operator
+        // grepping for the audit trail expects.
+        let opts = SecurityOpts {
+            cap_add: vec!["NET_BIND_SERVICE".to_string()],
+            ..SecurityOpts::hardened_default()
+        };
+        let flags = opts.to_create_flags();
+        let drop_idx = flags
+            .iter()
+            .position(|s| s == "--cap-drop")
+            .expect("cap-drop must be present");
+        let add_idx = flags
+            .iter()
+            .position(|s| s == "--cap-add")
+            .expect("cap-add must be present");
+        assert!(drop_idx < add_idx, "cap-drop must precede cap-add");
+        assert_eq!(flags[add_idx + 1], "NET_BIND_SERVICE");
     }
 }

--- a/crates/forge-oci/src/podman.rs
+++ b/crates/forge-oci/src/podman.rs
@@ -8,7 +8,7 @@
 use crate::runner::{CommandOutcome, CommandRunner, TokioCommandRunner};
 use crate::{
     ContainerHandle, ContainerLogs, ContainerRuntime, ExecResult, ImageRef, LogLine, OciError,
-    Stats,
+    SecurityOpts, Stats,
 };
 use async_trait::async_trait;
 
@@ -134,7 +134,12 @@ impl ContainerRuntime for PodmanRuntime {
         Ok(())
     }
 
-    async fn create(&self, image: &ImageRef, argv: &[&str]) -> Result<ContainerHandle, OciError> {
+    async fn create(
+        &self,
+        image: &ImageRef,
+        argv: &[&str],
+        opts: &SecurityOpts,
+    ) -> Result<ContainerHandle, OciError> {
         let img = image.to_image_string();
         // `podman create [options] IMAGE [COMMAND [ARG...]]` — podman's
         // argument grammar terminates flag parsing at the IMAGE positional, so
@@ -145,7 +150,19 @@ impl ContainerRuntime for PodmanRuntime {
         // "executable file `--` not found"). The flag-injection regression
         // test in this module pins that behaviour by feeding `--privileged`
         // through and asserting podman does not apply it as a runtime flag.
-        let mut args: Vec<&str> = vec!["create", &img];
+        //
+        // F-642: SecurityOpts flags are inserted between `create` and the
+        // IMAGE positional so podman parses them as runtime options. Order
+        // is pinned by `SecurityOpts::to_create_flags` and asserted by both
+        // unit tests in this module and the integration test in
+        // `tests/podman_integration.rs`.
+        let security_flags = opts.to_create_flags();
+        let mut args: Vec<&str> = Vec::with_capacity(2 + security_flags.len() + argv.len());
+        args.push("create");
+        for flag in &security_flags {
+            args.push(flag.as_str());
+        }
+        args.push(&img);
         args.extend_from_slice(argv);
         let outcome = self.run_or_fail(&args).await?;
         let id = String::from_utf8_lossy(&outcome.stdout).trim().to_string();
@@ -485,10 +502,15 @@ mod tests {
 
         let runtime = rt(runner);
         let img = ImageRef::parse("alpine:3.19").unwrap();
-        let h = runtime.create(&img, &["echo", "hi"]).await.unwrap();
+        let h = runtime
+            .create(&img, &["echo", "hi"], &SecurityOpts::permissive())
+            .await
+            .unwrap();
         assert_eq!(h.id, "abc1234deadbeef");
 
         let calls = calls.lock().unwrap();
+        // SecurityOpts::permissive emits zero flags, keeping the
+        // historical argv shape for tests that pre-date F-642.
         assert_eq!(calls[0].1, vec!["create", "alpine:3.19", "echo", "hi"]);
     }
 
@@ -508,7 +530,10 @@ mod tests {
 
         let runtime = rt(runner);
         let img = ImageRef::parse("alpine:3.19").unwrap();
-        runtime.create(&img, &["--privileged", "sh"]).await.unwrap();
+        runtime
+            .create(&img, &["--privileged", "sh"], &SecurityOpts::permissive())
+            .await
+            .unwrap();
 
         let argv = calls.lock().unwrap()[0].1.clone();
         let image_idx = argv
@@ -541,7 +566,10 @@ mod tests {
         let runtime = rt(runner);
         let img = ImageRef::parse("alpine:3.19").unwrap();
         let argv: [&str; 0] = [];
-        let err = runtime.create(&img, &argv).await.unwrap_err();
+        let err = runtime
+            .create(&img, &argv, &SecurityOpts::permissive())
+            .await
+            .unwrap_err();
         assert!(matches!(err, OciError::CommandFailed { .. }));
     }
 
@@ -895,6 +923,124 @@ mod tests {
         assert_eq!(l.stream, "stdout");
         assert_eq!(l.line, "hello world");
         assert_eq!(l.timestamp.as_deref(), Some("2025-04-26T10:00:00Z"));
+    }
+
+    // ── F-642: SecurityOpts plumbed through `create` ─────────────────
+
+    #[tokio::test]
+    async fn create_emits_every_hardened_default_flag_before_image() {
+        // Load-bearing: the F-642 DoD says PodmanRuntime::create must
+        // inject no-new-privileges + cap-drop ALL + restricted network
+        // + read-only rootfs by default. This test pins the exact argv
+        // shape so a regression that drops a flag (or moves it past
+        // the IMAGE positional, where podman would treat it as the
+        // in-container command) fails the test loudly.
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"abc1234\n".to_vec()));
+        let calls = runner.calls.clone();
+
+        let runtime = rt(runner);
+        let img = ImageRef::parse("alpine:3.19").unwrap();
+        runtime
+            .create(
+                &img,
+                &["sleep", "infinity"],
+                &SecurityOpts::hardened_default(),
+            )
+            .await
+            .unwrap();
+
+        let calls = calls.lock().unwrap();
+        let argv = &calls[0].1;
+        // Every hardening flag must be present before the IMAGE positional.
+        let image_idx = argv
+            .iter()
+            .position(|a| a == "alpine:3.19")
+            .expect("argv must contain image positional");
+        let prefix = &argv[..image_idx];
+        for required in [
+            "--security-opt",
+            "no-new-privileges",
+            "--cap-drop",
+            "ALL",
+            "--read-only",
+            "--network",
+            "none",
+            "--userns",
+            "keep-id",
+        ] {
+            assert!(
+                prefix.iter().any(|a| a == required),
+                "missing hardening flag {required:?} in {argv:?}"
+            );
+        }
+        // Caller argv lands strictly after IMAGE.
+        let suffix = &argv[image_idx + 1..];
+        assert_eq!(suffix, &["sleep".to_string(), "infinity".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn create_renders_security_flags_in_canonical_order() {
+        // Pinning the exact rendered prefix so operators reading the
+        // audit log see a stable shape and so reorderings can't sneak
+        // through review. The order is documented on
+        // `SecurityOpts::to_create_flags`.
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"abc1234\n".to_vec()));
+        let calls = runner.calls.clone();
+
+        let runtime = rt(runner);
+        let img = ImageRef::parse("alpine:3.19").unwrap();
+        runtime
+            .create(
+                &img,
+                &["sleep", "infinity"],
+                &SecurityOpts::hardened_default(),
+            )
+            .await
+            .unwrap();
+
+        let calls = calls.lock().unwrap();
+        let argv = &calls[0].1;
+        assert_eq!(
+            argv,
+            &vec![
+                "create".to_string(),
+                "--security-opt".to_string(),
+                "no-new-privileges".to_string(),
+                "--cap-drop".to_string(),
+                "ALL".to_string(),
+                "--read-only".to_string(),
+                "--network".to_string(),
+                "none".to_string(),
+                "--userns".to_string(),
+                "keep-id".to_string(),
+                "alpine:3.19".to_string(),
+                "sleep".to_string(),
+                "infinity".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn create_with_permissive_opts_emits_no_security_flags() {
+        // Regression guard for the test-only `permissive` preset:
+        // every test in this module that calls `create` with
+        // SecurityOpts::permissive expects a clean argv with no
+        // hardening flags interleaved.
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"abc1234\n".to_vec()));
+        let calls = runner.calls.clone();
+
+        let runtime = rt(runner);
+        let img = ImageRef::parse("alpine:3.19").unwrap();
+        runtime
+            .create(&img, &["sh"], &SecurityOpts::permissive())
+            .await
+            .unwrap();
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls[0].1, vec!["create", "alpine:3.19", "sh"]);
     }
 
     #[test]

--- a/crates/forge-oci/tests/podman_integration.rs
+++ b/crates/forge-oci/tests/podman_integration.rs
@@ -15,7 +15,7 @@
 
 #![cfg(target_os = "linux")]
 
-use forge_oci::{ContainerRuntime, ImageRef, PodmanRuntime};
+use forge_oci::{ContainerRuntime, ImageRef, PodmanRuntime, SecurityOpts};
 
 /// End-to-end flag-injection regression test for `create`.
 ///
@@ -43,7 +43,11 @@ async fn create_does_not_apply_caller_flags_as_runtime_flags() {
     // as its own `--privileged` flag, the resulting container would have
     // `HostConfig.Privileged = true`, which we explicitly check against.
     let handle = runtime
-        .create(&image, &["--privileged", "sh", "-c", "true"])
+        .create(
+            &image,
+            &["--privileged", "sh", "-c", "true"],
+            &SecurityOpts::permissive(),
+        )
         .await
         .expect("create container");
 
@@ -94,7 +98,7 @@ async fn exec_does_not_apply_caller_flags_as_runtime_flags() {
     runtime.pull(&image).await.expect("pull alpine");
 
     let handle = runtime
-        .create(&image, &["sleep", "30"])
+        .create(&image, &["sleep", "30"], &SecurityOpts::permissive())
         .await
         .expect("create container");
     runtime.start(&handle).await.expect("start container");
@@ -137,7 +141,7 @@ async fn podman_full_lifecycle_against_alpine() {
     // Long-lived foreground process so `exec` has something to attach to.
     // `sleep 60` is plenty for the test to do its work and tear down.
     let handle = runtime
-        .create(&image, &["sleep", "60"])
+        .create(&image, &["sleep", "60"], &SecurityOpts::permissive())
         .await
         .expect("create container");
 
@@ -169,4 +173,78 @@ async fn podman_full_lifecycle_against_alpine() {
         "expected inspect to fail after remove; stdout={:?}",
         String::from_utf8_lossy(&inspect.stdout)
     );
+}
+
+/// End-to-end proof that the F-642 hardened defaults actually land on
+/// the resulting container.
+///
+/// The unit-level tests in `crates/forge-oci/src/podman.rs` pin the
+/// shape of the rendered argv. This test pins the *behaviour* — by
+/// asking `podman inspect` whether the security flags took effect, we
+/// catch any silent podman-side rejection (e.g. unsupported flag, kernel
+/// missing the seccomp profile, podman renaming a JSON field) that
+/// argv-shaping assertions would miss.
+///
+/// `cargo test -p forge-oci -- --ignored` to run.
+#[tokio::test]
+#[ignore = "requires rootless podman on PATH (run with --ignored)"]
+async fn create_with_hardened_defaults_applies_every_flag() {
+    let runtime = PodmanRuntime::new();
+    runtime.detect().await.expect("podman detect");
+    let image = ImageRef::parse("docker.io/library/alpine:3.19").expect("valid image ref");
+    runtime.pull(&image).await.expect("pull alpine");
+
+    let handle = runtime
+        .create(&image, &["sleep", "30"], &SecurityOpts::hardened_default())
+        .await
+        .expect("create container with hardened defaults");
+
+    // Each format string asks podman a separate behavioural question.
+    // Combined into one inspect invocation to keep the test fast.
+    let inspect = std::process::Command::new("podman")
+        .args([
+            "inspect",
+            "--format",
+            "{{.HostConfig.SecurityOpt}}|{{.HostConfig.CapDrop}}|{{.HostConfig.ReadonlyRootfs}}|{{.HostConfig.NetworkMode}}|{{.HostConfig.UsernsMode}}",
+            &handle.id,
+        ])
+        .output()
+        .expect("podman inspect spawn");
+    assert!(
+        inspect.status.success(),
+        "podman inspect failed: {}",
+        String::from_utf8_lossy(&inspect.stderr)
+    );
+    let out = String::from_utf8_lossy(&inspect.stdout).trim().to_string();
+    let parts: Vec<&str> = out.splitn(5, '|').collect();
+    assert_eq!(
+        parts.len(),
+        5,
+        "expected 5 inspect fields, got {parts:?} from {out:?}"
+    );
+    let (security_opt, cap_drop, readonly, network, userns) =
+        (parts[0], parts[1], parts[2], parts[3], parts[4]);
+
+    assert!(
+        security_opt.contains("no-new-privileges"),
+        "no-new-privileges missing from SecurityOpt: {security_opt}"
+    );
+    assert!(
+        cap_drop.contains("ALL") || cap_drop.contains("CAP_"),
+        "cap-drop ALL not visible in CapDrop: {cap_drop}"
+    );
+    assert!(
+        readonly == "true",
+        "ReadonlyRootfs must be true, got {readonly:?}"
+    );
+    assert!(
+        network.contains("none"),
+        "NetworkMode must be none, got {network:?}"
+    );
+    assert!(
+        userns.contains("keep-id"),
+        "UsernsMode must be keep-id, got {userns:?}"
+    );
+
+    runtime.remove(&handle).await.expect("remove container");
 }

--- a/crates/forge-session/src/sandbox.rs
+++ b/crates/forge-session/src/sandbox.rs
@@ -1480,6 +1480,7 @@ mod tests {
             &self,
             _image: &OciImageRef,
             _argv: &[&str],
+            _opts: &forge_oci::SecurityOpts,
         ) -> Result<OciContainerHandle, OciError> {
             self.record("create");
             Ok(OciContainerHandle::new("c-id"))

--- a/crates/forge-session/src/sandbox/level2.rs
+++ b/crates/forge-session/src/sandbox/level2.rs
@@ -42,7 +42,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use forge_oci::{ContainerHandle, ContainerRuntime, ImageRef, OciError};
+use forge_oci::{ContainerHandle, ContainerRuntime, ImageRef, OciError, SecurityOpts};
 
 /// Binary used by [`Level2Session::drop`]'s panic-safety net to reap
 /// a leaked container. Hardcoded because the only `ContainerRuntime`
@@ -201,7 +201,17 @@ impl Level2Session {
         limits: ContainerLimits,
     ) -> Result<Self, OciError> {
         runtime.pull(&image).await?;
-        let handle = runtime.create(&image, Self::default_init_argv()).await?;
+        // F-642: every Level 2 container is created with the strict
+        // hardening defaults — no-new-privileges, cap-drop ALL, read-only
+        // rootfs, no network, keep-id user namespace. Documented at
+        // `docs/architecture/isolation-model.md` §8.3.
+        let handle = runtime
+            .create(
+                &image,
+                Self::default_init_argv(),
+                &SecurityOpts::hardened_default(),
+            )
+            .await?;
         runtime.start(&handle).await?;
         // Operator-facing notice when limits are configured but not
         // yet enforced. Until follow-up #631 lands, the container
@@ -453,6 +463,9 @@ mod tests {
         calls: Mutex<Vec<String>>,
         // Optional canned exec outcome.
         exec_outcome: Mutex<Option<ExecResult>>,
+        // Last SecurityOpts seen by `create`, captured for F-642 tests
+        // that need to verify the hardened defaults reached the trait.
+        last_create_opts: Mutex<Option<SecurityOpts>>,
     }
 
     impl MockRuntime {
@@ -461,6 +474,9 @@ mod tests {
         }
         fn record(&self, name: &str) {
             self.calls.lock().unwrap().push(name.to_string());
+        }
+        fn last_create_opts(&self) -> Option<SecurityOpts> {
+            self.last_create_opts.lock().unwrap().clone()
         }
     }
 
@@ -478,8 +494,10 @@ mod tests {
             &self,
             _image: &ImageRef,
             _argv: &[&str],
+            opts: &SecurityOpts,
         ) -> Result<ContainerHandle, OciError> {
             self.record("create");
+            *self.last_create_opts.lock().unwrap() = Some(opts.clone());
             Ok(ContainerHandle::new("mock-container"))
         }
         async fn start(&self, _handle: &ContainerHandle) -> Result<(), OciError> {
@@ -662,6 +680,32 @@ mod tests {
         // Defuse for the actual drop in this test environment so we
         // don't fork off a real `podman rm -f`.
         session.disable_drop_cleanup();
+    }
+
+    // ── F-642: Level2Session passes hardened defaults to runtime.create ──
+
+    #[tokio::test]
+    async fn create_passes_hardened_security_opts_to_runtime() {
+        // Load-bearing F-642 invariant: every Level 2 container must be
+        // created with the strict hardening preset. If a refactor drops
+        // this propagation, the integration test would still pass with
+        // a mock runtime — this test pins the explicit opt-in.
+        let mock: Arc<MockRuntime> = Arc::new(MockRuntime::default());
+        let runtime: Arc<dyn ContainerRuntime> = mock.clone();
+
+        let session = Level2Session::create(runtime, alpine(), ContainerLimits::default())
+            .await
+            .unwrap();
+        session.disable_drop_cleanup();
+
+        let opts = mock
+            .last_create_opts()
+            .expect("runtime.create must have been invoked");
+        assert_eq!(
+            opts,
+            SecurityOpts::hardened_default(),
+            "Level2Session must pass the hardened SecurityOpts preset to runtime.create"
+        );
     }
 
     // ── ContainerLimits flag shaping ─────────────────────────────────
@@ -874,6 +918,25 @@ mod tests {
         // create's argv ends with the init argv we shipped.
         let create_args = &calls[1].1;
         assert!(create_args.ends_with(&["sleep".into(), "infinity".into()]));
+        // F-642: every hardening flag must be present in the create argv —
+        // end-to-end proof that Level2Session ships the strict preset
+        // through the trait into PodmanRuntime's flag rendering.
+        for required in [
+            "--security-opt",
+            "no-new-privileges",
+            "--cap-drop",
+            "ALL",
+            "--read-only",
+            "--network",
+            "none",
+            "--userns",
+            "keep-id",
+        ] {
+            assert!(
+                create_args.iter().any(|a| a == required),
+                "create argv missing F-642 hardening flag {required:?}: {create_args:?}"
+            );
+        }
         // exec's argv carries the caller's command after the container id.
         let exec_args = &calls[3].1;
         assert!(exec_args.ends_with(&["echo".into(), "hello".into()]));

--- a/docs/architecture/isolation-model.md
+++ b/docs/architecture/isolation-model.md
@@ -103,7 +103,7 @@ and broadened in F-680 to host more than one runtime
 |---|---|
 | `detect()` | Probe the host and classify failure into one of the canonical `OciError` variants (`RuntimeMissing`, `RuntimeBroken`, `RootlessUnavailable`). |
 | `pull(image)` | Idempotent image fetch into the local store. |
-| `create(image, argv: &[&str])` | Create a container with the given in-container command. Argv is borrowed `&str` slices so callers don't have to allocate. |
+| `create(image, argv: &[&str], opts: &SecurityOpts)` | Create a container with the given in-container command and security-hardening flags. Argv is borrowed `&str` slices so callers don't have to allocate. The `opts` parameter is the F-642 plumbing point — see *Security hardening defaults* below. |
 | `start(handle)` / `stop(handle)` / `remove(handle)` | Lifecycle transitions. |
 | `exec(handle, argv: &[&str])` | Run a command inside a started container. |
 | `stats(handle)` | Snapshot resource usage. Implementations call `parse_stats` after fetching the runtime's stats blob. |
@@ -157,6 +157,59 @@ delegates to `session.exec_step(argv)`. The unified return shape is
 > `SandboxedCommand` instances per turn that all need to share the
 > same pre-warmed container, and `Box` cannot be cloned across those
 > handles.
+
+#### Security hardening defaults
+
+Rootless podman alone is not sufficient — the container's effective
+capability set, `NoNewPrivs` flag, network namespace, rootfs writability,
+and user namespace mapping all default to permissive values that leave
+escape-class CVEs in the kernel, podman, or `runc` exploitable from
+inside the sandbox (NIST SP 800-190 §4.5; CWE-269). F-642 closes that
+gap by routing every Level 2 `create` through `forge_oci::SecurityOpts`,
+applied as `podman create` flags between the verb and the IMAGE
+positional. The strict preset returned by `SecurityOpts::hardened_default`
+is what `Level2Session::create` ships, and what every production caller
+should reach for.
+
+| Flag rendered | Field | Default | Threat addressed |
+|---|---|---|---|
+| `--security-opt no-new-privileges` | `no_new_privileges: bool` | `true` | setuid binaries / file-cap escalation inside the container |
+| `--cap-drop ALL` | `cap_drop: Vec<String>` | `["ALL"]` | rootless-default capability set (`CAP_SETUID`, `CAP_NET_RAW`, etc.) |
+| `--cap-add <CAP>` (none) | `cap_add: Vec<String>` | `[]` (empty allow-list) | adds capabilities back after `cap-drop`. The `sleep infinity` init and `podman exec`'d agent commands need none; future tools requiring a capability must add it explicitly here, not by shrinking `cap_drop`. |
+| `--read-only` | `read_only_rootfs: bool` | `true` | persistence and anti-forensic writes to `/usr`, `/etc`, `/lib`, and the tmpfs-style runtime state directories |
+| `--network none` | `network: NetworkPolicy` | `NetworkPolicy::None` | data exfiltration / lateral movement / SSRF from inside the sandbox |
+| `--userns keep-id` | `userns: UserNsPolicy` | `UserNsPolicy::KeepId` | nested rootless mapping that turns workspace mounts hostile in either direction |
+
+The flag rendering is deterministic (pinned by
+`SecurityOpts::to_create_flags` and asserted by both unit and
+integration tests); ordering is `--security-opt` → `--cap-drop` →
+`--cap-add` → `--read-only` → `--network` → `--userns`. Operators
+auditing the daemon's `tracing` log can grep for the same fixed shape.
+
+> **Capability allow-list is intentionally empty.** Phase 3 Level 2
+> only ships a `sleep infinity` init and runs caller argv through
+> `podman exec`. Neither needs a non-zero capability, so the strict
+> default drops everything and adds nothing back. When a future
+> tool genuinely needs a capability (e.g. `CAP_NET_BIND_SERVICE` for
+> a privileged-port MCP server), the call site adds it explicitly to
+> `SecurityOpts::cap_add`. The rule: `cap_drop` stays at `["ALL"]`
+> forever — relaxations live in `cap_add`.
+
+> **Mounts and tmpfs.** `--read-only` makes the rootfs immutable,
+> but most agent tooling needs *some* writable scratch space.
+> Wiring named tmpfs / volume mounts (`/workspace`, `/tmp`,
+> `~/.config/forge/certs/`) is downstream work — see *Mounts (future
+> work)* below, and the F-642 follow-ups in the Phase 3 audit batch.
+> Until those land, agents that need to write fall back to Level 1
+> via the auto-fallback path or fail loudly inside the container.
+
+> **Drop-cleanup path.** The synchronous panic-safety net
+> (`Level2Session::drop`) shells out to `podman rm -f <id>`, not
+> `podman create`, so security flags don't apply there — the only
+> work the cleanup does is reap the already-created container.
+> If a future runtime grows its own teardown shape, the safety-net
+> argv abstraction would inherit the same "no `create` flags here"
+> property.
 
 #### Resource limits
 
@@ -268,10 +321,18 @@ level.
 - `~/.config/forge/certs/` mounted at `/etc/forge/certs/` for provider access.
 - No home dir, no `/tmp` cross-mount.
 
-#### Network (future work)
+#### Network
 
-- Default: no network.
+- **Default: `--network none`** (F-642). The container has only loopback
+  inside its own namespace; no inbound or outbound traffic is
+  reachable. This is the strictest interpretation of the F-642 DoD's
+  "restricted network" requirement and the same default Phase 3
+  ships unless a tool declares otherwise.
 - Declared hosts (for MCP or tools): CNI policy allows only those.
+  Tracked as future work — until it lands, tools that need network
+  must run at Level 1 or be wrapped in a Level 2 session whose
+  `SecurityOpts::network` is explicitly relaxed by the call site
+  (rare; document the relaxation).
 
 #### Trade-offs vs Level 1
 
@@ -280,7 +341,7 @@ level.
 | Blast radius of a compromised tool | Process tree of one sandbox | Container rootfs + namespace |
 | Cold-start cost | Microseconds (fork+exec) | Image pull (one-off) + container create+start (~hundreds of ms, once per session) |
 | Per-step cost | fork+exec | `podman exec` (~tens of ms) |
-| Network containment | None (open network) | CNI policy (future); default-deny once mounts are wired |
+| Network containment | None (open network) | `--network none` by default (F-642); CNI policy for declared hosts is future work |
 | Filesystem containment | `forge-fs` path checks | Container rootfs by construction |
 | Resource limits | `setrlimit` (per-process / per-uid) + cgroup v2 `pids.max` (per-sandbox) | cgroup v2 `cpu.max` / `memory.max` / `pids.max` (per-container) |
 | Operator burden | Linux + cgroup v2 | Linux + cgroup v2 + rootless `podman` |


### PR DESCRIPTION
Closes forge-ide/forge#678

## Summary

- Extends `ContainerRuntime::create` with a `SecurityOpts` parameter so every container spawn carries explicit hardening config.
- Adds `forge_oci::SecurityOpts` (plus `NetworkPolicy`, `UserNsPolicy` enums) with a `hardened_default()` preset that ships every F-642 DoD flag.
- Wires `Level2Session::create` to pass `SecurityOpts::hardened_default()` into `runtime.create`, so every Level 2 sandbox spawned through the session API is hardened by construction.
- Renders the strict preset as `--security-opt no-new-privileges`, `--cap-drop ALL`, `--read-only`, `--network none`, `--userns keep-id` between `podman create` and the IMAGE positional (the existing flag-injection grammar invariants still hold).
- Documents the security model and the empty capability allow-list in `docs/architecture/isolation-model.md` §8.3.

## Test plan

- `cargo fmt --check` — clean
- `cargo check --workspace` — clean
- `cargo test --workspace` — 122 test-result summaries, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS=-D warnings cargo doc -p forge-oci -p forge-session --no-deps` — clean
- New unit tests pinning hardened-default flag rendering, canonical order, default-trait equivalence, permissive preset emptiness, and cap-drop/cap-add ordering.
- Updated `Level2Session` integration test (RecordingRunner) asserts every hardening flag lands in the recorded `podman create` argv end-to-end.
- New ignored integration test `create_with_hardened_defaults_applies_every_flag` uses `podman inspect` to verify the flags actually take effect on a real container; run with `cargo test -p forge-oci -- --ignored`.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)