### PR TITLE
[F-678] Validate daemon↔shell schema_version bidirectionally on handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,6 +1509,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "ts-rs",
 ]
 

--- a/crates/forge-agent-host/src/lib.rs
+++ b/crates/forge-agent-host/src/lib.rs
@@ -324,6 +324,7 @@ fn make_hello(instance_id: &str) -> SidecarMessage {
         },
         sandbox_level: SidecarSandboxLevel::Level1,
         telemetry_endpoint: None,
+        schema_version: SIDECAR_SCHEMA_VERSION,
     })
 }
 
@@ -854,6 +855,7 @@ pub async fn run(args: AgentArgs) -> Result<()> {
                     schema = ack.schema_version,
                     "handshake complete"
                 );
+                validate_daemon_hello_ack(&ack);
             }
             other => {
                 anyhow::bail!("expected HelloAck, got {other:?}");
@@ -911,6 +913,16 @@ pub async fn run(args: AgentArgs) -> Result<()> {
 
     info!("forged-agent exiting cleanly");
     Ok(())
+}
+
+/// F-678: agent-host's leg of the bidirectional schema-version check.
+/// The daemon-side supervisor stamps its `SIDECAR_SCHEMA_VERSION` into
+/// the ack; this helper warn-logs through the shared
+/// [`forge_ipc::warn_if_schema_mismatch`] so a forged-agent connected
+/// to a version-skewed daemon surfaces in operator logs. Non-fatal —
+/// callers continue into the dispatch loop unchanged.
+pub(crate) fn validate_daemon_hello_ack(ack: &SidecarHelloAck) {
+    forge_ipc::warn_if_schema_mismatch("daemon", ack.schema_version, SIDECAR_SCHEMA_VERSION);
 }
 
 /// Build the `HelloAck` frame the daemon side should send. Lives here
@@ -1000,5 +1012,122 @@ mod tests {
         assert_eq!(seq.next(), 1);
         assert_eq!(seq.next(), 2);
         assert_eq!(seq.next(), 3);
+    }
+
+    /// F-678: a daemon `HelloAck` whose `schema_version` differs from
+    /// the agent-host's `SIDECAR_SCHEMA_VERSION` must emit a `warn!`
+    /// so an operator can spot the version skew. Non-fatal — the agent
+    /// continues into the dispatch loop. Pin the wire of that warn
+    /// under a capture subscriber.
+    #[test]
+    fn validate_daemon_hello_ack_warns_on_schema_mismatch() {
+        use chrono::Utc;
+        use std::io;
+        use std::sync::{Arc, Mutex as StdMutex};
+        use tracing_subscriber::fmt::MakeWriter;
+
+        #[derive(Clone, Default)]
+        struct CaptureWriter(Arc<StdMutex<Vec<u8>>>);
+        impl io::Write for CaptureWriter {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for CaptureWriter {
+            type Writer = CaptureWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let writer = CaptureWriter::default();
+        let buf = writer.0.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .with_target(true)
+            .with_writer(writer)
+            .finish();
+
+        let bogus_schema = SIDECAR_SCHEMA_VERSION.wrapping_add(7);
+        let ack = SidecarHelloAck {
+            pid: 1234,
+            started_at: Utc::now(),
+            schema_version: bogus_schema,
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            validate_daemon_hello_ack(&ack);
+        });
+
+        let captured = String::from_utf8(buf.lock().unwrap().clone()).expect("utf-8");
+        assert!(
+            captured.contains("schema_version mismatch"),
+            "expected mismatch warn, got: {captured}",
+        );
+        assert!(
+            captured.contains("peer=\"daemon\""),
+            "expected peer=daemon label, got: {captured}",
+        );
+        assert!(
+            captured.contains(&format!("peer_schema_version={bogus_schema}")),
+            "expected reported peer schema_version, got: {captured}",
+        );
+    }
+
+    /// F-678: a daemon `HelloAck` whose `schema_version` matches the
+    /// local constant is silent — no warn must fire on the happy path.
+    #[test]
+    fn validate_daemon_hello_ack_silent_on_match() {
+        use chrono::Utc;
+        use std::io;
+        use std::sync::{Arc, Mutex as StdMutex};
+        use tracing_subscriber::fmt::MakeWriter;
+
+        #[derive(Clone, Default)]
+        struct CaptureWriter(Arc<StdMutex<Vec<u8>>>);
+        impl io::Write for CaptureWriter {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for CaptureWriter {
+            type Writer = CaptureWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let writer = CaptureWriter::default();
+        let buf = writer.0.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .with_writer(writer)
+            .finish();
+
+        let ack = SidecarHelloAck {
+            pid: 1234,
+            started_at: Utc::now(),
+            schema_version: SIDECAR_SCHEMA_VERSION,
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            validate_daemon_hello_ack(&ack);
+        });
+
+        let captured = String::from_utf8(buf.lock().unwrap().clone()).expect("utf-8");
+        assert!(
+            !captured.contains("schema_version mismatch"),
+            "matching schema_version must not warn, got: {captured}",
+        );
     }
 }

--- a/crates/forge-cli/src/main.rs
+++ b/crates/forge-cli/src/main.rs
@@ -239,6 +239,7 @@ async fn session_list() -> Result<()> {
                         pid: std::process::id(),
                         user: whoami(),
                     },
+                    schema_version: forge_ipc::SCHEMA_VERSION,
                 });
                 if write_frame(&mut stream, &hello).await.is_ok() {
                     if let Ok(IpcMessage::HelloAck(ack)) =
@@ -295,6 +296,7 @@ async fn session_tail(id: &str) -> Result<()> {
                 pid: std::process::id(),
                 user: whoami(),
             },
+            schema_version: forge_ipc::SCHEMA_VERSION,
         }),
     )
     .await?;
