### PR TITLE
[#784] Consolidate frame-deadline constants + tighten IpcReadTimeout API

### DIFF
--- a/crates/forge-agent-host/src/lib.rs
+++ b/crates/forge-agent-host/src/lib.rs
@@ -706,31 +706,34 @@ async fn dispatch_loop(
     // tokio mutex.
     let event_sink = IpcEventSink::new(writer.clone(), seq.clone());
     let mut buf = Vec::new();
-    // F-652: deadline-bounded reads on the daemon → sidecar dispatch
-    // loop. A wedged or malicious daemon (or any same-uid attacker
-    // that can connect to the sidecar's UDS, post-F-651 peer-cred
-    // check) must not be able to pin this task forever by sending
-    // zero bytes. 60 s comfortably exceeds any realistic gap between
-    // daemon commands; on timeout we loop and try again.
-    const DAEMON_FRAME_DEADLINE: Duration = Duration::from_secs(60);
+    // F-652 / Issue #784: deadline-bounded reads on the daemon → sidecar
+    // dispatch loop, riding on the crate-level
+    // `forge_ipc::DEFAULT_PUMP_DEADLINE`. A wedged or malicious daemon (or
+    // any same-uid attacker that can connect to the sidecar's UDS, post-
+    // F-651 peer-cred check) must not be able to pin this task forever by
+    // sending zero bytes. 60 s comfortably exceeds any realistic gap
+    // between daemon commands; on timeout we loop and try again.
     loop {
-        let frame: SidecarMessage =
-            match forge_ipc::read_frame_into_with_deadline(reader, &mut buf, DAEMON_FRAME_DEADLINE)
-                .await
-            {
-                Ok(m) => m,
-                Err(e) if e.downcast_ref::<forge_ipc::IpcReadTimeout>().is_some() => {
-                    // Idle window — daemon simply has nothing to send.
-                    continue;
-                }
-                Err(e) => {
-                    // EOF or any read error is treated as the peer going
-                    // away. The sidecar drops the connection and exits;
-                    // the supervisor's restart logic owns the rest.
-                    debug!(error = %e, "read loop: peer closed or error");
-                    return Ok(LoopExit::PeerClosed);
-                }
-            };
+        let frame: SidecarMessage = match forge_ipc::read_frame_into_with_deadline(
+            reader,
+            &mut buf,
+            forge_ipc::DEFAULT_PUMP_DEADLINE,
+        )
+        .await
+        {
+            Ok(m) => m,
+            Err(e) if e.downcast_ref::<forge_ipc::IpcReadTimeout>().is_some() => {
+                // Idle window — daemon simply has nothing to send.
+                continue;
+            }
+            Err(e) => {
+                // EOF or any read error is treated as the peer going
+                // away. The sidecar drops the connection and exits;
+                // the supervisor's restart logic owns the rest.
+                debug!(error = %e, "read loop: peer closed or error");
+                return Ok(LoopExit::PeerClosed);
+            }
+        };
         match frame {
             SidecarMessage::RunTurn(turn) => {
                 pending_turns.fetch_add(1, Ordering::Relaxed);

--- a/crates/forge-cli/src/main.rs
+++ b/crates/forge-cli/src/main.rs
@@ -270,17 +270,18 @@ async fn session_tail(id: &str) -> Result<()> {
     use forge_core::Event;
     use forge_ipc::{
         read_frame_with_deadline, write_frame, ClientInfo, Hello, IpcMessage, IpcReadTimeout,
-        Subscribe, PROTO_VERSION,
+        Subscribe, DEFAULT_PUMP_DEADLINE, PROTO_VERSION,
     };
     use std::time::Duration;
     use tokio::net::UnixStream;
 
-    // F-652: per-frame deadlines on `forge session tail`. The
-    // handshake bound is short (5 s); the steady-state event read
-    // uses a longer idle window, and a deadline alone is not a
-    // teardown signal — it just means the daemon is between events.
+    // F-652 / Issue #784: per-frame deadlines on `forge session tail`. The
+    // handshake bound is short (5 s) and stays site-local — a daemon that
+    // hasn't framed an `HelloAck` in five seconds is wedged. The
+    // steady-state event read uses `DEFAULT_PUMP_DEADLINE`; a deadline-only
+    // error there is not a teardown signal — it just means the daemon is
+    // between events.
     const HANDSHAKE_DEADLINE: Duration = Duration::from_secs(5);
-    const TAIL_FRAME_DEADLINE: Duration = Duration::from_secs(60);
 
     let sock = forge_cli::socket::socket_path(id)?;
     let mut stream = UnixStream::connect(&sock)
@@ -309,7 +310,7 @@ async fn session_tail(id: &str) -> Result<()> {
         // (`read_u32` fails), malformed bodies, **and** the F-652
         // idle deadline. The first two end the tail; the deadline
         // alone is just an idle window — loop and try again.
-        match read_frame_with_deadline(&mut stream, TAIL_FRAME_DEADLINE).await {
+        match read_frame_with_deadline(&mut stream, DEFAULT_PUMP_DEADLINE).await {
             Ok(IpcMessage::Event(ipc_event)) => {
                 // F-112: IpcEvent.event is typed — no Value decode.
                 let event = ipc_event.event;
@@ -349,16 +350,15 @@ async fn run_agent(name: &str, input_source: &str) -> Result<()> {
     use forge_core::Event;
     use forge_ipc::{
         read_frame_with_deadline, write_frame, ClientInfo, Hello, IpcMessage, IpcReadTimeout,
-        SendUserMessage, Subscribe, PROTO_VERSION,
+        SendUserMessage, Subscribe, DEFAULT_PUMP_DEADLINE, PROTO_VERSION,
     };
     use std::time::Duration;
     use tokio::net::UnixStream;
 
-    // F-652: same shape as `session_tail` — short handshake bound,
-    // longer per-frame idle deadline, deadline-only errors do not
-    // stop streaming.
+    // F-652 / Issue #784: same shape as `session_tail` — short handshake
+    // bound stays site-local, the per-frame idle deadline rides on
+    // `DEFAULT_PUMP_DEADLINE`, deadline-only errors do not stop streaming.
     const HANDSHAKE_DEADLINE: Duration = Duration::from_secs(5);
-    const RUN_FRAME_DEADLINE: Duration = Duration::from_secs(60);
 
     let text = if input_source == "-" {
         use tokio::io::AsyncReadExt;
@@ -425,7 +425,7 @@ async fn run_agent(name: &str, input_source: &str) -> Result<()> {
     // determine the outcome.
     let mut event_exit_code = 0i32;
     loop {
-        match read_frame_with_deadline(&mut stream, RUN_FRAME_DEADLINE).await {
+        match read_frame_with_deadline(&mut stream, DEFAULT_PUMP_DEADLINE).await {
             Ok(IpcMessage::Event(ipc_event)) => {
                 // F-112: IpcEvent.event is typed — no Value decode.
                 let event = ipc_event.event;

--- a/crates/forge-ipc/src/lib.rs
+++ b/crates/forge-ipc/src/lib.rs
@@ -578,9 +578,17 @@ where
 {
     match tokio::time::timeout(deadline, read_frame_into_undeadlined::<R, T>(reader, buf)).await {
         Ok(inner) => inner,
-        Err(_) => Err(IpcReadTimeout(deadline).into()),
+        Err(_) => Err(IpcReadTimeout::new(deadline).into()),
     }
 }
+
+/// Issue #784: shared per-frame deadline for every long-lived IPC pump
+/// (sidecar pump, shell bridge pump, CLI `tail`/`run`, daemon dispatch).
+/// The value bounds the worst-case silence window before a stalled or
+/// slowloris-style peer is treated as gone (CWE-770). Handshake / probe
+/// deadlines stay site-local: they have a different rationale (a peer
+/// that hasn't framed a `HelloAck` in 5 s is wedged).
+pub const DEFAULT_PUMP_DEADLINE: Duration = Duration::from_secs(60);
 
 /// F-652: typed marker error returned by [`read_frame_with_deadline`] /
 /// [`read_frame_into_with_deadline`] when the deadline elapses.
@@ -591,8 +599,22 @@ where
 /// error that should tear the connection down. Callers that treat
 /// every error path as fatal (handshakes, one-shot reads) can ignore
 /// the type and rely on the boxed `anyhow::Error`'s `Display`.
+///
+/// Issue #784: the inner `Duration` is private so the representation
+/// can grow (e.g. carry the originating call site for diagnostics)
+/// without a breaking churn at every downcast site.
 #[derive(Debug)]
-pub struct IpcReadTimeout(pub Duration);
+pub struct IpcReadTimeout(Duration);
+
+impl IpcReadTimeout {
+    pub fn new(deadline: Duration) -> Self {
+        Self(deadline)
+    }
+
+    pub fn duration(&self) -> Duration {
+        self.0
+    }
+}
 
 impl std::fmt::Display for IpcReadTimeout {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -704,6 +726,28 @@ mod tests {
             IpcMessage::SwitchProvider(s) => assert_eq!(s.provider_id, "custom_openai:vllm"),
             other => panic!("expected SwitchProvider, got {other:?}"),
         }
+    }
+
+    /// Issue #784: `DEFAULT_PUMP_DEADLINE` is the single source of truth for
+    /// the steady-state pump deadline shared by every long-lived `read_frame_*`
+    /// call site (sidecar pump, shell bridge pump, CLI tail/run, daemon
+    /// dispatch). Pinning the value here means a regression that drifts one
+    /// call site away from 60 s would have to drift this constant first.
+    #[test]
+    fn default_pump_deadline_is_sixty_seconds() {
+        assert_eq!(DEFAULT_PUMP_DEADLINE, Duration::from_secs(60));
+    }
+
+    /// Issue #784: `IpcReadTimeout` exposes its inner `Duration` via the
+    /// `duration()` accessor rather than a public tuple field. The accessor
+    /// guards the option to evolve the representation later (e.g. carry the
+    /// originating call site for diagnostics) without a breaking churn at
+    /// every downcast site.
+    #[test]
+    fn ipc_read_timeout_duration_accessor_returns_constructed_duration() {
+        let d = Duration::from_millis(250);
+        let err = IpcReadTimeout::new(d);
+        assert_eq!(err.duration(), d);
     }
 
     /// F-652: the buffer-reusing `read_frame_into_with_deadline` must

--- a/crates/forge-session/src/sidecar/mod.rs
+++ b/crates/forge-session/src/sidecar/mod.rs
@@ -95,13 +95,12 @@ const MAX_RETRIES_IN_WINDOW: usize = 3;
 /// architecture-doc §4 default.
 const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_millis(2000);
 
-/// F-652: per-frame read deadline on the steady-state sidecar event
-/// pump. A healthy `forged-agent` heartbeats every few seconds; a 60 s
-/// silence is unambiguously a stalled or wedged child (and a
-/// slowloris-style same-uid attacker holding the socket open without
-/// sending data). On timeout the pump treats the read as an EOF /
-/// crash and the supervisor's restart loop kicks in.
-const PUMP_FRAME_DEADLINE: Duration = Duration::from_secs(60);
+// F-652 / Issue #784: the steady-state sidecar event pump uses the
+// crate-level `forge_ipc::DEFAULT_PUMP_DEADLINE`. A healthy `forged-agent`
+// heartbeats every few seconds; the 60 s silence window is unambiguously a
+// stalled or wedged child (and a slowloris-style same-uid attacker holding
+// the socket open without sending data). On timeout the pump treats the
+// read as an EOF / crash and the supervisor's restart loop kicks in.
 
 /// Buffer depth on the daemon → child command channel. Sized for the
 /// realistic burst of approval frames a single turn can produce; an
@@ -790,7 +789,7 @@ impl SupervisorTask {
                         }
                     }
                 }
-                read = forge_ipc::read_frame_into_with_deadline::<_, SidecarMessage>(&mut live.reader, &mut buf, PUMP_FRAME_DEADLINE) => {
+                read = forge_ipc::read_frame_into_with_deadline::<_, SidecarMessage>(&mut live.reader, &mut buf, forge_ipc::DEFAULT_PUMP_DEADLINE) => {
                     match read {
                         Ok(frame) => {
                             if let Some(reason) = self.handle_inbound(frame).await {
@@ -1401,7 +1400,7 @@ mod tests {
 
     /// F-652: an idle (silent) sidecar peer must not pin the steady-
     /// state pump indefinitely. `read_frame_into_with_deadline` returns
-    /// an error after `PUMP_FRAME_DEADLINE`; the supervisor's
+    /// an error after `forge_ipc::DEFAULT_PUMP_DEADLINE`; the supervisor's
     /// `pump_until_exit` then routes that into its EOF-classification
     /// branch and the restart loop.
     #[tokio::test]

--- a/crates/forge-shell/src/bridge.rs
+++ b/crates/forge-shell/src/bridge.rs
@@ -32,7 +32,7 @@ use forge_ipc::{
     InterruptSession, IpcMessage, IpcReadTimeout, ListMcpServers, McpImportResult, McpServersList,
     McpToggleResult, PauseSession, RefineHandoff, RerunMessage, ResumeSession, SelectBranch,
     SendUserMessage, Subscribe, SwitchProvider, ToggleMcpServer, ToolCallApproved,
-    ToolCallRejected, PROTO_VERSION, SCHEMA_VERSION,
+    ToolCallRejected, DEFAULT_PUMP_DEADLINE, PROTO_VERSION, SCHEMA_VERSION,
 };
 use serde::Serialize;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
@@ -45,13 +45,13 @@ use tokio::task::JoinHandle;
 /// has not framed an `HelloAck` within five seconds is wedged.
 const HANDSHAKE_FRAME_DEADLINE: Duration = Duration::from_secs(5);
 
-/// F-652: per-frame deadline on the steady-state event pump. The pump
-/// waits indefinitely for the *next* event in normal operation, so the
-/// deadline must be long enough to swallow real silence (an idle
-/// session between turns) without a false reset. Sixty seconds covers
-/// every realistic gap between frames and still bounds the worst case
-/// where a same-uid attacker pins the connection (CWE-770).
-const PUMP_FRAME_DEADLINE: Duration = Duration::from_secs(60);
+// F-652 / Issue #784: the steady-state event pump uses the crate-level
+// `forge_ipc::DEFAULT_PUMP_DEADLINE`. The pump waits indefinitely for the
+// *next* event in normal operation, so the deadline must be long enough to
+// swallow real silence (an idle session between turns) without a false
+// reset. Sixty seconds covers every realistic gap between frames and still
+// bounds the worst case where a same-uid attacker pins the connection
+// (CWE-770).
 
 /// Payload emitted to the webview for every session event forwarded by the
 /// background reader task. `event` is the daemon's typed [`forge_core::Event`]
@@ -715,7 +715,8 @@ async fn pump_events(
     // frames grow the buffer in place once and the capacity is retained.
     let mut frame_buf: Vec<u8> = Vec::with_capacity(4096);
     loop {
-        match read_frame_into_with_deadline(&mut reader, &mut frame_buf, PUMP_FRAME_DEADLINE).await
+        match read_frame_into_with_deadline(&mut reader, &mut frame_buf, DEFAULT_PUMP_DEADLINE)
+            .await
         {
             Ok(IpcMessage::Event(event)) => {
                 sink.emit(SessionEventPayload {


### PR DESCRIPTION
Closes forge-ide/forge#784

## Summary

- Lift the duplicated 60s pump deadline (sidecar pump, shell bridge pump, CLI `tail`/`run`, daemon dispatch) into a single `forge_ipc::DEFAULT_PUMP_DEADLINE`. All five call sites now reference the shared const so a future tuning of the steady-state silence window moves in one place.
- Handshake/probe deadlines (5s) stay per-call-site — they have different rationale (a peer that hasn't framed an `HelloAck` in five seconds is wedged) and a different value.
- Privatize `IpcReadTimeout`'s inner `Duration` and expose it via `IpcReadTimeout::duration()` (plus a `new(deadline)` constructor). All existing external callers only `downcast_ref::<IpcReadTimeout>()`, so the API change is invisible to them while leaving room to grow the representation later (e.g. carry the originating call site for diagnostics).

## Test plan

- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` passes
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` passes
- New unit tests in `forge-ipc`: `default_pump_deadline_is_sixty_seconds` pins the value, `ipc_read_timeout_duration_accessor_returns_constructed_duration` pins the accessor's behavior

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)