### PR TITLE
[F-643] Pin OCI images by digest and verify signatures before pull

### DIFF
--- a/crates/forge-oci/src/lib.rs
+++ b/crates/forge-oci/src/lib.rs
@@ -6,30 +6,112 @@
 //!
 //! See `docs/architecture/crate-architecture.md` §3.6 for the design rationale
 //! and `docs/architecture/isolation-model.md` for how this slots into the
-//! agent execution model.
+//! agent execution model — including the supply-chain story (digest pinning
+//! and signature verification) that [`ImageRef`] and
+//! [`signature::SignatureVerifier`] enforce.
 
 #![deny(missing_docs)]
 
 mod podman;
 mod runner;
+pub mod signature;
 
 pub use podman::PodmanRuntime;
 pub use runner::{
     CommandOutcome, CommandRunner, RecordedCall, RecordedCalls, RecordingRunner, StubResponse,
     TokioCommandRunner,
 };
+pub use signature::{
+    CosignVerifier, NoopVerifier, SignaturePolicy, SignatureVerifier, VerificationError,
+};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+/// Allowlist of image-reference prefixes for which a tag-only (no digest)
+/// reference is accepted. Production runs should still pin even allowlisted
+/// images by digest — this list exists so the first-party Forge tool images
+/// can roll new tags during early Phase 3 without forcing every test fixture
+/// and dev sandbox to know the latest digest.
+///
+/// A prefix matches the *canonical* `[registry/]name` portion of an
+/// [`ImageRef`] (i.e. the part before the tag/digest). The empty string is
+/// not allowed; every entry must include the registry so docker.io aliases
+/// like `library/alpine` cannot accidentally satisfy the allowlist.
+const TAG_ONLY_ALLOWLIST: &[&str] = &["oci.io/forge/"];
+
+/// SHA-256 image digest (e.g. the bytes after `sha256:` in
+/// `alpine@sha256:abcdef...`). Newtype so the parser can validate the format
+/// once and downstream code never has to.
+///
+/// The wrapped string is the *full* canonical form including the `sha256:`
+/// algorithm prefix — that is what `podman pull` and `cosign verify` both
+/// expect to see verbatim.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Digest(String);
+
+impl Digest {
+    /// Parse a digest of the form `sha256:<64 lowercase hex chars>`.
+    ///
+    /// We only accept `sha256` today because that is what every relevant
+    /// registry, signer, and policy emits. When/if a stronger algorithm
+    /// becomes the default, extend this match without changing the
+    /// representation.
+    pub fn parse(input: &str) -> Result<Self, OciError> {
+        let trimmed = input.trim();
+        let (algo, hex) = trimmed.split_once(':').ok_or(OciError::InvalidDigest {
+            input: input.to_string(),
+            reason: "missing algorithm prefix (expected `sha256:<hex>`)",
+        })?;
+        if algo != "sha256" {
+            return Err(OciError::InvalidDigest {
+                input: input.to_string(),
+                reason: "only sha256 digests are accepted",
+            });
+        }
+        if hex.len() != 64
+            || !hex
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        {
+            return Err(OciError::InvalidDigest {
+                input: input.to_string(),
+                reason: "sha256 digest must be 64 lowercase hex characters",
+            });
+        }
+        Ok(Self(trimmed.to_string()))
+    }
+
+    /// Return the full canonical form including the `sha256:` prefix.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for Digest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Reference to an OCI image, decomposed into the parts the runtime cares
 /// about.
 ///
-/// `parse` is intentionally lenient: it accepts the common forms
-/// `name`, `name:tag`, `registry/name:tag`, `registry/namespace/name:tag`.
-/// When `tag` is omitted it defaults to `latest`. When `registry` is omitted
-/// it stays `None` so callers can decide whether to default to `docker.io` or
-/// require an explicit registry.
+/// `parse` accepts three reference shapes:
+///
+/// - `[registry/]name@sha256:<hex>` — pinned by digest. Always accepted.
+/// - `[registry/]name@sha256:<hex>:tag` — digest with a human-readable tag
+///   for diagnostics. The digest is what runs.
+/// - `[registry/]name:tag` — tag-only. Rejected for any source not on the
+///   first-party tag-only allowlist (today: `oci.io/forge/`). This is the
+///   supply-chain mitigation in F-643: a tag is mutable, so an attacker who
+///   pushes to the registry can replace the bytes that get pulled and
+///   executed inside the Level 2 sandbox.
+///
+/// `name` here means the registry-qualified path (e.g.
+/// `docker.io/library/alpine`) so the allowlist check cannot be bypassed by
+/// dropping the registry — `parse` resolves an implicit `docker.io` and
+/// `library/` namespace before testing the allowlist.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ImageRef {
     /// Optional registry hostname (e.g. `docker.io`, `quay.io`).
@@ -37,12 +119,18 @@ pub struct ImageRef {
     /// Image name including any namespace (e.g. `library/alpine`,
     /// `myorg/myapp`).
     pub name: String,
-    /// Image tag (e.g. `3.19`, `latest`).
+    /// Image tag (e.g. `3.19`, `latest`). For digest-pinned references this
+    /// is informational only — `podman pull` runs on the digest.
     pub tag: String,
+    /// Pinned content digest (`sha256:<hex>`). When present, the runtime
+    /// fetches and verifies *this* exact image regardless of the tag.
+    pub digest: Option<Digest>,
 }
 
 impl ImageRef {
-    /// Construct an [`ImageRef`] from explicit parts.
+    /// Construct an [`ImageRef`] from explicit parts. Use [`Self::parse`] for
+    /// validated input — this constructor skips the supply-chain checks and
+    /// is intended for tests and explicit programmatic references.
     pub fn new(
         registry: Option<impl Into<String>>,
         name: impl Into<String>,
@@ -52,16 +140,27 @@ impl ImageRef {
             registry: registry.map(Into::into),
             name: name.into(),
             tag: tag.into(),
+            digest: None,
         }
     }
 
-    /// Parse an image reference string of the form
-    /// `[registry/]name[:tag]`.
-    ///
-    /// A leading segment counts as a registry only when it contains `.` or `:`
-    /// (port). This matches the convention `podman` and `docker` follow when
-    /// disambiguating `library/alpine` (no registry, namespace `library`)
-    /// from `quay.io/myorg/myapp`.
+    /// Construct a digest-pinned [`ImageRef`] from explicit parts.
+    pub fn with_digest(
+        registry: Option<impl Into<String>>,
+        name: impl Into<String>,
+        tag: impl Into<String>,
+        digest: Digest,
+    ) -> Self {
+        Self {
+            registry: registry.map(Into::into),
+            name: name.into(),
+            tag: tag.into(),
+            digest: Some(digest),
+        }
+    }
+
+    /// Parse an image reference. See type-level docs for the accepted
+    /// shapes and the allowlist semantics.
     pub fn parse(input: &str) -> Result<Self, OciError> {
         let trimmed = input.trim();
         if trimmed.is_empty() {
@@ -71,15 +170,22 @@ impl ImageRef {
             });
         }
 
-        let (path, tag) = match trimmed.rsplit_once(':') {
+        // Split off the digest first so a `:` inside the digest portion (or
+        // after it) cannot be misread as a tag separator.
+        let (path_and_tag, digest) = match trimmed.split_once('@') {
+            Some((before, after)) => (before, Some(Digest::parse(after)?)),
+            None => (trimmed, None),
+        };
+
+        let (path, tag) = match path_and_tag.rsplit_once(':') {
             // A `:` inside the first segment is part of the registry port,
             // not a tag separator. Detect by checking whether the substring
             // before the colon contains a `/`.
-            Some((before, after)) if before.contains('/') => (before, after.to_string()),
+            Some((before, after)) if before.contains('/') => (before, Some(after.to_string())),
             Some((before, after)) if !before.contains('/') && !after.contains('/') => {
-                (before, after.to_string())
+                (before, Some(after.to_string()))
             }
-            _ => (trimmed, "latest".to_string()),
+            _ => (path_and_tag, None),
         };
 
         let (registry, name) = match path.split_once('/') {
@@ -96,20 +202,63 @@ impl ImageRef {
             });
         }
 
+        // Tag fallback. We retain `latest` as the informational default so
+        // the renderer keeps producing the canonical `name:tag` form podman
+        // expects, but the F-643 supply-chain check below still rejects
+        // the reference if it has no digest AND is not allowlisted.
+        let tag = tag.unwrap_or_else(|| "latest".to_string());
+
+        // Supply-chain guard: a reference with no digest is only safe if the
+        // *canonical* registry-qualified path matches the first-party
+        // allowlist. We canonicalize `docker.io` and the `library/`
+        // namespace so a bare `alpine` cannot sneak past by stripping
+        // identifiers the allowlist would otherwise see.
+        if digest.is_none() {
+            let canonical = canonical_path(registry.as_deref(), &name);
+            if !TAG_ONLY_ALLOWLIST
+                .iter()
+                .any(|prefix| canonical.starts_with(prefix))
+            {
+                return Err(OciError::UntrustedTagOnlyRef {
+                    input: input.to_string(),
+                });
+            }
+        }
+
         Ok(Self {
             registry,
             name,
             tag,
+            digest,
         })
     }
 
-    /// Render the reference back into the canonical `[registry/]name:tag` form
-    /// that `podman` accepts.
+    /// Render the reference into the canonical form `podman` accepts.
+    /// Digest-pinned refs render as `[registry/]name@sha256:<hex>` so the
+    /// runtime fetches and verifies the exact bytes — the tag is dropped
+    /// from the wire form because podman uses whichever of `:tag` or
+    /// `@digest` comes last and we want the digest to win unambiguously.
     pub fn to_image_string(&self) -> String {
-        match &self.registry {
-            Some(reg) => format!("{}/{}:{}", reg, self.name, self.tag),
-            None => format!("{}:{}", self.name, self.tag),
+        let path = match &self.registry {
+            Some(reg) => format!("{}/{}", reg, self.name),
+            None => self.name.clone(),
+        };
+        match &self.digest {
+            Some(d) => format!("{}@{}", path, d.as_str()),
+            None => format!("{}:{}", path, self.tag),
         }
+    }
+}
+
+/// Canonicalize a `(registry, name)` pair into a single comparison key for
+/// the [`TAG_ONLY_ALLOWLIST`]. The convention is podman's: missing registry
+/// is `docker.io`, missing namespace under docker.io is `library/`.
+fn canonical_path(registry: Option<&str>, name: &str) -> String {
+    let registry = registry.unwrap_or("docker.io");
+    if registry == "docker.io" && !name.contains('/') {
+        format!("docker.io/library/{}", name)
+    } else {
+        format!("{}/{}", registry, name)
     }
 }
 
@@ -213,6 +362,41 @@ pub enum OciError {
         input: String,
         /// Why it failed.
         reason: &'static str,
+    },
+
+    /// A digest string did not match the accepted form
+    /// (`sha256:<64 lowercase hex chars>`).
+    #[error("invalid image digest '{input}': {reason}")]
+    InvalidDigest {
+        /// Original digest input that failed to parse.
+        input: String,
+        /// Why it failed.
+        reason: &'static str,
+    },
+
+    /// The image reference is tag-only and the source is not on the
+    /// first-party allowlist. F-643 supply-chain mitigation: a mutable tag
+    /// from a third-party registry could be repointed by a registry
+    /// compromise and yield code execution inside the Level 2 sandbox.
+    /// Pin the image by digest (`name@sha256:<hex>`) instead.
+    #[error(
+        "image reference '{input}' is tag-only and not on the digest-pin allowlist; \
+         pin by digest (e.g. `{input}@sha256:<hex>`) to use this image"
+    )]
+    UntrustedTagOnlyRef {
+        /// Original reference the caller supplied.
+        input: String,
+    },
+
+    /// Signature / content-trust verification rejected the image before it
+    /// was pulled. F-643 supply-chain mitigation.
+    #[error("signature verification failed for image '{image}': {reason}")]
+    SignatureVerificationFailed {
+        /// Image reference that failed verification.
+        image: String,
+        /// Reason surfaced by the verifier (cosign output, policy mismatch,
+        /// etc.).
+        reason: String,
     },
 
     /// Runtime spawn / I/O failure (process couldn't be launched, pipe died,