@@ -402,6 +404,7 @@ async fn run_agent(name: &str, input_source: &str) -> Result<()> {
                 pid: std::process::id(),
                 user: whoami(),
             },
+            schema_version: forge_ipc::SCHEMA_VERSION,
         }),
     )
     .await?;

--- a/crates/forge-ipc/Cargo.toml
+++ b/crates/forge-ipc/Cargo.toml
@@ -22,6 +22,11 @@ forge-mcp = { path = "../forge-mcp" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 tokio = { version = "1", features = ["io-util", "net", "time"] }
+# F-678: `warn_if_schema_mismatch` emits a structured `warn!` shared by
+# every handshake site. Lives in this crate so the four legs
+# (daemon↔shell, sidecar↔supervisor) share one message format and log
+# target.
+tracing = "0.1"
 # F-604: `RefineHandoff` crosses the Tauri boundary as the return type of
 # `session_interrupt_and_refine`; ts-rs emits its TypeScript declaration
 # under web/packages/ipc/src/generated/.
@@ -31,6 +36,9 @@ ts-rs = "12"
 chrono = { version = "0.4", features = ["serde"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time"] }
+# F-678: the schema-mismatch helper test installs a capture subscriber
+# to assert the `warn!` actually fires.
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 [[bench]]
 name = "frame"

--- a/crates/forge-ipc/benches/frame.rs
+++ b/crates/forge-ipc/benches/frame.rs
@@ -221,6 +221,7 @@ fn padded_hello(body_len: usize) -> IpcMessage {
             pid: 1,
             user: "b".to_string(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     })
 }
 

--- a/crates/forge-ipc/src/lib.rs
+++ b/crates/forge-ipc/src/lib.rs
@@ -19,6 +19,30 @@ pub mod sidecar;
 pub const PROTO_VERSION: u32 = 1;
 pub const SCHEMA_VERSION: u32 = 1;
 
+/// F-678: log a `warn!` when a handshake peer reports a schema version
+/// that does not match the local [`SCHEMA_VERSION`] (or the per-leg
+/// equivalent — same shape, same comparison). Used on every handshake
+/// site that exchanges a schema_version field so the four legs
+/// (daemon↔shell, sidecar↔supervisor) share a single message format and
+/// log target. `peer_label` identifies the remote side ("shell",
+/// "daemon", "sidecar", "supervisor") — surfaced verbatim in the log
+/// line so triage can pinpoint which leg drifted.
+///
+/// Today the mismatch is non-fatal: the connection still completes. A
+/// later `strict_schema_version` toggle (per F-678 finding) can elevate
+/// to error and reject the connection without touching the call sites.
+pub fn warn_if_schema_mismatch(peer_label: &str, peer_version: u32, local_version: u32) {
+    if peer_version != local_version {
+        tracing::warn!(
+            target: "forge_ipc::handshake",
+            peer = peer_label,
+            peer_schema_version = peer_version,
+            local_schema_version = local_version,
+            "schema_version mismatch on handshake; serde drift possible",
+        );
+    }
+}
+
 /// Hard cap on a single IPC frame body, enforced on both the write side
 /// (pre-send in [`write_frame`]) and the read side (pre-allocation in
 /// [`read_frame`], before the body buffer is sized). 4 MiB is generous
@@ -323,6 +347,14 @@ pub struct IpcEvent {
 pub struct Hello {
     pub proto: u32,
     pub client: ClientInfo,
+    /// F-678: peer-reported schema version. The daemon compares this against
+    /// the local [`SCHEMA_VERSION`] and `tracing::warn!`s on mismatch so a
+    /// version-skewed shell cannot silently corrupt downstream serde.
+    /// `#[serde(default)]` defaults to `0` for legacy peers that pre-date
+    /// the bidirectional check — those connections are surfaced via the
+    /// same warn path rather than rejected outright.
+    #[serde(default)]
+    pub schema_version: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -521,6 +553,7 @@ mod tests {
                 pid: 1234,
                 user: "alice".to_string(),
             },
+            schema_version: SCHEMA_VERSION,
         })
     }
 
@@ -652,5 +685,95 @@ mod tests {
             .await
             .expect("frame should arrive before deadline");
         matches!(got, IpcMessage::Hello(_));
+    }
+
+    /// F-678: the `schema_version` field on `Hello` is `#[serde(default)]`
+    /// so a legacy peer that omits it deserializes to `0`, surfacing
+    /// through the warn path rather than failing at the deserialize
+    /// layer. Pin the wire-shape here so a future rename / type change
+    /// can't drift past CI silently.
+    #[test]
+    fn hello_defaults_schema_version_when_field_absent() {
+        let body = serde_json::json!({
+            "t": "Hello",
+            "proto": PROTO_VERSION,
+            "client": { "kind": "shell", "pid": 1, "user": "u" }
+            // no schema_version
+        });
+        let msg: IpcMessage = serde_json::from_value(body).expect("legacy Hello deserializes");
+        match msg {
+            IpcMessage::Hello(h) => {
+                assert_eq!(
+                    h.schema_version, 0,
+                    "missing schema_version must default to 0",
+                );
+            }
+            other => panic!("expected Hello, got {other:?}"),
+        }
+    }
+
+    /// F-678: the helper emits exactly one `warn!` event when the peer
+    /// version differs and stays silent on a match. Capture the tracing
+    /// subscriber output and assert the event surface so the four
+    /// handshake legs share an audited contract.
+    #[test]
+    fn warn_if_schema_mismatch_emits_warn_on_drift() {
+        use std::io;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt::MakeWriter;
+
+        #[derive(Clone, Default)]
+        struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+        impl io::Write for CaptureWriter {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for CaptureWriter {
+            type Writer = CaptureWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let writer = CaptureWriter::default();
+        let buf = writer.0.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .with_target(true)
+            .with_writer(writer)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            // Match → silent.
+            warn_if_schema_mismatch("shell", SCHEMA_VERSION, SCHEMA_VERSION);
+            // Mismatch → warn.
+            warn_if_schema_mismatch("shell", 999, SCHEMA_VERSION);
+        });
+
+        let captured = String::from_utf8(buf.lock().unwrap().clone()).expect("utf-8");
+        assert!(
+            captured.contains("schema_version mismatch"),
+            "expected mismatch warn in capture: {captured}",
+        );
+        assert!(
+            captured.contains("peer=\"shell\""),
+            "expected peer label in capture: {captured}",
+        );
+        assert!(
+            captured.contains("peer_schema_version=999"),
+            "expected peer version in capture: {captured}",
+        );
+        // Exactly one event — the matching call must not log.
+        assert_eq!(
+            captured.matches("schema_version mismatch").count(),
+            1,
+            "matching version should not log: {captured}",
+        );
     }
 }

