### PR TITLE
[F-646 follow-up] Consolidate CustomOpenAI redirect onto shared build_stream_client

### DIFF
--- a/crates/forge-providers/src/anthropic/mod.rs
+++ b/crates/forge-providers/src/anthropic/mod.rs
@@ -48,7 +48,10 @@ impl AnthropicProvider {
             api_key: api_key.into(),
             model: model.into(),
             max_tokens,
-            stream_client: http_util::build_stream_client(&HttpClientConfig::DEFAULT),
+            stream_client: http_util::build_stream_client(
+                &HttpClientConfig::DEFAULT,
+                reqwest::redirect::Policy::none(),
+            ),
             stream_cfg: sse::StreamConfig::DEFAULT,
         }
     }

--- a/crates/forge-providers/src/http_util.rs
+++ b/crates/forge-providers/src/http_util.rs
@@ -21,21 +21,24 @@
 //!   — every resolved `SocketAddr` is re-validated against `url_safety`,
 //!   so a TTL=0 DNS rebinding answer of `169.254.169.254` cannot reach the
 //!   socket layer even if `check_url` originally accepted the hostname.
-//! - **No-redirect policy** (`reqwest::redirect::Policy::none`) — a
+//! - **Redirect policy** (caller-supplied) — Anthropic/OpenAI pass
+//!   `reqwest::redirect::Policy::none()` because the official endpoints do
+//!   not redirect on `/v1/messages` or `/v1/chat/completions`, so a
 //!   misconfigured proxy or BGP-hijack injecting `302 Location: <internal>`
-//!   surfaces to the caller as an HTTP error rather than being silently
-//!   followed. The official-vendor APIs (Anthropic, OpenAI) do not redirect
-//!   on `/v1/messages` or `/v1/chat/completions`, so disabling redirects
-//!   has no behavioural cost.
+//!   surfaces as an HTTP error rather than being silently followed.
+//!   `CustomOpenAiProvider` passes a per-hop validator that re-runs each
+//!   3xx target URL through `forge_core::url_safety::check_url` and caps
+//!   the chain length, since user-supplied OpenAI-compatible gateways may
+//!   legitimately redirect.
 
 use std::time::Duration;
 
 use crate::sse::SseError;
 use crate::StreamErrorKind;
 
-pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-pub(crate) const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
-pub(crate) const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(30);
 
 /// HTTP-layer timeouts applied at `reqwest::ClientBuilder` construction for
 /// SSE-streaming providers (Anthropic, OpenAI, OpenAI-compatible custom).
@@ -61,17 +64,20 @@ impl Default for HttpClientConfig {
 }
 
 /// Build a streaming `reqwest::Client` with the SSE provider hardening
-/// posture: per-connect / per-read / TCP keepalive timeouts, the F-644
-/// SSRF-safe DNS resolver, and a no-redirect policy (F-647). The official
-/// Anthropic and OpenAI endpoints do not return 3xx on the streaming
-/// chat paths, so refusing to follow redirects costs nothing in normal
-/// operation while closing the redirect-to-internal-IP smuggling vector.
-pub(crate) fn build_stream_client(cfg: &HttpClientConfig) -> reqwest::Client {
+/// posture: per-connect / per-read / TCP keepalive timeouts and the F-644
+/// SSRF-safe DNS resolver. The redirect policy is caller-supplied so the
+/// official-vendor providers can lock to `Policy::none()` while the
+/// custom OpenAI provider can install a per-hop SSRF-validating policy
+/// for user-supplied gateways that may legitimately redirect.
+pub(crate) fn build_stream_client(
+    cfg: &HttpClientConfig,
+    redirect: reqwest::redirect::Policy,
+) -> reqwest::Client {
     forge_core::http::secure_client_builder()
         .connect_timeout(cfg.connect_timeout)
         .read_timeout(cfg.read_timeout)
         .tcp_keepalive(Some(cfg.tcp_keepalive))
-        .redirect(reqwest::redirect::Policy::none())
+        .redirect(redirect)
         .build()
         .expect("reqwest stream client builder — only fails if no TLS backend is available")
 }
@@ -120,7 +126,10 @@ mod tests {
     fn build_stream_client_succeeds_with_default_config() {
         // Smoke test — the only failure mode is "no TLS backend available",
         // which would already break every other test in the workspace.
-        let _ = build_stream_client(&HttpClientConfig::DEFAULT);
+        let _ = build_stream_client(
+            &HttpClientConfig::DEFAULT,
+            reqwest::redirect::Policy::none(),
+        );
     }
 
     #[test]

--- a/crates/forge-providers/src/openai/custom.rs
+++ b/crates/forge-providers/src/openai/custom.rs
@@ -40,7 +40,7 @@ use forge_core::Result;
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 
-use crate::http_util::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_TCP_KEEPALIVE};
+use crate::http_util::{self, HttpClientConfig};
 use crate::sse;
 use crate::{ChatChunk, ChatRequest, Provider};
 
@@ -167,7 +167,10 @@ impl CustomOpenAiProvider {
             model,
             model_list,
             max_tokens: None,
-            stream_client: build_secure_custom_client(),
+            stream_client: http_util::build_stream_client(
+                &HttpClientConfig::DEFAULT,
+                custom_redirect_policy(),
+            ),
             stream_cfg: sse::StreamConfig::DEFAULT,
         })
     }
@@ -273,33 +276,20 @@ impl std::fmt::Debug for CustomOpenAiProvider {
     }
 }
 
