### PR TITLE
[F-599-followup] Mark FsReadTool::read_only() = true and update approval-required tests

### DIFF
--- a/crates/forge-session/src/tools/fs_read.rs
+++ b/crates/forge-session/src/tools/fs_read.rs
@@ -22,6 +22,14 @@ impl Tool for FsReadTool {
         Self::NAME
     }
 
+    /// F-599 follow-up (#647): `fs.read` never mutates external state, so
+    /// the orchestrator can auto-approve it (logging `ApprovalSource::Auto`
+    /// in place of an interactive prompt) and dispatch consecutive reads in
+    /// the parallel branch alongside other read-only tools.
+    fn read_only(&self) -> bool {
+        true
+    }
+
     fn approval_preview(&self, args: &serde_json::Value) -> ApprovalPreview {
         // Preview shows whatever the client sent (including blank) so the user
         // sees exactly what was requested before approval. Required-argument

--- a/crates/forge-session/tests/fs_read_tool.rs
+++ b/crates/forge-session/tests/fs_read_tool.rs
@@ -1,10 +1,10 @@
 #![allow(deprecated)] // F-652: tests/benches still drive the deprecated bare read_frame helpers.
 /// Integration test: Mock provider scripts an fs.read tool call against a real
-/// temp file. Verifies ToolCallCompleted.result contains content, bytes, sha256.
-use forge_core::Event;
+/// temp file. Verifies ToolCallCompleted.result contains content, bytes, sha256
+/// and that `fs.read` auto-approves under the read-only fast path (#647).
+use forge_core::{ApprovalSource, Event};
 use forge_ipc::{
-    ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, ToolCallApproved,
-    PROTO_VERSION,
+    ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, PROTO_VERSION,
 };
 use forge_providers::MockProvider;
 use forge_session::{server::serve_with_session, session::Session};
@@ -117,8 +117,10 @@ async fn fs_read_tool_returns_content_bytes_sha256() {
     .await
     .unwrap();
 
-    let (mut reader, mut writer) = stream.into_split();
+    let (mut reader, _writer) = stream.into_split();
     let mut tool_completed_result: Option<serde_json::Value> = None;
+    let mut auto_approved = false;
+    let mut saw_approval_requested = false;
 
     for _ in 0..20 {
         let frame = forge_ipc::read_frame(&mut reader).await.unwrap();
@@ -126,25 +128,31 @@ async fn fs_read_tool_returns_content_bytes_sha256() {
             continue;
         };
 
-        // Auto-approve tool calls
-        if let Event::ToolCallApprovalRequested { ref id, .. } = event {
-            forge_ipc::write_frame(
-                &mut writer,
-                &IpcMessage::ToolCallApproved(ToolCallApproved {
-                    id: id.to_string(),
-                    scope: "Once".to_string(),
-                }),
-            )
-            .await
-            .unwrap();
-        }
-
-        if let Event::ToolCallCompleted { result, .. } = event {
-            tool_completed_result = Some(result);
-            break;
+        match event {
+            // #647: `fs.read` is read-only — the orchestrator must NOT
+            // emit an interactive approval prompt. We track and assert on
+            // this below.
+            Event::ToolCallApprovalRequested { .. } => saw_approval_requested = true,
+            Event::ToolCallApproved {
+                by: ApprovalSource::Auto,
+                ..
+            } => auto_approved = true,
+            Event::ToolCallCompleted { result, .. } => {
+                tool_completed_result = Some(result);
+                break;
+            }
+            _ => {}
         }
     }
 
+    assert!(
+        !saw_approval_requested,
+        "fs.read is read-only — the orchestrator must skip the interactive approval gate (#647)"
+    );
+    assert!(
+        auto_approved,
+        "fs.read must surface a ToolCallApproved {{ by: Auto }} so the event log records why no human approved"
+    );
     let result = tool_completed_result.expect("ToolCallCompleted event not received");
 
     assert_eq!(

--- a/crates/forge-session/tests/orchestrator.rs
+++ b/crates/forge-session/tests/orchestrator.rs
@@ -10,9 +10,23 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::net::UnixStream;
 
-// Script 1: provider returns a text delta, then a tool call, then Done("tool_use")
+// Script 1: provider returns a text delta, then a `fs.read` tool call,
+// then Done("tool_use"). `fs.read` is read-only so the orchestrator
+// auto-approves it (issue #647) — the recorded event sequence skips
+// `ToolCallApprovalRequested` and emits `ToolCallApproved { by: Auto }`.
 const SCRIPT_INITIAL: &str = r#"{"delta":"Hi there. "}
 {"tool_call":{"name":"fs.read","args":{"path":"readme.txt"}}}
+{"done":"tool_use"}
+"#;
+
+// Mirror of `SCRIPT_INITIAL` that drives a non-read-only tool (`fs.write`)
+// so the approval gate actually fires. Tests that pin behaviour of the
+// interactive approval flow (gate firing, scope fidelity, malformed-scope
+// rejection, pause-during-approval) use this script — switching `fs.read`
+// to read-only would otherwise auto-approve them and bypass the gate
+// entirely.
+const SCRIPT_INITIAL_NEEDS_APPROVAL: &str = r#"{"delta":"Hi there. "}
+{"tool_call":{"name":"fs.write","args":{"path":"readme.txt","content":"x"}}}
 {"done":"tool_use"}
 "#;
 
@@ -62,13 +76,17 @@ fn extract_event(msg: &IpcMessage) -> Option<Event> {
 
 /// Full turn with tool call: verifies correct event sequence end-to-end.
 ///
+/// `fs.read` is read-only (issue #647), so the orchestrator skips the
+/// interactive approval gate and emits `ToolCallApproved { by: Auto }`
+/// directly. The expected sequence is otherwise identical to the
+/// pre-#647 shape.
+///
 /// Expected sequence:
 ///   UserMessage
 ///   AssistantMessage { stream_finalised: false }   ← opened before first chunk
 ///   AssistantDelta("Hi there. ")
 ///   ToolCallStarted { tool: "fs.read" }
-///   ToolCallApprovalRequested   ← approval gate fires for non-whitelisted tool
-///   ToolCallApproved            ← logged after client approves
+///   ToolCallApproved { by: Auto }   ← read-only tools skip the gate
 ///   ToolCallCompleted
 ///   AssistantMessage { stream_finalised: true }    ← finalised when Done("tool_use") arrives
 ///   AssistantMessage { stream_finalised: false }   ← continuation turn opens
@@ -122,7 +140,7 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
     // Collect events; when we see ToolCallApprovalRequested, send approval back.
     // The full turn produces two AssistantMessage(final) events: one when the
     // initial stream ends with Done("tool_use"), and one when the continuation ends.
-    let (mut reader, mut writer) = stream.into_split();
+    let (mut reader, _writer) = stream.into_split();
     let mut events: Vec<Event> = Vec::new();
     let mut final_count = 0;
 
@@ -132,16 +150,8 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
             continue;
         };
 
-        // Auto-approve tool calls during the test
-        if let Event::ToolCallApprovalRequested { ref id, .. } = event {
-            let approval = IpcMessage::ToolCallApproved(ToolCallApproved {
-                id: id.to_string(),
-                scope: "Once".to_string(),
-            });
-            forge_ipc::write_frame(&mut writer, &approval)
-                .await
-                .unwrap();
-        }
+        // No client-side approval needed — `fs.read` is read-only and the
+        // orchestrator emits `ToolCallApproved { by: Auto }` on its own.
 
         if matches!(
             event,
@@ -194,8 +204,7 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
             "AssistantMessage(open)", // opened before first chunk
             "AssistantDelta",
             "ToolCallStarted",
-            "ToolCallApprovalRequested",
-            "ToolCallApproved",
+            "ToolCallApproved", // read-only auto-approval (#647) — no prompt
             "ToolCallCompleted",
             "AssistantMessage(final)", // finalised when Done("tool_use") arrives
             "AssistantMessage(open)",  // continuation turn opens
@@ -203,6 +212,20 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
             "AssistantMessage(final)", // continuation turn finalised
         ],
         "event sequence mismatch: got {kinds:?}"
+    );
+
+    // The single ToolCallApproved must carry `ApprovalSource::Auto` so the
+    // event log reflects that no human approved the call.
+    use forge_core::ApprovalSource;
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            Event::ToolCallApproved {
+                by: ApprovalSource::Auto,
+                ..
+            }
+        )),
+        "expected ToolCallApproved {{ by: Auto }} for read-only fs.read"
     );
 
     // Verify text delta content
