### PR TITLE
[F-644] Close DNS-rebinding gap in url_safety with policy-enforcing resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "dirs 5.0.1",
  "keyring",
  "rand 0.8.6",
+ "reqwest 0.12.28",
  "secrecy",
  "secret-service",
  "security-framework",

--- a/crates/forge-core/Cargo.toml
+++ b/crates/forge-core/Cargo.toml
@@ -25,6 +25,13 @@ secrecy = "0.10"
 # F-346) lifted here so both forge-mcp and forge-providers can reuse the SSRF
 # guard without forge-providers gaining a wrong-direction dep on forge-mcp.
 url = "2"
+# F-644: `http::secure_client_builder` houses a `reqwest::dns::Resolve` impl
+# that re-checks every resolved IP against `url_safety` policy, closing the
+# DNS-rebinding gap between `check_url` and the actual TCP connect. We pull
+# reqwest with only the rustls-tls backend — no `json`, `stream`, or other
+# feature flags — because callers compose their own builders on top of this
+# helper and bring their own feature requirements.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 # F-587: Platform-gated keyring backends. Linux uses Secret Service over
 # DBus directly; macOS uses the system Keychain via `security-framework`;

--- a/crates/forge-core/src/http.rs
+++ b/crates/forge-core/src/http.rs
@@ -1,0 +1,364 @@
+//! Hardened `reqwest::Client` construction shared across the workspace.
+//!
+//! [`check_url`](crate::url_safety::check_url) validates a URL at config
+//! time, but the IP that `reqwest` actually dials is whatever DNS returns
+//! at connect time — not what we parsed earlier. An attacker controlling a
+//! DNS record with a short TTL can answer `8.8.8.8` for the safety check
+//! and `169.254.169.254` for the connect that follows, smuggling a request
+//! to AWS IMDS or another internal target through a guard that "passed".
+//!
+//! This module closes that gap with a `reqwest::dns::Resolve` implementation
+//! that runs the same `url_safety` IPv4/IPv6 range checks against every
+//! `SocketAddr` returned by the inner resolver. Addresses that match a
+//! blocked range are filtered out; if the filtered set is empty the lookup
+//! fails and reqwest never opens the socket.
+//!
+//! ## Helpers
+//!
+//! - [`secure_client_builder`] — `reqwest::ClientBuilder` pre-wired with the
+//!   policy resolver. Zero-config drop-in for callers that don't already
+//!   construct a builder of their own.
+//! - [`policy_resolver`] — concrete [`PolicyEnforcingResolver`] for callers
+//!   that compose their own builders (provider-specific timeouts, redirect
+//!   policies, etc.) and just need to plug the resolver in via
+//!   `ClientBuilder::dns_resolver(Arc::new(...))`. Returned as a sized
+//!   concrete type because `dns_resolver` requires `R: Resolve + Sized`.
+//! - [`policy_resolver_with_inner`] — same, but accepts a caller-supplied
+//!   inner resolver. Used by the rebinding regression test to inject a
+//!   scripted DNS sequence; downstream callers can use it to wrap a
+//!   non-default resolver (e.g. hickory-dns) without losing the SSRF guard.
+//!
+//! ## Scope (F-644)
+//!
+//! This PR lands the helper. The downstream redirect-policy fixes
+//! (F-645/646/647 — issues #681/#682/#683) adopt it across forge-mcp,
+//! forge-providers, and forge-shell. The API exposes both a builder helper
+//! and a bare resolver so those callers can adopt it without giving up
+//! their own connect/read-timeout, redirect, or user-agent settings.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
+use crate::url_safety;
+
+/// Build a `reqwest::ClientBuilder` with the SSRF-safe DNS resolver
+/// pre-installed. Callers chain their own settings (timeouts, headers,
+/// redirect policy) and call `.build()` as usual.
+///
+/// ```no_run
+/// let client = forge_core::http::secure_client_builder()
+///     .connect_timeout(std::time::Duration::from_secs(5))
+///     .build()
+///     .expect("client build");
+/// # let _ = client;
+/// ```
+pub fn secure_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder().dns_resolver(Arc::new(policy_resolver()))
+}
+
+/// SSRF-aware DNS resolver wrapping the system resolver. Use this when you
+/// already have a `reqwest::ClientBuilder` and just want to install the
+/// guard without inheriting any other defaults — pass the returned value to
+/// [`reqwest::ClientBuilder::dns_resolver`] (wrapped in an `Arc`).
+///
+/// The return type is the concrete [`PolicyEnforcingResolver`] rather than
+/// `Arc<dyn Resolve>` because reqwest's `dns_resolver` accepts `Arc<R>`
+/// over a sized `R: Resolve + 'static`, not a trait object.
+pub fn policy_resolver() -> PolicyEnforcingResolver {
+    PolicyEnforcingResolver::new(Arc::new(SystemResolver))
+}
+
+/// Same as [`policy_resolver`] but with a caller-supplied inner resolver.
+/// Allows tests to script DNS answers and lets downstream callers stack the
+/// SSRF guard on top of an alternate resolver (e.g. hickory) without losing
+/// the policy check.
+pub fn policy_resolver_with_inner(inner: Arc<dyn Resolve>) -> PolicyEnforcingResolver {
+    PolicyEnforcingResolver::new(inner)
+}
+
+/// reqwest DNS resolver that wraps an inner resolver and filters resolved
+/// `SocketAddr`s through the `url_safety` IPv4/IPv6 policy. If every
+/// resolved address is blocked the lookup returns an `io::Error` and
+/// reqwest aborts the connect — so a hostile DNS answer can never reach
+/// the TCP layer.
+pub struct PolicyEnforcingResolver {
+    inner: Arc<dyn Resolve>,
+}
+
+impl PolicyEnforcingResolver {
+    fn new(inner: Arc<dyn Resolve>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Resolve for PolicyEnforcingResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let inner = Arc::clone(&self.inner);
+        let name_for_err = name.as_str().to_string();
+        Box::pin(async move {
+            let addrs = inner.resolve(name).await?;
+            let filtered: Vec<SocketAddr> = addrs.filter(|sa| !is_blocked(sa.ip())).collect();
+            if filtered.is_empty() {
+                return Err(Box::new(std::io::Error::other(format!(
+                    "SSRF guard: DNS for {name_for_err:?} resolved exclusively to \
+                     url_safety-blocked IP ranges (loopback / private / link-local)"
+                )))
+                    as Box<dyn std::error::Error + Send + Sync>);
+            }
+            Ok(Box::new(filtered.into_iter()) as Addrs)
+        })
+    }
+}
+
+/// Run a single resolved IP through the `url_safety` IPv4/IPv6 policy.
+/// IPv4-mapped IPv6 (`::ffff:a.b.c.d`) is unwrapped to its embedded IPv4 so
+/// `https://[::ffff:169.254.169.254]/...` is rejected as link-local rather
+/// than slipping past as "unknown IPv6".
+fn is_blocked(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            if v4.is_loopback() {
+                return false; // url_safety treats loopback as allowed
+            }
+            url_safety::check_ipv4(v4, "<dns>").is_err()
+        }
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                if mapped.is_loopback() {
+                    return false;
+                }
+                return url_safety::check_ipv4(mapped, "<dns>").is_err();
+            }
+            if v6.is_loopback() {
+                return false;
+            }
+            url_safety::check_ipv6(v6, "<dns>").is_err()
+        }
+    }
+}
+
+/// System-default DNS resolver used as the inner resolver in production.
+/// Wraps `tokio::net::lookup_host`, which delegates to the platform
+/// `getaddrinfo`. This is the same shape that reqwest's built-in resolver
+/// uses; we stand it up explicitly so the [`PolicyEnforcingResolver`] has
+/// a stable inner without depending on a private reqwest type.
+struct SystemResolver;
+
+impl Resolve for SystemResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            // `lookup_host` wants `host:port`; port 0 is a placeholder.
+            // reqwest rewrites the port from the request URL / scheme
+            // before dialing, so the placeholder never reaches TCP.
+            let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                .collect();
+            Ok(Box::new(addrs.into_iter()) as Addrs)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Test resolver that returns a scripted sequence of `SocketAddr` lists.
+    /// The first call returns `answers[0]`, the second `answers[1]`, and so
+    /// on (saturating at the last entry). Used to simulate a DNS-rebinding
+    /// attacker who answers safely on one lookup and hostilely on the next.
+    struct ScriptedResolver {
+        answers: Vec<Vec<SocketAddr>>,
+        call: AtomicUsize,
+    }
+
+    impl ScriptedResolver {
+        fn new(answers: Vec<Vec<SocketAddr>>) -> Self {
+            Self {
+                answers,
+                call: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl Resolve for ScriptedResolver {
+        fn resolve(&self, _name: Name) -> Resolving {
+            let idx = self.call.fetch_add(1, Ordering::SeqCst);
+            let i = idx.min(self.answers.len() - 1);
+            let answer = self.answers[i].clone();
+            Box::pin(async move { Ok(Box::new(answer.into_iter()) as Addrs) })
+        }
+    }
+
+    fn name(s: &str) -> Name {
+        Name::from_str(s).expect("valid DNS name")
+    }
+
+    fn sa_v4(a: u8, b: u8, c: u8, d: u8) -> SocketAddr {
+        SocketAddr::from((Ipv4Addr::new(a, b, c, d), 0))
+    }
+
+    fn sa_v6(addr: &str) -> SocketAddr {
+        SocketAddr::from((Ipv6Addr::from_str(addr).expect("ipv6"), 0))
+    }
+
+    async fn collect(
+        resolver: &PolicyEnforcingResolver,
+        n: &str,
+    ) -> Result<Vec<SocketAddr>, String> {
+        match resolver.resolve(name(n)).await {
+            Ok(addrs) => Ok(addrs.collect()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    // --- DoD #1: resolver validates resolved IPs against url_safety policy ---
+
+    #[tokio::test]
+    async fn resolver_passes_public_ipv4() {
+        let inner = Arc::new(ScriptedResolver::new(vec![vec![sa_v4(8, 8, 8, 8)]]));
+        let resolver = PolicyEnforcingResolver::new(inner);
+        let got = collect(&resolver, "example.com")
+            .await
+            .expect("public IP must pass");
+        assert_eq!(got, vec![sa_v4(8, 8, 8, 8)]);
+    }
+
+    #[tokio::test]
+    async fn resolver_blocks_imds() {
+        let inner = Arc::new(ScriptedResolver::new(vec![vec![sa_v4(169, 254, 169, 254)]]));
+        let resolver = PolicyEnforcingResolver::new(inner);
+        let err = collect(&resolver, "metadata.attacker.test")
+            .await
+            .expect_err("IMDS must be filtered out");
+        assert!(
+            err.contains("SSRF guard"),
+            "error must name the guard: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolver_blocks_rfc1918_ranges() {
+        for ip in [
+            sa_v4(10, 0, 0, 1),
+            sa_v4(172, 16, 0, 1),
+            sa_v4(192, 168, 0, 1),
+        ] {
+            let inner = Arc::new(ScriptedResolver::new(vec![vec![ip]]));
+            let resolver = PolicyEnforcingResolver::new(inner);
+            collect(&resolver, "private.attacker.test")
+                .await
+                .expect_err(&format!("{ip} must be filtered out"));
+        }
+    }
+
+    #[tokio::test]
+    async fn resolver_filters_partial_answer() {
+        // Mixed answer: one blocked, one public. Filter keeps only the
+        // public one so the connect can still proceed against a safe IP.
+        let inner = Arc::new(ScriptedResolver::new(vec![vec![
+            sa_v4(169, 254, 169, 254),
+            sa_v4(8, 8, 8, 8),
+        ]]));
+        let resolver = PolicyEnforcingResolver::new(inner);
+        let got = collect(&resolver, "mixed.test")
+            .await
+            .expect("public IP survives filter");
+        assert_eq!(got, vec![sa_v4(8, 8, 8, 8)]);
+    }
+
+    #[tokio::test]
+    async fn resolver_blocks_ipv4_mapped_ipv6_imds() {
+        // `::ffff:169.254.169.254` must be rejected as link-local even
+        // though the literal is an IPv6 address — otherwise an attacker
+        // smuggles IMDS through an IPv6 DNS answer.
+        let mapped = sa_v6("::ffff:169.254.169.254");
+        let inner = Arc::new(ScriptedResolver::new(vec![vec![mapped]]));
+        let resolver = PolicyEnforcingResolver::new(inner);
+        collect(&resolver, "v6mapped.test")
+            .await
+            .expect_err("IPv4-mapped IPv6 IMDS must be filtered");
+    }
+
+    #[tokio::test]
+    async fn resolver_blocks_ipv6_unique_local() {
+        let inner = Arc::new(ScriptedResolver::new(vec![vec![sa_v6("fd00::1")]]));
+        let resolver = PolicyEnforcingResolver::new(inner);
+        collect(&resolver, "v6ula.test")
+            .await
+            .expect_err("fc00::/7 must be filtered");
+    }
+
+    #[tokio::test]
+    async fn resolver_passes_loopback_v4() {
+        // url_safety treats loopback as allowed (debug-build dev servers,
+        // https://localhost). The resolver must not over-filter.
+        let inner = Arc::new(ScriptedResolver::new(vec![vec![sa_v4(127, 0, 0, 1)]]));
+        let resolver = PolicyEnforcingResolver::new(inner);
+        collect(&resolver, "localhost")
+            .await
+            .expect("loopback must pass");
+    }
+
+    // --- DoD #3: rebinding regression — first lookup safe, second hostile ---
+
+    #[tokio::test]
+    async fn rebinding_second_lookup_is_blocked() {
+        // Simulates the F-644 attack: hostile DNS serves `8.8.8.8` for the
+        // first resolution (would bypass `check_url`) and `169.254.169.254`
+        // for the second (would hit IMDS without this resolver). The guard
+        // must reject the second lookup so the connect fails.
+        let inner = Arc::new(ScriptedResolver::new(vec![
+            vec![sa_v4(8, 8, 8, 8)],
+            vec![sa_v4(169, 254, 169, 254)],
+        ]));
+        let resolver = PolicyEnforcingResolver::new(inner);
+
+        let first = collect(&resolver, "rebinding.attacker.test")
+            .await
+            .expect("first lookup mirrors check_url's view — passes");
+        assert_eq!(first, vec![sa_v4(8, 8, 8, 8)]);
+
+        let err = collect(&resolver, "rebinding.attacker.test")
+            .await
+            .expect_err("second lookup hits IMDS — must be blocked at the resolver");
+        assert!(
+            err.contains("SSRF guard"),
+            "error must name the guard: {err}"
+        );
+    }
+
+    // --- DoD #2: helper APIs build clients that use the resolver ---
+
+    #[test]
+    fn secure_client_builder_builds_a_client() {
+        let _client = secure_client_builder()
+            .build()
+            .expect("default secure client must build");
+    }
+
+    #[test]
+    fn policy_resolver_is_send_sync() {
+        // The concrete resolver must be Send + Sync for reqwest to accept
+        // it via `ClientBuilder::dns_resolver`. This compiles iff the bound
+        // is met.
+        fn assert_send_sync<T: Send + Sync>(_: &T) {}
+        let r = policy_resolver();
+        assert_send_sync(&r);
+    }
+
+    #[test]
+    fn policy_resolver_is_installable_on_client_builder() {
+        // Compile-time check: the type the public API returns is the same
+        // shape `reqwest::ClientBuilder::dns_resolver` accepts. Catches a
+        // future regression where someone changes the return type to a
+        // trait object that no longer satisfies the `R: Sized` bound.
+        let _builder = reqwest::Client::builder().dns_resolver(Arc::new(policy_resolver()));
+    }
+}

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 mod event;
 mod event_log;
 mod event_sink;
+pub mod http;
 pub mod ids;
 pub mod mcp_state;
 pub mod meta;

--- a/crates/forge-core/src/url_safety.rs
+++ b/crates/forge-core/src/url_safety.rs
@@ -111,7 +111,14 @@ fn is_host_loopback(host: &url::Host<&str>) -> bool {
     }
 }
 
-fn check_ipv4(addr: std::net::Ipv4Addr, raw: &str) -> Result<()> {
+/// Apply the IPv4 range policy used by [`check_url`] to a single address.
+///
+/// Exposed for [`crate::http`]: the SSRF-aware DNS resolver runs every
+/// resolved IPv4 from `getaddrinfo` through the same checks `check_url`
+/// would apply if the URL had been an IP literal. Loopback is *not*
+/// rejected here — it's the caller's job to pre-filter loopback per the
+/// [`check_url`] scheme/build-profile rules.
+pub fn check_ipv4(addr: std::net::Ipv4Addr, raw: &str) -> Result<()> {
     let o = addr.octets();
 
     // 10.0.0.0/8
@@ -134,7 +141,13 @@ fn check_ipv4(addr: std::net::Ipv4Addr, raw: &str) -> Result<()> {
     Ok(())
 }
 
-fn check_ipv6(addr: std::net::Ipv6Addr, raw: &str) -> Result<()> {
+/// Apply the IPv6 range policy used by [`check_url`] to a single address.
+///
+/// Exposed for [`crate::http`]: the SSRF-aware DNS resolver runs every
+/// resolved IPv6 through the same checks `check_url` would apply. Loopback
+/// (`::1`) is *not* rejected here — callers must pre-filter loopback if
+/// their scheme/build-profile rules require it.
+pub fn check_ipv6(addr: std::net::Ipv6Addr, raw: &str) -> Result<()> {
     let s = addr.segments();
 
     // fc00::/7 — unique-local (fc00:: through fdff::)


### PR DESCRIPTION
Closes #680 (partial — see scope note below).

## Summary

- Lands `forge_core::http::secure_client_builder()` and `forge_core::http::policy_resolver()` — a `reqwest::dns::Resolve` impl that re-checks every resolved `SocketAddr` against `url_safety::check_ipv4` / `check_ipv6` and aborts the lookup if every address is blocked. This is the long-promised hardening referenced in `url_safety.rs` lines 86-93.
- Closes the root DNS-rebinding gap: an attacker who answers `8.8.8.8` for `check_url`'s view and `169.254.169.254` for the actual TCP connect can no longer reach IMDS. The resolver runs on every connect (including redirects) so the rebinding window is closed on every fresh DNS lookup.
- Promotes `url_safety::check_ipv4` / `check_ipv6` from private to `pub` so the resolver can reuse the canonical CIDR policy without forking range tables.

## Scope vs. caller migration

The original DoD includes *"All workspace `reqwest::Client` constructions use a shared helper that installs the resolver"*. Per the milestone plan, that adoption is split across this PR and the three downstream redirect-policy fixes that already touch each surface:

- **F-645 / #681** — `forge-mcp` HTTP transport adopts the helper as part of its redirect-policy fix.
- **F-646 / #682** — `forge-providers` (Anthropic / OpenAI / OpenAI-compatible / Ollama clients) adopts the helper alongside its redirect-policy fix.
- **F-647 / #683** — `forge-shell::context_fetch` adopts the helper alongside its redirect-policy fix. (Note: forge-shell already ships a near-identical `PolicyEnforcingResolver` against a stricter range table — F-647 will reconcile.)

Splitting this way keeps each PR surgical and lands the redirect-policy work in one place per surface. **This PR is intentionally limited to `forge-core`** and does not touch the existing `reqwest::Client` construction sites — that is downstream work.

The API was designed to make those adoptions cheap:

- `secure_client_builder()` is a zero-config drop-in for callers without bespoke settings.
- `policy_resolver()` returns the concrete resolver type so callers that already build their own `reqwest::ClientBuilder` (provider-specific timeouts, custom redirect policy, user-agent, etc.) can install the SSRF guard via `.dns_resolver(Arc::new(policy_resolver()))` without losing any other settings.
- `policy_resolver_with_inner()` lets callers stack the guard over an alternate inner resolver (hickory, scripted test resolver) without forking the policy.

## DoD evidence

| DoD item | Evidence |
|---|---|
| Custom `reqwest::dns::Resolve` impl validates resolved IPs against `url_safety` policy | `crates/forge-core/src/http.rs` — `PolicyEnforcingResolver` + `is_blocked` route every `IpAddr` through `url_safety::check_ipv4` / `check_ipv6`. |
| `forge_core::http::secure_client_builder()` helper provided | `secure_client_builder()` in `crates/forge-core/src/http.rs:56` (plus `policy_resolver` and `policy_resolver_with_inner` for callers that compose their own builders). |
| Regression test simulates rebinding and asserts the connect fails | `rebinding_second_lookup_is_blocked` in `crates/forge-core/src/http.rs` uses a `ScriptedResolver` that returns 8.8.8.8 first and 169.254.169.254 second — the second lookup returns an `io::Error` so reqwest aborts the connect. |
| Tests pass in CI | 11 new tests under `forge-core` `http::tests`; full workspace `cargo test --workspace` passes; `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --all-features` all clean. |
| Workspace migration to the helper | **Tracked downstream** — F-645 #681, F-646 #682, F-647 #683 each adopt the helper alongside their own redirect-policy work. |

## Test plan

- [x] `cargo test -p forge-core --lib http::` — 11/11 pass
- [x] `cargo test -p forge-core` — all 242 unit + integration tests pass
- [x] `cargo test --workspace` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --all-features` — clean
- [ ] Reviewer: confirm rebinding test exercises the second-lookup hostile answer (not just first-call rejection).
- [ ] Reviewer: confirm `is_blocked` does not over-filter loopback (would break `https://localhost` dev flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)