--- a/crates/forge-ipc/src/sidecar.rs
+++ b/crates/forge-ipc/src/sidecar.rs
@@ -185,7 +185,8 @@ pub enum SidecarMessage {
 
 // ── daemon → sidecar payloads ────────────────────────────────────────────
 
-/// Initial daemon → sidecar handshake payload.
+/// Initial sidecar → daemon handshake payload (and, in step-4 of F-608,
+/// the daemon → sidecar follow-up that forwards the spawn parameters).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SidecarHello {
     pub proto: u32,
@@ -197,6 +198,15 @@ pub struct SidecarHello {
     pub sandbox_level: SidecarSandboxLevel,
     /// Optional OTLP / tracing collector endpoint. `None` skips export.
     pub telemetry_endpoint: Option<String>,
+    /// F-678: peer-reported schema version. The supervisor compares this
+    /// against [`SIDECAR_SCHEMA_VERSION`] and `tracing::warn!`s on
+    /// mismatch; the agent-host applies the same check on the
+    /// `HelloAck` it receives back. `#[serde(default)]` defaults to `0`
+    /// for legacy peers (e.g. older `forged-agent` builds) so a skewed
+    /// peer is surfaced via the warn rather than silently rejected at
+    /// the deserialize layer.
+    #[serde(default)]
+    pub schema_version: u32,
 }
 
 /// Wire-friendly subset of `forge_agents::AgentDef` carried over the
@@ -406,6 +416,7 @@ mod tests {
                 },
                 sandbox_level: SidecarSandboxLevel::Level1,
                 telemetry_endpoint: None,
+                schema_version: SIDECAR_SCHEMA_VERSION,
             }),
             SidecarMessage::Hello(SidecarHello {
                 proto: SIDECAR_PROTO_VERSION,
@@ -429,6 +440,7 @@ mod tests {
                     image: "registry.example.com/forge/sandbox:1".into(),
                 },
                 telemetry_endpoint: Some("http://otel:4317".into()),
+                schema_version: SIDECAR_SCHEMA_VERSION,
             }),
             SidecarMessage::RunTurn(SidecarRunTurn {
                 turn_id: "turn-1".into(),

--- a/crates/forge-ipc/tests/frame_sizing.rs
+++ b/crates/forge-ipc/tests/frame_sizing.rs
@@ -138,5 +138,6 @@ fn _ensure_symbols_compile() -> IpcMessage {
             pid: 0,
             user: String::new(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     })
 }

--- a/crates/forge-session/benches/sidecar_overhead.rs
+++ b/crates/forge-session/benches/sidecar_overhead.rs
@@ -294,6 +294,7 @@ fn fixture_hello(instance_id: &AgentInstanceId) -> SidecarHello {
         },
         sandbox_level: SidecarSandboxLevel::Level1,
         telemetry_endpoint: None,
+        schema_version: forge_ipc::sidecar::SIDECAR_SCHEMA_VERSION,
     }
 }
 

--- a/crates/forge-session/src/bg_agents.rs
+++ b/crates/forge-session/src/bg_agents.rs
@@ -33,6 +33,7 @@ use forge_agents::{
 use forge_core::{ids::AgentId, AgentInstanceId, Event, EventSink};
 use forge_ipc::sidecar::{
     SidecarAgentDef, SidecarHello, SidecarProviderSpec, SidecarSandboxLevel, SIDECAR_PROTO_VERSION,
+    SIDECAR_SCHEMA_VERSION,
 };
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -206,6 +207,7 @@ fn build_sidecar_hello(instance_id: &AgentInstanceId, def: &AgentDef) -> Sidecar
         },
         sandbox_level: SidecarSandboxLevel::Level1,
         telemetry_endpoint: None,
+        schema_version: SIDECAR_SCHEMA_VERSION,
     }
 }
 

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -1252,6 +1252,13 @@ async fn handle_connection<P: Provider + 'static>(
     if hello.proto != PROTO_VERSION {
         anyhow::bail!("unsupported protocol version: {}", hello.proto);
     }