@@ -254,9 +277,12 @@ async fn approval_gate_fires_and_blocks_until_client_approves() {
     let sock_path = dir.path().join("test2.sock");
 
     let session = Arc::new(Session::create(log_path).await.unwrap());
-    // Single-script provider: tool call only (no continuation needed for this test)
-    let provider =
-        Arc::new(MockProvider::from_responses(vec![SCRIPT_INITIAL.to_string()]).unwrap());
+    // Single-script provider: tool call only (no continuation needed for this test).
+    // Use the non-read-only script so the approval gate actually fires
+    // (issue #647 made `fs.read` auto-approve).
+    let provider = Arc::new(
+        MockProvider::from_responses(vec![SCRIPT_INITIAL_NEEDS_APPROVAL.to_string()]).unwrap(),
+    );
 
     let server_session = Arc::clone(&session);
     let server_provider = Arc::clone(&provider);
@@ -334,6 +360,11 @@ async fn approval_gate_fires_and_blocks_until_client_approves() {
 
 /// With --auto-approve-unsafe, tool calls proceed without client approval.
 /// ToolCallApproved { by: Auto } must be emitted; ToolCallApprovalRequested must not.
+///
+/// Uses the non-read-only `fs.write` script so this exercises the server-
+/// level `--auto-approve-unsafe` flag rather than the per-tool read-only
+/// shortcut introduced in #647 (which would also emit `Auto` and mask a
+/// regression in the flag itself).
 #[tokio::test]
 async fn auto_approve_skips_approval_gate_and_emits_auto_approved() {
     let dir = TempDir::new().unwrap();
@@ -343,7 +374,7 @@ async fn auto_approve_skips_approval_gate_and_emits_auto_approved() {
     let session = Arc::new(Session::create(log_path).await.unwrap());
     let provider = Arc::new(
         MockProvider::from_responses(vec![
-            SCRIPT_INITIAL.to_string(),
+            SCRIPT_INITIAL_NEEDS_APPROVAL.to_string(),
             SCRIPT_CONTINUATION.to_string(),
         ])
         .unwrap(),
@@ -596,8 +627,11 @@ async fn approval_with_this_tool_scope_is_recorded_faithfully() {
     let sock_path = dir.path().join("scope_fidelity.sock");
 
     let session = Arc::new(Session::create(log_path).await.unwrap());
-    let provider =
-        Arc::new(MockProvider::from_responses(vec![SCRIPT_INITIAL.to_string()]).unwrap());
+    // Use the non-read-only script — `fs.read` auto-approves under #647 and
+    // would never reach the gate this test is asserting on.
+    let provider = Arc::new(
+        MockProvider::from_responses(vec![SCRIPT_INITIAL_NEEDS_APPROVAL.to_string()]).unwrap(),
+    );
 
     let server_session = Arc::clone(&session);
     let server_provider = Arc::clone(&provider);
@@ -680,8 +714,11 @@ async fn malformed_approval_scope_rejects_instead_of_silently_downgrading_to_onc
     let sock_path = dir.path().join("scope_reject.sock");
 
     let session = Arc::new(Session::create(log_path).await.unwrap());
-    let provider =
-        Arc::new(MockProvider::from_responses(vec![SCRIPT_INITIAL.to_string()]).unwrap());
+    // Use the non-read-only script — `fs.read` auto-approves under #647 so
+    // the gate we're stress-testing here would never fire on it.
+    let provider = Arc::new(
+        MockProvider::from_responses(vec![SCRIPT_INITIAL_NEEDS_APPROVAL.to_string()]).unwrap(),
+    );
 
     let server_session = Arc::clone(&session);
     let server_provider = Arc::clone(&provider);

--- a/crates/forge-session/tests/parallel_read_dispatch.rs
+++ b/crates/forge-session/tests/parallel_read_dispatch.rs
@@ -1,0 +1,243 @@
+#![allow(deprecated)] // F-652: tests/benches still drive the deprecated bare read_frame helpers.
+//! Issue #647: end-to-end coverage that two real `fs.read` calls in one
+//! turn dispatch through the parallel branch, without the orchestrator
+//! emitting an interactive approval prompt for either call.
+//!
+//! The matching unit tests in `crates/forge-session/src/orchestrator.rs`
+//! exercise the parallel-dispatch shape with a synthetic `SleepyTool`.
+//! This integration test wires the real `FsReadTool` against the public
+//! `serve_with_session` daemon so a regression in `FsReadTool::read_only`
+//! (or in any of the tool-handling glue between dispatcher registration
+//! and the orchestrator's grouping pass) surfaces here even if the
+//! synthetic harness keeps passing.
+
+use forge_core::{ApprovalSource, Event};
+use forge_ipc::{
+    ClientInfo, Hello, IpcEvent, IpcMessage, SendUserMessage, Subscribe, PROTO_VERSION,
+};
+use forge_providers::MockProvider;
+use forge_session::{server::serve_with_session, session::Session};
+use std::io::Write;
+use std::sync::Arc;
+use tempfile::{NamedTempFile, TempDir};
+use tokio::net::UnixStream;
+
+async fn connect_with_retry(path: &std::path::PathBuf) -> UnixStream {
+    for _ in 0..50 {
+        match UnixStream::connect(path).await {
+            Ok(s) => return s,
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+        }
+    }
+    UnixStream::connect(path)
+        .await
+        .expect("daemon did not create socket in time")
+}
+
+async fn do_handshake(stream: &mut UnixStream) {
+    let hello = IpcMessage::Hello(Hello {
+        proto: PROTO_VERSION,
+        client: ClientInfo {
+            kind: "test".into(),
+            pid: std::process::id(),
+            user: "tester".into(),
+        },
+        schema_version: forge_ipc::SCHEMA_VERSION,
+    });
+    forge_ipc::write_frame(stream, &hello).await.unwrap();
+    let response = forge_ipc::read_frame(stream).await.unwrap();
+    assert!(
+        matches!(response, IpcMessage::HelloAck(_)),
+        "expected HelloAck"
+    );
+}
+
+fn extract_event(msg: &IpcMessage) -> Option<Event> {
+    if let IpcMessage::Event(IpcEvent { event, .. }) = msg {
+        Some(event.clone())
+    } else {
+        None
+    }
+}
+
+/// Two consecutive `fs.read` calls in one model turn:
+///   * neither call surfaces `ToolCallApprovalRequested` (read-only auto-approve);
+///   * both `ToolCallApproved` events carry `by: ApprovalSource::Auto`;
+///   * both `ToolCallStarted` events share a single `Some(parallel_group)` id,
+///     proving the orchestrator placed them on the parallel-dispatch branch.
+#[tokio::test]
+async fn two_real_fs_read_calls_dispatch_in_parallel_without_approval() {
+    let dir = TempDir::new().unwrap();
+    let log_path = dir.path().join("events.jsonl");
+    let sock_path = dir.path().join("parallel_read.sock");
+
+    // Two distinct files inside the workspace so `allowed_paths` derived
+    // from the workspace root admits both reads cleanly.
+    let mut f_a = NamedTempFile::new_in(dir.path()).unwrap();
+    f_a.write_all(b"alpha").unwrap();
+    let mut f_b = NamedTempFile::new_in(dir.path()).unwrap();
+    f_b.write_all(b"beta").unwrap();
+    let path_a = f_a.path().to_str().unwrap().to_string();
+    let path_b = f_b.path().to_str().unwrap().to_string();
+
+    // One turn, two consecutive `fs.read` calls, then Done("tool_use") so
+    // the orchestrator dispatches the batch and asks the provider for a
+    // continuation. The continuation script just ends the turn.
+    let initial = format!(
+        "{}\n{}\n{}\n",
+        serde_json::json!({"tool_call": {"name": "fs.read", "args": {"path": path_a}}}),
+        serde_json::json!({"tool_call": {"name": "fs.read", "args": {"path": path_b}}}),
+        serde_json::json!({"done": "tool_use"}),
+    );
+    let cont = format!("{}\n", serde_json::json!({"done": "end_turn"}));
+
+    let session = Arc::new(Session::create(log_path).await.unwrap());
+    let provider = Arc::new(MockProvider::from_responses(vec![initial, cont]).unwrap());
+
+    let server_session = Arc::clone(&session);
+    let server_provider = Arc::clone(&provider);
+    let server_sock = sock_path.clone();
+    let server_workspace = Some(dir.path().to_path_buf());
+    tokio::spawn(async move {
+        serve_with_session(
+            &server_sock,
+            server_session,
+            server_provider,
+            // auto_approve OFF — if read-only auto-approve regresses, the
+            // orchestrator parks on the approval gate and the test times
+            // out. We must NOT mask that regression with the global flag.
+            false,
+            false,
+            server_workspace,
+            None,
+            None, // F-587: keyless test wiring
+            None, // F-601: no active agent — memory off in this test
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut stream = connect_with_retry(&sock_path).await;
+    do_handshake(&mut stream).await;
+    forge_ipc::write_frame(&mut stream, &IpcMessage::Subscribe(Subscribe { since: 0 }))
+        .await
+        .unwrap();
+    forge_ipc::write_frame(
+        &mut stream,
+        &IpcMessage::SendUserMessage(SendUserMessage {
+            text: "read both".into(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Drain until the continuation completes (two AssistantMessage(final)
+    // events — one closing the tool turn, one closing the end_turn).
+    let mut events: Vec<Event> = Vec::new();
+    let mut final_count = 0;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let (mut reader, _writer) = stream.into_split();
+    loop {
+        let frame = tokio::time::timeout_at(deadline, forge_ipc::read_frame(&mut reader))
+            .await
+            .expect(
+                "timed out — read-only auto-approval regressed and the daemon \
+                 is parked on an approval prompt",
+            )
+            .unwrap();
+        let Some(event) = extract_event(&frame) else {
+            continue;
+        };
+        if matches!(
+            event,
+            Event::AssistantMessage {
+                stream_finalised: true,
+                ..
+            }
+        ) {
+            final_count += 1;
+        }
+        events.push(event);
+        if final_count >= 2 {
+            break;
+        }
+    }
+
+    // ── Approval-gate behaviour ──────────────────────────────────────────
+    let approval_requests = events
+        .iter()
+        .filter(|e| matches!(e, Event::ToolCallApprovalRequested { .. }))
+        .count();
+    assert_eq!(
+        approval_requests, 0,
+        "fs.read must auto-approve under #647 — saw {approval_requests} ToolCallApprovalRequested events"
+    );
+
+    let auto_approvals = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                Event::ToolCallApproved {
+                    by: ApprovalSource::Auto,
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(
+        auto_approvals, 2,
+        "expected two ToolCallApproved {{ by: Auto }} (one per fs.read)"
+    );
+
+    // ── Parallel-dispatch branch ────────────────────────────────────────
+    let started_groups: Vec<Option<u32>> = events
+        .iter()
+        .filter_map(|e| {
+            if let Event::ToolCallStarted { parallel_group, .. } = e {
+                Some(*parallel_group)
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(
+        started_groups.len(),
+        2,
+        "expected two ToolCallStarted events (one per fs.read), got {}",
+        started_groups.len()
+    );
+    assert!(
+        started_groups.iter().all(|g| g.is_some()),
+        "both fs.read calls must carry parallel_group=Some(_) — sequential dispatch \
+         (parallel_group=None) means the orchestrator skipped the parallel branch: {started_groups:?}"
+    );
+    assert_eq!(
+        started_groups[0], started_groups[1],
+        "both fs.read calls must share the same parallel_group id; got {started_groups:?}"
+    );
+
+    // ── Tool results landed ─────────────────────────────────────────────
+    let read_payloads: Vec<String> = events
+        .iter()
+        .filter_map(|e| {
+            if let Event::ToolCallCompleted { result, .. } = e {
+                result
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(
+        read_payloads.len(),
+        2,
+        "both fs.read calls must complete with a content payload; got {read_payloads:?}"
+    );
+    assert!(
+        read_payloads.contains(&"alpha".to_string()) && read_payloads.contains(&"beta".to_string()),
+        "fs.read results must contain both file contents; got {read_payloads:?}"
+    );
+}

--- a/crates/forge-session/tests/pause_resume.rs
+++ b/crates/forge-session/tests/pause_resume.rs
@@ -33,8 +33,12 @@ use tokio::time::{timeout, Duration};
 // continuation also emits one delta + Done. The pause checkpoint sits
 // between provider passes, so wedging a pause between the two passes is
 // the cleanest way to exercise the between-step contract.
+//
+// The tool call is `fs.write` (non-read-only) so the approval gate
+// actually fires when `auto_approve` is off — `fs.read` auto-approves
+// since issue #647 and would skip the gate the test depends on.
 const SCRIPT_FIRST: &str = r#"{"delta":"step one"}
-{"tool_call":{"name":"fs.read","args":{"path":"a.txt"}}}
+{"tool_call":{"name":"fs.write","args":{"path":"a.txt","content":"x"}}}
 {"done":"tool_use"}
 "#;
 


### PR DESCRIPTION
Closes forge-ide/forge#647

## Summary
- Override `FsReadTool::read_only()` to `true` so consecutive `fs.read` calls land in the F-599 parallel-dispatch branch and skip the interactive approval gate (logging `ApprovalSource::Auto` in its place).
- Update existing approval-required tests for `fs.read` to expect the read-only auto-approval shape; switch tests that pin behaviour of the gate itself (scope fidelity, malformed-scope rejection, pause-during-approval) to a non-read-only `fs.write` script so they still exercise the gate.
- Add `crates/forge-session/tests/parallel_read_dispatch.rs`: end-to-end test driving two real `FsReadTool` calls through `serve_with_session` and asserting both land on the parallel branch (shared `parallel_group`) with no approval prompt and `ApprovalSource::Auto` for each call.

## Test plan
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `just check-rust` passes (CI rustdoc gate)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)