### PR TITLE
[F-658] Bound sidecar->daemon event channel with backpressure

### DIFF
--- a/crates/forge-session/src/sidecar/mod.rs
+++ b/crates/forge-session/src/sidecar/mod.rs
@@ -101,6 +101,24 @@ const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_millis(2000);
 /// memory.
 const COMMAND_CHANNEL_DEPTH: usize = 64;
 
+/// Buffer depth on the sidecar → daemon event channel.
+///
+/// F-658: the inbound `SidecarMessage::Event` reader hands frames to a
+/// dedicated emitter task through a bounded `mpsc::channel`. A
+/// misbehaving (or compromised) sidecar that emits at line rate is
+/// back-pressured at this boundary: once the channel is full, the read
+/// loop awaits on `Sender::send`, the kernel UDS read buffer fills, and
+/// the sidecar's own [`forge_ipc::write_frame`] call blocks. End-to-end
+/// flow control with a documented memory ceiling — no daemon-side queue
+/// can grow unbounded regardless of peer behavior.
+///
+/// Sized at 1024 frames (~few-hundred-KiB worst case for typical
+/// `Event` payloads) so a normal turn's burst — token streaming chunks
+/// plus tool-call envelopes — never observes backpressure under
+/// healthy conditions, but a sustained flood saturates well before
+/// memory pressure.
+pub const EVENT_CHANNEL_DEPTH: usize = 1024;
+
 /// Resolve the supervisor's effective handshake deadline. Reads the
 /// same `FORGE_IPC_HANDSHAKE_DEADLINE_MS` env override the daemon's
 /// shell-facing handshake honors so `cargo test` can wind the value
@@ -317,6 +335,17 @@ impl SidecarSupervisor {
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<ShutdownRequest>();
         let pid_cell = Arc::new(AtomicU32::new(initial.child_pid));
 
+        // F-658: decouple inbound-event reads from sink emission with a
+        // bounded mpsc. The supervisor task pushes onto `event_tx` and
+        // backpressures the read loop when full; the emitter task drains
+        // `event_rx` into the sink without ever blocking the IPC read
+        // path. Failure-path escalations bypass the channel via the
+        // retained `event_sink` clone in `SupervisorTask` so an
+        // exhausted-budget event is delivered even if the channel is
+        // saturated.
+        let (event_tx, event_rx) = mpsc::channel::<Event>(EVENT_CHANNEL_DEPTH);
+        let emitter_join = spawn_event_emitter(event_rx, event_sink.clone(), instance_id.clone());
+
         let supervisor = SupervisorTask {
             socket_dir: self.socket_dir.clone(),
             forged_agent_path: self.forged_agent_path.clone(),
@@ -325,6 +354,8 @@ impl SidecarSupervisor {
             instance_id: instance_id.clone(),
             params,
             event_sink: event_sink.clone(),
+            event_tx,
+            emitter_join: Some(emitter_join),
             command_rx,
             shutdown_rx,
             pid_cell: pid_cell.clone(),
@@ -517,7 +548,18 @@ struct SupervisorTask {
     socket_path: PathBuf,
     instance_id: AgentInstanceId,
     params: SpawnParams,
+    /// Direct sink reference. Used **only** for failure-path
+    /// escalations (`emit_failure`); routine inbound events flow through
+    /// `event_tx` so the F-658 backpressure contract is preserved.
     event_sink: Arc<dyn EventSink>,
+    /// Bounded sender feeding the per-supervisor emitter task. Frames
+    /// arrive on the IPC read half; the supervisor awaits this send so
+    /// a slow sink propagates backpressure all the way to the sidecar.
+    event_tx: mpsc::Sender<Event>,
+    /// JoinHandle for the emitter task. Held `Option<>` so the
+    /// supervisor can `take()` it on shutdown, drop the sender, and
+    /// await final drain.
+    emitter_join: Option<JoinHandle<()>>,
     command_rx: mpsc::Receiver<SidecarMessage>,
     shutdown_rx: oneshot::Receiver<ShutdownRequest>,
     pid_cell: Arc<AtomicU32>,
@@ -561,6 +603,7 @@ impl SupervisorTask {
                         instance_id = %self.instance_id,
                         "sidecar supervisor exiting after clean shutdown"
                     );
+                    self.drain_emitter().await;
                     return;
                 }
                 LifecycleOutcome::Crashed(reason) => {
@@ -589,6 +632,7 @@ impl SupervisorTask {
                             "sidecar exhausted retry budget; escalating to BackgroundAgentCompleted (failure)"
                         );
                         self.emit_failure(reason).await;
+                        self.drain_emitter().await;
                         return;
                     }
 
@@ -650,6 +694,7 @@ impl SupervisorTask {
                                     "sidecar restart-after-crash budget exhausted; escalating"
                                 );
                                 self.emit_failure(format!("restart failed: {e}")).await;
+                                self.drain_emitter().await;
                                 return;
                             }
                             // Otherwise sleep briefly to avoid a hot
@@ -677,6 +722,7 @@ impl SupervisorTask {
                                     );
                                     self.emit_failure(format!("relaunch retry failed: {e2}"))
                                         .await;
+                                    self.drain_emitter().await;
                                     return;
                                 }
                             }