+    // F-678: bidirectional schema-version validation. The shell reports
+    // its `schema_version` in the `Hello` frame; if it diverges from the
+    // daemon's `SCHEMA_VERSION`, log a warn so a version-skewed peer
+    // surfaces in operator logs rather than failing later through
+    // opaque serde drift. Non-fatal today; a future
+    // `strict_schema_version` toggle can elevate to error.
+    forge_ipc::warn_if_schema_mismatch("shell", hello.schema_version, SCHEMA_VERSION);
 
     let ack = IpcMessage::HelloAck(HelloAck {
         session_id: (*session_id).clone(),

--- a/crates/forge-session/src/sidecar/mod.rs
+++ b/crates/forge-session/src/sidecar/mod.rs
@@ -471,13 +471,9 @@ impl SidecarSupervisor {
         };
         match &hello_frame {
             SidecarMessage::Hello(h) => {
-                if h.instance_id.to_string() != instance_id.to_string() {
+                if let Err(e) = validate_sidecar_hello(h, instance_id) {
                     let _ = child.kill().await;
-                    anyhow::bail!(
-                        "forged-agent reported instance_id={}, expected {}",
-                        h.instance_id,
-                        instance_id
-                    );
+                    return Err(e);
                 }
             }
             other => {
@@ -994,6 +990,27 @@ fn current_euid() -> u32 {
     unsafe { libc::geteuid() }
 }
 
+/// F-678: validate a sidecar's `Hello` frame. The `instance_id` check
+/// is hard (returns `Err` so the supervisor can kill the misrouted
+/// child); the `schema_version` check is soft and emits `tracing::warn!`
+/// through the shared [`forge_ipc::warn_if_schema_mismatch`] helper.
+/// Lives outside `LiveSidecar::spawn` so unit tests can drive the
+/// validation path without spawning a real `forged-agent` binary.
+pub(crate) fn validate_sidecar_hello(
+    hello: &SidecarHello,
+    expected_instance_id: &AgentInstanceId,
+) -> Result<()> {
+    if hello.instance_id.to_string() != expected_instance_id.to_string() {
+        anyhow::bail!(
+            "forged-agent reported instance_id={}, expected {}",
+            hello.instance_id,
+            expected_instance_id
+        );
+    }
+    forge_ipc::warn_if_schema_mismatch("sidecar", hello.schema_version, SIDECAR_SCHEMA_VERSION);
+    Ok(())
+}
+
 /// F-651: assert that the connected peer's uid matches `expected_uid`.
 /// Tokio's `peer_cred()` wraps SO_PEERCRED on Linux and LOCAL_PEERCRED
 /// on macOS; both report the credentials of the process that
@@ -1088,6 +1105,174 @@ mod tests {
         assert!(
             msg.contains("does not match"),
             "expected mismatch error, got: {msg}"
+        );
+    }
+
+    /// F-678: a sidecar `Hello` whose `schema_version` matches the
+    /// supervisor's `SIDECAR_SCHEMA_VERSION` validates without
+    /// emitting a warn — the silent path.
+    #[test]
+    fn validate_sidecar_hello_silent_on_match() {
+        use forge_core::AgentInstanceId;
+        use forge_ipc::sidecar::{
+            SidecarAgentDef, SidecarHello, SidecarProviderSpec, SidecarSandboxLevel,
+            SIDECAR_PROTO_VERSION,
+        };
+        let id = AgentInstanceId::from_string("inst-match".into());
+        let hello = SidecarHello {
+            proto: SIDECAR_PROTO_VERSION,
+            instance_id: id.clone(),
+            agent_def: SidecarAgentDef {
+                name: "t".into(),
+                description: None,
+                body: String::new(),
+                allowed_paths: vec![],
+                isolation: "process".into(),
+                memory_enabled: false,
+            },
+            allowed_paths: vec![],
+            workspace_path: "/tmp".into(),
+            provider_spec: SidecarProviderSpec {
+                kind: "stub".into(),
+                model: "stub".into(),
+                base_url: None,
+            },
+            sandbox_level: SidecarSandboxLevel::Level1,
+            telemetry_endpoint: None,
+            schema_version: SIDECAR_SCHEMA_VERSION,
+        };
+        validate_sidecar_hello(&hello, &id).expect("matching schema_version must validate");
+    }
+
+    /// F-678: a sidecar `Hello` whose `schema_version` differs from
+    /// `SIDECAR_SCHEMA_VERSION` still passes validation (warn-only,
+    /// non-fatal) and emits a `warn!` through the shared helper. Pin
+    /// the wire of that warn under a capture subscriber so the contract
+    /// stays observable from operator logs.
+    #[test]
+    fn validate_sidecar_hello_warns_on_schema_mismatch() {
+        use forge_core::AgentInstanceId;
+        use forge_ipc::sidecar::{
+            SidecarAgentDef, SidecarHello, SidecarProviderSpec, SidecarSandboxLevel,
+            SIDECAR_PROTO_VERSION,
+        };
+        use std::io;
+        use std::sync::{Arc, Mutex as StdMutex};
+        use tracing_subscriber::fmt::MakeWriter;
+
+        #[derive(Clone, Default)]
+        struct CaptureWriter(Arc<StdMutex<Vec<u8>>>);
+        impl io::Write for CaptureWriter {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for CaptureWriter {
+            type Writer = CaptureWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let writer = CaptureWriter::default();
+        let buf = writer.0.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .with_target(true)
+            .with_writer(writer)
+            .finish();
+
+        let id = AgentInstanceId::from_string("inst-skew".into());
+        let bogus_schema = SIDECAR_SCHEMA_VERSION.wrapping_add(99);
+        let hello = SidecarHello {
+            proto: SIDECAR_PROTO_VERSION,
+            instance_id: id.clone(),
+            agent_def: SidecarAgentDef {
+                name: "t".into(),
+                description: None,
+                body: String::new(),
+                allowed_paths: vec![],
+                isolation: "process".into(),
+                memory_enabled: false,
+            },
+            allowed_paths: vec![],
+            workspace_path: "/tmp".into(),
+            provider_spec: SidecarProviderSpec {
+                kind: "stub".into(),
+                model: "stub".into(),
+                base_url: None,
+            },
+            sandbox_level: SidecarSandboxLevel::Level1,
+            telemetry_endpoint: None,
+            schema_version: bogus_schema,
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            validate_sidecar_hello(&hello, &id)
+                .expect("schema mismatch must be warn-only, not an error");
+        });
+
+        let captured = String::from_utf8(buf.lock().unwrap().clone()).expect("utf-8");
+        assert!(
+            captured.contains("schema_version mismatch"),
+            "expected mismatch warn, got: {captured}",
+        );
+        assert!(
+            captured.contains("peer=\"sidecar\""),
+            "expected peer=sidecar label, got: {captured}",
+        );
+        assert!(
+            captured.contains(&format!("peer_schema_version={bogus_schema}")),
+            "expected reported peer schema_version, got: {captured}",
+        );
+    }
+
+    /// F-678: a sidecar `Hello` carrying a wrong `instance_id` still
+    /// hard-rejects (the supervisor would kill the misrouted child).
+    /// Pin this so the validator refactor cannot accidentally swallow
+    /// the instance_id check while preserving the new schema warn.
+    #[test]
+    fn validate_sidecar_hello_rejects_bad_instance_id() {
+        use forge_core::AgentInstanceId;
+        use forge_ipc::sidecar::{
+            SidecarAgentDef, SidecarHello, SidecarProviderSpec, SidecarSandboxLevel,
+            SIDECAR_PROTO_VERSION,
+        };
+        let expected = AgentInstanceId::from_string("inst-expected".into());
+        let reported = AgentInstanceId::from_string("inst-other".into());
+        let hello = SidecarHello {
+            proto: SIDECAR_PROTO_VERSION,
+            instance_id: reported,
+            agent_def: SidecarAgentDef {
+                name: "t".into(),
+                description: None,
+                body: String::new(),
+                allowed_paths: vec![],
+                isolation: "process".into(),
+                memory_enabled: false,
+            },
+            allowed_paths: vec![],
+            workspace_path: "/tmp".into(),
+            provider_spec: SidecarProviderSpec {
+                kind: "stub".into(),
+                model: "stub".into(),
+                base_url: None,
+            },
+            sandbox_level: SidecarSandboxLevel::Level1,
+            telemetry_endpoint: None,
+            schema_version: SIDECAR_SCHEMA_VERSION,
+        };
+        let err = validate_sidecar_hello(&hello, &expected)
+            .expect_err("instance_id mismatch must hard-reject");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("instance_id"),
+            "expected instance_id error, got: {msg}",
         );
     }
 

--- a/crates/forge-session/tests/archive_shutdown.rs
+++ b/crates/forge-session/tests/archive_shutdown.rs
@@ -81,6 +81,7 @@ async fn ephemeral_shutdown_removes_session_dir_and_socket() {
                 pid: std::process::id(),
                 user: "tester".into(),
             },
+            schema_version: forge_ipc::SCHEMA_VERSION,
         }),
     )
     .await
@@ -189,6 +190,7 @@ async fn persistent_sigterm_archives_session_dir_and_meta() {
                 pid: std::process::id(),
                 user: "tester".into(),
             },
+            schema_version: forge_ipc::SCHEMA_VERSION,
         }),
     )
     .await

