### PR TITLE
[F-661] MCP HTTP POST response body lacks size cap

### DIFF
--- a/crates/forge-mcp/src/transport/http.rs
+++ b/crates/forge-mcp/src/transport/http.rs
@@ -103,6 +103,11 @@ fn shared_client() -> &'static reqwest::Client {
 /// MCP notifications and small enough to keep the worst-case resident set
 /// bounded. Over-cap accumulators surface as [`HttpEvent::Malformed`] and
 /// force a backoff + reconnect via the sse-reader-loop's error path.
+///
+/// F-661: also reused as the cap for POST response bodies in [`Http::send`]
+/// so a hostile MCP server cannot exhaust daemon memory by replying with a
+/// multi-GiB JSON-RPC response. Same threat shape as F-347, same parity
+/// limit — JSON-RPC responses don't legitimately exceed an SSE frame.
 pub const MAX_SSE_FRAME_BYTES: usize = 4 * 1024 * 1024;
 
 /// Events emitted on [`Http::recv`].
@@ -254,20 +259,27 @@ impl Http {
 
         let status = resp.status();
         if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
+            let body = read_body_capped(resp, MAX_SSE_FRAME_BYTES)
+                .await
+                .unwrap_or_default();
             return Err(anyhow!(
                 "POST {} returned HTTP {}: {}",
                 redacted(&self.url),
                 status,
-                truncate(&body, 512),
+                truncate(&String::from_utf8_lossy(&body), 512),
             ));
         }
 
         // MCP HTTP responses are JSON-RPC objects; empty 2xx bodies (e.g.
         // 202 Accepted for a fire-and-forget notification) are legal and
         // we silently skip them — there's nothing to forward.
-        let body = resp
-            .bytes()
+        //
+        // F-661: stream the body through a counting accumulator that
+        // aborts on cap overflow. A hostile MCP server could otherwise
+        // answer one JSON-RPC POST with a multi-GiB body (or an unbounded
+        // chunked stream) and exhaust daemon memory. The cap mirrors
+        // `MAX_SSE_FRAME_BYTES` for parity with the SSE GET path.
+        let body = read_body_capped(resp, MAX_SSE_FRAME_BYTES)
             .await
             .with_context(|| format!("reading POST {} response body", redacted(&self.url)))?;
         if body.is_empty() {
@@ -359,6 +371,45 @@ fn apply_headers(mut req: reqwest::RequestBuilder, headers: &HeaderMap) -> reqwe
         req = req.header(name, value);
     }
     req
