### PR TITLE
[F-654] Container resource limits captured but never applied to podman create

### DIFF
--- a/crates/forge-oci/src/lib.rs
+++ b/crates/forge-oci/src/lib.rs
@@ -290,6 +290,116 @@ pub enum UserNsPolicy {
     Default,
 }
 
+/// Per-container cgroup-v2 caps applied at create time.
+///
+/// Every field maps to a `podman create` flag; the units mirror what
+/// podman accepts:
+///
+/// | Field | Flag | Unit |
+/// |---|---|---|
+/// | `cpus` | `--cpus` | float CPU shares (e.g. `1.5` = 1.5 cores) |
+/// | `memory_bytes` | `--memory` | bytes |
+/// | `memory_swap_bytes` | `--memory-swap` | bytes; equal to `memory_bytes` disables swap |
+/// | `pids_max` | `--pids-limit` | process count |
+///
+/// `None` on a field means "leave the cap unset" — the container
+/// inherits whatever the parent cgroup slice applies. Production
+/// callers should reach for [`ContainerLimits::conservative_default`]
+/// (the F-654 strict preset: 4 GiB / 2 cpus / 1024 pids, no swap) so
+/// a fork-bomb or memory-exhaust workload inside a Level 2 sandbox
+/// cannot starve the host.
+///
+/// Field ordering in [`ContainerLimits::to_create_flags`] is
+/// deterministic so argv assertions can pin the rendering:
+/// `--cpus` → `--memory` → `--memory-swap` → `--pids-limit`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct ContainerLimits {
+    /// `--cpus N.NN`. Float CPU shares; `1.5` = 1.5 cores. `None`
+    /// inherits the slice cap.
+    pub cpus: Option<f32>,
+    /// `--memory <bytes>`. `None` inherits the slice cap.
+    pub memory_bytes: Option<u64>,
+    /// `--memory-swap <bytes>`. Setting this equal to `memory_bytes`
+    /// disables swap entirely (the conservative default); leaving it
+    /// `None` lets podman apply its own default, which is `2 *
+    /// memory_bytes`.
+    pub memory_swap_bytes: Option<u64>,
+    /// `--pids-limit <N>`. Process count cap. `None` inherits.
+    pub pids_max: Option<u64>,
+}
+
+impl ContainerLimits {
+    /// F-654 strict preset: 2 cpus, 4 GiB memory with swap disabled,
+    /// 1024 pids. Production callers should pass this to every Level
+    /// 2 container so an unbounded workload inside the sandbox cannot
+    /// take down the host.
+    ///
+    /// Tunables live on the [`ContainerLimits`] struct itself —
+    /// callers that need more (or less) headroom override the
+    /// specific field rather than reaching for an "unlimited" preset.
+    pub const fn conservative_default() -> Self {
+        const FOUR_GIB: u64 = 4 * 1024 * 1024 * 1024;
+        Self {
+            cpus: Some(2.0),
+            memory_bytes: Some(FOUR_GIB),
+            memory_swap_bytes: Some(FOUR_GIB),
+            pids_max: Some(1024),
+        }
+    }
+
+    /// Render into the canonical podman create flag list. Order is
+    /// fixed: `--cpus`, `--memory`, `--memory-swap`, `--pids-limit`.
+    /// Fields set to `None` emit nothing.
+    pub fn to_create_flags(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if let Some(cpus) = self.cpus {
+            out.push("--cpus".to_string());
+            out.push(format_cpus(cpus));
+        }
+        if let Some(bytes) = self.memory_bytes {
+            out.push("--memory".to_string());
+            out.push(bytes.to_string());
+        }
+        if let Some(bytes) = self.memory_swap_bytes {
+            out.push("--memory-swap".to_string());
+            out.push(bytes.to_string());
+        }
+        if let Some(pids) = self.pids_max {
+            out.push("--pids-limit".to_string());
+            out.push(pids.to_string());
+        }
+        out
+    }
+}
+
+impl Eq for ContainerLimits {}
+
+impl std::hash::Hash for ContainerLimits {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // f32 has no `Hash`; round-trip via bits so callers that put
+        // `SecurityOpts` in a set still work. Two limits compare equal
+        // (PartialEq) iff their cpu shares are bit-identical, so this
+        // hash is consistent with eq for all values that survive the
+        // PartialEq check (NaN doesn't, but it's nonsensical to put a
+        // NaN cpu share in here).
+        self.cpus.map(f32::to_bits).hash(state);
+        self.memory_bytes.hash(state);
+        self.memory_swap_bytes.hash(state);
+        self.pids_max.hash(state);
+    }
+}
+
+/// Format CPU shares without a trailing `.0` for integer values
+/// (`1.0` → `"1"`) so the resulting podman command line matches the
+/// convention `podman` itself emits in `inspect`.
+fn format_cpus(cpus: f32) -> String {
+    if cpus.fract() == 0.0 {
+        format!("{}", cpus.trunc() as i64)
+    } else {
+        format!("{cpus}")
+    }
+}
+
 /// Security hardening options applied at container create time.
 ///
 /// Every field maps to a concrete `podman create` flag; the defaults are