--- a/crates/forge-session/tests/fs_read_tool.rs
+++ b/crates/forge-session/tests/fs_read_tool.rs
@@ -33,6 +33,7 @@ async fn do_handshake(stream: &mut UnixStream) {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();

--- a/crates/forge-session/tests/handshake.rs
+++ b/crates/forge-session/tests/handshake.rs
@@ -1,5 +1,5 @@
 #![allow(deprecated)] // F-652: tests/benches still drive the deprecated bare read_frame helpers.
-use forge_ipc::{ClientInfo, Hello, IpcMessage, PROTO_VERSION};
+use forge_ipc::{ClientInfo, Hello, IpcMessage, PROTO_VERSION, SCHEMA_VERSION};
 use forge_providers::MockProvider;
 use forge_session::server::{serve, serve_with_session};
 use forge_session::session::Session;
@@ -8,6 +8,10 @@ use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
+
+// F-678: bidirectional schema-version warn tests use the shared capture
+// subscriber to assert the daemon-side `warn!` actually fires.
+mod common;
 
 /// F-354: The deadline tests mutate process-wide env vars
 /// (`FORGE_IPC_HANDSHAKE_DEADLINE_MS` / `FORGE_IPC_IDLE_TIMEOUT_MS`) that
@@ -53,6 +57,7 @@ async fn handshake_succeeds_with_valid_proto() {
             pid: std::process::id(),
             user: "test-user".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
 
@@ -83,6 +88,7 @@ async fn unknown_proto_rejected() {
             pid: std::process::id(),
             user: "test-user".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
 
@@ -101,6 +107,7 @@ async fn perform_handshake(stream: &mut UnixStream) -> forge_ipc::HelloAck {
             pid: std::process::id(),
             user: "test-user".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();
@@ -275,6 +282,7 @@ async fn handshake_deadline_disconnects_half_handshaked_peer() {
             pid: std::process::id(),
             user: "test-user".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
     let _ack: IpcMessage = forge_ipc::read_frame(&mut stream).await.unwrap();
@@ -327,6 +335,7 @@ async fn post_handshake_idle_timeout_disconnects_peer() {
             pid: std::process::id(),
             user: "test-user".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
     let _ack: IpcMessage = forge_ipc::read_frame(&mut stream).await.unwrap();
@@ -409,5 +418,133 @@ async fn garbage_frame_rejected() {
     assert!(
         result.is_err(),
         "expected connection to be closed for garbage frame"
+    );
+}
+
+/// F-678: a shell whose `Hello.schema_version` does not match the daemon's
+/// `SCHEMA_VERSION` must complete the handshake (warn, do not reject) and
+/// the daemon's `warn!` must fire so a version-skewed peer surfaces in
+/// operator logs. This is the explicit DoD acceptance test for the
+/// daemon↔shell leg.
+// The capture-subscriber lock is a `std::sync::Mutex` held across awaits
+// to serialize the `drain_capture()` invariant — the existing
+// `bg_agents_tracing` tests use the same pattern. Clippy's concern
+// (waker deadlocks) doesn't apply: the guard is uncontended apart from
+// other capture-reading tests, which serialize through the same lock.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn handshake_with_mismatched_schema_version_warns_and_proceeds() {
+    let _test_lock = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture(); // clear any prior emissions
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("schema-mismatch.sock");
+
+    let server_path = path.clone();
+    tokio::spawn(async move {
+        serve(&server_path, false, false).await.unwrap();
+    });
+
+    let mut stream = connect_with_retry(&path).await;
+
+    // Stamp a deliberately wrong schema_version. The daemon should warn
+    // but still produce a HelloAck.
+    let bogus_schema: u32 = SCHEMA_VERSION.wrapping_add(42);
+    let hello = IpcMessage::Hello(Hello {
+        proto: PROTO_VERSION,
+        client: ClientInfo {
+            kind: "shell".into(),
+            pid: std::process::id(),
+            user: "test-user".into(),
+        },
+        schema_version: bogus_schema,
+    });
+    forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
+
+    let response = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let IpcMessage::HelloAck(ack) = response else {
+        panic!("expected HelloAck, got {response:?}");
+    };
+    assert_eq!(
+        ack.schema_version, SCHEMA_VERSION,
+        "daemon should still ack with its local SCHEMA_VERSION",
+    );
+
+    // Give the daemon a moment to flush the warn through the subscriber.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("schema_version mismatch"),
+        "expected mismatch warn in capture, got: {logs}",
+    );
+    assert!(
+        logs.contains("peer=\"shell\""),
+        "expected peer=shell label in capture, got: {logs}",
+    );
+    assert!(
+        logs.contains(&format!("peer_schema_version={bogus_schema}")),
+        "expected reported peer schema_version in capture, got: {logs}",
+    );
+}
+
+/// F-678: a shell that omits `schema_version` entirely (legacy peer that
+/// pre-dates the bidirectional check) deserializes via `#[serde(default)]`
+/// to `0`, surfaces through the warn path, and the connection still
+/// completes. Pins the wire-shape compatibility contract.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn handshake_with_legacy_hello_omitting_schema_version_warns_and_proceeds() {
+    let _test_lock = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("legacy-hello.sock");
+
+    let server_path = path.clone();
+    tokio::spawn(async move {
+        serve(&server_path, false, false).await.unwrap();
+    });
+
+    let mut stream = connect_with_retry(&path).await;
+
+    // Hand-build a legacy `Hello` body with no `schema_version` key. We
+    // can't use the typed `Hello { ... }` literal because the field is
+    // mandatory in Rust; emit raw JSON to mimic an older shell.
+    let body = serde_json::json!({
+        "t": "Hello",
+        "proto": PROTO_VERSION,
+        "client": {
+            "kind": "shell",
+            "pid": std::process::id(),
+            "user": "legacy",
+        },
+    });
+    let bytes = serde_json::to_vec(&body).unwrap();
+    let len = bytes.len() as u32;
+    use tokio::io::AsyncWriteExt;
+    stream.write_u32(len).await.unwrap();
+    stream.write_all(&bytes).await.unwrap();
+
+    let response = forge_ipc::read_frame(&mut stream).await.unwrap();
+    let IpcMessage::HelloAck(ack) = response else {
+        panic!("expected HelloAck for legacy peer, got {response:?}");
+    };
+    assert_eq!(ack.schema_version, SCHEMA_VERSION);
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("schema_version mismatch"),
+        "legacy peer should still warn (default 0 vs local): {logs}",
+    );
+    assert!(
+        logs.contains("peer_schema_version=0"),
+        "legacy peer reports default 0: {logs}",
     );
 }

--- a/crates/forge-session/tests/headless_session/basic.rs
+++ b/crates/forge-session/tests/headless_session/basic.rs
@@ -101,6 +101,7 @@ async fn full_headless_turn_emits_correct_event_sequence() {
                 pid: std::process::id(),
                 user: "tester".into(),
             },
+            schema_version: forge_ipc::SCHEMA_VERSION,
         }),
     )
     .await