@@ -662,49 +846,113 @@ pub trait ContainerRuntime: Send + Sync {
 mod tests {
     use super::*;
 
+    /// Convenience: a 64-char lowercase hex literal for use in tests that
+    /// need a syntactically valid sha256 digest.
+    const SHA: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
     #[test]
-    fn image_ref_parses_bare_name() {
-        let r = ImageRef::parse("alpine").unwrap();
-        assert_eq!(r.registry, None);
-        assert_eq!(r.name, "alpine");
-        assert_eq!(r.tag, "latest");
-        assert_eq!(r.to_image_string(), "alpine:latest");
+    fn image_ref_rejects_bare_name_when_not_allowlisted() {
+        // F-643: a bare image name resolves to docker.io/library/<name> with
+        // tag `latest` — both the name source and the tag are mutable, so we
+        // refuse to pull it. Callers must pin by digest.
+        let err = ImageRef::parse("alpine").unwrap_err();
+        assert!(
+            matches!(err, OciError::UntrustedTagOnlyRef { .. }),
+            "expected UntrustedTagOnlyRef, got {err:?}"
+        );
     }
 
     #[test]
-    fn image_ref_parses_name_and_tag() {
-        let r = ImageRef::parse("alpine:3.19").unwrap();
-        assert_eq!(r.registry, None);
-        assert_eq!(r.name, "alpine");
-        assert_eq!(r.tag, "3.19");
+    fn image_ref_rejects_tag_only_when_not_allowlisted() {
+        // F-643: tag-only references are mutable; reject for non-allowlisted
+        // sources. End-state callers must supply `@sha256:<hex>`.
+        for input in [
+            "alpine:3.19",
+            "library/alpine:1",
+            "docker.io/library/alpine:3.19",
+            "quay.io/myorg/myapp:v1",
+            "localhost:5000/myapp:dev",
+        ] {
+            let err = ImageRef::parse(input).unwrap_err();
+            assert!(
+                matches!(err, OciError::UntrustedTagOnlyRef { .. }),
+                "expected UntrustedTagOnlyRef for {input:?}, got {err:?}"
+            );
+        }
     }
 
     #[test]
-    fn image_ref_parses_full_form_round_trip() {
-        let r = ImageRef::parse("docker.io/library/alpine:3.19").unwrap();
+    fn image_ref_accepts_tag_only_for_allowlisted_first_party_source() {
+        // F-643: the first-party `oci.io/forge/` namespace is allowlisted so
+        // dev/test fixtures can roll tags without forcing every call site to
+        // know the latest digest. Production should still pin even
+        // allowlisted images by digest.
+        let r = ImageRef::parse("oci.io/forge/rust-tools:0.1").unwrap();
+        assert_eq!(r.registry.as_deref(), Some("oci.io"));
+        assert_eq!(r.name, "forge/rust-tools");
+        assert_eq!(r.tag, "0.1");
+        assert!(r.digest.is_none());
+        assert_eq!(r.to_image_string(), "oci.io/forge/rust-tools:0.1");
+    }
+
+    #[test]
+    fn image_ref_parses_digest_pinned_form() {
+        // F-643: `@sha256:<hex>` is the supply-chain-safe form. It's
+        // accepted regardless of source because the digest is the
+        // immutable identity of the image bytes.
+        let input = format!("docker.io/library/alpine@sha256:{SHA}");
+        let r = ImageRef::parse(&input).unwrap();
         assert_eq!(r.registry.as_deref(), Some("docker.io"));
         assert_eq!(r.name, "library/alpine");
+        assert_eq!(
+            r.digest.as_ref().map(|d| d.as_str()),
+            Some(format!("sha256:{SHA}").as_str())
+        );
+        // Renderer drops the tag on the wire so podman cannot resolve the
+        // tag in preference to the digest.
+        assert_eq!(
+            r.to_image_string(),
+            format!("docker.io/library/alpine@sha256:{SHA}")
+        );
+    }
+
+    #[test]
+    fn image_ref_parses_digest_with_informational_tag() {
+        // Some operators want a human-readable tag *and* a digest in their
+        // config files. The digest is what runs.
+        let input = format!("docker.io/library/alpine:3.19@sha256:{SHA}");
+        let r = ImageRef::parse(&input).unwrap();
         assert_eq!(r.tag, "3.19");
-        assert_eq!(r.to_image_string(), "docker.io/library/alpine:3.19");
+        assert!(r.digest.is_some());
+        assert_eq!(
+            r.to_image_string(),
+            format!("docker.io/library/alpine@sha256:{SHA}")
+        );
     }
 
     #[test]
-    fn image_ref_parses_namespace_no_registry() {
-        // `library/alpine` is a namespace + name, not a registry — there's no
-        // `.` or `:` in the head segment.
-        let r = ImageRef::parse("library/alpine:1").unwrap();
-        assert_eq!(r.registry, None);
-        assert_eq!(r.name, "library/alpine");
-        assert_eq!(r.tag, "1");
-    }
-
-    #[test]
-    fn image_ref_parses_registry_with_port() {
-        let r = ImageRef::parse("localhost:5000/myapp:dev").unwrap();
-        assert_eq!(r.registry.as_deref(), Some("localhost:5000"));
-        assert_eq!(r.name, "myapp");
-        assert_eq!(r.tag, "dev");
-        assert_eq!(r.to_image_string(), "localhost:5000/myapp:dev");
+    fn image_ref_rejects_malformed_digest() {
+        // Bad algorithm
+        assert!(matches!(
+            ImageRef::parse("alpine@md5:0123456789abcdef0123456789abcdef"),
+            Err(OciError::InvalidDigest { .. })
+        ));
+        // Wrong hex length
+        assert!(matches!(
+            ImageRef::parse("alpine@sha256:abc"),
+            Err(OciError::InvalidDigest { .. })
+        ));
+        // Uppercase hex (we require canonical lowercase)
+        let upper = "ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        assert!(matches!(
+            ImageRef::parse(&format!("alpine@sha256:{upper}")),
+            Err(OciError::InvalidDigest { .. })
+        ));
+        // Missing algorithm prefix
+        assert!(matches!(
+            ImageRef::parse(&format!("alpine@{SHA}")),
+            Err(OciError::InvalidDigest { .. })
+        ));
     }
 
     #[test]
@@ -717,6 +965,12 @@ mod tests {
             ImageRef::parse("   "),
             Err(OciError::InvalidImageRef { .. })
         ));
+    }
+
+    #[test]
+    fn digest_round_trip_display() {
+        let d = Digest::parse(&format!("sha256:{SHA}")).unwrap();
+        assert_eq!(format!("{}", d), format!("sha256:{SHA}"));
     }
 
     #[test]
@@ -799,7 +1053,7 @@ mod tests {
     async fn mock_runtime_satisfies_trait() {
         let rt: &dyn ContainerRuntime = &MockRuntime;
         rt.detect().await.unwrap();
-        let img = ImageRef::parse("alpine:3.19").unwrap();
+        let img = ImageRef::parse(&format!("docker.io/library/alpine@sha256:{SHA}")).unwrap();
         rt.pull(&img).await.unwrap();
         // `create`/`exec` accept caller-borrowed `&str` slices directly —
         // no `.into()` allocation required.
@@ -837,7 +1091,7 @@ mod tests {
         // F-680: argv parameters are `&[&str]` so callers with borrowed
         // string slices can call directly without allocating a Vec<String>.
         let rt: &dyn ContainerRuntime = &MockRuntime;
-        let img = ImageRef::parse("alpine:3.19").unwrap();
+        let img = ImageRef::parse(&format!("docker.io/library/alpine@sha256:{SHA}")).unwrap();
         let argv: [&str; 2] = ["echo", "hi"];
         let _ = rt
             .create(&img, &argv, &SecurityOpts::hardened_default())

--- a/crates/forge-oci/src/podman.rs
+++ b/crates/forge-oci/src/podman.rs
@@ -6,7 +6,9 @@
 //! logic without a real binary.
 
 use crate::runner::{CommandOutcome, CommandRunner, TokioCommandRunner};
-use crate::signature::{enforce_policy, NoopVerifier, SignaturePolicy, SignatureVerifier};
+use crate::signature::{
+    enforce_policy, CosignVerifier, NoopVerifier, SignaturePolicy, SignatureVerifier,
+};
 use crate::{
     ContainerHandle, ContainerLogs, ContainerRuntime, ExecResult, ImageRef, LogLine, OciError,
     SecurityOpts, Stats,
@@ -32,21 +34,32 @@ pub struct PodmanRuntime {
 impl PodmanRuntime {
     /// Build a runtime that shells out via `tokio::process::Command`. The
     /// runtime starts in [`SignaturePolicy::Permissive`] mode with a
-    /// [`NoopVerifier`] — production deployments should call
-    /// [`Self::with_verifier`] to wire a real verifier (typically
-    /// [`crate::CosignVerifier`]) and switch to
-    /// [`SignaturePolicy::Strict`].
+    /// [`CosignVerifier`] — operators get identity-pinned signature
+    /// verification by default once they set
+    /// [`crate::signature::IDENTITY_ENV`] /
+    /// [`crate::signature::OIDC_ENV`]; until then the permissive policy
+    /// logs a warning and lets the pull through so dev environments still
+    /// function. Production deployments call [`Self::with_verifier`] to
+    /// switch to [`SignaturePolicy::Strict`] (or to swap in a custom
+    /// verifier).
+    ///
+    /// **Why CosignVerifier and not NoopVerifier**: a previous default of
+    /// [`NoopVerifier`] gave silent zero verification — operators who
+    /// forgot to call [`Self::with_verifier`] got no signature gate AND
+    /// no warning, ever. The new default ensures every pull either
+    /// consults cosign or emits a warning explaining what was skipped.
     pub fn new() -> Self {
         Self {
             runner: Box::new(TokioCommandRunner),
-            verifier: Box::new(NoopVerifier),
+            verifier: Box::new(CosignVerifier::new(SignaturePolicy::Permissive)),
             policy: SignaturePolicy::Permissive,
         }
     }
 
     /// Build a runtime backed by a custom [`CommandRunner`] — for tests.
-    /// Defaults to a no-op verifier; tests that exercise the verification
-    /// path should call [`Self::with_verifier`] afterwards.
+    /// Defaults to a no-op verifier so tests that don't care about the
+    /// supply-chain gate stay simple; tests that exercise the verification
+    /// path call [`Self::with_verifier`] afterwards.
     pub fn with_runner(runner: Box<dyn CommandRunner>) -> Self {
         Self {
             runner,
@@ -976,6 +989,90 @@ mod tests {
             1,
             "podman pull must run when permissive policy lets the missing verifier through"
         );
+    }
+
+    /// Test verifier that records every call so we can assert the
+    /// default-constructed runtime actually wires a verifier in.
+    struct CountingNoopVerifier {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl SignatureVerifier for CountingNoopVerifier {
+        async fn verify(
+            &self,
+            _image: &ImageRef,
+        ) -> Result<(), crate::signature::VerificationError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn new_defaults_to_a_real_verifier_not_noop() {
+        // Regression for F-643 follow-up: `PodmanRuntime::new()` previously
+        // wired `NoopVerifier`, so an operator who forgot to call
+        // `with_verifier` got ZERO signature verification and no warning
+        // ever logged. The new default is `CosignVerifier::new(Permissive)`
+        // — pulls without identity env vars set are warned about, not
+        // silently waved through.
+        //
+        // Asserting this through behaviour: the type-level default must
+        // not return `Ok(())` for an arbitrary pull without producing
+        // either a verification call or a permissive warning. We can't
+        // assert tracing output cheaply, so we instead pin the
+        // construction by checking the verifier is NOT a `NoopVerifier`
+        // — concretely, by exercising the env-missing path which a real
+        // CosignVerifier rejects with `VerifierUnavailable`.
+        //
+        // Use a SINGLE-threaded runtime for this test so the env mutation
+        // doesn't race with sibling tests.
+        use crate::signature::{IDENTITY_ENV, OIDC_ENV};
+        // Snapshot/restore env to be polite to other tests.
+        let prev_id = std::env::var(IDENTITY_ENV).ok();
+        let prev_oidc = std::env::var(OIDC_ENV).ok();
+        std::env::remove_var(IDENTITY_ENV);
+        std::env::remove_var(OIDC_ENV);
+
+        let runtime = PodmanRuntime::new();
+        // Delegate verification through the public verifier accessor: we
+        // call the verifier directly so the test doesn't need a real
+        // podman on PATH.
+        let img = alpine_pinned();
+        let res = runtime.verifier.verify(&img).await;
+
+        // Restore env.
+        match prev_id {
+            Some(v) => std::env::set_var(IDENTITY_ENV, v),
+            None => std::env::remove_var(IDENTITY_ENV),
+        }
+        match prev_oidc {
+            Some(v) => std::env::set_var(OIDC_ENV, v),
+            None => std::env::remove_var(OIDC_ENV),
+        }
+
+        match res {
+            Err(crate::signature::VerificationError::VerifierUnavailable(_)) => {}
+            other => panic!(
+                "expected default verifier to be CosignVerifier (returns VerifierUnavailable when \
+                 identity env is unset); got {other:?} — has the default regressed back to NoopVerifier?"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn with_verifier_noop_is_still_available_for_tests() {
+        // NoopVerifier must remain a valid override so tests that don't
+        // care about the signature gate stay terse. The new default for
+        // production is CosignVerifier — but `.with_verifier(NoopVerifier)`
+        // explicitly opts out, making the test intent visible.
+        let counter = Box::new(CountingNoopVerifier {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"".to_vec()));
+        let runtime = rt(runner).with_verifier(counter, SignaturePolicy::Permissive);
+        runtime.pull(&alpine_pinned()).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/forge-oci/src/podman.rs
+++ b/crates/forge-oci/src/podman.rs
@@ -6,6 +6,7 @@
 //! logic without a real binary.
 
 use crate::runner::{CommandOutcome, CommandRunner, TokioCommandRunner};
+use crate::signature::{enforce_policy, NoopVerifier, SignaturePolicy, SignatureVerifier};
 use crate::{
     ContainerHandle, ContainerLogs, ContainerRuntime, ExecResult, ImageRef, LogLine, OciError,
     SecurityOpts, Stats,
@@ -16,21 +17,55 @@ use async_trait::async_trait;
 const PODMAN: &str = "podman";
 
 /// `ContainerRuntime` backed by the rootless `podman` CLI.
+///
+/// Every [`Self::pull`] call runs the configured [`SignatureVerifier`]
+/// before invoking `podman pull`. This is the F-643 supply-chain story:
+/// even with digest pinning enforced by [`ImageRef`](crate::ImageRef),
+/// signature verification gives operators an attestation that the bytes
+/// behind the digest were produced by a trusted signer.
 pub struct PodmanRuntime {
     runner: Box<dyn CommandRunner>,
+    verifier: Box<dyn SignatureVerifier>,
+    policy: SignaturePolicy,
 }
 
 impl PodmanRuntime {
-    /// Build a runtime that shells out via `tokio::process::Command`.
+    /// Build a runtime that shells out via `tokio::process::Command`. The
+    /// runtime starts in [`SignaturePolicy::Permissive`] mode with a
+    /// [`NoopVerifier`] — production deployments should call
+    /// [`Self::with_verifier`] to wire a real verifier (typically
+    /// [`crate::CosignVerifier`]) and switch to
+    /// [`SignaturePolicy::Strict`].
     pub fn new() -> Self {
         Self {
             runner: Box::new(TokioCommandRunner),
+            verifier: Box::new(NoopVerifier),
+            policy: SignaturePolicy::Permissive,
         }
     }
 
     /// Build a runtime backed by a custom [`CommandRunner`] — for tests.
+    /// Defaults to a no-op verifier; tests that exercise the verification
+    /// path should call [`Self::with_verifier`] afterwards.
     pub fn with_runner(runner: Box<dyn CommandRunner>) -> Self {
-        Self { runner }
+        Self {
+            runner,
+            verifier: Box::new(NoopVerifier),
+            policy: SignaturePolicy::Permissive,
+        }
+    }
+
+    /// Wire a signature verifier and the policy that governs how its
+    /// failures are handled. Returning `self` keeps the call site
+    /// composable with [`Self::new`] / [`Self::with_runner`].
+    pub fn with_verifier(
+        mut self,
+        verifier: Box<dyn SignatureVerifier>,
+        policy: SignaturePolicy,
+    ) -> Self {
+        self.verifier = verifier;
+        self.policy = policy;
+        self
     }
 
     async fn run_or_fail(&self, args: &[&str]) -> Result<CommandOutcome, OciError> {
@@ -129,6 +164,14 @@ impl ContainerRuntime for PodmanRuntime {
     }
 
     async fn pull(&self, image: &ImageRef) -> Result<(), OciError> {
+        // F-643: verify the image's signature *before* podman is allowed to
+        // write any bytes to the local store. A failed verification under a
+        // strict policy aborts the pull entirely; under a permissive policy
+        // a missing verifier degrades to a logged warning while a real
+        // mismatch still aborts. See `signature::enforce_policy`.
+        if let Err(verr) = self.verifier.verify(image).await {
+            enforce_policy(image, self.policy, verr)?;
+        }
         let img = image.to_image_string();
         self.run_or_fail(&["pull", &img]).await?;
         Ok(())
@@ -404,8 +447,18 @@ mod tests {
     use super::*;
     use crate::runner::{RecordingRunner, StubResponse};
 
+    /// 64-char lowercase hex literal — a syntactically valid sha256 digest
+    /// for tests that need a digest-pinned [`ImageRef`].
+    const SHA: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
     fn rt(runner: RecordingRunner) -> PodmanRuntime {
         PodmanRuntime::with_runner(Box::new(runner))
+    }
+
+    /// Helper: a digest-pinned alpine reference that satisfies the F-643
+    /// supply-chain check.
+    fn alpine_pinned() -> ImageRef {
+        ImageRef::parse(&format!("docker.io/library/alpine@sha256:{SHA}")).unwrap()
     }
 
     // `ContainerRuntime` is already in scope via `use super::*;` — tests
@@ -485,13 +538,16 @@ mod tests {
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
-        let img = ImageRef::parse("docker.io/library/alpine:3.19").unwrap();
+        let img = alpine_pinned();
         runtime.pull(&img).await.unwrap();
 
         let calls = calls.lock().unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].0, "podman");
-        assert_eq!(calls[0].1, vec!["pull", "docker.io/library/alpine:3.19"]);
+        assert_eq!(
+            calls[0].1,
+            vec!["pull", &format!("docker.io/library/alpine@sha256:{SHA}"),]
+        );
     }
 
     #[tokio::test]
@@ -501,7 +557,7 @@ mod tests {
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
-        let img = ImageRef::parse("alpine:3.19").unwrap();
+        let img = alpine_pinned();
         let h = runtime
             .create(&img, &["echo", "hi"], &SecurityOpts::permissive())
             .await
@@ -511,7 +567,15 @@ mod tests {
         let calls = calls.lock().unwrap();
         // SecurityOpts::permissive emits zero flags, keeping the
         // historical argv shape for tests that pre-date F-642.
-        assert_eq!(calls[0].1, vec!["create", "alpine:3.19", "echo", "hi"]);
+        assert_eq!(
+            calls[0].1,
+            vec![
+                "create",
+                &format!("docker.io/library/alpine@sha256:{SHA}"),
+                "echo",
+                "hi",
+            ]
+        );
     }
 
     #[tokio::test]
@@ -529,16 +593,17 @@ mod tests {
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
-        let img = ImageRef::parse("alpine:3.19").unwrap();
+        let img = alpine_pinned();
         runtime
             .create(&img, &["--privileged", "sh"], &SecurityOpts::permissive())
             .await
             .unwrap();
 
         let argv = calls.lock().unwrap()[0].1.clone();
+        let image_str = format!("docker.io/library/alpine@sha256:{SHA}");
         let image_idx = argv
             .iter()
-            .position(|a| a == "alpine:3.19")
+            .position(|a| a == &image_str)
             .expect("argv must contain image positional");
         let first_caller_idx = argv
             .iter()
@@ -564,7 +629,7 @@ mod tests {
         let runner = RecordingRunner::new();
         runner.push(StubResponse::ok_stdout(b"".to_vec()));
         let runtime = rt(runner);
-        let img = ImageRef::parse("alpine:3.19").unwrap();
+        let img = alpine_pinned();
         let argv: [&str; 0] = [];
         let err = runtime
             .create(&img, &argv, &SecurityOpts::permissive())
@@ -799,12 +864,132 @@ mod tests {
     async fn command_failure_surfaces_typed_error() {
         let runner = RecordingRunner::new();
         runner.push(StubResponse::err(b"image not found\n".to_vec()));
-        let img = ImageRef::parse("does/not:exist").unwrap();
+        // Use a digest-pinned ref so the pull reaches `podman pull`; the
+        // failure under test is the runtime's exit, not the supply-chain
+        // gate.
+        let img = alpine_pinned();
         let err = rt(runner).pull(&img).await.unwrap_err();
         assert!(matches!(
             err,
             OciError::CommandFailed { tool: "podman", .. }
         ));
+    }
+
+    // ── F-643: signature verification wired into pull ────────────────
+
+    /// Test verifier that always rejects with a configurable variant.
+    struct RejectingVerifier(crate::signature::VerificationError);
+
+    #[async_trait]
+    impl SignatureVerifier for RejectingVerifier {
+        async fn verify(
+            &self,
+            _image: &ImageRef,
+        ) -> Result<(), crate::signature::VerificationError> {
+            Err(match &self.0 {
+                crate::signature::VerificationError::Mismatch(s) => {
+                    crate::signature::VerificationError::Mismatch(s.clone())
+                }
+                crate::signature::VerificationError::VerifierUnavailable(s) => {
+                    crate::signature::VerificationError::VerifierUnavailable(s.clone())
+                }
+                crate::signature::VerificationError::Io(s) => {
+                    crate::signature::VerificationError::Io(s.clone())
+                }
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn pull_runs_verifier_before_invoking_podman() {
+        // Load-bearing: verification must happen *before* podman writes
+        // anything to the local store. We assert ordering by checking the
+        // verifier observed a call and the rejection short-circuits the
+        // runner — no `podman pull` invocation reaches the recording stub.
+        struct CountingVerifier {
+            count: std::sync::atomic::AtomicUsize,
+        }
+        #[async_trait]
+        impl SignatureVerifier for CountingVerifier {
+            async fn verify(
+                &self,
+                _image: &ImageRef,
+            ) -> Result<(), crate::signature::VerificationError> {
+                self.count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err(crate::signature::VerificationError::Mismatch(
+                    "no signature".to_string(),
+                ))
+            }
+        }
+        let verifier = Box::new(CountingVerifier {
+            count: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let runner = RecordingRunner::new();
+        // Push a happy-path response to prove it would have been used if
+        // the verifier had not blocked — the test then asserts the runner
+        // was *not* invoked.
+        runner.push(StubResponse::ok_stdout(b"".to_vec()));
+        let calls = runner.calls.clone();
+        let runtime = rt(runner).with_verifier(verifier, SignaturePolicy::Strict);
+
+        let err = runtime.pull(&alpine_pinned()).await.unwrap_err();
+        assert!(
+            matches!(err, OciError::SignatureVerificationFailed { .. }),
+            "expected SignatureVerificationFailed, got {err:?}"
+        );
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            0,
+            "podman pull must not run when signature verification fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn pull_strict_policy_blocks_on_missing_verifier() {
+        // F-643: in strict mode, even a missing cosign binary blocks the
+        // pull. Operators must install the verifier to opt into Level 2.
+        let verifier = Box::new(RejectingVerifier(
+            crate::signature::VerificationError::VerifierUnavailable("missing".to_string()),
+        ));
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"".to_vec()));
+        let runtime = rt(runner).with_verifier(verifier, SignaturePolicy::Strict);
+        let err = runtime.pull(&alpine_pinned()).await.unwrap_err();
+        assert!(matches!(err, OciError::SignatureVerificationFailed { .. }));
+    }
+
+    #[tokio::test]
+    async fn pull_permissive_policy_proceeds_when_verifier_unavailable() {
+        // F-643: permissive mode permits the pull when cosign is not
+        // installed, so dev environments still function. A real signature
+        // mismatch is still fatal — covered by the next test.
+        let verifier = Box::new(RejectingVerifier(
+            crate::signature::VerificationError::VerifierUnavailable("missing".to_string()),
+        ));
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"".to_vec()));
+        let calls = runner.calls.clone();
+        let runtime = rt(runner).with_verifier(verifier, SignaturePolicy::Permissive);
+        runtime.pull(&alpine_pinned()).await.unwrap();
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "podman pull must run when permissive policy lets the missing verifier through"
+        );
+    }
+
+    #[tokio::test]
+    async fn pull_permissive_policy_still_blocks_on_signature_mismatch() {
+        // The permissive escape hatch is for *missing tooling*, not for
+        // bad signatures. A real mismatch must always block.
+        let verifier = Box::new(RejectingVerifier(
+            crate::signature::VerificationError::Mismatch("bad sig".to_string()),
+        ));
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"".to_vec()));
+        let runtime = rt(runner).with_verifier(verifier, SignaturePolicy::Permissive);
+        let err = runtime.pull(&alpine_pinned()).await.unwrap_err();
+        assert!(matches!(err, OciError::SignatureVerificationFailed { .. }));
     }
 
     #[test]
@@ -940,7 +1125,7 @@ mod tests {
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
-        let img = ImageRef::parse("alpine:3.19").unwrap();
+        let img = alpine_pinned();
         runtime
             .create(
                 &img,
@@ -953,9 +1138,10 @@ mod tests {
         let calls = calls.lock().unwrap();
         let argv = &calls[0].1;
         // Every hardening flag must be present before the IMAGE positional.
+        let image_str = format!("docker.io/library/alpine@sha256:{SHA}");
         let image_idx = argv
             .iter()
-            .position(|a| a == "alpine:3.19")
+            .position(|a| a == &image_str)
             .expect("argv must contain image positional");
         let prefix = &argv[..image_idx];
         for required in [
@@ -990,7 +1176,7 @@ mod tests {
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
-        let img = ImageRef::parse("alpine:3.19").unwrap();
+        let img = alpine_pinned();
         runtime
             .create(
                 &img,
@@ -1027,7 +1213,7 @@ mod tests {
                 FOUR_GIB_STR.to_string(),
                 "--pids-limit".to_string(),
                 "1024".to_string(),
-                "alpine:3.19".to_string(),
+                format!("docker.io/library/alpine@sha256:{SHA}"),
                 "sleep".to_string(),
                 "infinity".to_string(),
             ]
@@ -1045,14 +1231,21 @@ mod tests {
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
-        let img = ImageRef::parse("alpine:3.19").unwrap();
+        let img = alpine_pinned();
         runtime
             .create(&img, &["sh"], &SecurityOpts::permissive())
             .await
             .unwrap();
 
         let calls = calls.lock().unwrap();
-        assert_eq!(calls[0].1, vec!["create", "alpine:3.19", "sh"]);
+        assert_eq!(
+            calls[0].1,
+            vec![
+                "create",
+                &format!("docker.io/library/alpine@sha256:{SHA}"),
+                "sh",
+            ]
+        );
     }
 
     #[test]

--- a/crates/forge-oci/src/signature.rs
+++ b/crates/forge-oci/src/signature.rs
@@ -1,0 +1,321 @@
+//! Image signature verification — the second half of F-643's supply-chain
+//! mitigation. [`ImageRef`] makes the *identity* of the image bytes
+//! immutable (digest pinning); this module makes the *provenance* of those
+//! bytes attestable (signature verification).
+//!
+//! ## Design
+//!
+//! Verification runs **before** [`crate::ContainerRuntime::pull`] writes
+//! anything to the local store. The trait is stateless and synchronous-shape:
+//! it takes an `&ImageRef` and returns either `Ok(())` (good — proceed with
+//! pull) or [`VerificationError`] (stop — never pull this image).
+//!
+//! Two implementations ship today:
+//!
+//! - [`CosignVerifier`] shells out to the `cosign` binary. The default
+//!   keyless flow validates against the configured Fulcio root + Rekor
+//!   transparency log — this is what production runs should use.
+//! - [`NoopVerifier`] accepts every image. It exists for tests and for the
+//!   permissive [`SignaturePolicy::Permissive`] mode, which logs a warning
+//!   when no usable verifier is installed instead of hard-failing.
+//!
+//! ## Policy
+//!
+//! [`SignaturePolicy`] selects the operational stance:
+//!
+//! - [`SignaturePolicy::Strict`] — every pull must verify successfully.
+//!   Missing `cosign` binary, signature absent, signature mismatch all
+//!   abort the pull. This is the production default once cosign rolls out.
+//! - [`SignaturePolicy::Permissive`] — verification still runs when
+//!   feasible, but a missing `cosign` binary degrades to a logged warning
+//!   instead of hard-failing. Useful for early Phase 3 dev environments.
+//!
+//! The policy lives next to the verifier rather than inside `PodmanRuntime`
+//! so a future host (`DockerRuntime`, an in-process containerd, etc.) can
+//! reuse the same verification surface.
+
+use crate::{ImageRef, OciError};
+use async_trait::async_trait;
+
+use crate::runner::{CommandRunner, TokioCommandRunner};
+
+/// Stance the runtime takes when verifying images.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignaturePolicy {
+    /// Every pull must verify successfully. Missing tooling, missing
+    /// signatures, and mismatched signatures all hard-fail. This is the
+    /// production target.
+    Strict,
+    /// Verification runs when the verifier is operational; a missing
+    /// verifier (e.g. `cosign` not on `PATH`) degrades to a logged warning
+    /// rather than blocking the pull. Mismatched signatures still
+    /// hard-fail — the policy only relaxes the "verifier available" check.
+    Permissive,
+}
+
+impl Default for SignaturePolicy {
+    /// `Permissive` is the default so existing dev environments without
+    /// `cosign` do not break on upgrade. Production wiring should opt into
+    /// [`Self::Strict`] explicitly.
+    fn default() -> Self {
+        Self::Permissive
+    }
+}
+
+/// Reasons a verifier may reject an image.
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+    /// The verifier itself was not available (binary missing, daemon not
+    /// running, etc.). [`SignaturePolicy::Strict`] turns this into a hard
+    /// failure; [`SignaturePolicy::Permissive`] downgrades to a warning.
+    #[error("signature verifier unavailable: {0}")]
+    VerifierUnavailable(String),
+    /// The verifier ran but rejected the image (signature missing, expired,
+    /// or signed by an untrusted identity).
+    #[error("signature mismatch: {0}")]
+    Mismatch(String),
+    /// I/O error invoking the verifier.
+    #[error("io error invoking signature verifier: {0}")]
+    Io(String),
+}
+
+/// Verify an image's signature before it is pulled. Implementations are
+/// stateless — they take only the image reference and return a verdict.
+#[async_trait]
+pub trait SignatureVerifier: Send + Sync {
+    /// Return `Ok(())` if the image is acceptable, [`VerificationError`]
+    /// otherwise.
+    async fn verify(&self, image: &ImageRef) -> Result<(), VerificationError>;
+}
+
+/// Permissive verifier that accepts every image. Use only in tests or when
+/// the operator has explicitly opted into [`SignaturePolicy::Permissive`]
+/// and no real verifier is installed.
+pub struct NoopVerifier;
+
+#[async_trait]
+impl SignatureVerifier for NoopVerifier {
+    async fn verify(&self, _image: &ImageRef) -> Result<(), VerificationError> {
+        Ok(())
+    }
+}
+
+/// Default binary name used by [`CosignVerifier`].
+const COSIGN: &str = "cosign";
+
+/// Verify images by shelling out to `cosign verify`. Runs in keyless mode
+/// against the configured Fulcio root + Rekor transparency log; operators
+/// pin trusted signer identities by setting `COSIGN_CERTIFICATE_IDENTITY`
+/// and `COSIGN_CERTIFICATE_OIDC_ISSUER` in the daemon's environment, the
+/// same conventions cosign reads natively.
+///
+/// The verifier is parameterised on [`CommandRunner`] so the unit tests in
+/// this module can drive it without a real cosign binary on `PATH`.
+pub struct CosignVerifier {
+    runner: Box<dyn CommandRunner>,
+    policy: SignaturePolicy,
+}
+
+impl CosignVerifier {
+    /// Build a verifier that shells out via `tokio::process::Command`.
+    pub fn new(policy: SignaturePolicy) -> Self {
+        Self {
+            runner: Box::new(TokioCommandRunner),
+            policy,
+        }
+    }
+
+    /// Build a verifier with a custom [`CommandRunner`] — for tests.
+    pub fn with_runner(runner: Box<dyn CommandRunner>, policy: SignaturePolicy) -> Self {
+        Self { runner, policy }
+    }
+
+    /// The policy this verifier was built with.
+    pub fn policy(&self) -> SignaturePolicy {
+        self.policy
+    }
+}
+
+#[async_trait]
+impl SignatureVerifier for CosignVerifier {
+    async fn verify(&self, image: &ImageRef) -> Result<(), VerificationError> {
+        // We invoke cosign on the canonical image string — for digest-pinned
+        // refs that resolves to `name@sha256:<hex>`, which is exactly what
+        // cosign expects to verify. Refs that reach this path without a
+        // digest are first-party allowlisted (`oci.io/forge/`); cosign will
+        // resolve their tag to a digest itself before validating.
+        let img = image.to_image_string();
+        let result = self.runner.run(COSIGN, &["verify", &img]).await;
+        match result {
+            Ok(outcome) if outcome.success() => Ok(()),
+            Ok(outcome) => {
+                let stderr = String::from_utf8_lossy(&outcome.stderr).to_string();
+                Err(VerificationError::Mismatch(stderr))
+            }
+            // `Io` covers "binary not found" — kind == NotFound on Linux —
+            // as well as other spawn failures. Distinguish them so the
+            // policy layer can downgrade missing-binary to a warning while
+            // still treating a real I/O blow-up as fatal.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(
+                VerificationError::VerifierUnavailable(format!("cosign not on PATH: {e}")),
+            ),
+            Err(e) => Err(VerificationError::Io(e.to_string())),
+        }
+    }
+}
+
+/// Apply [`SignaturePolicy`] to a [`VerificationError`]: in
+/// [`SignaturePolicy::Permissive`] mode a missing verifier is downgraded to
+/// a logged warning so dev environments without cosign still function;
+/// every other variant hard-fails regardless of policy.
+///
+/// Returns `Ok(())` if the policy permits proceeding, `Err(OciError)` if it
+/// does not.
+pub fn enforce_policy(
+    image: &ImageRef,
+    policy: SignaturePolicy,
+    err: VerificationError,
+) -> Result<(), OciError> {
+    match (&policy, &err) {
+        (SignaturePolicy::Permissive, VerificationError::VerifierUnavailable(reason)) => {
+            tracing::warn!(
+                image = %image,
+                reason = %reason,
+                "signature verifier unavailable; permissive policy permits pull"
+            );
+            Ok(())
+        }
+        _ => Err(OciError::SignatureVerificationFailed {
+            image: image.to_image_string(),
+            reason: err.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::{CommandOutcome, RecordingRunner, StubResponse};
+
+    fn alpine_digest() -> ImageRef {
+        const SHA: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        ImageRef::parse(&format!("docker.io/library/alpine@sha256:{SHA}")).unwrap()
+    }
+
+    #[tokio::test]
+    async fn noop_verifier_accepts_anything() {
+        NoopVerifier.verify(&alpine_digest()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cosign_verifier_invokes_cosign_with_canonical_image_string() {
+        // Load-bearing: cosign must see the digest-pinned canonical form,
+        // not the human-readable `name:tag`. The renderer drops the tag in
+        // that case so the wire form is unambiguous.
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"verified\n".to_vec()));
+        let calls = runner.calls.clone();
+        let verifier = CosignVerifier::with_runner(Box::new(runner), SignaturePolicy::Strict);
+
+        verifier.verify(&alpine_digest()).await.unwrap();
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "cosign");
+        assert_eq!(calls[0].1[0], "verify");
+        assert!(
+            calls[0].1[1].contains("@sha256:"),
+            "cosign verify must run on the digest-pinned form, got {:?}",
+            calls[0].1
+        );
+    }
+
+    #[tokio::test]
+    async fn cosign_verifier_surfaces_mismatch_when_cosign_exits_nonzero() {
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse {
+            matches_args: None,
+            outcome: CommandOutcome {
+                exit_code: Some(1),
+                stdout: Vec::new(),
+                stderr: b"no matching signatures\n".to_vec(),
+            },
+        });
+        let verifier = CosignVerifier::with_runner(Box::new(runner), SignaturePolicy::Strict);
+        let err = verifier.verify(&alpine_digest()).await.unwrap_err();
+        assert!(
+            matches!(err, VerificationError::Mismatch(_)),
+            "expected Mismatch, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cosign_verifier_classifies_missing_binary_as_unavailable() {
+        // Simulate `cosign` not on PATH by pushing a spawn-error stub. The
+        // RecordingRunner uses `StubResponse::err` for non-zero exit but we
+        // need a real I/O NotFound to exercise the unavailable branch —
+        // emulate it via a custom runner.
+        struct NotFoundRunner;
+        #[async_trait::async_trait]
+        impl crate::runner::CommandRunner for NotFoundRunner {
+            async fn run(
+                &self,
+                _bin: &str,
+                _args: &[&str],
+            ) -> std::io::Result<crate::runner::CommandOutcome> {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "no such file",
+                ))
+            }
+        }
+        let verifier =
+            CosignVerifier::with_runner(Box::new(NotFoundRunner), SignaturePolicy::Strict);
+        let err = verifier.verify(&alpine_digest()).await.unwrap_err();
+        assert!(
+            matches!(err, VerificationError::VerifierUnavailable(_)),
+            "expected VerifierUnavailable, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn permissive_policy_downgrades_unavailable_to_ok() {
+        // F-643 dev-friendliness: missing cosign in permissive mode is a
+        // warning, not a block. Any other error stays fatal.
+        let img = alpine_digest();
+        let permitted = enforce_policy(
+            &img,
+            SignaturePolicy::Permissive,
+            VerificationError::VerifierUnavailable("not on PATH".to_string()),
+        );
+        assert!(permitted.is_ok());
+
+        let blocked = enforce_policy(
+            &img,
+            SignaturePolicy::Permissive,
+            VerificationError::Mismatch("no signatures".to_string()),
+        );
+        assert!(matches!(
+            blocked,
+            Err(OciError::SignatureVerificationFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn strict_policy_blocks_every_failure_including_unavailable() {
+        // F-643 production stance: even a missing verifier is fatal in
+        // strict mode. Production must install cosign before opting in.
+        let img = alpine_digest();
+        for err in [
+            VerificationError::VerifierUnavailable("missing".to_string()),
+            VerificationError::Mismatch("bad".to_string()),
+            VerificationError::Io("kapow".to_string()),
+        ] {
+            let r = enforce_policy(&img, SignaturePolicy::Strict, err);
+            assert!(
+                matches!(r, Err(OciError::SignatureVerificationFailed { .. })),
+                "strict policy must block {r:?}"
+            );
+        }
+    }
+}

--- a/crates/forge-oci/src/signature.rs
+++ b/crates/forge-oci/src/signature.rs
@@ -14,10 +14,19 @@
 //!
 //! - [`CosignVerifier`] shells out to the `cosign` binary. The default
 //!   keyless flow validates against the configured Fulcio root + Rekor
-//!   transparency log — this is what production runs should use.
-//! - [`NoopVerifier`] accepts every image. It exists for tests and for the
-//!   permissive [`SignaturePolicy::Permissive`] mode, which logs a warning
-//!   when no usable verifier is installed instead of hard-failing.
+//!   transparency log AND pins the trusted signer identity through
+//!   [`IDENTITY_ENV`] + [`OIDC_ENV`] (forwarded to cosign as the matching
+//!   `--certificate-identity` / `--certificate-oidc-issuer` flags). Without
+//!   identity pinning cosign accepts any Fulcio-signed artifact, so the
+//!   verifier refuses to invoke cosign at all when those env vars are
+//!   unset under [`SignaturePolicy::Strict`]. This is what production
+//!   runs should use.
+//! - [`NoopVerifier`] accepts every image. It exists for tests where the
+//!   verification path is irrelevant. Production wiring should never use
+//!   it; [`crate::PodmanRuntime::new`] defaults to [`CosignVerifier`] in
+//!   [`SignaturePolicy::Permissive`] so an operator who forgets to wire a
+//!   verifier still gets identity-pinned verification once they set the
+//!   env vars.
 //!
 //! ## Policy
 //!
@@ -103,11 +112,42 @@ impl SignatureVerifier for NoopVerifier {
 /// Default binary name used by [`CosignVerifier`].
 const COSIGN: &str = "cosign";
 
+/// Env var operators set to pin the trusted signer identity. The verifier
+/// reads it at [`CosignVerifier::verify`] time and forwards the value as
+/// `--certificate-identity=<value>` to the cosign argv.
+///
+/// The variable name matches the cosign convention, but cosign itself does
+/// **not** read it — it only reads the equivalent CLI flag. The verifier
+/// bridges the two so operators can configure trust through the daemon
+/// environment (the same place every other Forge runtime knob lives)
+/// instead of patching argv at every call site.
+pub const IDENTITY_ENV: &str = "COSIGN_CERTIFICATE_IDENTITY";
+
+/// Env var operators set to pin the trusted OIDC issuer. Forwarded to
+/// cosign as `--certificate-oidc-issuer=<value>`. Same naming convention
+/// and bridging rationale as [`IDENTITY_ENV`].
+pub const OIDC_ENV: &str = "COSIGN_CERTIFICATE_OIDC_ISSUER";
+
 /// Verify images by shelling out to `cosign verify`. Runs in keyless mode
-/// against the configured Fulcio root + Rekor transparency log; operators
-/// pin trusted signer identities by setting `COSIGN_CERTIFICATE_IDENTITY`
-/// and `COSIGN_CERTIFICATE_OIDC_ISSUER` in the daemon's environment, the
-/// same conventions cosign reads natively.
+/// against the configured Fulcio root + Rekor transparency log.
+///
+/// **Identity pinning is mandatory.** Without `--certificate-identity` and
+/// `--certificate-oidc-issuer`, cosign accepts *any* signature from *any*
+/// Fulcio-issued cert — a legitimate signing run by a random user passes.
+/// The verifier reads [`IDENTITY_ENV`] and [`OIDC_ENV`] from the process
+/// environment at [`Self::verify`] time and forwards them as the matching
+/// cosign flags. Note: cosign reads the flags, not the env vars — Forge
+/// imposes the env-var convention so operator config lives in the daemon
+/// environment.
+///
+/// Behaviour when the env vars are unset:
+/// - [`SignaturePolicy::Strict`] — verify fails with
+///   [`VerificationError::VerifierUnavailable`] before cosign is invoked.
+///   Operators must set both env vars before opting in to Strict.
+/// - [`SignaturePolicy::Permissive`] — same error shape (so the existing
+///   policy enforcement layer downgrades to a warning), with an extra
+///   `tracing::warn!` describing the gap. Useful in dev environments where
+///   the operator hasn't decided on a signer identity yet.
 ///
 /// The verifier is parameterised on [`CommandRunner`] so the unit tests in
 /// this module can drive it without a real cosign binary on `PATH`.
@@ -139,13 +179,39 @@ impl CosignVerifier {
 #[async_trait]
 impl SignatureVerifier for CosignVerifier {
     async fn verify(&self, image: &ImageRef) -> Result<(), VerificationError> {
+        // Identity pinning gate — see the type-level docs. Without these
+        // flags cosign accepts ANY Fulcio-signed artifact, which defeats
+        // the entire purpose of keyless verification.
+        let identity = std::env::var(IDENTITY_ENV).ok().filter(|v| !v.is_empty());
+        let oidc = std::env::var(OIDC_ENV).ok().filter(|v| !v.is_empty());
+        let (identity, oidc) = match (identity, oidc) {
+            (Some(i), Some(o)) => (i, o),
+            _ => {
+                let reason = format!(
+                    "{IDENTITY_ENV} and {OIDC_ENV} must both be set so cosign can pin the trusted signer; \
+                     unset means every Fulcio-issued cert would be accepted"
+                );
+                if matches!(self.policy, SignaturePolicy::Permissive) {
+                    tracing::warn!(
+                        image = %image,
+                        reason = %reason,
+                        "cosign identity env unset; permissive policy will skip signature verification"
+                    );
+                }
+                return Err(VerificationError::VerifierUnavailable(reason));
+            }
+        };
+
         // We invoke cosign on the canonical image string — for digest-pinned
         // refs that resolves to `name@sha256:<hex>`, which is exactly what
         // cosign expects to verify. Refs that reach this path without a
         // digest are first-party allowlisted (`oci.io/forge/`); cosign will
         // resolve their tag to a digest itself before validating.
         let img = image.to_image_string();
-        let result = self.runner.run(COSIGN, &["verify", &img]).await;
+        let identity_flag = format!("--certificate-identity={identity}");
+        let oidc_flag = format!("--certificate-oidc-issuer={oidc}");
+        let args: [&str; 4] = ["verify", &identity_flag, &oidc_flag, &img];
+        let result = self.runner.run(COSIGN, &args).await;
         match result {
             Ok(outcome) if outcome.success() => Ok(()),
             Ok(outcome) => {
@@ -196,10 +262,47 @@ pub fn enforce_policy(
 mod tests {
     use super::*;
     use crate::runner::{CommandOutcome, RecordingRunner, StubResponse};
+    use std::sync::Mutex;
 
     fn alpine_digest() -> ImageRef {
         const SHA: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
         ImageRef::parse(&format!("docker.io/library/alpine@sha256:{SHA}")).unwrap()
+    }
+
+    /// Tests that mutate `IDENTITY_ENV`/`OIDC_ENV` must serialise through
+    /// this lock — otherwise the tokio multi-threaded runner interleaves
+    /// `set_var` / `remove_var` calls across tests and they all race.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Set the identity env vars to representative values and clear them
+    /// at scope exit. Tests that need to drive cosign argv assertions use
+    /// this so they're decoupled from whatever the host env happens to
+    /// have set.
+    struct IdentityEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl IdentityEnvGuard {
+        fn set() -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            std::env::set_var(IDENTITY_ENV, "ci@forge.example");
+            std::env::set_var(OIDC_ENV, "https://token.actions.githubusercontent.com");
+            Self { _lock: lock }
+        }
+
+        fn unset() -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            std::env::remove_var(IDENTITY_ENV);
+            std::env::remove_var(OIDC_ENV);
+            Self { _lock: lock }
+        }
+    }
+
+    impl Drop for IdentityEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(IDENTITY_ENV);
+            std::env::remove_var(OIDC_ENV);
+        }
     }
 
     #[tokio::test]
@@ -212,6 +315,7 @@ mod tests {
         // Load-bearing: cosign must see the digest-pinned canonical form,
         // not the human-readable `name:tag`. The renderer drops the tag in
         // that case so the wire form is unambiguous.
+        let _env = IdentityEnvGuard::set();
         let runner = RecordingRunner::new();
         runner.push(StubResponse::ok_stdout(b"verified\n".to_vec()));
         let calls = runner.calls.clone();
@@ -223,8 +327,10 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].0, "cosign");
         assert_eq!(calls[0].1[0], "verify");
+        // The image string is the LAST positional after the identity flags.
+        let last = calls[0].1.last().expect("cosign argv must be non-empty");
         assert!(
-            calls[0].1[1].contains("@sha256:"),
+            last.contains("@sha256:"),
             "cosign verify must run on the digest-pinned form, got {:?}",
             calls[0].1
         );
@@ -232,6 +338,7 @@ mod tests {
 
     #[tokio::test]
     async fn cosign_verifier_surfaces_mismatch_when_cosign_exits_nonzero() {
+        let _env = IdentityEnvGuard::set();
         let runner = RecordingRunner::new();
         runner.push(StubResponse {
             matches_args: None,
@@ -255,6 +362,7 @@ mod tests {
         // RecordingRunner uses `StubResponse::err` for non-zero exit but we
         // need a real I/O NotFound to exercise the unavailable branch —
         // emulate it via a custom runner.
+        let _env = IdentityEnvGuard::set();
         struct NotFoundRunner;
         #[async_trait::async_trait]
         impl crate::runner::CommandRunner for NotFoundRunner {
@@ -317,5 +425,92 @@ mod tests {
                 "strict policy must block {r:?}"
             );
         }
+    }
+
+    // ── F-643 follow-up: identity pinning gate ───────────────────────
+    //
+    // The default keyless cosign flow only checks that *some* Fulcio cert
+    // signed the artifact — every public Sigstore signing run satisfies
+    // that. The verifier MUST pass `--certificate-identity` /
+    // `--certificate-oidc-issuer` so cosign rejects signatures from
+    // identities the operator hasn't whitelisted.
+
+    #[tokio::test]
+    async fn cosign_verifier_passes_identity_flags_from_env() {
+        let _env = IdentityEnvGuard::set();
+
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"verified\n".to_vec()));
+        let calls = runner.calls.clone();
+        let verifier = CosignVerifier::with_runner(Box::new(runner), SignaturePolicy::Strict);
+
+        verifier.verify(&alpine_digest()).await.unwrap();
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        let argv = &calls[0].1;
+        assert!(
+            argv.iter()
+                .any(|a| a == "--certificate-identity=ci@forge.example"),
+            "expected --certificate-identity flag in argv, got {argv:?}"
+        );
+        assert!(
+            argv.iter()
+                .any(|a| a
+                    == "--certificate-oidc-issuer=https://token.actions.githubusercontent.com"),
+            "expected --certificate-oidc-issuer flag in argv, got {argv:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cosign_verifier_strict_fails_when_identity_env_missing() {
+        let _env = IdentityEnvGuard::unset();
+
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"verified\n".to_vec()));
+        let calls = runner.calls.clone();
+        let verifier = CosignVerifier::with_runner(Box::new(runner), SignaturePolicy::Strict);
+
+        let err = verifier.verify(&alpine_digest()).await.unwrap_err();
+        match &err {
+            VerificationError::VerifierUnavailable(reason) => {
+                assert!(
+                    reason.contains(IDENTITY_ENV) && reason.contains(OIDC_ENV),
+                    "error must mention both env vars so operators know what to set; got {reason}"
+                );
+            }
+            other => panic!("expected VerifierUnavailable, got {other:?}"),
+        }
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            0,
+            "cosign must NOT be invoked when identity env is missing under Strict"
+        );
+    }
+
+    #[tokio::test]
+    async fn cosign_verifier_permissive_returns_unavailable_when_identity_env_missing() {
+        // Under Permissive the verifier still returns
+        // `VerifierUnavailable` so the existing `enforce_policy` plumbing
+        // can downgrade to a warning. The verifier itself logs an extra
+        // `tracing::warn!` so operators see the gap, but the error shape
+        // matches the missing-binary path for symmetry.
+        let _env = IdentityEnvGuard::unset();
+
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"verified\n".to_vec()));
+        let calls = runner.calls.clone();
+        let verifier = CosignVerifier::with_runner(Box::new(runner), SignaturePolicy::Permissive);
+
+        let err = verifier.verify(&alpine_digest()).await.unwrap_err();
+        assert!(
+            matches!(err, VerificationError::VerifierUnavailable(_)),
+            "permissive + missing identity env must yield VerifierUnavailable, got {err:?}"
+        );
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            0,
+            "cosign must NOT be invoked when identity env is missing"
+        );
     }
 }

--- a/crates/forge-oci/tests/podman_integration.rs
+++ b/crates/forge-oci/tests/podman_integration.rs
@@ -41,7 +41,16 @@ const SHA: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abc
 #[tokio::test]
 #[ignore = "requires rootless podman on PATH (run with --ignored)"]
 async fn create_does_not_apply_caller_flags_as_runtime_flags() {
-    let runtime = PodmanRuntime::new();
+    // F-643 follow-up: production `new()` defaults to a real
+    // `CosignVerifier` so nobody silently runs without verification.
+    // These ignored end-to-end tests deliberately opt out via
+    // `with_verifier(NoopVerifier)` because they exercise podman
+    // semantics, not the signature gate (which has its own coverage in
+    // `mismatched_signature_is_rejected` below).
+    let runtime = PodmanRuntime::new().with_verifier(
+        Box::new(forge_oci::NoopVerifier),
+        SignaturePolicy::Permissive,
+    );
     runtime.detect().await.expect("podman detect");
     // F-643: tag-only refs are rejected for non-allowlisted sources; pin
     // by digest. We use a known-good alpine 3.19 amd64 digest. If alpine's
@@ -106,7 +115,16 @@ async fn create_does_not_apply_caller_flags_as_runtime_flags() {
 #[tokio::test]
 #[ignore = "requires rootless podman on PATH (run with --ignored)"]
 async fn exec_does_not_apply_caller_flags_as_runtime_flags() {
-    let runtime = PodmanRuntime::new();
+    // F-643 follow-up: production `new()` defaults to a real
+    // `CosignVerifier` so nobody silently runs without verification.
+    // These ignored end-to-end tests deliberately opt out via
+    // `with_verifier(NoopVerifier)` because they exercise podman
+    // semantics, not the signature gate (which has its own coverage in
+    // `mismatched_signature_is_rejected` below).
+    let runtime = PodmanRuntime::new().with_verifier(
+        Box::new(forge_oci::NoopVerifier),
+        SignaturePolicy::Permissive,
+    );
     runtime.detect().await.expect("podman detect");
     // F-643: tag-only refs are rejected for non-allowlisted sources; pin
     // by digest. We use a known-good alpine 3.19 amd64 digest. If alpine's
@@ -148,7 +166,16 @@ async fn exec_does_not_apply_caller_flags_as_runtime_flags() {
 #[tokio::test]
 #[ignore = "requires rootless podman on PATH (run with --ignored)"]
 async fn podman_full_lifecycle_against_alpine() {
-    let runtime = PodmanRuntime::new();
+    // F-643 follow-up: production `new()` defaults to a real
+    // `CosignVerifier` so nobody silently runs without verification.
+    // These ignored end-to-end tests deliberately opt out via
+    // `with_verifier(NoopVerifier)` because they exercise podman
+    // semantics, not the signature gate (which has its own coverage in
+    // `mismatched_signature_is_rejected` below).
+    let runtime = PodmanRuntime::new().with_verifier(
+        Box::new(forge_oci::NoopVerifier),
+        SignaturePolicy::Permissive,
+    );
 
     runtime
         .detect()

--- a/crates/forge-oci/tests/podman_integration.rs
+++ b/crates/forge-oci/tests/podman_integration.rs
@@ -15,7 +15,14 @@
 
 #![cfg(target_os = "linux")]
 
-use forge_oci::{ContainerLimits, ContainerRuntime, ImageRef, PodmanRuntime, SecurityOpts};
+use forge_oci::signature::{SignaturePolicy, SignatureVerifier, VerificationError};
+use forge_oci::{
+    ContainerLimits, ContainerRuntime, ImageRef, OciError, PodmanRuntime, SecurityOpts,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// 64-char lowercase hex literal — a syntactically valid sha256 digest.
+const SHA: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 /// End-to-end flag-injection regression test for `create`.
 ///
@@ -36,7 +43,14 @@ use forge_oci::{ContainerLimits, ContainerRuntime, ImageRef, PodmanRuntime, Secu
 async fn create_does_not_apply_caller_flags_as_runtime_flags() {
     let runtime = PodmanRuntime::new();
     runtime.detect().await.expect("podman detect");
-    let image = ImageRef::parse("docker.io/library/alpine:3.19").expect("valid image ref");
+    // F-643: tag-only refs are rejected for non-allowlisted sources; pin
+    // by digest. We use a known-good alpine 3.19 amd64 digest. If alpine's
+    // multi-arch index changes, this digest needs to be regenerated with
+    // `podman pull docker.io/library/alpine:3.19 && podman image inspect ...`.
+    let image = ImageRef::parse(
+        "docker.io/library/alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b",
+    )
+    .expect("valid image ref");
     runtime.pull(&image).await.expect("pull alpine");
 
     // Caller argv begins with `--privileged`. If podman wrongly treated this
@@ -94,7 +108,14 @@ async fn create_does_not_apply_caller_flags_as_runtime_flags() {
 async fn exec_does_not_apply_caller_flags_as_runtime_flags() {
     let runtime = PodmanRuntime::new();
     runtime.detect().await.expect("podman detect");
-    let image = ImageRef::parse("docker.io/library/alpine:3.19").expect("valid image ref");
+    // F-643: tag-only refs are rejected for non-allowlisted sources; pin
+    // by digest. We use a known-good alpine 3.19 amd64 digest. If alpine's
+    // multi-arch index changes, this digest needs to be regenerated with
+    // `podman pull docker.io/library/alpine:3.19 && podman image inspect ...`.
+    let image = ImageRef::parse(
+        "docker.io/library/alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b",
+    )
+    .expect("valid image ref");
     runtime.pull(&image).await.expect("pull alpine");
 
     let handle = runtime
@@ -134,7 +155,14 @@ async fn podman_full_lifecycle_against_alpine() {
         .await
         .expect("podman detect: rootless podman must be configured");
 
-    let image = ImageRef::parse("docker.io/library/alpine:3.19").expect("valid image ref");
+    // F-643: tag-only refs are rejected for non-allowlisted sources; pin
+    // by digest. We use a known-good alpine 3.19 amd64 digest. If alpine's
+    // multi-arch index changes, this digest needs to be regenerated with
+    // `podman pull docker.io/library/alpine:3.19 && podman image inspect ...`.
+    let image = ImageRef::parse(
+        "docker.io/library/alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b",
+    )
+    .expect("valid image ref");
 
     runtime.pull(&image).await.expect("pull alpine");
 
@@ -413,4 +441,94 @@ async fn pids_limit_bounds_a_fork_bomb_inside_the_container() {
     );
 
     runtime.remove(&handle).await.expect("remove container");
+}
+
+// ── F-643: supply-chain integration tests ─────────────────────────────
+//
+// These do NOT require a real podman or cosign on the host — they
+// exercise the F-643 supply-chain gates through the public API surface
+// (`ImageRef::parse`, `PodmanRuntime::pull` with a stub verifier). They
+// run on every `cargo test -p forge-oci` invocation, so CI keeps the
+// supply-chain story under continuous regression.
+
+/// Verifier that always rejects with a `Mismatch` — simulates cosign
+/// reporting "no matching signatures" or "signature does not verify".
+struct MismatchVerifier {
+    calls: AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl SignatureVerifier for MismatchVerifier {
+    async fn verify(&self, _image: &ImageRef) -> Result<(), VerificationError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(VerificationError::Mismatch(
+            "no matching signatures (test fixture)".to_string(),
+        ))
+    }
+}
+
+/// DoD: "pinned digest accepted". Parse + render round-trip a digest-
+/// pinned reference end-to-end through the public API.
+#[test]
+fn pinned_digest_reference_is_accepted() {
+    let input = format!("docker.io/library/alpine@sha256:{SHA}");
+    let r = ImageRef::parse(&input).expect("digest-pinned ref must parse");
+    assert!(r.digest.is_some(), "digest field must be populated");
+    assert_eq!(
+        r.to_image_string(),
+        format!("docker.io/library/alpine@sha256:{SHA}"),
+        "renderer must drop the tag in favour of the digest on the wire"
+    );
+}
+
+/// DoD: "tag-only rejected". A non-allowlisted tag-only reference must
+/// be refused at parse time before any runtime sees it.
+#[test]
+fn tag_only_reference_is_rejected() {
+    for input in [
+        "alpine",
+        "alpine:3.19",
+        "library/alpine:1",
+        "docker.io/library/alpine:3.19",
+        "quay.io/myorg/myapp:v1",
+    ] {
+        let err = ImageRef::parse(input).unwrap_err();
+        assert!(
+            matches!(err, OciError::UntrustedTagOnlyRef { .. }),
+            "{input:?} must yield UntrustedTagOnlyRef, got {err:?}"
+        );
+    }
+}
+
+/// DoD: "mismatched signature rejected". Wire a verifier that reports a
+/// mismatch and confirm `pull` aborts before podman is invoked, surfacing
+/// `OciError::SignatureVerificationFailed`.
+#[tokio::test]
+async fn mismatched_signature_is_rejected() {
+    let verifier = MismatchVerifier {
+        calls: AtomicUsize::new(0),
+    };
+    let verifier = Box::new(verifier);
+    // We don't need a real podman for this test — `with_runner` accepts
+    // a recording stub, and the verifier should short-circuit before the
+    // runner is invoked.
+    let runner = forge_oci::RecordingRunner::new();
+    runner.push(forge_oci::StubResponse::ok_stdout(b"".to_vec()));
+    let calls = runner.calls.clone();
+    let runtime = PodmanRuntime::with_runner(Box::new(runner))
+        .with_verifier(verifier, SignaturePolicy::Strict);
+
+    let img = ImageRef::parse(&format!("docker.io/library/alpine@sha256:{SHA}"))
+        .expect("digest-pinned ref must parse");
+    let err = runtime.pull(&img).await.unwrap_err();
+
+    assert!(
+        matches!(err, OciError::SignatureVerificationFailed { .. }),
+        "expected SignatureVerificationFailed, got {err:?}"
+    );
+    assert_eq!(
+        calls.lock().unwrap().len(),
+        0,
+        "podman pull must not be invoked when signature verification fails"
+    );
 }

--- a/crates/forge-session/src/sandbox.rs
+++ b/crates/forge-session/src/sandbox.rs
@@ -1546,7 +1546,7 @@ mod tests {
         let session = Arc::new(
             Level2Session::create(
                 runtime,
-                OciImageRef::parse("alpine:3.19").unwrap(),
+                OciImageRef::parse("docker.io/library/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef").unwrap(),
                 ContainerLimits::default(),
             )
             .await
@@ -1575,7 +1575,7 @@ mod tests {
         let session = Arc::new(
             Level2Session::create(
                 runtime,
-                OciImageRef::parse("alpine:3.19").unwrap(),
+                OciImageRef::parse("docker.io/library/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef").unwrap(),
                 ContainerLimits::default(),
             )
             .await
@@ -1635,7 +1635,7 @@ mod tests {
         let session = Arc::new(
             Level2Session::create(
                 runtime,
-                OciImageRef::parse("alpine:3.19").unwrap(),
+                OciImageRef::parse("docker.io/library/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef").unwrap(),
                 ContainerLimits::default(),
             )
             .await

--- a/crates/forge-session/src/sandbox/level2.rs
+++ b/crates/forge-session/src/sandbox/level2.rs
@@ -516,7 +516,14 @@ mod tests {
     }
 
     fn alpine() -> ImageRef {
-        ImageRef::parse("alpine:3.19").unwrap()
+        // F-643: tag-only references are rejected at parse time for
+        // non-allowlisted sources. Tests use a syntactically valid digest
+        // — these tests don't actually contact a registry, so the digest
+        // contents are irrelevant; only the supply-chain shape matters.
+        ImageRef::parse(
+            "docker.io/library/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap()
     }
 
     #[tokio::test]
@@ -536,7 +543,10 @@ mod tests {
         // image is local before create), create (so the cgroup leaf
         // is shaped before exec), start (so exec has a running ns).
         assert_eq!(mock.calls(), vec!["pull", "create", "start"]);
-        assert_eq!(session.image().to_image_string(), "alpine:3.19");
+        assert_eq!(
+            session.image().to_image_string(),
+            "docker.io/library/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
         assert_eq!(session.handle().id, "mock-container");
     }
 

--- a/docs/architecture/isolation-model.md
+++ b/docs/architecture/isolation-model.md
@@ -92,18 +92,27 @@ The rejection path returns `OciError::UntrustedTagOnlyRef` so callers — includ
 
 #### Gate 2 — Signature verification before pull
 
-[`PodmanRuntime::pull`](../../crates/forge-oci/src/podman.rs) invokes a [`SignatureVerifier`](../../crates/forge-oci/src/signature.rs) on the digest-pinned reference *before* `podman pull` runs. The default production verifier is [`CosignVerifier`], which shells to `cosign verify` in keyless mode against the configured Fulcio root + Rekor transparency log. Operators pin trusted signer identities through the standard cosign environment (`COSIGN_CERTIFICATE_IDENTITY`, `COSIGN_CERTIFICATE_OIDC_ISSUER`).
+[`PodmanRuntime::pull`](../../crates/forge-oci/src/podman.rs) invokes a [`SignatureVerifier`](../../crates/forge-oci/src/signature.rs) on the digest-pinned reference *before* `podman pull` runs. `PodmanRuntime::new()` defaults to [`CosignVerifier`] in `SignaturePolicy::Permissive` — operators get identity-pinned verification by default once they configure the daemon environment, and never silently get zero verification. Production deployments call `with_verifier` to switch to `SignaturePolicy::Strict`.
+
+[`CosignVerifier`] shells to `cosign verify` in keyless mode against the configured Fulcio root + Rekor transparency log AND pins the trusted signer identity. Cosign by itself accepts *any* Fulcio-issued certificate, so the verifier reads two env vars at verify time and forwards them as cosign flags:
+
+| Env var | Forwarded to cosign as |
+|---|---|
+| `COSIGN_CERTIFICATE_IDENTITY` | `--certificate-identity=<value>` |
+| `COSIGN_CERTIFICATE_OIDC_ISSUER` | `--certificate-oidc-issuer=<value>` |
+
+The env-var convention is a Forge bridge — cosign itself only reads the equivalent CLI flags. The names match cosign's CLI flag names so operators have one mental model. Forge supports literal-string match only; operators who need regex pinning can wire a custom `SignatureVerifier` impl.
 
 A failed verification surfaces as `OciError::SignatureVerificationFailed` and aborts the pull — `podman` is never invoked.
 
-The `SignaturePolicy` enum governs how a missing verifier is handled:
+The `SignaturePolicy` enum governs how an unavailable verifier is handled. "Unavailable" includes both the cosign binary missing from `PATH` AND the identity env vars being unset (because either case means cosign cannot enforce identity pinning):
 
-| Policy | Missing verifier | Signature mismatch |
+| Policy | Verifier unavailable | Signature mismatch |
 |---|---|---|
 | `Strict` | hard-fail | hard-fail |
 | `Permissive` (default) | logged warning, pull proceeds | hard-fail |
 
-Permissive is the default so existing dev environments without `cosign` continue to function. Production wiring opts into `Strict` explicitly. **The permissive escape hatch only relaxes the "verifier installed" check** — a real signature mismatch always blocks the pull regardless of policy.
+Permissive is the default so existing dev environments without `cosign` (or without a chosen signer identity) continue to function. Production wiring opts into `Strict` explicitly, after the daemon environment is wired with both identity env vars. **The permissive escape hatch only relaxes the "verifier operational" check** — a real signature mismatch always blocks the pull regardless of policy.
 
 #### Why both gates
 

--- a/docs/architecture/isolation-model.md
+++ b/docs/architecture/isolation-model.md
@@ -70,6 +70,56 @@ Whitelist scope is **session only** — never persisted across sessions. At sess
 
 Forge ships an OCI manager using `oci-spec-rs` and shelling to `podman` or `docker`. v1 requires the user to have podman or docker installed; bundling a runtime is deferred. Dashboard onboarding detects missing runtimes and surfaces install instructions. Images pulled on first use, layers cached.
 
+### 6.8 Supply-chain model (F-643)
+
+Level 2 executes user code inside images pulled from external registries. Treating those images as trusted on the basis of a tag is unsafe: tags are mutable, and an attacker who gains push access (or a registry compromise / MITM on the pull) can replace the bytes that get pulled and run inside the sandbox.
+
+Two independent gates close that gap. Both must succeed before `podman pull` writes anything to the local store.
+
+#### Gate 1 — Digest pinning at parse time
+
+[`forge_oci::ImageRef::parse`](../../crates/forge-oci/src/lib.rs) accepts three reference shapes:
+
+| Shape | Status |
+|---|---|
+| `[registry/]name@sha256:<hex>` | Always accepted. |
+| `[registry/]name:tag@sha256:<hex>` | Accepted; the digest is what runs. The tag is informational. |
+| `[registry/]name:tag` (no digest) | **Rejected** unless the canonical `[registry]/[namespace]/<name>` matches an entry in `TAG_ONLY_ALLOWLIST`. |
+
+The allowlist is a small first-party-only set (today: `oci.io/forge/`) and exists so the Forge tool images can roll tags during early Phase 3 without forcing every dev sandbox to know the latest digest. **Production deployments should still pin even allowlisted images by digest.**
+
+The rejection path returns `OciError::UntrustedTagOnlyRef` so callers — including `Level2Session::create` and any future config loader — fail loudly rather than silently pulling a mutable reference. Canonicalization (resolving an implicit `docker.io` registry and the `library/` namespace) happens before the allowlist check, so `alpine` cannot bypass it by dropping segments the allowlist would otherwise see.
+
+#### Gate 2 — Signature verification before pull
+
+[`PodmanRuntime::pull`](../../crates/forge-oci/src/podman.rs) invokes a [`SignatureVerifier`](../../crates/forge-oci/src/signature.rs) on the digest-pinned reference *before* `podman pull` runs. The default production verifier is [`CosignVerifier`], which shells to `cosign verify` in keyless mode against the configured Fulcio root + Rekor transparency log. Operators pin trusted signer identities through the standard cosign environment (`COSIGN_CERTIFICATE_IDENTITY`, `COSIGN_CERTIFICATE_OIDC_ISSUER`).
+
+A failed verification surfaces as `OciError::SignatureVerificationFailed` and aborts the pull — `podman` is never invoked.
+
+The `SignaturePolicy` enum governs how a missing verifier is handled:
+
+| Policy | Missing verifier | Signature mismatch |
+|---|---|---|
+| `Strict` | hard-fail | hard-fail |
+| `Permissive` (default) | logged warning, pull proceeds | hard-fail |
+
+Permissive is the default so existing dev environments without `cosign` continue to function. Production wiring opts into `Strict` explicitly. **The permissive escape hatch only relaxes the "verifier installed" check** — a real signature mismatch always blocks the pull regardless of policy.
+
+#### Why both gates
+
+A digest alone proves identity (the bytes Forge pulls are the bytes the digest names) but not provenance (those bytes were produced by a trusted signer). A signature alone proves provenance but not identity at the call site (a compromised CI could sign a malicious image at a tag the user knows). Together they close the loop: the user types a digest, signed by a trusted identity, and only then does `podman` see a byte.
+
+#### Tested invariants
+
+The supply-chain story has both unit and integration coverage that runs on every `cargo test -p forge-oci`:
+
+- `image_ref_rejects_tag_only_when_not_allowlisted` — non-allowlisted tag-only refs fail at parse time.
+- `image_ref_accepts_tag_only_for_allowlisted_first_party_source` — first-party allowlist works as documented.
+- `image_ref_parses_digest_pinned_form` — digest-pinned refs round-trip through parse + render with the tag dropped on the wire.
+- `pull_runs_verifier_before_invoking_podman` — verifier is consulted before the runner; a rejection short-circuits the pull.
+- `pull_strict_policy_blocks_on_missing_verifier` / `pull_permissive_policy_proceeds_when_verifier_unavailable` / `pull_permissive_policy_still_blocks_on_signature_mismatch` — the policy matrix.
+- `mismatched_signature_is_rejected` (integration) — end-to-end DoD coverage.
+
 ---
 
 ## 8. Sandboxing implementation


### PR DESCRIPTION
Closes forge-ide/forge#679

## Summary

Phase 3 supply-chain hardening for the Level 2 OCI image pull path.

- `ImageRef` carries a `digest: Option<Digest>` field; `parse` rejects untagged or tag-only references for non-allowlisted sources (`OciError::UntrustedTagOnlyRef`). The first-party allowlist is `oci.io/forge/`. Canonical-path resolution (implicit `docker.io` + `library/` namespace) closes the bypass where dropping segments would let an attacker satisfy the allowlist.
- `Digest` is a sha256-only newtype; `parse` rejects bad algorithms, wrong hex length, uppercase hex, and missing prefixes.
- `SignatureVerifier` trait + `CosignVerifier` (keyless cosign) + `NoopVerifier`. `SignaturePolicy::Strict` hard-fails any verification error; `Permissive` (default) degrades missing-verifier to a logged warning but still hard-fails on signature mismatch.
- `PodmanRuntime::pull` invokes the verifier before `podman pull` runs. Failure surfaces as `OciError::SignatureVerificationFailed` and the runner is never invoked.
- `docs/architecture/isolation-model.md` §6.8 documents the supply-chain model end-to-end.

## Test plan

- `cargo test -p forge-oci` (55 unit tests + 3 new F-643 integration tests in `tests/podman_integration.rs`):
  - `pinned_digest_reference_is_accepted`
  - `tag_only_reference_is_rejected`
  - `mismatched_signature_is_rejected`
- `cargo test --workspace` passes (no regressions; existing forge-session sandbox fixtures updated to digest-pinned form)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `RUSTDOCFLAGS=-D warnings cargo doc` all clean
- `just check-rust` exits 0

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)