### PR TITLE
[F-646] CustomOpenAI redirect policy + secure DNS resolver

### DIFF
--- a/crates/forge-providers/src/openai/custom.rs
+++ b/crates/forge-providers/src/openai/custom.rs
@@ -40,10 +40,19 @@ use forge_core::Result;
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 
+use crate::http_util::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_TCP_KEEPALIVE};
 use crate::sse;
 use crate::{ChatChunk, ChatRequest, Provider};
 
-use super::{build_stream_client_default, chat_request, translate};
+use super::{chat_request, translate};
+
+/// Cap on redirect hops the streaming client will follow. The redirect
+/// policy *also* re-validates each hop's URL via
+/// [`forge_core::url_safety::check_url`] (rejecting non-http(s) schemes and
+/// private/link-local/IMDS IP literals), so the cap is strictly a
+/// belt-and-suspenders bound on chain length — the per-hop check is the
+/// primary SSRF guard.
+const MAX_REDIRECT_HOPS: usize = 5;
 
 /// How the API key is presented on outbound requests.
 ///
@@ -158,7 +167,7 @@ impl CustomOpenAiProvider {
             model,
             model_list,
             max_tokens: None,
-            stream_client: build_stream_client_default(),
+            stream_client: build_secure_custom_client(),
             stream_cfg: sse::StreamConfig::DEFAULT,
         })
     }
@@ -262,6 +271,56 @@ impl std::fmt::Debug for CustomOpenAiProvider {
             .field("max_tokens", &self.max_tokens)
             .finish()
     }
