### PR TITLE
[F-645] MCP HTTP transport follows redirects without SSRF re-validation

### DIFF
--- a/crates/forge-mcp/src/transport/http.rs
+++ b/crates/forge-mcp/src/transport/http.rs
@@ -68,11 +68,22 @@ const EVENT_CHANNEL_CAPACITY: usize = 128;
 /// timeouts on the [`reqwest::RequestBuilder`] continue to work because
 /// they override the client default. `connect_timeout` is identical
 /// across all MCP servers so the shared default is correct.
+///
+/// F-645: built on top of `forge_core::http::secure_client_builder()` so
+/// every connect runs through the DNS-rebinding-safe resolver from F-644
+/// (resolved IPs are filtered against the `url_safety` policy before
+/// reqwest opens a socket). We also pin `Policy::none()` for redirects:
+/// MCP JSON-RPC has no legitimate use for 3xx hops, and following them
+/// would let a hostile endpoint pivot the request to an internal target
+/// (e.g. IMDS at 169.254.169.254) without re-running `ssrf::check_url`
+/// against the redirect target. With redirects disabled the 302 surfaces
+/// as a non-2xx response in [`Http::send`] and the request fails closed.
 fn shared_client() -> &'static reqwest::Client {
     static SHARED: OnceLock<reqwest::Client> = OnceLock::new();
     SHARED.get_or_init(|| {
-        reqwest::Client::builder()
+        forge_core::http::secure_client_builder()
             .connect_timeout(CONNECT_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             // The only documented failure path is "no TLS backend compiled
             // in" — we always link rustls (see Cargo.toml). Falling back to

--- a/crates/forge-mcp/tests/http_roundtrip.rs
+++ b/crates/forge-mcp/tests/http_roundtrip.rs
@@ -614,3 +614,67 @@ async fn sse_sixteen_mib_no_boundary_surfaces_malformed() {
         }
     }
 }
+
+/// F-645: SSRF redirect-pivot regression. A hostile MCP endpoint that
+/// answers a JSON-RPC POST with `302 Location: http://169.254.169.254/...`
+/// must NOT be followed by the shared client. With redirects enabled,
+/// reqwest would re-issue the POST against IMDS without re-running
+/// `url_safety::check_url`. The transport's redirect policy must treat the
+/// 302 as the final response so the request fails and IMDS is never hit.
+///
+/// We assert two things:
+/// 1. `send()` returns `Err` (the 302 surfaces as a non-2xx HTTP status,
+///    same as any other unexpected response).
+/// 2. The redirect target server records zero hits — proving the redirect
+///    was never followed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn post_does_not_follow_redirect_to_internal_target() {
+    // The "internal target" — stands in for IMDS. If the redirect is ever
+    // followed, this server records a hit and we fail the test.
+    let internal = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/latest/meta-data"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("SECRET"))
+        .expect(0) // must never be hit
+        .mount(&internal)
+        .await;
+
+    // The "attacker" MCP endpoint — answers POSTs with a 302 redirect to
+    // the internal target. GET (for SSE) returns an empty event stream so
+    // the reader task settles cleanly.
+    let attacker = MockServer::start().await;
+    let redirect_to = format!("{}/latest/meta-data", internal.uri());
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(302).insert_header("Location", redirect_to.as_str()))
+        .mount(&attacker)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(""),
+        )
+        .mount(&attacker)
+        .await;
+
+    let t = Http::connect(&http_spec(&attacker.uri(), "Bearer token"))
+        .await
+        .expect("connect");
+
+    let err = t
+        .send(serde_json::json!({"jsonrpc":"2.0","id":1}))
+        .await
+        .expect_err("302 redirect must not be followed and must surface as an error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("302"),
+        "error should mention the 302 status: {msg}",
+    );
+
+    // Belt-and-braces: explicitly assert the internal target saw no
+    // request. wiremock's `expect(0)` is verified on drop.
+    drop(internal);
+    drop(attacker);
+}


### PR DESCRIPTION
Closes forge-ide/forge#681

## Summary
- `forge-mcp`'s shared `reqwest::Client` inherited reqwest's default redirect policy (`limited(10)`), so a hostile MCP endpoint could pivot a JSON-RPC POST to IMDS via `302 Location: http://169.254.169.254/...` without re-running the SSRF guard.
- Build the shared client on `forge_core::http::secure_client_builder()` (F-644) for the DNS-rebinding-safe resolver, and pin `reqwest::redirect::Policy::none()` so 3xx surfaces as a non-2xx error in `Http::send` instead of being followed.
- Adds a regression test that drives a POST against a wiremock attacker returning 302 to a second mock standing in for IMDS, and asserts the internal target sees zero hits.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` passes
- New test `post_does_not_follow_redirect_to_internal_target` fails on `main` (RED) and passes after the fix (GREEN)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)