+}
+
+/// Read a `reqwest::Response` body into a `Vec<u8>` with a hard size cap.
+///
+/// F-661: closes the DoS surface where `Http::send` previously called
+/// `resp.bytes().await` without an upper bound. A hostile (or misconfigured)
+/// MCP HTTP server could answer a JSON-RPC POST with a multi-GiB response
+/// body — or an unbounded `Transfer-Encoding: chunked` stream — and exhaust
+/// daemon memory. We defend in two layers:
+///
+/// 1. If `Content-Length` is advertised and exceeds `cap`, fail fast before
+///    pulling any body bytes.
+/// 2. Otherwise stream chunks via `bytes_stream()` and abort the moment the
+///    accumulator passes `cap`. This catches the chunked-without-Content-
+///    Length attack shape that the early check can't see.
+///
+/// The error message names the cap so operators can correlate with the
+/// `MAX_SSE_FRAME_BYTES` constant during incident triage.
+async fn read_body_capped(resp: reqwest::Response, cap: usize) -> Result<Vec<u8>> {
+    if let Some(advertised) = resp.content_length() {
+        if advertised > cap as u64 {
+            return Err(anyhow!(
+                "response body advertised {advertised} bytes, exceeds cap of {cap} bytes"
+            ));
+        }
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("reading response body chunk")?;
+        if buf.len().saturating_add(chunk.len()) > cap {
+            return Err(anyhow!(
+                "response body exceeds cap of {cap} bytes; aborting to avoid OOM"
+            ));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
 }
 
 /// Drive the SSE reader indefinitely. Each iteration opens a GET and

--- a/crates/forge-mcp/tests/http_roundtrip.rs
+++ b/crates/forge-mcp/tests/http_roundtrip.rs
@@ -615,6 +615,192 @@ async fn sse_sixteen_mib_no_boundary_surfaces_malformed() {
     }
 }
 
+/// F-661 DoD regression: a POST response body larger than the cap
+/// (`MAX_SSE_FRAME_BYTES`) must be rejected with a clear error rather than
+/// fully buffered into memory. A hostile MCP HTTP server could otherwise
+/// answer one JSON-RPC request with a multi-GiB body and exhaust daemon
+/// memory.
+///
+/// Two shapes need coverage:
+/// * advertised oversize via `Content-Length` — must fail fast before any
+///   body bytes are streamed,
+/// * unadvertised (chunked) oversize where the accumulator only learns
+///   the body is too big partway through.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn post_oversize_advertised_body_is_rejected() {
+    let server = MockServer::start().await;
+
+    // Body strictly larger than the cap. wiremock writes `Content-Length`
+    // automatically from `set_body_bytes`, so reqwest sees the advertised
+    // size before any body byte is read.
+    let oversize = MAX_SSE_FRAME_BYTES + 1;
+    let body = vec![b'A'; oversize];
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_bytes(body),
+        )
+        .mount(&server)
+        .await;
+    // Empty SSE stream so the reader settles.
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(""),
+        )
+        .mount(&server)
+        .await;
+
+    let t = Http::connect(&http_spec(&server.uri(), "Bearer token"))
+        .await
+        .expect("connect");
+
+    let err = t
+        .send(serde_json::json!({"jsonrpc":"2.0","id":1}))
+        .await
+        .expect_err("oversize body must be rejected");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.to_ascii_lowercase().contains("response body")
+            || msg.to_ascii_lowercase().contains("body"),
+        "error should mention the body: {msg}"
+    );
+    assert!(
+        msg.contains(&MAX_SSE_FRAME_BYTES.to_string()) || msg.to_ascii_lowercase().contains("cap"),
+        "error should mention the cap: {msg}"
+    );
+}
+
+/// F-661: even when the server omits `Content-Length` (chunked transfer),
+/// the streaming accumulator must abort once it has buffered more than the
+/// cap. This is the path that actually defends against an
+/// infinite-stream-without-Content-Length attack.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn post_oversize_chunked_body_is_rejected() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let shutdown = Arc::new(Notify::new());
+    let server_shutdown = Arc::clone(&shutdown);
+
+    let handle = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = server_shutdown.notified() => return,
+                accept = listener.accept() => {
+                    let Ok((mut sock, _)) = accept else { return };
+                    tokio::spawn(async move {
+                        // Read request head, then stream a chunked body
+                        // that exceeds the cap so the transport's
+                        // streaming accumulator triggers — Content-Length
+                        // is absent on POST and present-but-tiny on GET.
+                        let mut buf = Vec::with_capacity(1024);
+                        let mut tmp = [0u8; 1024];
+                        loop {
+                            match sock.read(&mut tmp).await {
+                                Ok(0) | Err(_) => return,
+                                Ok(n) => {
+                                    buf.extend_from_slice(&tmp[..n]);
+                                    if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                                        break;
+                                    }
+                                    if buf.len() > 16 * 1024 {
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                        let head = std::str::from_utf8(&buf).unwrap_or("");
+                        if head.starts_with("POST ") {
+                            // Drain request body if any.
+                            let header_end = buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap_or(buf.len()) + 4;
+                            let content_length = head
+                                .lines()
+                                .find_map(|l| l.strip_prefix("Content-Length: ")
+                                    .or_else(|| l.strip_prefix("content-length: ")))
+                                .and_then(|v| v.trim().parse::<usize>().ok())
+                                .unwrap_or(0);
+                            let already = buf.len().saturating_sub(header_end);
+                            let mut remaining = content_length.saturating_sub(already);
+                            while remaining > 0 {
+                                let n = match sock.read(&mut tmp).await {
+                                    Ok(0) | Err(_) => return,
+                                    Ok(n) => n,
+                                };
+                                remaining = remaining.saturating_sub(n);
+                            }
+
+                            // Stream a chunked body well beyond the cap.
+                            // No Content-Length — transfer-encoding: chunked
+                            // forces the streaming accumulator path.
+                            let resp = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n";
+                            if sock.write_all(resp.as_bytes()).await.is_err() {
+                                return;
+                            }
+                            // 64 KiB chunks; cap is 4 MiB so anything
+                            // beyond ~64 chunks must trigger the abort.
+                            let chunk_size = 64 * 1024;
+                            let chunk = vec![b'A'; chunk_size];
+                            let chunk_header = format!("{:x}\r\n", chunk_size);
+                            let mut written = 0usize;
+                            // Bound the loop generously above the cap so
+                            // we don't accidentally buffer forever if the
+                            // implementation regresses to "no cap".
+                            let max_total = MAX_SSE_FRAME_BYTES * 4;
+                            while written < max_total {
+                                if sock.write_all(chunk_header.as_bytes()).await.is_err() {
+                                    return;
+                                }
+                                if sock.write_all(&chunk).await.is_err() {
+                                    return;
+                                }
+                                if sock.write_all(b"\r\n").await.is_err() {
+                                    return;
+                                }
+                                written += chunk_size;
+                            }
+                            // Terminating zero-length chunk.
+                            let _ = sock.write_all(b"0\r\n\r\n").await;
+                            let _ = sock.shutdown().await;
+                        } else if head.starts_with("GET ") {
+                            // Empty SSE stream so the reader settles.
+                            let resp = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                            let _ = sock.write_all(resp.as_bytes()).await;
+                            let _ = sock.shutdown().await;
+                        }
+                    });
+                }
+            }
+        }
+    });
+
+    let url = format!("http://{}/", addr);
+    let t = Http::connect(&http_spec(&url, "Bearer token"))
+        .await
+        .expect("connect");
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(30),
+        t.send(serde_json::json!({"jsonrpc":"2.0","id":1})),
+    )
+    .await
+    .expect("send must not hang on oversize body — cap is missing")
+    .expect_err("oversize chunked body must surface as Err");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.to_ascii_lowercase().contains("body")
+            || msg.to_ascii_lowercase().contains("cap")
+            || msg.contains(&MAX_SSE_FRAME_BYTES.to_string()),
+        "error should mention the body cap: {msg}"
+    );
+
+    shutdown.notify_waiters();
+    handle.abort();
+}
+
 /// F-645: SSRF redirect-pivot regression. A hostile MCP endpoint that
 /// answers a JSON-RPC POST with `302 Location: http://169.254.169.254/...`
 /// must NOT be followed by the shared client. With redirects enabled,


### PR DESCRIPTION
Closes forge-ide/forge#697

## Summary
- POST response body now bounded by `MAX_SSE_FRAME_BYTES` (4 MiB) — same cap as the SSE reader.
- Stream the body via `bytes_stream()` and abort the moment the accumulator passes the cap (defends against `Transfer-Encoding: chunked` without `Content-Length`).
- Pre-check `Content-Length`: fail fast when the server advertises an oversize body before pulling any bytes.
- Two regression tests cover both the advertised and chunked oversize shapes.

## Test plan
- `cargo test -p forge-mcp` passes (10/10 in `http_roundtrip.rs`, including the two new oversize tests)
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `just check-rust` (rustdoc gate) passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)