--- a/crates/forge-session/tests/interrupt_refine.rs
+++ b/crates/forge-session/tests/interrupt_refine.rs
@@ -76,6 +76,7 @@ async fn do_handshake(stream: &mut UnixStream) {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();

--- a/crates/forge-session/tests/memory_injection.rs
+++ b/crates/forge-session/tests/memory_injection.rs
@@ -184,6 +184,7 @@ async fn serve_with_session_accepts_typed_active_agent_parameter() {
             pid: std::process::id(),
             user: "test-user".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(&mut stream, &hello).await.unwrap();
 

--- a/crates/forge-session/tests/orchestrator.rs
+++ b/crates/forge-session/tests/orchestrator.rs
@@ -41,6 +41,7 @@ async fn do_handshake(stream: &mut UnixStream) {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();
@@ -822,6 +823,7 @@ async fn unexpected_post_handshake_frame_is_logged_not_silently_dropped() {
                 pid: std::process::id(),
                 user: "tester".into(),
             },
+            schema_version: forge_ipc::SCHEMA_VERSION,
         }),
     )
     .await

--- a/crates/forge-session/tests/pause_resume.rs
+++ b/crates/forge-session/tests/pause_resume.rs
@@ -62,6 +62,7 @@ async fn do_handshake(stream: &mut UnixStream) {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();

--- a/crates/forge-session/tests/pid_file_lifecycle.rs
+++ b/crates/forge-session/tests/pid_file_lifecycle.rs
@@ -64,6 +64,7 @@ async fn handshake(sock: &std::path::Path) {
                 pid: std::process::id(),
                 user: "tester".into(),
             },
+            schema_version: forge_ipc::SCHEMA_VERSION,
         }),
     )
     .await

