### PR TITLE
[F-647] Anthropic + OpenAI redirect policy

### DIFF
--- a/crates/forge-providers/src/http_util.rs
+++ b/crates/forge-providers/src/http_util.rs
@@ -10,6 +10,23 @@
 //! public-API surface (used by integration tests) and second `request_client`
 //! both diverge from the SSE-streaming providers and were intentionally left
 //! untouched by the F-679 refactor.
+//!
+//! ## SSRF posture (F-647)
+//!
+//! [`build_stream_client`] is the single construction site for the
+//! `reqwest::Client` used by `AnthropicProvider`, `OpenAiProvider`, and
+//! `CustomOpenAiProvider`. It wires in two SSRF defences:
+//!
+//! - **DNS policy resolver** ([`forge_core::http::secure_client_builder`])
+//!   — every resolved `SocketAddr` is re-validated against `url_safety`,
+//!   so a TTL=0 DNS rebinding answer of `169.254.169.254` cannot reach the
+//!   socket layer even if `check_url` originally accepted the hostname.
+//! - **No-redirect policy** (`reqwest::redirect::Policy::none`) — a
+//!   misconfigured proxy or BGP-hijack injecting `302 Location: <internal>`
+//!   surfaces to the caller as an HTTP error rather than being silently
+//!   followed. The official-vendor APIs (Anthropic, OpenAI) do not redirect
+//!   on `/v1/messages` or `/v1/chat/completions`, so disabling redirects
+//!   has no behavioural cost.
 
 use std::time::Duration;
 
@@ -44,12 +61,17 @@ impl Default for HttpClientConfig {
 }
 
 /// Build a streaming `reqwest::Client` with the SSE provider hardening
-/// posture (per-connect / per-read / TCP keepalive timeouts).
+/// posture: per-connect / per-read / TCP keepalive timeouts, the F-644
+/// SSRF-safe DNS resolver, and a no-redirect policy (F-647). The official
+/// Anthropic and OpenAI endpoints do not return 3xx on the streaming
+/// chat paths, so refusing to follow redirects costs nothing in normal
+/// operation while closing the redirect-to-internal-IP smuggling vector.
 pub(crate) fn build_stream_client(cfg: &HttpClientConfig) -> reqwest::Client {
-    reqwest::Client::builder()
+    forge_core::http::secure_client_builder()
         .connect_timeout(cfg.connect_timeout)
         .read_timeout(cfg.read_timeout)
         .tcp_keepalive(Some(cfg.tcp_keepalive))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .expect("reqwest stream client builder — only fails if no TLS backend is available")
 }

--- a/crates/forge-providers/tests/anthropic.rs
+++ b/crates/forge-providers/tests/anthropic.rs
@@ -284,3 +284,37 @@ async fn chat_line_too_long_yields_typed_error_and_terminates() {
         "stream must terminate after a fatal error"
     );
 }
+
+// F-647: Anthropic provider must not follow HTTP redirects. A misconfigured
+// proxy or network-layer attacker can inject `302 Location: 169.254.169.254`
+// and the default reqwest client would follow blindly to IMDS or another
+// internal target. With the SSRF-safe redirect policy in place, the 302
+// surfaces to the caller as an error rather than being silently followed.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_does_not_follow_redirects() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(302).insert_header("location", "https://example.com/elsewhere"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(server.uri(), "sk-test", "claude-3-5-sonnet", 4096);
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+    let err = match provider.chat(req).await {
+        Ok(_) => panic!("redirect must surface as an error, not be followed"),
+        Err(e) => e,
+    };
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("302"),
+        "error must reflect the upstream 302 status: {msg}"
+    );
+}

--- a/crates/forge-providers/tests/openai.rs
+++ b/crates/forge-providers/tests/openai.rs
@@ -278,3 +278,37 @@ async fn chat_line_too_long_yields_typed_error_and_terminates() {
         "stream must terminate after a fatal error"
     );
 }
+
+// F-647: OpenAI provider must not follow HTTP redirects. A misconfigured
+// proxy or network-layer attacker can inject `302 Location: 169.254.169.254`
+// and the default reqwest client would follow blindly to IMDS or another
+// internal target. With the SSRF-safe redirect policy in place, the 302
+// surfaces to the caller as an error rather than being silently followed.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_does_not_follow_redirects() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(302).insert_header("location", "https://example.com/elsewhere"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = OpenAiProvider::new(server.uri(), "sk-test", "gpt-4o");
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+    let err = match provider.chat(req).await {
+        Ok(_) => panic!("redirect must surface as an error, not be followed"),
+        Err(e) => e,
+    };
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("302"),
+        "error must reflect the upstream 302 status: {msg}"
+    );
+}


### PR DESCRIPTION
Closes forge-ide/forge#683

## Summary
- Wire `forge_core::http::secure_client_builder()` (F-644) into the shared `forge-providers::http_util::build_stream_client` so every resolved `SocketAddr` is re-validated against `url_safety` — a TTL=0 DNS rebinding answer cannot reach the socket layer.
- Set `reqwest::redirect::Policy::none()` on the same builder so `302 Location: 169.254.169.254` (or any other 3xx) surfaces to the caller as an HTTP error rather than being silently followed to an internal target.
- Both `AnthropicProvider` and `OpenAiProvider` (and `CustomOpenAiProvider`, which already routes through `build_stream_client_default`) inherit the fix from the one shared construction site.
- Regression coverage: `chat_does_not_follow_redirects` in `tests/anthropic.rs` and `tests/openai.rs` mounts a wiremock that returns `302` and asserts `chat()` errors carry the `302` status — pre-fix the tests fail because reqwest follows to a different host and surfaces `404`.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` clean
- `cargo doc -p forge-providers -p forge-core` clean (`forge-term` rustdoc errors are pre-existing on main, unrelated)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)