-/// Build the `reqwest::Client` used by `CustomOpenAiProvider` for outbound
-/// chat completions. Layered defenses against SSRF on a user-supplied
-/// `base_url`:
+/// Per-hop redirect policy installed on the `CustomOpenAiProvider` streaming
+/// client. 3xx responses do not auto-follow blindly: each hop's URL is
+/// re-validated through [`forge_core::url_safety::check_url`] before reqwest
+/// dispatches the follow-up request, so a malicious vendor that responds
+/// with `302 Location: http://169.254.169.254/...` cannot smuggle a private
+/// IP target into the chain. The hop count is capped at
+/// [`MAX_REDIRECT_HOPS`] regardless.
 ///
-/// 1. **Policy-enforcing DNS resolver**
-///    ([`forge_core::http::secure_client_builder`]): every resolved
-///    `SocketAddr` is filtered through the `url_safety` IPv4/IPv6 range
-///    policy. A short-TTL DNS rebind that answers safely on
-///    [`crate::openai::custom::CustomOpenAiProvider::new`]'s `check_url`
-///    pass and hostilely on the connect that follows is refused at the
-///    DNS layer — reqwest never opens the socket.
-///
-/// 2. **Custom redirect policy**: 3xx responses do not auto-follow blindly.
-///    Each hop's URL is re-validated through
-///    [`forge_core::url_safety::check_url`] before reqwest dispatches the
-///    follow-up request, so a malicious vendor that responds with
-///    `302 Location: http://169.254.169.254/...` cannot smuggle a private
-///    IP target into the chain. The hop count is capped at
-///    [`MAX_REDIRECT_HOPS`] regardless.
-///
-/// The streaming-HTTP timeouts (connect, read, TCP keepalive) match the
-/// shared [`crate::http_util::HttpClientConfig::DEFAULT`] posture used by
-/// [`super::OpenAiProvider`]; they are inlined here because
-/// [`forge_core::http::secure_client_builder`] returns a fresh
-/// `reqwest::ClientBuilder` we must populate ourselves.
-fn build_secure_custom_client() -> reqwest::Client {
-    let redirect_policy = reqwest::redirect::Policy::custom(|attempt| {
+/// The DNS-resolver SSRF defence and the streaming-HTTP timeouts come from
+/// the shared [`crate::http_util::build_stream_client`] — this helper only
+/// supplies the redirect policy that distinguishes the custom provider from
+/// the official-vendor `Policy::none()` posture.
+fn custom_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
         if attempt.previous().len() >= MAX_REDIRECT_HOPS {
             return attempt.error(format!(
                 "custom_openai redirect chain exceeded {MAX_REDIRECT_HOPS} hops"
@@ -312,15 +302,7 @@ fn build_secure_custom_client() -> reqwest::Client {
                 "custom_openai redirect to {url} refused by SSRF guard: {e}"
             )),
         }
-    });
-
-    forge_core::http::secure_client_builder()
-        .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
-        .read_timeout(DEFAULT_READ_TIMEOUT)
-        .tcp_keepalive(Some(DEFAULT_TCP_KEEPALIVE))
-        .redirect(redirect_policy)
-        .build()
-        .expect("reqwest custom-openai client builder — only fails if no TLS backend is available")
+    })
 }
 
 impl Provider for CustomOpenAiProvider {

--- a/crates/forge-providers/src/openai/mod.rs
+++ b/crates/forge-providers/src/openai/mod.rs
@@ -49,7 +49,10 @@ impl OpenAiProvider {
             api_key: api_key.into(),
             model: model.into(),
             max_tokens: None,
-            stream_client: http_util::build_stream_client(&HttpClientConfig::DEFAULT),
+            stream_client: http_util::build_stream_client(
+                &HttpClientConfig::DEFAULT,
+                reqwest::redirect::Policy::none(),
+            ),
             stream_cfg: sse::StreamConfig::DEFAULT,
         }
     }


### PR DESCRIPTION
Closes forge-ide/forge#796

## Summary
- Extend `http_util::build_stream_client` to accept a caller-supplied `reqwest::redirect::Policy`. Anthropic + OpenAI pass `Policy::none()`; CustomOpenAI passes a per-hop `url_safety::check_url` validator policy.
- Replace `build_secure_custom_client` with a small `custom_redirect_policy()` helper. CustomOpenAI now constructs its client via the shared `build_stream_client(&HttpClientConfig::DEFAULT, custom_redirect_policy())`.
- Remove the duplicated `DEFAULT_CONNECT_TIMEOUT` / `DEFAULT_READ_TIMEOUT` / `DEFAULT_TCP_KEEPALIVE` import path and the inlined `secure_client_builder()` block in `openai/custom.rs`. The timeout constants now live solely in `http_util` and are downgraded to module-private since no other file consumes them.

## Test plan
- `cargo test --workspace` passes — including the redirect/SSRF gates that pin this change's behaviour:
  - `tests/anthropic.rs::chat_does_not_follow_redirects`
  - `tests/openai.rs::chat_does_not_follow_redirects`
  - `tests/openai_custom.rs::redirect_to_private_range_ip_is_refused`
  - `tests/openai_custom.rs::redirect_to_rfc1918_ip_is_refused`
- `cargo clippy --all-targets -- -D warnings` passes
- `RUSTDOCFLAGS=-D warnings cargo doc -p forge-providers --no-deps` passes
- `just check-rust` passes

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)