@@ -302,7 +412,9 @@ pub enum UserNsPolicy {
 /// rootless capability set, an open network namespace, and a writable
 /// rootfs — every escape-class CVE in the kernel, podman, or runc that
 /// these flags would otherwise defeat is exploitable from inside the
-/// container.
+/// container. F-654 also bounds resource usage via [`Self::limits`] so a
+/// fork-bomb or memory-exhaust workload inside the sandbox cannot starve
+/// the host.
 ///
 /// Field ordering in [`SecurityOpts::to_create_flags`] is deterministic so
 /// argv assertions can pin the rendering.
@@ -335,6 +447,15 @@ pub struct SecurityOpts {
 
     /// User-namespace policy. Default [`UserNsPolicy::KeepId`].
     pub userns: UserNsPolicy,
+
+    /// Per-container cgroup caps. Default
+    /// [`ContainerLimits::conservative_default`] — F-654's strict
+    /// preset (2 cpus, 4 GiB memory with no swap, 1024 pids). Callers
+    /// that need different headroom should override the specific
+    /// field; reaching for [`ContainerLimits::default`] (every field
+    /// `None`) silently disables resource enforcement and is what the
+    /// permissive preset uses for tests.
+    pub limits: ContainerLimits,
 }
 
 impl SecurityOpts {
@@ -352,6 +473,7 @@ impl SecurityOpts {
             read_only_rootfs: true,
             network: NetworkPolicy::None,
             userns: UserNsPolicy::KeepId,
+            limits: ContainerLimits::conservative_default(),
         }
     }
 
@@ -366,6 +488,7 @@ impl SecurityOpts {
             read_only_rootfs: false,
             network: NetworkPolicy::Named("default".to_string()), // inherit runtime default
             userns: UserNsPolicy::Default,
+            limits: ContainerLimits::default(),
         }
     }
 
@@ -379,6 +502,10 @@ impl SecurityOpts {
     /// 5. `--network <value>` (always emitted unless the variant maps to
     ///    `None`, which currently never happens)
     /// 6. `--userns keep-id` (if `KeepId`)
+    /// 7. resource limit flags from
+    ///    [`ContainerLimits::to_create_flags`] — `--cpus`, `--memory`,
+    ///    `--memory-swap`, `--pids-limit`, in that order, each emitted
+    ///    only when its field is `Some`.
     ///
     /// The flags are inserted between `podman create` and the IMAGE
     /// positional so podman parses them as runtime options. See
@@ -413,6 +540,7 @@ impl SecurityOpts {
             out.push("--userns".to_string());
             out.push("keep-id".to_string());
         }
+        out.extend(self.limits.to_create_flags());
         out
     }
 }