@@ -853,12 +899,21 @@ impl SupervisorTask {
     async fn handle_inbound(&self, frame: SidecarMessage) -> Option<String> {
         match frame {
             SidecarMessage::Event(ev) => {
-                if let Err(e) = self.event_sink.emit(ev.event).await {
+                // F-658: route routine events through the bounded
+                // channel. `send().await` parks the read loop when the
+                // channel is full — that's the daemon-side backpressure
+                // signal that propagates back through the kernel UDS
+                // buffer to the sidecar's writer. A `Closed` error
+                // means the emitter task has exited (sink dropped or
+                // panicked); log and continue rather than taking the
+                // supervisor down on a downstream subscriber's
+                // collapse.
+                if let Err(e) = self.event_tx.send(ev.event).await {
                     warn!(
                         target: "forge_session::sidecar",
                         instance_id = %self.instance_id,
                         error = %e,
-                        "event_sink emit failed"
+                        "event channel closed; emitter task gone"
                     );
                 }
                 None
@@ -937,6 +992,31 @@ impl SupervisorTask {
         let _ = tokio::fs::remove_file(&self.socket_path).await;
     }
 
+    /// Close the event channel and await the emitter task's final
+    /// drain so callers observing the supervisor's exit are guaranteed
+    /// every accepted frame has reached the sink. Idempotent — calling
+    /// twice is a no-op because the JoinHandle has been taken.
+    async fn drain_emitter(&mut self) {
+        // Replace `event_tx` with a fresh, unconnected sender so the
+        // original is dropped here; the emitter task observes
+        // `recv() -> None` and exits. We can't simply move out of
+        // `self.event_tx` because the surrounding methods take `&mut self`
+        // for the duration of the supervisor's run.
+        let (sentinel_tx, _) = mpsc::channel::<Event>(1);
+        let closing = std::mem::replace(&mut self.event_tx, sentinel_tx);
+        drop(closing);
+        if let Some(join) = self.emitter_join.take() {
+            if let Err(e) = join.await {
+                warn!(
+                    target: "forge_session::sidecar",
+                    instance_id = %self.instance_id,
+                    error = %e,
+                    "event emitter task did not exit cleanly"
+                );
+            }
+        }
+    }
+
     /// Drop crash-log entries older than [`RETRY_WINDOW`].
     fn prune_crash_log(&mut self, now: Instant) {
         while let Some(&front) = self.crash_log.front() {
@@ -947,6 +1027,49 @@ impl SupervisorTask {
             }
         }
     }
+}
+
+/// F-658: spawn the event emitter task that drains a bounded channel
+/// of `Event`s into a real [`EventSink`].
+///
+/// The supervisor's IPC read loop pushes inbound `SidecarMessage::Event`
+/// payloads onto the paired [`mpsc::Sender`] using `send().await`. When
+/// the sink is slow, the channel fills, the read loop parks, the kernel
+/// UDS read buffer fills, and the sidecar's writer blocks — end-to-end
+/// flow control with a documented memory ceiling
+/// ([`EVENT_CHANNEL_DEPTH`]).
+///
+/// Sink errors are logged at `warn!` and **do not** stop the task —
+/// dropping the entire pump on a single transient failure would leave
+/// the daemon's read loop wedged on a saturated channel forever. The
+/// task exits only when its receiver closes (sender dropped), which
+/// happens on the supervisor's shutdown / failure-escalation path.
+///
+/// Exposed as a free function (rather than baked into the supervisor)
+/// so the F-658 regression test can drive the same drain logic without
+/// spawning a real `forged-agent` binary.
+pub fn spawn_event_emitter(
+    mut rx: mpsc::Receiver<Event>,
+    sink: Arc<dyn EventSink>,
+    instance_id: AgentInstanceId,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            if let Err(e) = sink.emit(event).await {
+                warn!(
+                    target: "forge_session::sidecar",
+                    instance_id = %instance_id,
+                    error = %e,
+                    "event_sink emit failed"
+                );
+            }
+        }
+        debug!(
+            target: "forge_session::sidecar",
+            instance_id = %instance_id,
+            "event emitter task drained; exiting"
+        );
+    })
 }
 
 /// Mode-700 the per-supervisor socket dir. Idempotent: a pre-existing

--- a/crates/forge-session/tests/sidecar_event_backpressure.rs
+++ b/crates/forge-session/tests/sidecar_event_backpressure.rs
@@ -1,0 +1,166 @@
+//! F-658 regression: the sidecar→daemon event path must be bounded.
+//!
+//! Before F-658 the daemon's read loop awaited [`EventSink::emit`]
+//! synchronously per inbound `SidecarMessage::Event` frame. That self-
+//! paced the read loop but meant a misbehaving sidecar emitting at line
+//! rate could drive downstream subscribers (broadcast bus, IPC writers)
+//! to buffer with no upper bound — daemon RSS grew until OOM. The fix
+//! decouples the read loop from the sink behind a bounded
+//! [`mpsc::channel`] sized at [`EVENT_CHANNEL_DEPTH`]; once the channel
+//! fills, [`Sender::send`] awaits, which in turn parks the read loop,
+//! which fills the kernel UDS buffer, which finally backpressures the
+//! sidecar's own [`forge_ipc::write_frame`] write. End-to-end backpressure
+//! with a documented memory ceiling.
+//!
+//! The test below drives the public emitter helper directly: it floods
+//! events through a bounded channel into a deliberately-slow
+//! [`EventSink`] and asserts the channel saturates at its documented
+//! capacity rather than growing without bound. The assertion shape —
+//! `try_send` returns [`TrySendError::Full`] under flood — is the
+//! observable signature of correct backpressure; without it the channel
+//! would either be unbounded (no `Full` ever) or sized too generously
+//! (no `Full` for the test's burst).
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::Utc;
+use forge_core::{AgentId, AgentInstanceId, Event, EventSink};
+use forge_session::sidecar::{spawn_event_emitter, EVENT_CHANNEL_DEPTH};
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+/// Slow [`EventSink`] used to exercise backpressure: each emit awaits a
+/// configurable delay before recording. The test holds the emitter task
+/// "behind" the channel so the channel saturates at its declared depth.
+#[derive(Debug)]
+struct SlowCountingSink {
+    seen: AtomicUsize,
+    delay: Duration,
+}
+
+impl SlowCountingSink {
+    fn new(delay: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            seen: AtomicUsize::new(0),
+            delay,
+        })
+    }
+
+    fn seen(&self) -> usize {
+        self.seen.load(Ordering::Acquire)
+    }
+}
+
+#[async_trait]
+impl EventSink for SlowCountingSink {
+    async fn emit(&self, _event: Event) -> Result<()> {
+        sleep(self.delay).await;
+        self.seen.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+}
+
+fn dummy_event() -> Event {
+    Event::BackgroundAgentStarted {
+        id: AgentInstanceId::new(),
+        agent: AgentId::new(),
+        at: Utc::now(),
+    }
+}
+
+/// Documented depth is non-zero and large enough to absorb a normal
+/// turn's burst. The number is part of the security contract — a
+/// regression that silently shrinks it to 1 would still pass this test
+/// but a regression that flips back to `mpsc::unbounded_channel` would
+/// not (channel capacity becomes irrelevant). The companion flood test
+/// below catches the unbounded regression.
+#[tokio::test]
+async fn event_channel_depth_is_documented_and_nontrivial() {
+    const _: () = {
+        assert!(
+            EVENT_CHANNEL_DEPTH >= 64,
+            "EVENT_CHANNEL_DEPTH too small to absorb a normal turn"
+        );
+        assert!(
+            EVENT_CHANNEL_DEPTH <= 8192,
+            "EVENT_CHANNEL_DEPTH larger than the documented ceiling"
+        );
+    };
+}
+
+/// Flood the channel with significantly more events than its capacity
+/// while the sink consumes slowly. Any unbounded buffer would accept
+/// every send; a bounded one returns `TrySendError::Full` once the
+/// buffer is saturated, which is the test's positive signal.
+#[tokio::test]
+async fn flooding_event_channel_yields_backpressure_not_unbounded_growth() {
+    let sink = SlowCountingSink::new(Duration::from_millis(5));
+    let instance_id = AgentInstanceId::new();
+    let (tx, rx) = mpsc::channel::<Event>(EVENT_CHANNEL_DEPTH);
+
+    let emitter = spawn_event_emitter(rx, sink.clone() as Arc<dyn EventSink>, instance_id.clone());
+
+    // Burst well past capacity; with a slow sink, only `EVENT_CHANNEL_DEPTH`
+    // (plus the one in-flight emit) will fit before `try_send` reports
+    // `Full`.
+    let burst = EVENT_CHANNEL_DEPTH * 8;
+    let mut accepted = 0usize;
+    let mut full_seen = false;
+    for _ in 0..burst {
+        match tx.try_send(dummy_event()) {
+            Ok(()) => accepted += 1,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                full_seen = true;
+                break;
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                panic!("emitter dropped channel mid-test");
+            }
+        }
+    }
+
+    assert!(
+        full_seen,
+        "expected TrySendError::Full from a bounded channel; got {accepted} sends without saturation \
+         (this almost certainly means the channel reverted to unbounded)"
+    );
+    assert!(
+        accepted <= EVENT_CHANNEL_DEPTH + 1,
+        "channel admitted {accepted} sends before saturating; bound is {EVENT_CHANNEL_DEPTH}"
+    );
+
+    // Drop the sender so the emitter task can drain and exit, then
+    // observe that every accepted event reached the sink — backpressure
+    // must not silently lose frames.
+    drop(tx);
+    emitter.await.expect("emitter task panicked or was aborted");
+    assert_eq!(
+        sink.seen(),
+        accepted,
+        "emitter task lost events between channel and sink"
+    );
+}
+
+/// Sender drop cleanly winds the emitter down. Without this property
+/// the supervisor's shutdown path would leak a tokio task per spawned
+/// sidecar.
+#[tokio::test]
+async fn dropping_sender_terminates_emitter_task() {
+    let sink = SlowCountingSink::new(Duration::ZERO);
+    let instance_id = AgentInstanceId::new();
+    let (tx, rx) = mpsc::channel::<Event>(EVENT_CHANNEL_DEPTH);
+
+    let emitter = spawn_event_emitter(rx, sink as Arc<dyn EventSink>, instance_id);
+
+    drop(tx);
+
+    // The task must complete promptly once its receiver closes.
+    tokio::time::timeout(Duration::from_secs(2), emitter)
+        .await
+        .expect("emitter task did not exit within 2s of sender drop")
+        .expect("emitter task panicked");
+}


### PR DESCRIPTION
Closes forge-ide/forge#694

## Summary
- Bound the sidecar->daemon event path with `EVENT_CHANNEL_DEPTH = 1024` (documented inline). The supervisor's IPC read loop now `send().await`s onto a `tokio::sync::mpsc::channel`, which a dedicated emitter task drains into the supplied `EventSink`.
- Backpressure (not drop): a slow sink parks the read loop, the kernel UDS read buffer fills, and the sidecar's `forge_ipc::write_frame` blocks. End-to-end flow control with a documented memory ceiling.
- Failure-escalation events (retry-budget exhaustion) bypass the channel and call `EventSink::emit` directly so the `BackgroundAgentCompleted` signal lands even when the channel is saturated.

## Test plan
- `cargo test -p forge-session` passes (incl. existing `sidecar_supervisor`, `bg_agents_sidecar`, `sidecar_crash_dump` suites).
- New `tests/sidecar_event_backpressure.rs` floods past capacity and asserts `TrySendError::Full`, catching any regression to an unbounded channel.
- `just check-rust` passes (fmt, clippy `-D warnings`, rustdoc `-D warnings`).
- `cargo test --workspace` green.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).