### PR TITLE
[F-705] Add markdown link checker to CI (lychee)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,85 @@
+name: Link Check
+
+# F-705: markdown link-rot gate. Two lanes:
+#
+# - PR / push: offline-only — internal cross-references against the
+#   working tree. Fast, deterministic, no network flakes. Required
+#   to remain green.
+#
+# - Nightly: full sweep including external URLs. Tagged
+#   continue-on-error so a transient outage on a third-party host
+#   doesn't page the on-call. Failures land as a workflow_run summary
+#   that we triage manually.
+#
+# Both lanes share lychee.toml (excludes superpowers/audits dumps,
+# loopback addresses, and bounds redirects/timeout). Per-URL
+# allowlist lives in .lycheeignore.
+#
+# This workflow is intentionally NOT in branch protection on first
+# landing — flip to required after the corpus stabilises.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/link-check.yml'
+      - 'lychee.toml'
+      - '.lycheeignore'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - '.github/workflows/link-check.yml'
+      - 'lychee.toml'
+      - '.lycheeignore'
+  schedule:
+    # 09:17 UTC daily — off-peak, avoids the top-of-hour cron stampede.
+    - cron: '17 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  internal-links:
+    name: Internal links (offline)
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: lychee --offline
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --offline
+            --no-progress
+            'docs/**/*.md'
+            'crates/**/README.md'
+            'web/packages/**/README.md'
+            README.md
+            CHANGELOG.md
+            AGENTS.md
+          fail: true
+
+  external-links:
+    name: External links (nightly)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: lychee (full sweep)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            'docs/**/*.md'
+            'crates/**/README.md'
+            'web/packages/**/README.md'
+            README.md
+            CHANGELOG.md
+            AGENTS.md
+          fail: false
+        env:
+          # Authenticated GitHub requests dodge the unauth rate limit
+          # that otherwise flags every issue/PR cross-link as 429.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+# Per-URL allowlist for the lychee link checker (F-705).
+#
+# Each entry is a regex matched against the full URL. Add a comment
+# above every entry explaining why the URL is exempt — drift here is
+# how a real broken link silently slips through.

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE-2.0) or [M
 
 Supply-chain scanners and suppression policy: [`docs/dev/security.md`](docs/dev/security.md).
 
-Legacy VS Code fork preserved at tag [`legacy-vscode-fork`](../../tree/legacy-vscode-fork).
+Legacy VS Code fork preserved at tag [`legacy-vscode-fork`](https://github.com/forge-ide/forge/tree/legacy-vscode-fork).

--- a/justfile
+++ b/justfile
@@ -72,6 +72,13 @@ check-web:
     cd web && pnpm -r typecheck
     cd web && pnpm check-tokens
 
+# Markdown link-rot gate (F-705). Offline lane only — mirrors the
+# `internal-links` job in .github/workflows/link-check.yml. The
+# nightly external sweep is CI-only because it needs network and
+# scheduled cadence.
+check-links:
+    lychee --offline --no-progress 'docs/**/*.md' 'crates/**/README.md' 'web/packages/**/README.md' README.md CHANGELOG.md AGENTS.md
+
 # Both lanes.
 check: check-rust check-web
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,38 @@
+# Lychee config — markdown link-rot gate (F-705).
+#
+# CI runs offline-only (internal links) on every PR, and a separate
+# nightly job sweeps external URLs. Tunables here apply to both lanes.
+
+# Paths excluded from the corpus. Generated artifacts and curated
+# audit / brainstorming dumps are intentionally not link-checked.
+exclude_path = [
+    "docs/superpowers/",
+    "docs/audits/",
+    "node_modules/",
+    "target/",
+    "web/packages/app/dist/",
+]
+
+# URL-level excludes. Loopback addresses are example-only and should
+# never resolve from a CI runner.
+exclude = [
+    "^http://localhost",
+    "^http://127\\.0\\.0\\.1",
+    "^https?://0\\.0\\.0\\.0",
+]
+
+# Drop mailto: links and any loopback hosts the regex above missed.
+# `include_mail` is the supported toggle (default = exclude); we keep
+# it explicit so future readers see the intent.
+include_mail = false
+exclude_loopback = true
+
+# External-link tuning. Cheap servers redirect through CDNs and
+# auth walls; cap the chain so a misconfigured target can't hang CI.
+max_redirects = 5
+timeout = 30
+
+# Quiet output for CI logs. `info` surfaces failures with full URL +
+# source location without dumping every successful check.
+no_progress = true
+verbose = "info"

--- a/web/packages/design/README.md
+++ b/web/packages/design/README.md
@@ -15,6 +15,6 @@ The Forge design-token package. Ships a single static CSS file (`src/tokens.css`
 
 ## Further reading
 
-- [Token pipeline](../../../docs/frontend/token-pipeline.md)
+- [Token pipeline](../../../docs/frontend/architecture.md#94-design-token-pipeline)
 - [Frontend architecture](../../../docs/frontend/architecture.md)
 - [Crate architecture overview](../../../docs/architecture/crate-architecture.md)


### PR DESCRIPTION
Closes forge-ide/forge#741

## Summary
- New `.github/workflows/link-check.yml` runs lychee in two lanes: an internal-only (offline) check on every PR / push to main, and a nightly full sweep that includes external URLs with `continue-on-error: true` so third-party flake doesn't break the build.
- New `lychee.toml` shared by both lanes — excludes `docs/superpowers/`, `docs/audits/`, `node_modules/`, `target/`, and the web build dir; drops loopback + mailto; caps redirects at 5 with a 30s timeout.
- New empty `.lycheeignore` allowlist scaffold for URL-level exemptions.
- `just check-links` mirrors the offline CI lane locally.
- Baseline fixes so the gate is green on first run:
  - `README.md`: rewrote the legacy-vscode-fork relative tree link as an absolute GitHub URL (the relative form only resolves on github.com).
  - `web/packages/design/README.md`: `docs/frontend/token-pipeline.md` redirected to the live section in `architecture.md` — the standalone file never existed.

## Test plan
- `just check-links` passes locally — 242 links checked, 0 errors.
- `cargo fmt --check` / `cargo check --workspace` / `cargo clippy --all-targets -- -D warnings` / `just check-rust` all pass (no Rust changes).
- Workflow YAML and `lychee.toml` validated by `python3 -c yaml.safe_load` and `tomllib`.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

The workflow is intentionally NOT yet in branch protection — flip to required after the corpus stabilises.