@@ -757,7 +885,14 @@ mod tests {
         // The order is pinned because the integration test asserts the
         // exact rendered argv. Any reorder is a breaking change to
         // operators reading the audit trail.
+        //
+        // F-654: the hardened default also bounds resource use via
+        // `ContainerLimits::conservative_default` — 2 cpus, 4 GiB
+        // memory with swap disabled, 1024 pids. The limit flags
+        // render after the security flags, in the order
+        // `--cpus`, `--memory`, `--memory-swap`, `--pids-limit`.
         let flags = SecurityOpts::hardened_default().to_create_flags();
+        const FOUR_GIB_STR: &str = "4294967296";
         assert_eq!(
             flags,
             vec![
@@ -770,6 +905,14 @@ mod tests {
                 "none".to_string(),
                 "--userns".to_string(),
                 "keep-id".to_string(),
+                "--cpus".to_string(),
+                "2".to_string(),
+                "--memory".to_string(),
+                FOUR_GIB_STR.to_string(),
+                "--memory-swap".to_string(),
+                FOUR_GIB_STR.to_string(),
+                "--pids-limit".to_string(),
+                "1024".to_string(),
             ]
         );
     }
@@ -792,6 +935,139 @@ mod tests {
             flags.is_empty(),
             "permissive preset must render zero flags, got {flags:?}"
         );
+    }
+
+    // ── F-654: ContainerLimits plumbed through SecurityOpts ──────────
+
+    #[test]
+    fn container_limits_default_renders_no_flags() {
+        // Default = every field None = container inherits the slice's
+        // limits. No flags emitted; this is what the permissive
+        // preset uses so existing tests aren't perturbed.
+        assert!(ContainerLimits::default().to_create_flags().is_empty());
+    }
+
+    #[test]
+    fn container_limits_renders_in_canonical_order() {
+        // `--cpus`, `--memory`, `--memory-swap`, `--pids-limit`. The
+        // integration test asserts this exact ordering against
+        // `podman inspect`.
+        let limits = ContainerLimits {
+            cpus: Some(1.5),
+            memory_bytes: Some(512 * 1024 * 1024),
+            memory_swap_bytes: Some(512 * 1024 * 1024),
+            pids_max: Some(256),
+        };
+        assert_eq!(
+            limits.to_create_flags(),
+            vec![
+                "--cpus".to_string(),
+                "1.5".to_string(),
+                "--memory".to_string(),
+                (512 * 1024 * 1024u64).to_string(),
+                "--memory-swap".to_string(),
+                (512 * 1024 * 1024u64).to_string(),
+                "--pids-limit".to_string(),
+                "256".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn container_limits_skips_none_fields() {
+        // Sparse limits emit only the flags that have a value — no
+        // default-inserted flags that would trigger a podman warning
+        // on hosts where the controller is missing.
+        let limits = ContainerLimits {
+            cpus: None,
+            memory_bytes: Some(1_000),
+            memory_swap_bytes: None,
+            pids_max: None,
+        };
+        assert_eq!(
+            limits.to_create_flags(),
+            vec!["--memory".to_string(), "1000".to_string()]
+        );
+    }
+
+    #[test]
+    fn container_limits_integer_cpus_have_no_decimal() {
+        // `1.0` renders as `"1"` so the rendered argv matches what
+        // `podman inspect` reports back to operators.
+        let limits = ContainerLimits {
+            cpus: Some(1.0),
+            ..Default::default()
+        };
+        assert_eq!(
+            limits.to_create_flags(),
+            vec!["--cpus".to_string(), "1".to_string()]
+        );
+    }
+
+    #[test]
+    fn conservative_default_caps_match_dod() {
+        // F-654 strict preset is documented as 2 cpus / 4 GiB /
+        // 1024 pids with swap disabled. Pinning the values here
+        // catches accidental relaxation of the DoS-resistance
+        // posture.
+        let limits = ContainerLimits::conservative_default();
+        assert_eq!(limits.cpus, Some(2.0), "default must cap at 2 cpus");
+        assert_eq!(
+            limits.memory_bytes,
+            Some(4 * 1024 * 1024 * 1024),
+            "default must cap memory at 4 GiB"
+        );
+        assert_eq!(
+            limits.memory_swap_bytes, limits.memory_bytes,
+            "default must disable swap by setting memory-swap == memory"
+        );
+        assert_eq!(limits.pids_max, Some(1024), "default must cap pids at 1024");
+    }
+
+    #[test]
+    fn hardened_default_includes_conservative_limits() {
+        // Production callers reach for SecurityOpts::hardened_default
+        // and must transitively pick up the F-654 caps. If a refactor
+        // ever drops `limits` from the hardened preset, the host is
+        // back on "rootless slice's default limits" and the DoS
+        // surface returns.
+        let opts = SecurityOpts::hardened_default();
+        assert_eq!(
+            opts.limits,
+            ContainerLimits::conservative_default(),
+            "hardened_default must ship the F-654 conservative limits"
+        );
+    }
+
+    #[test]
+    fn permissive_includes_no_limits() {
+        // The permissive preset is for tests that need a clean argv;
+        // it must not interleave limit flags into those assertions.
+        let opts = SecurityOpts::permissive();
+        assert_eq!(opts.limits, ContainerLimits::default());
+        let flags = opts.to_create_flags();
+        assert!(
+            flags.is_empty(),
+            "permissive preset must render zero flags, got {flags:?}"
+        );
+    }
+
+    #[test]
+    fn limits_render_after_security_flags() {
+        // Order is load-bearing for the audit trail: security flags
+        // first, then resource caps. The integration test reads the
+        // argv linearly and the operator-facing tracing log relies on
+        // the same shape.
+        let flags = SecurityOpts::hardened_default().to_create_flags();
+        let userns_idx = flags.iter().position(|s| s == "--userns").unwrap();
+        let cpus_idx = flags.iter().position(|s| s == "--cpus").unwrap();
+        let memory_idx = flags.iter().position(|s| s == "--memory").unwrap();
+        let memory_swap_idx = flags.iter().position(|s| s == "--memory-swap").unwrap();
+        let pids_idx = flags.iter().position(|s| s == "--pids-limit").unwrap();
+        assert!(userns_idx < cpus_idx, "security flags must precede limits");
+        assert!(cpus_idx < memory_idx);
+        assert!(memory_idx < memory_swap_idx);
+        assert!(memory_swap_idx < pids_idx);
     }
 
     #[test]

--- a/crates/forge-oci/src/podman.rs
+++ b/crates/forge-oci/src/podman.rs
@@ -1002,6 +1002,10 @@ mod tests {
 
         let calls = calls.lock().unwrap();
         let argv = &calls[0].1;
+        // F-654: hardened_default carries the conservative cgroup
+        // caps (2 cpus, 4 GiB, 1024 pids, no swap) which render after
+        // the security flags and before the IMAGE positional.
+        const FOUR_GIB_STR: &str = "4294967296";
         assert_eq!(
             argv,
             &vec![
@@ -1015,6 +1019,14 @@ mod tests {
                 "none".to_string(),
                 "--userns".to_string(),
                 "keep-id".to_string(),
+                "--cpus".to_string(),
+                "2".to_string(),
+                "--memory".to_string(),
+                FOUR_GIB_STR.to_string(),
+                "--memory-swap".to_string(),
+                FOUR_GIB_STR.to_string(),
+                "--pids-limit".to_string(),
+                "1024".to_string(),
                 "alpine:3.19".to_string(),
                 "sleep".to_string(),
                 "infinity".to_string(),

--- a/crates/forge-oci/tests/podman_integration.rs
+++ b/crates/forge-oci/tests/podman_integration.rs
@@ -15,7 +15,7 @@
 
 #![cfg(target_os = "linux")]
 
-use forge_oci::{ContainerRuntime, ImageRef, PodmanRuntime, SecurityOpts};
+use forge_oci::{ContainerLimits, ContainerRuntime, ImageRef, PodmanRuntime, SecurityOpts};
 
 /// End-to-end flag-injection regression test for `create`.
 ///
@@ -244,6 +244,172 @@ async fn create_with_hardened_defaults_applies_every_flag() {
     assert!(
         userns.contains("keep-id"),
         "UsernsMode must be keep-id, got {userns:?}"
+    );
+
+    runtime.remove(&handle).await.expect("remove container");
+}
+
+/// F-654: end-to-end proof that the F-654 conservative cgroup caps
+/// land on the resulting container.
+///
+/// Argv-shaping is pinned by the unit tests in
+/// `crates/forge-oci/src/lib.rs` and `crates/forge-oci/src/podman.rs`.
+/// This test pins the *behaviour* — by asking `podman inspect` what
+/// the container's cgroup caps actually are, we catch any silent
+/// podman-side rejection (e.g. unsupported flag, kernel missing the
+/// pids controller, podman renaming a JSON field) that argv assertions
+/// would miss.
+///
+/// `cargo test -p forge-oci -- --ignored` to run.
+#[tokio::test]
+#[ignore = "requires rootless podman on PATH (run with --ignored)"]
+async fn create_with_conservative_limits_applies_every_cgroup_cap() {
+    let runtime = PodmanRuntime::new();
+    runtime.detect().await.expect("podman detect");
+    let image = ImageRef::parse("docker.io/library/alpine:3.19").expect("valid image ref");
+    runtime.pull(&image).await.expect("pull alpine");
+
+    // Use a distinct, easy-to-verify limit set so the inspect output
+    // is unambiguous (the conservative-default values are the same
+    // for cpus and memory bytes, which would let a swapped accessor
+    // pass silently).
+    let limits = ContainerLimits {
+        cpus: Some(1.0),
+        memory_bytes: Some(256 * 1024 * 1024),
+        memory_swap_bytes: Some(256 * 1024 * 1024),
+        pids_max: Some(128),
+    };
+    let opts = SecurityOpts {
+        limits,
+        ..SecurityOpts::permissive()
+    };
+
+    let handle = runtime
+        .create(&image, &["sleep", "30"], &opts)
+        .await
+        .expect("create container with limits");
+
+    // One inspect, four cgroup fields.
+    //   - NanoCpus is podman's bytes-per-second representation of
+    //     `--cpus`: 1.0 cpu = 1_000_000_000 nanoseconds-of-cpu.
+    //   - Memory / MemorySwap are bytes.
+    //   - PidsLimit is the cap.
+    let inspect = std::process::Command::new("podman")
+        .args([
+            "inspect",
+            "--format",
+            "{{.HostConfig.NanoCpus}}|{{.HostConfig.Memory}}|{{.HostConfig.MemorySwap}}|{{.HostConfig.PidsLimit}}",
+            &handle.id,
+        ])
+        .output()
+        .expect("podman inspect spawn");
+    assert!(
+        inspect.status.success(),
+        "podman inspect failed: {}",
+        String::from_utf8_lossy(&inspect.stderr)
+    );
+    let out = String::from_utf8_lossy(&inspect.stdout).trim().to_string();
+    let parts: Vec<&str> = out.splitn(4, '|').collect();
+    assert_eq!(
+        parts.len(),
+        4,
+        "expected 4 inspect fields, got {parts:?} from {out:?}"
+    );
+    let (nano_cpus, memory, memory_swap, pids_limit) = (parts[0], parts[1], parts[2], parts[3]);
+
+    assert_eq!(
+        nano_cpus, "1000000000",
+        "NanoCpus must reflect --cpus 1.0 (got {nano_cpus:?})"
+    );
+    assert_eq!(
+        memory,
+        (256 * 1024 * 1024_u64).to_string(),
+        "Memory must reflect --memory (got {memory:?})"
+    );
+    assert_eq!(
+        memory_swap,
+        (256 * 1024 * 1024_u64).to_string(),
+        "MemorySwap must reflect --memory-swap == memory (no swap; got {memory_swap:?})"
+    );
+    assert_eq!(
+        pids_limit, "128",
+        "PidsLimit must reflect --pids-limit (got {pids_limit:?})"
+    );
+
+    runtime.remove(&handle).await.expect("remove container");
+}
+
+/// F-654: behavioural proof that `--pids-limit` actually bounds a
+/// fork-bomb. Without the cap the container would inherit the user
+/// slice's default and a `:(){ :|:& };:` style workload would
+/// saturate the host until OOM.
+///
+/// Strategy: run a small fork-bomb inside a container with
+/// `pids_max = 16`, capture exec stderr, then assert the kernel
+/// surfaced a "Resource temporarily unavailable" / "fork: retry"
+/// signal — that's the cgroup `pids.max` rejection. The exec call
+/// also returns within the foreground sleep window, proving the
+/// container did not run unbounded.
+#[tokio::test]
+#[ignore = "requires rootless podman on PATH (run with --ignored)"]
+async fn pids_limit_bounds_a_fork_bomb_inside_the_container() {
+    let runtime = PodmanRuntime::new();
+    runtime.detect().await.expect("podman detect");
+    let image = ImageRef::parse("docker.io/library/alpine:3.19").expect("valid image ref");
+    runtime.pull(&image).await.expect("pull alpine");
+
+    let limits = ContainerLimits {
+        cpus: Some(1.0),
+        memory_bytes: Some(256 * 1024 * 1024),
+        memory_swap_bytes: Some(256 * 1024 * 1024),
+        pids_max: Some(16),
+    };
+    let opts = SecurityOpts {
+        limits,
+        ..SecurityOpts::permissive()
+    };
+
+    let handle = runtime
+        .create(&image, &["sleep", "30"], &opts)
+        .await
+        .expect("create container with pid cap");
+    runtime.start(&handle).await.expect("start container");
+
+    // The shell loop forks repeatedly; each `&` backgrounds a
+    // detached subshell. With `pids_max=16` the kernel rejects
+    // additional `clone()` calls and the loop's stderr captures the
+    // refusal. We bound iterations to keep the test fast and exit
+    // 0 on its own so exec returns promptly even when no caps fire
+    // (in which case the assertion below catches the regression).
+    let result = runtime
+        .exec(
+            &handle,
+            &[
+                "sh",
+                "-c",
+                "i=0; while [ $i -lt 200 ]; do (sleep 5) & i=$((i+1)); done; wait 2>/dev/null; true",
+            ],
+        )
+        .await
+        .expect("exec returns even when forks fail");
+
+    // The shell prints `sh: can't fork: Resource temporarily
+    // unavailable` (or similar) once the cgroup refuses additional
+    // tasks. Either pattern is enough: any text in stderr proves the
+    // cap fired, since a successful run produces no stderr at all.
+    assert!(
+        !result.stderr.is_empty(),
+        "expected fork-failure noise in stderr (cap should have fired); \
+         stdout={:?} stderr={:?}",
+        result.stdout,
+        result.stderr
+    );
+    assert!(
+        result.stderr.to_lowercase().contains("fork")
+            || result.stderr.to_lowercase().contains("resource")
+            || result.stderr.to_lowercase().contains("retry"),
+        "expected stderr to mention fork/Resource/retry, got: {:?}",
+        result.stderr
     );
 
     runtime.remove(&handle).await.expect("remove container");

--- a/crates/forge-session/src/sandbox/level2.rs
+++ b/crates/forge-session/src/sandbox/level2.rs
@@ -19,15 +19,16 @@
 //!
 //! # Resource limits
 //!
-//! Per-step caps are captured in [`ContainerLimits`] and intended for the
-//! `--cpus` / `--memory` / `--pids-limit` flags `podman` applies at *create*
-//! time (cgroup v2 leaf). The current F-595 [`ContainerRuntime::create`]
-//! signature does not yet accept resource flags; this is tracked as
-//! follow-up issue #631 (see `docs/architecture/isolation-model.md` §8.3).
-//! Until that lands, [`Level2Session::create`] stores the limits on the
-//! session for observability and the `argv`-shaping helper
-//! [`limits_to_create_flags`] pins the canonical podman-flag rendering so
-//! the eventual wiring is a one-line change.
+//! Per-step caps are captured in [`ContainerLimits`] (re-exported from
+//! `forge_oci`) and applied to `podman create` via
+//! [`forge_oci::SecurityOpts::limits`]. F-654 closed the loop:
+//! [`Level2Session::create`] now plumbs the configured limits through
+//! to the runtime — when a caller passes `ContainerLimits::default()`
+//! (every field `None`), the session falls back to
+//! [`ContainerLimits::conservative_default`] (2 cpus, 4 GiB, 1024
+//! pids, no swap) so a fork-bomb or memory-exhaust workload inside
+//! the sandbox cannot starve the host. See
+//! `docs/architecture/isolation-model.md` §8.3 for the unit conventions.
 //!
 //! # Deviation from the F-596 DoD
 //!
@@ -44,6 +45,15 @@ use std::sync::Arc;
 
 use forge_oci::{ContainerHandle, ContainerRuntime, ImageRef, OciError, SecurityOpts};
 
+/// Per-step resource limits enforced via the container's cgroup v2
+/// leaf. Re-exported from [`forge_oci`] so call sites in the session
+/// crate keep the original `level2::ContainerLimits` import path.
+///
+/// See [`forge_oci::ContainerLimits`] for the field-level units and
+/// [`forge_oci::ContainerLimits::conservative_default`] for the F-654
+/// strict preset (2 cpus, 4 GiB, 1024 pids, no swap).
+pub use forge_oci::ContainerLimits;
+
 /// Binary used by [`Level2Session::drop`]'s panic-safety net to reap
 /// a leaked container. Hardcoded because the only `ContainerRuntime`
 /// impl in the workspace today is `PodmanRuntime`; if a second
@@ -51,64 +61,31 @@ use forge_oci::{ContainerHandle, ContainerRuntime, ImageRef, OciError, SecurityO
 /// abstraction (e.g. each impl supplies its own teardown argv).
 const DROP_CLEANUP_BINARY: &str = "podman";
 
-/// Per-step resource limits enforced via the container's cgroup v2 leaf.
-///
-/// All fields are `Option` because Level 2 inherits whatever limit was set
-/// on the daemon's slice (or "unlimited") when a field is absent. Callers
-/// that want the same shape as [`super::SandboxConfig`] can map
-/// `cpu_seconds` / `address_space_bytes` / `max_processes` onto the
-/// matching container fields.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
-pub struct ContainerLimits {
-    /// Equivalent of `podman create --cpus N.NN`. Float CPU shares
-    /// (`1.5` = 1.5 cores). `None` leaves the cap unset.
-    pub cpus: Option<f32>,
-    /// Equivalent of `podman create --memory <bytes>`. `None` leaves the
-    /// cap unset.
-    pub memory_bytes: Option<u64>,
-    /// Equivalent of `podman create --pids-limit N`. `None` leaves the
-    /// cap unset.
-    pub pids_max: Option<u64>,
-}
-
-impl ContainerLimits {
-    /// Convert into the canonical podman create flag list. Returned in the
-    /// order podman expects, with the units it expects (memory in bytes,
-    /// cpus as a float). Pinned by unit tests so the eventual call-site
-    /// wiring matches what the trait will receive.
-    pub fn to_create_flags(self) -> Vec<String> {
-        limits_to_create_flags(self)
-    }
-}
-
 /// Render [`ContainerLimits`] into the argv fragment that would be
-/// inserted between `podman create` and the IMAGE positional. Order is
-/// deterministic so test assertions can pin it.
+/// inserted between `podman create` and the IMAGE positional.
+///
+/// Thin wrapper over [`forge_oci::ContainerLimits::to_create_flags`]
+/// kept on this module path because earlier call sites and tests
+/// reach for `level2::limits_to_create_flags`. The actual shaping
+/// lives in `forge-oci` so the limit flags travel through the same
+/// `SecurityOpts` rendering as the security flags.
 pub fn limits_to_create_flags(limits: ContainerLimits) -> Vec<String> {
-    let mut out = Vec::new();
-    if let Some(cpus) = limits.cpus {
-        out.push("--cpus".to_string());
-        out.push(format_cpus(cpus));
-    }
-    if let Some(bytes) = limits.memory_bytes {
-        out.push("--memory".to_string());
-        out.push(bytes.to_string());
-    }
-    if let Some(pids) = limits.pids_max {
-        out.push("--pids-limit".to_string());
-        out.push(pids.to_string());
-    }
-    out
+    limits.to_create_flags()
 }
 
-/// Format CPU shares without a trailing `.0` for integer values (`1.0` →
-/// `"1"`) so the resulting podman command line matches the convention
-/// `podman` itself emits in `inspect`.
-fn format_cpus(cpus: f32) -> String {
-    if cpus.fract() == 0.0 {
-        format!("{}", cpus.trunc() as i64)
+/// Resolve the limits actually applied to the container.
+///
+/// `ContainerLimits::default()` (every field `None`) means the caller
+/// did not specify caps; in that case we substitute the F-654
+/// conservative preset so a fork-bomb / OOM workload cannot starve
+/// the host. Any non-default input is honoured verbatim — operators
+/// who explicitly opt for tighter or looser caps get exactly what
+/// they asked for, including a single field that they wanted unset.
+fn effective_limits(requested: ContainerLimits) -> ContainerLimits {
+    if requested == ContainerLimits::default() {
+        ContainerLimits::conservative_default()
     } else {
-        format!("{cpus}")
+        requested
     }
 }
 
@@ -186,15 +163,22 @@ impl Level2Session {
     /// Sequence (matches the F-595 lifecycle):
     /// 1. `runtime.pull(image)` — idempotent; layers cached if already
     ///    present.
-    /// 2. `runtime.create(image, init_argv)` — the container's "init"
-    ///    process. We default this to a `sleep infinity`-style argv via
-    ///    [`Self::default_init_argv`] so the container stays alive long
-    ///    enough for `exec` to hit it.
+    /// 2. `runtime.create(image, init_argv, opts)` — the container's
+    ///    "init" process plus the F-642 hardening flags and F-654
+    ///    resource caps. We default the argv to `sleep infinity` via
+    ///    [`Self::default_init_argv`] so the container stays alive
+    ///    long enough for `exec` to hit it.
     /// 3. `runtime.start(handle)` — flips the container to running.
     ///
-    /// Resource limits live on the returned session for observability
-    /// and will be passed at `create` time once F-595's trait is
-    /// extended (see module docs).
+    /// Resource limits travel through
+    /// [`forge_oci::SecurityOpts::limits`]: callers passing
+    /// [`ContainerLimits::default`] (every field `None`) get the
+    /// F-654 strict preset
+    /// ([`ContainerLimits::conservative_default`]) so a config
+    /// without explicit overrides still gets bounded — 2 cpus, 4
+    /// GiB memory with swap disabled, 1024 pids. Callers that need
+    /// looser caps override the specific field; an explicit
+    /// `Some(value)` is always honoured.
     pub async fn create(
         runtime: Arc<dyn ContainerRuntime>,
         image: ImageRef,
@@ -203,38 +187,23 @@ impl Level2Session {
         runtime.pull(&image).await?;
         // F-642: every Level 2 container is created with the strict
         // hardening defaults — no-new-privileges, cap-drop ALL, read-only
-        // rootfs, no network, keep-id user namespace. Documented at
-        // `docs/architecture/isolation-model.md` §8.3.
+        // rootfs, no network, keep-id user namespace. F-654 extends the
+        // same opts struct with cgroup caps so the same
+        // `runtime.create` call applies both layers.
+        let effective_limits = effective_limits(limits);
+        let opts = SecurityOpts {
+            limits: effective_limits,
+            ..SecurityOpts::hardened_default()
+        };
         let handle = runtime
-            .create(
-                &image,
-                Self::default_init_argv(),
-                &SecurityOpts::hardened_default(),
-            )
+            .create(&image, Self::default_init_argv(), &opts)
             .await?;
         runtime.start(&handle).await?;
-        // Operator-facing notice when limits are configured but not
-        // yet enforced. Until follow-up #631 lands, the container
-        // inherits whatever limits its parent slice applies — which
-        // for rootless podman is "the user's slice", not the values
-        // captured here. Logging at runtime catches accidental
-        // reliance on the not-yet-wired path.
-        if limits != ContainerLimits::default() {
-            tracing::warn!(
-                cpus = ?limits.cpus,
-                memory_bytes = ?limits.memory_bytes,
-                pids_max = ?limits.pids_max,
-                container_id = %handle.id,
-                "Level 2 ContainerLimits captured but not enforced; \
-                 cgroup wiring deferred to follow-up #631 — container \
-                 will run with host-slice default limits"
-            );
-        }
         Ok(Self {
             runtime,
             image,
             handle,
-            limits,
+            limits: effective_limits,
             teardown_done: AtomicBool::new(false),
         })
     }
@@ -690,6 +659,12 @@ mod tests {
         // created with the strict hardening preset. If a refactor drops
         // this propagation, the integration test would still pass with
         // a mock runtime — this test pins the explicit opt-in.
+        //
+        // F-654: the hardened preset now also carries the
+        // conservative cgroup caps, which `Level2Session::create`
+        // applies whenever the caller passes
+        // `ContainerLimits::default()` (the historical "no caps"
+        // signal). The full struct must round-trip identically.
         let mock: Arc<MockRuntime> = Arc::new(MockRuntime::default());
         let runtime: Arc<dyn ContainerRuntime> = mock.clone();
 
@@ -708,61 +683,113 @@ mod tests {
         );
     }
 
+    // ── F-654: Level2Session plumbs ContainerLimits through SecurityOpts ──
+
+    #[tokio::test]
+    async fn create_substitutes_conservative_limits_when_requested_is_default() {
+        // The historical entry point passes `ContainerLimits::default()`
+        // (every field None) to mean "no per-step caps configured".
+        // F-654 says that must NOT mean "container runs unbounded" —
+        // the strict preset takes over so the host stays protected.
+        let mock: Arc<MockRuntime> = Arc::new(MockRuntime::default());
+        let runtime: Arc<dyn ContainerRuntime> = mock.clone();
+
+        let session = Level2Session::create(runtime, alpine(), ContainerLimits::default())
+            .await
+            .unwrap();
+        session.disable_drop_cleanup();
+
+        let opts = mock
+            .last_create_opts()
+            .expect("runtime.create must have been invoked");
+        assert_eq!(
+            opts.limits,
+            ContainerLimits::conservative_default(),
+            "default ContainerLimits must be substituted with the F-654 conservative preset"
+        );
+        // The session also reflects the substitution so callers
+        // observing `session.limits()` see what actually landed on
+        // the container, not the (empty) request.
+        assert_eq!(session.limits(), ContainerLimits::conservative_default());
+    }
+
+    #[tokio::test]
+    async fn create_honours_caller_supplied_limits_verbatim() {
+        // An explicit non-default `ContainerLimits` reaches the
+        // runtime untouched — including a single tightened field
+        // with the rest left unset. Operators who pin a value get
+        // exactly that value, no merge with the conservative preset.
+        let mock: Arc<MockRuntime> = Arc::new(MockRuntime::default());
+        let runtime: Arc<dyn ContainerRuntime> = mock.clone();
+
+        let requested = ContainerLimits {
+            cpus: Some(0.5),
+            memory_bytes: Some(128 * 1024 * 1024),
+            memory_swap_bytes: Some(128 * 1024 * 1024),
+            pids_max: Some(64),
+        };
+        let session = Level2Session::create(runtime, alpine(), requested)
+            .await
+            .unwrap();
+        session.disable_drop_cleanup();
+
+        let opts = mock
+            .last_create_opts()
+            .expect("runtime.create must have been invoked");
+        assert_eq!(opts.limits, requested);
+        assert_eq!(session.limits(), requested);
+    }
+
+    #[tokio::test]
+    async fn create_renders_limit_flags_in_security_opts_argv() {
+        // Companion to the integration test against a real podman:
+        // here we assert the SecurityOpts the trait observed would
+        // render the four expected flags (`--cpus`, `--memory`,
+        // `--memory-swap`, `--pids-limit`). The MockRuntime captures
+        // the SecurityOpts struct directly so we can render off the
+        // recorded value.
+        let mock: Arc<MockRuntime> = Arc::new(MockRuntime::default());
+        let runtime: Arc<dyn ContainerRuntime> = mock.clone();
+
+        let _session = Level2Session::create(runtime, alpine(), ContainerLimits::default())
+            .await
+            .unwrap();
+        _session.disable_drop_cleanup();
+
+        let opts = mock.last_create_opts().expect("create invoked");
+        let flags = opts.to_create_flags();
+        for required in ["--cpus", "--memory", "--memory-swap", "--pids-limit"] {
+            assert!(
+                flags.iter().any(|f| f == required),
+                "rendered argv missing F-654 limit flag {required:?}: {flags:?}"
+            );
+        }
+    }
+
     // ── ContainerLimits flag shaping ─────────────────────────────────
+    //
+    // The struct itself, including `--cpus` / `--memory` /
+    // `--memory-swap` / `--pids-limit` rendering and the F-654
+    // conservative preset, is owned by `forge-oci` and tested in that
+    // crate. The session-level wiring (substitute conservative when
+    // the caller passes default; honour explicit limits verbatim) is
+    // covered by the `create_substitutes_conservative_limits…` and
+    // `create_honours_caller_supplied_limits_verbatim` tests above.
 
     #[test]
-    fn limits_to_create_flags_emits_in_canonical_order() {
-        // Order is fixed: --cpus, --memory, --pids-limit. The eventual
-        // `create_with_limits` extension on the F-595 trait will feed
-        // these directly into the IMAGE-prefixed argv.
+    fn level2_helper_delegates_to_forge_oci_rendering() {
+        // `level2::limits_to_create_flags` is a thin wrapper kept on
+        // this module path for older call sites; it must stay
+        // consistent with the canonical `ContainerLimits` rendering
+        // owned by forge-oci so call sites grep'd against either path
+        // observe identical argv shape.
         let limits = ContainerLimits {
             cpus: Some(1.5),
             memory_bytes: Some(512 * 1024 * 1024),
+            memory_swap_bytes: Some(512 * 1024 * 1024),
             pids_max: Some(256),
         };
-        assert_eq!(
-            limits.to_create_flags(),
-            vec![
-                "--cpus".to_string(),
-                "1.5".to_string(),
-                "--memory".to_string(),
-                (512 * 1024 * 1024u64).to_string(),
-                "--pids-limit".to_string(),
-                "256".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn limits_to_create_flags_skips_none_fields() {
-        let limits = ContainerLimits {
-            cpus: None,
-            memory_bytes: Some(1_000),
-            pids_max: None,
-        };
-        assert_eq!(
-            limits.to_create_flags(),
-            vec!["--memory".to_string(), "1000".to_string()]
-        );
-    }
-
-    #[test]
-    fn limits_to_create_flags_default_is_empty() {
-        // No limits configured → no flags. Matches "inherit slice
-        // limits" semantics.
-        assert!(ContainerLimits::default().to_create_flags().is_empty());
-    }
-
-    #[test]
-    fn cpus_integer_value_renders_without_decimal() {
-        let limits = ContainerLimits {
-            cpus: Some(1.0),
-            ..Default::default()
-        };
-        assert_eq!(
-            limits.to_create_flags(),
-            vec!["--cpus".to_string(), "1".to_string()]
-        );
+        assert_eq!(limits_to_create_flags(limits), limits.to_create_flags());
     }
 
     // ── classify_detect_error: fallback variants ─────────────────────
@@ -921,6 +948,10 @@ mod tests {
         // F-642: every hardening flag must be present in the create argv —
         // end-to-end proof that Level2Session ships the strict preset
         // through the trait into PodmanRuntime's flag rendering.
+        // F-654: the conservative cgroup caps must travel through the
+        // same rendering when the caller asked for the default
+        // limits, so a host-default config still bounds the
+        // container.
         for required in [
             "--security-opt",
             "no-new-privileges",
@@ -931,10 +962,14 @@ mod tests {
             "none",
             "--userns",
             "keep-id",
+            "--cpus",
+            "--memory",
+            "--memory-swap",
+            "--pids-limit",
         ] {
             assert!(
                 create_args.iter().any(|a| a == required),
-                "create argv missing F-642 hardening flag {required:?}: {create_args:?}"
+                "create argv missing required flag {required:?}: {create_args:?}"
             );
         }
         // exec's argv carries the caller's command after the container id.

--- a/docs/architecture/isolation-model.md
+++ b/docs/architecture/isolation-model.md
@@ -125,14 +125,10 @@ for the duration of the session. The lifecycle, owned by
    `Level2Unavailable` and trigger auto-fallback (see below):
    `RuntimeMissing`, `RuntimeBroken`, `RootlessUnavailable`.
 2. **Pull** — `runtime.pull(image)`. Idempotent; layers cached.
-3. **Create** — `runtime.create(image, ["sleep", "infinity"])`. The
-   `sleep infinity` init keeps the container alive between `exec`
-   calls. Resource limits attach at this step in the long-term
-   design (see below) — **deferred to follow-up #631**; containers
-   currently run with the host slice's default limits, and
-   `Level2Session::create` emits a `tracing::warn!` whenever a
-   non-default `ContainerLimits` is passed so operators are not
-   surprised at runtime.
+3. **Create** — `runtime.create(image, ["sleep", "infinity"], &opts)`.
+   The `sleep infinity` init keeps the container alive between `exec`
+   calls. The `opts` carry both the F-642 security flags and the F-654
+   cgroup caps; both apply at create time (see below).
 4. **Start** — `runtime.start(handle)`. Container is now ready for
    `exec`.
 5. **Exec, repeated** — every step in the session runs through
@@ -215,14 +211,18 @@ auditing the daemon's `tracing` log can grep for the same fixed shape.
 
 Per-step caps land on the container's cgroup v2 leaf at **create
 time**, not exec time — `podman exec` does not accept resource
-flags. `ContainerLimits` captures the three caps Phase 1 cares
+flags. F-654 routes them through `forge_oci::SecurityOpts::limits`
+so the same `runtime.create(...)` call applies both the security
+flags and the cgroup caps. `forge_oci::ContainerLimits` (re-exported
+as `level2::ContainerLimits`) captures the four caps Phase 3 cares
 about:
 
-| Field | podman flag | Maps to |
-|---|---|---|
-| `cpus: Option<f32>` | `--cpus <N>` | cgroup v2 `cpu.max` |
-| `memory_bytes: Option<u64>` | `--memory <bytes>` | cgroup v2 `memory.max` |
-| `pids_max: Option<u64>` | `--pids-limit <N>` | cgroup v2 `pids.max` |
+| Field | podman flag | Unit | Maps to |
+|---|---|---|---|
+| `cpus: Option<f32>` | `--cpus <N>` | float CPU shares | cgroup v2 `cpu.max` |
+| `memory_bytes: Option<u64>` | `--memory <bytes>` | bytes | cgroup v2 `memory.max` |
+| `memory_swap_bytes: Option<u64>` | `--memory-swap <bytes>` | bytes; equal to `memory_bytes` disables swap | cgroup v2 `memory.swap.max` |
+| `pids_max: Option<u64>` | `--pids-limit <N>` | process count | cgroup v2 `pids.max` |
 
 These map directly onto the same intent as the Level-1
 `SandboxConfig` — `cpu_seconds` ↔ `--cpus`, `address_space_bytes`
@@ -230,16 +230,24 @@ These map directly onto the same intent as the Level-1
 enforcement (per-container) instead of `setrlimit` (per-process /
 per-uid).
 
-> **Known gap, tracked as a follow-up (issue #631).** F-595's
-> `ContainerRuntime::create` signature accepts only
-> `(image, argv)`. To preserve the F-595 public API (per F-596's
-> constraints), `Level2Session::create` currently stores the
-> `ContainerLimits` on the session for observability rather than
-> passing them through to `podman create`. The argv-shaping helper
-> `level2::limits_to_create_flags` pins the canonical podman flag
-> rendering (verified by unit test) so the eventual wiring — once
-> the trait grows a `create_with_limits` method — is a one-line
-> change.
+The hardened preset
+(`SecurityOpts::hardened_default`) ships
+`ContainerLimits::conservative_default()` — **2 cpus, 4 GiB memory
+with swap disabled, 1024 pids**. `Level2Session::create`
+substitutes the conservative preset whenever the caller passes
+`ContainerLimits::default()` (every field `None`), so a config
+without explicit overrides still gets bounded; an explicit
+non-default `ContainerLimits` reaches the runtime verbatim. This
+closes CWE-770: a fork-bomb (`:(){ :|:& };:`) or memory-exhaust
+workload inside a Level 2 sandbox now hits the cgroup `pids.max` /
+`memory.max` ceiling instead of starving the host.
+
+> **Why `--memory-swap` defaults to `--memory`.** Without
+> `--memory-swap`, podman lets the container use `2 ×
+> memory_bytes` of swap, which makes `--memory` advisory rather
+> than enforced. Setting them equal disables swap and pins the
+> total memory budget to the headline number. Operators that need
+> swap explicitly opt in by overriding `memory_swap_bytes`.
 
 #### Auto-fallback to Level 1
 


### PR DESCRIPTION
Closes forge-ide/forge#690

## Summary

Level 2 sandboxes captured `ContainerLimits` but the values never
reached `podman create` — containers ran with the host slice's
default cgroup limits, leaving a fork-bomb / memory-exhaust DoS
surface (CWE-770).

This change wires the limits through `forge_oci::SecurityOpts` so the
same `runtime.create()` call applies both the F-642 hardening flags
and the F-654 cgroup caps:

- `ContainerLimits` moves into `forge-oci` (re-exported from
  `forge_session::sandbox::level2`) and grows a `memory_swap_bytes`
  field; setting it equal to `memory_bytes` disables swap and pins
  the total memory budget to the headline number.
- `ContainerLimits::conservative_default()` ships **2 cpus / 4 GiB
  memory (no swap) / 1024 pids** as the F-654 strict preset.
- `SecurityOpts::hardened_default()` carries the conservative preset
  in `limits`, so production callers transitively pick up the caps.
- `Level2Session::create` substitutes the conservative preset
  whenever the caller passes `ContainerLimits::default()` (the
  historical "no caps configured" signal); explicit non-default
  limits are honoured verbatim.
- `SecurityOpts::to_create_flags` renders the limit flags in a
  pinned order — `--cpus` → `--memory` → `--memory-swap` →
  `--pids-limit` — after the security flags.

## Test plan

- `cargo test --workspace` passes (1100+ tests; new F-654 tests
  cover the substitution rule, the hardened-default plumbing,
  argv-shape assertions, and the existing `RecordingRunner`
  end-to-end check now also asserts every limit flag is in the
  rendered argv).
- `cargo clippy --all-targets -- -D warnings` passes.
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`
  passes.
- New `#[ignore]` integration tests in
  `crates/forge-oci/tests/podman_integration.rs`:
  - `create_with_conservative_limits_applies_every_cgroup_cap` —
    runs against real podman, asserts `podman inspect` reports the
    expected `NanoCpus / Memory / MemorySwap / PidsLimit`.
  - `pids_limit_bounds_a_fork_bomb_inside_the_container` — boots
    a real container with `pids_max=16`, runs a fork-bomb-ish
    workload, and asserts the kernel's cgroup-rejection chatter
    surfaces in stderr (i.e. the cap actually fired).

## Verification status

PR is open; DoD and code-review gates are pending in the parent
context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)