--- a/crates/forge-session/tests/provider_selection.rs
+++ b/crates/forge-session/tests/provider_selection.rs
@@ -56,6 +56,7 @@ async fn handshake(stream: &mut UnixStream) {
                 pid: std::process::id(),
                 user: "tester".into(),
             },
+            schema_version: forge_ipc::SCHEMA_VERSION,
         }),
     )
     .await

--- a/crates/forge-session/tests/provider_swap.rs
+++ b/crates/forge-session/tests/provider_swap.rs
@@ -52,6 +52,7 @@ async fn do_handshake(stream: &mut UnixStream) {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();

--- a/crates/forge-session/tests/rerun_branch.rs
+++ b/crates/forge-session/tests/rerun_branch.rs
@@ -55,6 +55,7 @@ async fn do_handshake(stream: &mut UnixStream) {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();

--- a/crates/forge-session/tests/rerun_fresh.rs
+++ b/crates/forge-session/tests/rerun_fresh.rs
@@ -57,6 +57,7 @@ async fn do_handshake(stream: &mut UnixStream) {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();

--- a/crates/forge-session/tests/rerun_replace.rs
+++ b/crates/forge-session/tests/rerun_replace.rs
@@ -52,6 +52,7 @@ async fn do_handshake(stream: &mut UnixStream) {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();

--- a/crates/forge-session/tests/session_ended.rs
+++ b/crates/forge-session/tests/session_ended.rs
@@ -73,6 +73,7 @@ async fn ephemeral_session_emits_session_ended_with_completed_reason() {
                 pid: std::process::id(),
                 user: "tester".into(),
             },
+            schema_version: forge_ipc::SCHEMA_VERSION,
         }),
     )
     .await

--- a/crates/forge-session/tests/sidecar_crash_dump.rs
+++ b/crates/forge-session/tests/sidecar_crash_dump.rs
@@ -101,6 +101,7 @@ fn fixture_hello(instance_id: &AgentInstanceId) -> SidecarHello {
         },
         sandbox_level: SidecarSandboxLevel::Level1,
         telemetry_endpoint: None,
+        schema_version: forge_ipc::sidecar::SIDECAR_SCHEMA_VERSION,
     }
 }
 

--- a/crates/forge-session/tests/sidecar_supervisor.rs
+++ b/crates/forge-session/tests/sidecar_supervisor.rs
@@ -112,6 +112,7 @@ fn fixture_hello(instance_id: &AgentInstanceId) -> SidecarHello {
         },
         sandbox_level: SidecarSandboxLevel::Level1,
         telemetry_endpoint: None,
+        schema_version: forge_ipc::sidecar::SIDECAR_SCHEMA_VERSION,
     }
 }
 

--- a/crates/forge-session/tests/step_events.rs
+++ b/crates/forge-session/tests/step_events.rs
@@ -61,6 +61,7 @@ async fn do_handshake(stream: &mut UnixStream) {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();

--- a/crates/forge-session/tests/subscribe_replay.rs
+++ b/crates/forge-session/tests/subscribe_replay.rs
@@ -36,6 +36,7 @@ async fn do_handshake(stream: &mut UnixStream) -> u64 {
             pid: std::process::id(),
             user: "tester".into(),
         },
+        schema_version: forge_ipc::SCHEMA_VERSION,
     });
     forge_ipc::write_frame(stream, &hello).await.unwrap();
     let response = forge_ipc::read_frame(stream).await.unwrap();