+}
+
+/// Build the `reqwest::Client` used by `CustomOpenAiProvider` for outbound
+/// chat completions. Layered defenses against SSRF on a user-supplied
+/// `base_url`:
+///
+/// 1. **Policy-enforcing DNS resolver**
+///    ([`forge_core::http::secure_client_builder`]): every resolved
+///    `SocketAddr` is filtered through the `url_safety` IPv4/IPv6 range
+///    policy. A short-TTL DNS rebind that answers safely on
+///    [`crate::openai::custom::CustomOpenAiProvider::new`]'s `check_url`
+///    pass and hostilely on the connect that follows is refused at the
+///    DNS layer — reqwest never opens the socket.
+///
+/// 2. **Custom redirect policy**: 3xx responses do not auto-follow blindly.
+///    Each hop's URL is re-validated through
+///    [`forge_core::url_safety::check_url`] before reqwest dispatches the
+///    follow-up request, so a malicious vendor that responds with
+///    `302 Location: http://169.254.169.254/...` cannot smuggle a private
+///    IP target into the chain. The hop count is capped at
+///    [`MAX_REDIRECT_HOPS`] regardless.
+///
+/// The streaming-HTTP timeouts (connect, read, TCP keepalive) match the
+/// shared [`crate::http_util::HttpClientConfig::DEFAULT`] posture used by
+/// [`super::OpenAiProvider`]; they are inlined here because
+/// [`forge_core::http::secure_client_builder`] returns a fresh
+/// `reqwest::ClientBuilder` we must populate ourselves.
+fn build_secure_custom_client() -> reqwest::Client {
+    let redirect_policy = reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= MAX_REDIRECT_HOPS {
+            return attempt.error(format!(
+                "custom_openai redirect chain exceeded {MAX_REDIRECT_HOPS} hops"
+            ));
+        }
+        let url = attempt.url().to_string();
+        match forge_core::url_safety::check_url(&url) {
+            Ok(()) => attempt.follow(),
+            Err(e) => attempt.error(format!(
+                "custom_openai redirect to {url} refused by SSRF guard: {e}"
+            )),
+        }
+    });
+
+    forge_core::http::secure_client_builder()
+        .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+        .read_timeout(DEFAULT_READ_TIMEOUT)
+        .tcp_keepalive(Some(DEFAULT_TCP_KEEPALIVE))
+        .redirect(redirect_policy)
+        .build()
+        .expect("reqwest custom-openai client builder — only fails if no TLS backend is available")
 }
 
 impl Provider for CustomOpenAiProvider {

--- a/crates/forge-providers/src/openai/mod.rs
+++ b/crates/forge-providers/src/openai/mod.rs
@@ -116,11 +116,14 @@ pub(crate) fn chat_request(
         for (name, value) in auth_headers {
             builder = builder.header(name, value);
         }
-        let resp = builder
-            .body(body)
-            .send()
-            .await
-            .map_err(|e| anyhow::anyhow!("openai chat request failed: {e}"))?;
+        let resp = builder.body(body).send().await.map_err(|e| {
+            // Preserve the source chain so a redirect-policy refusal
+            // (CustomOpenAI's SSRF guard, F-646) — which reqwest stores
+            // on the error's source — surfaces through anyhow's `{:#}`
+            // walker rather than being collapsed to the opaque
+            // top-level "error following redirect" message.
+            anyhow::Error::new(e).context("openai chat request failed")
+        })?;
 
         let status = resp.status();
         if !status.is_success() {
@@ -134,13 +137,6 @@ pub(crate) fn chat_request(
 
         Ok(decode_openai_stream(resp.bytes_stream(), cfg))
     }
-}
-
-/// Construct a stream HTTP client with the same hardening posture as
-/// [`OpenAiProvider`]. Re-exported so [`CustomOpenAiProvider`] can build its
-/// own client with identical timeouts.
-pub(crate) fn build_stream_client_default() -> reqwest::Client {
-    http_util::build_stream_client(&HttpClientConfig::DEFAULT)
 }
 
 /// Decode the raw `bytes` stream into a `ChatChunk` stream by piping through

--- a/crates/forge-providers/tests/openai_custom.rs
+++ b/crates/forge-providers/tests/openai_custom.rs
@@ -167,6 +167,83 @@ async fn none_auth_sends_no_auth_header_and_decodes_stream() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn redirect_to_private_range_ip_is_refused() {
+    // F-646 regression: a malicious vendor pointing CustomOpenAI at their
+    // own loopback-bound endpoint that 302s to a private-range IP must not
+    // be followed — the provider's reqwest client installs a redirect
+    // policy that re-runs `url_safety::check_url` on each hop and refuses
+    // any private/link-local/IMDS target.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(302)
+                .insert_header("location", "http://169.254.169.254/latest/meta-data"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = CustomOpenAiProvider::new(
+        "evil",
+        server.uri(),
+        "gpt-4o",
+        vec!["gpt-4o".into()],
+        AuthShape::Bearer,
+        Some("sk-test".into()),
+    )
+    .expect("provider construction (loopback base_url is allowed in debug builds)");
+
+    let err = provider
+        .chat(req())
+        .await
+        .err()
+        .expect("redirect to IMDS must be refused by the redirect policy");
+    // anyhow's `{:#}` Display walks the source chain, so the SSRF-guard
+    // diagnostic from the redirect policy (which lives on reqwest's error
+    // source) surfaces in the formatted message.
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("169.254.169.254") || msg.contains("link-local") || msg.contains("SSRF"),
+        "error should mention the blocked redirect target: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn redirect_to_rfc1918_ip_is_refused() {
+    // Same posture as the IMDS regression, but for an RFC-1918 target —
+    // covers the broader private-range vector.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(302).insert_header("location", "http://10.0.0.1/v1/secrets"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = CustomOpenAiProvider::new(
+        "evil",
+        server.uri(),
+        "gpt-4o",
+        vec!["gpt-4o".into()],
+        AuthShape::Bearer,
+        Some("sk-test".into()),
+    )
+    .expect("provider construction");
+
+    let err = provider
+        .chat(req())
+        .await
+        .err()
+        .expect("redirect to RFC-1918 must be refused");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("10.0.0.1") || msg.contains("10.0.0.0/8") || msg.contains("SSRF"),
+        "error should mention the blocked redirect target: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn http_error_propagates_with_status_and_body() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))


### PR DESCRIPTION
Closes forge-ide/forge#682

## Summary

- Adopts `forge_core::http::secure_client_builder()` (F-644) on the CustomOpenAI streaming `reqwest::Client` so DNS answers are filtered through the `url_safety` IPv4/IPv6 range policy — closes the DNS-rebinding gap on user-supplied `base_url`.
- Installs a `reqwest::redirect::Policy::custom` that re-runs `forge_core::url_safety::check_url` on every hop. A malicious vendor that responds with `302 Location: http://169.254.169.254/...` (or any RFC-1918 / link-local target) is refused at the redirect-policy layer before reqwest follows the hop. Hop count capped at 5.
- Preserves the reqwest error source chain through `chat_request`'s anyhow wrap so the SSRF-guard diagnostic surfaces via `{:#}` Display instead of being collapsed to the opaque `error following redirect` message.

## Test plan

- New integration tests `redirect_to_private_range_ip_is_refused` and `redirect_to_rfc1918_ip_is_refused` in `tests/openai_custom.rs` use wiremock to issue `302` to `169.254.169.254` / `10.0.0.1` and assert the chat call fails with the SSRF guard diagnostic in the error chain.
- `cargo fmt --check`, `cargo check --workspace`, `cargo test --workspace`, `cargo clippy --all-targets -- -D warnings`, and `RUSTDOCFLAGS=-D warnings cargo doc -p forge-providers --no-deps` all pass locally.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)