--- a/crates/forge-shell/src/bridge.rs
+++ b/crates/forge-shell/src/bridge.rs
@@ -27,11 +27,12 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use forge_core::{ApprovalScope, RerunVariant};
 use forge_ipc::{
-    read_frame_into_with_deadline, read_frame_with_deadline, write_frame, ClientInfo,
-    CompactTranscript, DeleteBranch, Hello, HelloAck, ImportMcpConfig, InterruptSession,
-    IpcMessage, IpcReadTimeout, ListMcpServers, McpImportResult, McpServersList, McpToggleResult,
-    PauseSession, RefineHandoff, RerunMessage, ResumeSession, SelectBranch, SendUserMessage,
-    Subscribe, SwitchProvider, ToggleMcpServer, ToolCallApproved, ToolCallRejected, PROTO_VERSION,
+    read_frame_into_with_deadline, read_frame_with_deadline, warn_if_schema_mismatch, write_frame,
+    ClientInfo, CompactTranscript, DeleteBranch, Hello, HelloAck, ImportMcpConfig,
+    InterruptSession, IpcMessage, IpcReadTimeout, ListMcpServers, McpImportResult, McpServersList,
+    McpToggleResult, PauseSession, RefineHandoff, RerunMessage, ResumeSession, SelectBranch,
+    SendUserMessage, Subscribe, SwitchProvider, ToggleMcpServer, ToolCallApproved,
+    ToolCallRejected, PROTO_VERSION, SCHEMA_VERSION,
 };
 use serde::Serialize;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
@@ -241,6 +242,7 @@ impl SessionBridge {
                 pid: std::process::id(),
                 user: std::env::var("USER").unwrap_or_else(|_| "forge".to_string()),
             },
+            schema_version: SCHEMA_VERSION,
         });
         write_frame(&mut writer, &hello).await?;
 
@@ -250,6 +252,10 @@ impl SessionBridge {
         let IpcMessage::HelloAck(ack) = ack else {
             return Err(anyhow!("expected HelloAck, got unexpected frame"));
         };
+        // F-678: shell side of the bidirectional schema-version check.
+        // The daemon stamps its `SCHEMA_VERSION` into `HelloAck.schema_version`;
+        // logging a warn here closes the second leg of the handshake validation.
+        warn_if_schema_mismatch("daemon", ack.schema_version, SCHEMA_VERSION);
 
         let conn = Connection {
             writer: Arc::new(Mutex::new(writer)),

--- a/crates/forge-shell/src/dashboard_sessions.rs
+++ b/crates/forge-shell/src/dashboard_sessions.rs
@@ -229,6 +229,7 @@ impl Pinger for UdsPinger {
                         pid: std::process::id(),
                         user: whoami(),
                     },
+                    schema_version: forge_ipc::SCHEMA_VERSION,
                 }),
             )
             .await


### PR DESCRIPTION
Closes forge-ide/forge#714

## Summary

Adds bidirectional `schema_version` validation across the two IPC legs (daemon↔shell, sidecar↔supervisor). A version-skewed peer no longer succeeds silently — both sides log a `warn!` through a shared helper so operators see drift before downstream serde corrupts.

## Changes

- **`forge-ipc`** — `Hello` and `SidecarHello` gain a `schema_version` field with `#[serde(default)]` so legacy peers that omit it deserialize to `0` and surface through the same warn path. New shared helper `forge_ipc::warn_if_schema_mismatch(peer_label, peer_version, local_version)` is used by every handshake site so the warn target / field shape stays uniform.
- **`forge-session::server::handle_connection`** — daemon validates the shell's reported `schema_version` against `SCHEMA_VERSION`.
- **`forge-shell::bridge::SessionBridge::hello`** — shell validates the daemon's `HelloAck.schema_version`.
- **`forge-session::sidecar::mod`** — supervisor validates the sidecar's `Hello.schema_version`. Validation extracted into `validate_sidecar_hello` for unit testing without spawning the real binary.
- **`forge-agent-host::lib`** — agent-host validates the daemon's `HelloAck.schema_version`. Validation extracted into `validate_daemon_hello_ack`.

Mismatch is non-fatal today (warn-only per DoD). A future `strict_schema_version` toggle can elevate to error without touching call sites.

## Coordination with F-676 (#765)

PR #765 redesigns the sidecar Hello frame (introducing `DaemonHello`) and bumps `SIDECAR_SCHEMA_VERSION` to `3`. F-678 is scoped narrowly to validation logic and does not duplicate that work — the two PRs touch different concerns and can land independently. Expect a small textual conflict around the `SidecarHello` struct (one new field) and the supervisor's match arm; resolution is mechanical.

## Test plan

- `cargo fmt --check` clean
- `cargo check --workspace` clean
- `cargo test --workspace` passes (no regressions; new tests in 4 modules)
- `cargo clippy --all-targets -- -D warnings` clean

New test coverage:
- `forge-ipc`: `warn_if_schema_mismatch_emits_warn_on_drift`, `hello_defaults_schema_version_when_field_absent`
- `forge-session::sidecar::tests`: `validate_sidecar_hello_silent_on_match`, `validate_sidecar_hello_warns_on_schema_mismatch`, `validate_sidecar_hello_rejects_bad_instance_id`
- `forge-session/tests/handshake.rs`: `handshake_with_mismatched_schema_version_warns_and_proceeds`, `handshake_with_legacy_hello_omitting_schema_version_warns_and_proceeds`
- `forge-agent-host::tests`: `validate_daemon_hello_ack_warns_on_schema_mismatch`, `validate_daemon_hello_ack_silent_on_match`

## Verification status

PR is open; DoD and code-review gates run in the parent context per the forge-finish-task handoff protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)