### PR TITLE
[F-682] Quality hygiene cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,6 +1591,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 0.8.23",
+ "tracing",
  "wiremock",
 ]
 

--- a/crates/forge-core/src/event_sink.rs
+++ b/crates/forge-core/src/event_sink.rs
@@ -53,5 +53,38 @@ pub trait EventSink: Send + Sync {
     /// converts a write failure into a hard turn error so the
     /// supervisor can observe the connection drop and recycle the
     /// sidecar.
+    ///
+    /// # Error contract (sidecar semantics)
+    ///
+    /// Implementors classify their internal failures into one of two
+    /// shapes before mapping into [`anyhow::Error`]:
+    ///
+    /// * **Fatal** — the underlying transport / log is unrecoverable
+    ///   for the *current turn*. Examples: the sidecar's UDS write
+    ///   half is closed, the daemon's `EventLog` returned an I/O
+    ///   error from a full disk, the broadcast channel has zero live
+    ///   receivers AND the persistence write also failed. The caller
+    ///   (`run_turn`) treats the error as terminal: the turn aborts
+    ///   and (in the sidecar case) the supervisor recycles the
+    ///   process so a clean handshake can re-establish the channel.
+    ///
+    ///   Fatal errors propagate unchanged through `emit(...)?` — do
+    ///   *not* swallow them and `Ok(())` to keep the turn alive.
+    ///   Silent loss of an event corrupts the post-mortem record and
+    ///   defeats the durable-log invariant.
+    ///
+    /// * **Recoverable** — a transient sub-failure that does *not*
+    ///   invalidate the channel. Examples: a broadcast receiver lag
+    ///   when at least one subscriber is still attached, a
+    ///   best-effort observer that doesn't gate the turn (telemetry
+    ///   exporters, mirror sinks). Implementors handle these
+    ///   internally — log via `tracing` and return `Ok(())`. They
+    ///   must *not* propagate via the trait, because every caller
+    ///   treats a returned error as fatal per the rule above.
+    ///
+    /// In short: if a sink returns `Err`, the turn ends. Anything a
+    /// sink can absorb without ending the turn must be absorbed
+    /// inside the sink, with a `tracing::warn!` (or lower) for
+    /// visibility, before returning `Ok(())`.
     async fn emit(&self, event: Event) -> anyhow::Result<()>;
 }

--- a/crates/forge-core/src/settings.rs
+++ b/crates/forge-core/src/settings.rs
@@ -37,6 +37,13 @@ use ts_rs::TS;
 use crate::config_file::{load_toml_or_default, save_raw_atomic, save_toml_atomic};
 use crate::Result;
 
+/// Open-keyed boolean map written by the dashboard's dotted-key
+/// `set_setting` path. Keys are arbitrary user-supplied identifiers
+/// (catalog asset ids, agent names, etc.) and order on the wire is not
+/// stable. Used as the inner shape of [`CatalogSettings::enabled`] and
+/// directly as [`MemorySettings::enabled`].
+pub type OpenKeyMap = HashMap<String, bool>;
+
 /// Notification delivery mode for background-agent events (F-138 consumer).
 /// Serialized as snake_case string so TOML files read naturally
 /// (`bg_agents = "toast"`) and ts-rs emits a string literal union.
@@ -199,7 +206,7 @@ pub struct CatalogSettings {
     /// `enabled.<kind>.<id> = <bool>`. Outer key is the catalog tab
     /// (`"skills"`, `"mcp"`, `"agents"`); inner key is the asset id.
     #[serde(default)]
-    pub enabled: HashMap<String, HashMap<String, bool>>,
+    pub enabled: HashMap<String, OpenKeyMap>,
 }
 
 /// `[dashboard]` section. Per-user UI preferences for the Dashboard
@@ -238,7 +245,7 @@ pub struct MemorySettings {
     /// `enabled.<agent> = <bool>`. Absent agents fall back to the def-level
     /// `memory_enabled` frontmatter flag.
     #[serde(default)]
-    pub enabled: HashMap<String, bool>,
+    pub enabled: OpenKeyMap,
 }
 
 /// Top-level settings shape persisted to `settings.toml`.

--- a/crates/forge-core/src/usage.rs
+++ b/crates/forge-core/src/usage.rs
@@ -160,8 +160,20 @@ impl Default for SessionUsage {
 }
 
 impl SessionUsage {
-    /// All-zero starting point; cost is `Some(0 USD)` until a tick without a
-    /// priced row arrives.
+    /// All-zero starting point.
+    ///
+    /// `cost = Some(Money::usd(0))` is a *known* zero — the session has
+    /// observed no priced traffic *yet*, but the price table is in
+    /// scope and ready to attribute the next tick. This is distinct
+    /// from `cost = None`, which is the *missing-price* sentinel
+    /// produced by [`Self::fold`] once any priced tick lacks a row in
+    /// the embedded `prices.toml`. Once `None` is observed the value is
+    /// sticky — every subsequent fold leaves it `None` so live and
+    /// flushed totals report a missing price the same way (mirrors
+    /// [`MonthlyAggregate::record`]).
+    ///
+    /// UI rule of thumb: `Some(0)` renders as `$0.00`; `None` renders
+    /// as `—` (or "price unavailable").
     pub fn zero() -> Self {
         Self {
             tokens_in: 0,

--- a/crates/forge-ipc/src/lib.rs
+++ b/crates/forge-ipc/src/lib.rs
@@ -16,7 +16,38 @@ use ts_rs::TS;
 // `docs/architecture/agent-sidecar.md` §2.
 pub mod sidecar;
 
+/// Wire-protocol version negotiated at handshake (`Hello` /
+/// `HelloAck`). Bump this only when the *framing* contract changes —
+/// length-prefix size, magic bytes, the JSON-vs-bincode discriminator,
+/// etc. Adding a new variant to [`IpcMessage`] does **not** require a
+/// `PROTO_VERSION` bump: the receive side rejects unknown `t` tags as
+/// a deserialize error long before the framing layer sees them, and
+/// the existing schema-mismatch warn ([`warn_if_schema_mismatch`])
+/// already covers payload-shape drift.
+///
+/// See [`SCHEMA_VERSION`] for the version bumped on payload-shape
+/// changes; the F-640 `SwitchProvider` addition is a worked example
+/// that touched neither constant — additive variants don't perturb
+/// either layer.
 pub const PROTO_VERSION: u32 = 1;
+
+/// Schema version reported at handshake. Bump this when an existing
+/// payload field's serialization shape changes (renames, type
+/// widening, default semantics) — a peer that doesn't understand the
+/// new shape gets a `tracing::warn!` from
+/// [`warn_if_schema_mismatch`] but the connection still completes
+/// (the policy is informational today; F-678 leaves the door open to
+/// promote it to a hard reject behind a `strict_schema_version`
+/// toggle).
+///
+/// Adding a brand-new variant (e.g. F-640 `SwitchProvider`,
+/// F-603 `PauseSession`) is *additive* — older peers that don't
+/// emit it never trigger a deserialize failure, and newer peers
+/// emitting it against an older receiver fail at the
+/// `serde(tag = "t")` arm with a clear unknown-variant error. Neither
+/// case changes the wire shape of an *existing* variant, so neither
+/// requires a `SCHEMA_VERSION` bump. Bump only when an existing
+/// payload's field types or names drift.
 pub const SCHEMA_VERSION: u32 = 1;
 
 /// F-678: log a `warn!` when a handshake peer reports a schema version

--- a/crates/forge-ipc/src/sidecar.rs
+++ b/crates/forge-ipc/src/sidecar.rs
@@ -11,6 +11,24 @@
 //! Variants follow `docs/architecture/agent-sidecar.md` §2. This module
 //! defines the types only: transport, supervisor, and spawning land in
 //! later F-608 steps.
+//!
+//! ## Future work: centralized construction helpers
+//!
+//! Several payload structs in this module ([`SidecarHello`],
+//! [`SidecarRunTurn`], [`SidecarCredentials`]) are built across multiple
+//! call sites — supervisor side, agent-host side, and tests — with
+//! the same field invariants every time (non-empty `instance_id`,
+//! valid `proto`, redacted secret bytes). A small builder or factory
+//! that centralizes those checks (e.g.
+//! `SidecarHello::builder().proto(P).instance_id(id).build()`) would
+//! let us validate once instead of per-site, and would surface
+//! shape-drift at construction time rather than at serialize time.
+//!
+//! Tracked under F-682 quality-hygiene; deliberately deferred from this
+//! pass because a proper builder is a real refactor (every call site
+//! migrates) and is out of scope for a doc-only cleanup. Pick this up
+//! the next time a new field is added to one of those payloads —
+//! that's a natural touch point for the migration.
 
 use chrono::{DateTime, Utc};
 use forge_core::{AgentInstanceId, Event, MessageId, ProviderId};

--- a/crates/forge-oci/src/podman.rs
+++ b/crates/forge-oci/src/podman.rs
@@ -186,8 +186,25 @@ impl ContainerRuntime for PodmanRuntime {
             enforce_policy(image, self.policy, verr)?;
         }
         let img = image.to_image_string();
-        self.run_or_fail(&["pull", &img]).await?;
-        Ok(())
+        match self.run_or_fail(&["pull", &img]).await {
+            Ok(_) => {
+                tracing::info!(
+                    target: "forge_oci::podman",
+                    image = %img,
+                    "container.pull succeeded"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "forge_oci::podman",
+                    image = %img,
+                    error = %e,
+                    "container.pull failed"
+                );
+                Err(e)
+            }
+        }
     }
 
     async fn create(
@@ -220,7 +237,18 @@ impl ContainerRuntime for PodmanRuntime {
         }
         args.push(&img);
         args.extend_from_slice(argv);
-        let outcome = self.run_or_fail(&args).await?;
+        let outcome = match self.run_or_fail(&args).await {
+            Ok(o) => o,
+            Err(e) => {
+                tracing::warn!(
+                    target: "forge_oci::podman",
+                    image = %img,
+                    error = %e,
+                    "container.create failed"
+                );
+                return Err(e);
+            }
+        };
         let id = String::from_utf8_lossy(&outcome.stdout).trim().to_string();
         if id.is_empty() {
             return Err(OciError::CommandFailed {
@@ -230,12 +258,35 @@ impl ContainerRuntime for PodmanRuntime {
                 stderr: "podman create returned empty container id".to_string(),
             });
         }
+        tracing::info!(
+            target: "forge_oci::podman",
+            image = %img,
+            container_id = %id,
+            "container.create succeeded"
+        );
         Ok(ContainerHandle::new(id))
     }
 
     async fn start(&self, handle: &ContainerHandle) -> Result<(), OciError> {
-        self.run_or_fail(&["start", &handle.id]).await?;
-        Ok(())
+        match self.run_or_fail(&["start", &handle.id]).await {
+            Ok(_) => {
+                tracing::info!(
+                    target: "forge_oci::podman",
+                    container_id = %handle.id,
+                    "container.start succeeded"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "forge_oci::podman",
+                    container_id = %handle.id,
+                    error = %e,
+                    "container.start failed"
+                );
+                Err(e)
+            }
+        }
     }
 
     async fn exec(&self, handle: &ContainerHandle, argv: &[&str]) -> Result<ExecResult, OciError> {
@@ -251,14 +302,30 @@ impl ContainerRuntime for PodmanRuntime {
         // exec captures the inner program's stdout/stderr/exit even on a
         // non-zero exit — that's a meaningful signal, not a runtime failure.
         // So we go around `run_or_fail` here.
-        let outcome = self
-            .runner
-            .run(PODMAN, &args)
-            .await
-            .map_err(|source| OciError::Io {
-                tool: PODMAN,
-                source,
-            })?;
+        let outcome = match self.runner.run(PODMAN, &args).await {
+            Ok(o) => o,
+            Err(source) => {
+                tracing::warn!(
+                    target: "forge_oci::podman",
+                    container_id = %handle.id,
+                    error = %source,
+                    "container.exec spawn failed"
+                );
+                return Err(OciError::Io {
+                    tool: PODMAN,
+                    source,
+                });
+            }
+        };
+        // exec captures the inner program's stdout/stderr/exit even on a
+        // non-zero exit — that's a meaningful signal, not a runtime failure.
+        // We log at info regardless so latency attribution stays consistent.
+        tracing::info!(
+            target: "forge_oci::podman",
+            container_id = %handle.id,
+            exit_code = ?outcome.exit_code,
+            "container.exec completed"
+        );
         Ok(ExecResult {
             exit_code: outcome.exit_code,
             stdout: String::from_utf8_lossy(&outcome.stdout).into_owned(),
@@ -267,14 +334,48 @@ impl ContainerRuntime for PodmanRuntime {
     }
 
     async fn stop(&self, handle: &ContainerHandle) -> Result<(), OciError> {
-        self.run_or_fail(&["stop", &handle.id]).await?;
-        Ok(())
+        match self.run_or_fail(&["stop", &handle.id]).await {
+            Ok(_) => {
+                tracing::info!(
+                    target: "forge_oci::podman",
+                    container_id = %handle.id,
+                    "container.stop succeeded"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "forge_oci::podman",
+                    container_id = %handle.id,
+                    error = %e,
+                    "container.stop failed"
+                );
+                Err(e)
+            }
+        }
     }
 
     async fn remove(&self, handle: &ContainerHandle) -> Result<(), OciError> {
         // -f forces removal of running containers (podman stop+rm in one step).
-        self.run_or_fail(&["rm", "-f", &handle.id]).await?;
-        Ok(())
+        match self.run_or_fail(&["rm", "-f", &handle.id]).await {
+            Ok(_) => {
+                tracing::info!(
+                    target: "forge_oci::podman",
+                    container_id = %handle.id,
+                    "container.remove succeeded"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "forge_oci::podman",
+                    container_id = %handle.id,
+                    error = %e,
+                    "container.remove failed"
+                );
+                Err(e)
+            }
+        }
     }
 
     async fn stats(&self, handle: &ContainerHandle) -> Result<Stats, OciError> {
@@ -431,10 +532,36 @@ fn parse_percent(s: &str) -> Option<f64> {
 /// Parse the *first* size value from a podman `mem_usage` string of the form
 /// `"178.3MB / 67.31GB"` into bytes. The second number is the host total,
 /// which we don't surface.
+///
+/// Returns `None` when the input is the podman `"-- / --"` placeholder
+/// (mid-state container, expected) **or** when the string shape diverges
+/// from what we've seen in the wild. The latter is a podman-version-skew
+/// signal — emit a `tracing::debug!` so the log captures the offending
+/// payload while still treating the call as "metric missing" rather than
+/// failing the whole `stats` invocation.
 fn parse_size_first(s: &str) -> Option<u64> {
-    let first = s.split('/').next()?.trim();
-    let (num, unit) = split_number_unit(first)?;
-    let value: f64 = num.parse().ok()?;
+    fn warn(input: &str, reason: &'static str) -> Option<u64> {
+        // Skip the noisy expected case — `"-- / --"` is podman's
+        // "container is mid-transition" placeholder, not skew.
+        if input.trim() != "-- / --" {
+            tracing::debug!(
+                target: "forge_oci::podman",
+                input = %input,
+                reason = %reason,
+                "parse_size_first: returning None (possible podman version skew)"
+            );
+        }
+        None
+    }
+    let Some(first) = s.split('/').next().map(str::trim) else {
+        return warn(s, "no '/' separator");
+    };
+    let Some((num, unit)) = split_number_unit(first) else {
+        return warn(s, "no number+unit split");
+    };
+    let Ok(value): std::result::Result<f64, _> = num.parse() else {
+        return warn(s, "number parse failed");
+    };
     let multiplier: f64 = match unit.to_ascii_uppercase().as_str() {
         "" | "B" => 1.0,
         "KB" | "K" => 1_000.0,
@@ -445,7 +572,7 @@ fn parse_size_first(s: &str) -> Option<u64> {
         "MIB" => 1_024.0 * 1_024.0,
         "GIB" => 1_024.0 * 1_024.0 * 1_024.0,
         "TIB" => 1_024.0 * 1_024.0 * 1_024.0 * 1_024.0,
-        _ => return None,
+        _ => return warn(s, "unknown size unit"),
     };
     Some((value * multiplier) as u64)
 }

--- a/crates/forge-oci/tests/podman_integration.rs
+++ b/crates/forge-oci/tests/podman_integration.rs
@@ -578,3 +578,103 @@ async fn mismatched_signature_is_rejected() {
         "podman pull must not be invoked when signature verification fails"
     );
 }
+
+// ── F-682: failure-path coverage ────────────────────────────────────────
+//
+// The end-to-end happy paths above prove podman's argv grammar; this
+// section pins the *failure* shapes operators see in the field. Each
+// test is `#[ignore]`-gated so CI's default run skips them, but
+// `cargo test -p forge-oci -- --ignored` exercises them against a real
+// rootless podman.
+
+/// Pulling a nonexistent image must surface `OciError::CommandFailed`
+/// with podman's stderr captured in the variant — operators rely on
+/// the stderr text to disambiguate "registry rejected" from
+/// "rate-limited" from "network down" without re-running the
+/// command. The runtime must NOT collapse the failure into a generic
+/// "image not found" string and must NOT silently succeed.
+#[tokio::test]
+#[ignore = "requires rootless podman on PATH (run with --ignored)"]
+async fn pull_nonexistent_image_surfaces_command_failed() {
+    let runtime = PodmanRuntime::new().with_verifier(
+        Box::new(forge_oci::NoopVerifier),
+        SignaturePolicy::Permissive,
+    );
+    // Synthetic registry name that no public registry resolves. Using
+    // an invalid hostname keeps the failure local-side (DNS / dial),
+    // not registry-side, so the test is hermetic — no rate limit, no
+    // 24h cache miss, no flaky upstream.
+    let img = ImageRef::parse(&format!(
+        "registry.invalid.forge-test.example/nonexistent@sha256:{SHA}"
+    ))
+    .expect("digest-pinned ref must parse");
+    let err = runtime.pull(&img).await.unwrap_err();
+    assert!(
+        matches!(err, OciError::CommandFailed { tool: "podman", .. }),
+        "expected CommandFailed for nonexistent image, got {err:?}"
+    );
+}
+
+/// `exec` against a stopped container must surface a captured exit
+/// code and the runtime's stderr — not a runtime panic and not a
+/// silent zero-exit. The semantics matter: the dashboard's
+/// AgentMonitor reads stderr to render the failure to operators.
+#[tokio::test]
+#[ignore = "requires rootless podman on PATH (run with --ignored)"]
+async fn exec_against_stopped_container_surfaces_nonzero_exit() {
+    let runtime = PodmanRuntime::new().with_verifier(
+        Box::new(forge_oci::NoopVerifier),
+        SignaturePolicy::Permissive,
+    );
+    let img =
+        ImageRef::parse(&format!("docker.io/library/alpine@{ALPINE_DIGEST}")).expect("alpine ref");
+    runtime.pull(&img).await.expect("pull alpine");
+
+    // Create a container that exits immediately, do NOT start it (or
+    // start+let it exit), then exec against it. Either path leaves
+    // the container in a non-running state where `podman exec` must
+    // refuse with non-zero exit.
+    let h = runtime
+        .create(&img, &["true"], &SecurityOpts::permissive())
+        .await
+        .expect("create");
+
+    let res = runtime
+        .exec(&h, &["echo", "hi"])
+        .await
+        .expect("exec returns Ok");
+    assert!(
+        res.exit_code.unwrap_or(0) != 0,
+        "exec against non-running container must surface nonzero exit, got {res:?}"
+    );
+    assert!(
+        !res.stderr.is_empty(),
+        "exec against non-running container must surface stderr, got {res:?}"
+    );
+
+    // Cleanup so we don't leak the container into the host's podman state.
+    let _ = runtime.remove(&h).await;
+}
+
+/// `parse_stats` against a malformed JSON body returned by a future
+/// podman version (or a registry-injected payload, hypothetically)
+/// must surface `OciError::InvalidJson` rather than panicking or
+/// returning a `Stats` with garbage fields. The unit-test sibling
+/// covers this against a stub runner; this test pins the same shape
+/// through the real runtime so a future runtime swap doesn't quietly
+/// break the contract.
+#[tokio::test]
+#[ignore = "requires rootless podman on PATH (run with --ignored)"]
+async fn parse_stats_surfaces_invalid_json_via_real_runtime() {
+    // We can't easily make real podman emit malformed JSON, so this
+    // exercises the trait method directly through a real runtime
+    // instance. Hermetic, fast, but kept under `#[ignore]` so the
+    // failure-path suite groups together for `--ignored` runs.
+    let runtime = PodmanRuntime::new();
+    let err = ContainerRuntime::parse_stats(&runtime, b"not json")
+        .expect_err("malformed json must surface as typed error");
+    assert!(
+        matches!(err, OciError::InvalidJson { tool: "podman", .. }),
+        "expected InvalidJson, got {err:?}"
+    );
+}

--- a/crates/forge-providers/Cargo.toml
+++ b/crates/forge-providers/Cargo.toml
@@ -31,6 +31,11 @@ serde_json = "1"
 toml = "0.8"
 tokio = { version = "1", features = ["fs", "rt", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
+# F-682: latency / failure-mode attribution via `#[instrument]` on each
+# provider's `chat()` entry. Provider-side logs are useful for ops
+# triage even with no exporter wired — `tracing-subscriber`'s
+# fmt-layer surfaces them when set up by the host binary.
+tracing = "0.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }

--- a/crates/forge-providers/src/anthropic/mod.rs
+++ b/crates/forge-providers/src/anthropic/mod.rs
@@ -66,6 +66,18 @@ impl AnthropicProvider {
 }
 
 impl Provider for AnthropicProvider {
+    /// F-682: `#[instrument]` enables ops-level latency attribution for the
+    /// per-turn chat path. `skip_all` keeps the request body (and any
+    /// large transcript fragment inside it) out of the span fields;
+    /// `provider = "anthropic"` and `model` are the only attributes
+    /// surfaced on the span. The exporter, when wired, sees one span
+    /// per `chat` call covering the full request → first byte → stream
+    /// duration.
+    #[tracing::instrument(
+        name = "provider.chat",
+        skip_all,
+        fields(provider = "anthropic", model = %self.model),
+    )]
     fn chat(
         &self,
         req: ChatRequest,

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -127,6 +127,25 @@ pub enum ChatChunk {
 }
 
 /// Why a provider stream terminated abnormally.
+///
+/// # Asymmetry with [`crate::sse::SseError`]
+///
+/// `StreamErrorKind` is `Copy` and carries no payload, while the
+/// upstream [`crate::sse::SseError::Transport`] variant *does* carry
+/// a `String` description of the underlying transport failure
+/// (reqwest error, redirect refusal, malformed framing, etc.). The
+/// asymmetry is intentional: the descriptive transport string is
+/// surfaced separately on the [`ChatChunk::Error`] envelope via its
+/// sibling `message` field, so the kind→envelope mapping can stay
+/// allocation-free (`Copy` of an enum tag, no `Clone` of a heap
+/// string).
+///
+/// At the crate-internal boundary (`http_util::map_sse_error`), every
+/// `SseError` collapses to a `StreamErrorKind`: variants that already
+/// describe themselves (`LineTooLong`, `IdleTimeout`, `WallClockTimeout`)
+/// map one-to-one; `SseError::Transport(string)` drops the string here
+/// — the caller is expected to copy it into the surrounding
+/// `ChatChunk::Error.message` so the wire shape is consistent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamErrorKind {
     /// A single NDJSON line exceeded the per-line byte cap.
@@ -135,13 +154,35 @@ pub enum StreamErrorKind {
     IdleTimeout,
     /// The overall stream exceeded its wall-clock budget.
     WallClockTimeout,
-    /// Transport-level error from the underlying reader.
+    /// Transport-level error from the underlying reader. The
+    /// descriptive message lives on the sibling
+    /// [`ChatChunk::Error::message`] field — see the type-level
+    /// asymmetry note above.
     Transport,
 }
 
 // ── Provider trait ────────────────────────────────────────────────────────────
 
 /// Streaming chat provider.
+///
+/// # Why `impl Future`, not `dyn`
+///
+/// `Provider` returns `impl std::future::Future<Output = ...> + Send`
+/// rather than `Pin<Box<dyn Future ...>>`. The `impl Future` shape is
+/// monomorphized per concrete provider, so we get zero allocation on
+/// the hot per-turn entry path and the compiler's auto-trait inference
+/// can confirm `Send` without manual `Box::pin`-ing each variant.
+///
+/// The cost is that `Provider` is **not object-safe**: `Arc<dyn Provider>`
+/// is rejected by the compiler. That trade is deliberate — every
+/// caller in the workspace today knows the concrete provider at
+/// compile time except the hot-swap path, and the hot-swap path
+/// resolves the lack of dynamic dispatch with the
+/// [`crate::runtime::RuntimeProvider`] tagged-union enum: one `match`
+/// arm per built-in provider, zero virtual call. See
+/// [`crate::runtime::RuntimeProvider`] and
+/// [`crate::runtime::SwappableProvider`] for the rationale and the
+/// per-call dispatch shape.
 pub trait Provider: Send + Sync {
     fn chat(
         &self,

--- a/crates/forge-providers/src/ollama.rs
+++ b/crates/forge-providers/src/ollama.rs
@@ -309,6 +309,14 @@ impl OllamaProvider {
 }
 
 impl Provider for OllamaProvider {
+    /// F-682: see [`crate::anthropic::AnthropicProvider::chat`] for the
+    /// full instrumentation rationale; same shape, different provider
+    /// label.
+    #[tracing::instrument(
+        name = "provider.chat",
+        skip_all,
+        fields(provider = "ollama", model = %self.model),
+    )]
     fn chat(
         &self,
         req: ChatRequest,

--- a/crates/forge-providers/src/openai/custom.rs
+++ b/crates/forge-providers/src/openai/custom.rs
@@ -306,6 +306,16 @@ fn custom_redirect_policy() -> reqwest::redirect::Policy {
 }
 
 impl Provider for CustomOpenAiProvider {
+    /// F-682: see [`crate::anthropic::AnthropicProvider::chat`] for the
+    /// full instrumentation rationale. The `provider` field carries
+    /// the user-supplied provider name (e.g. `"vllm"`, `"together"`)
+    /// so latency attribution distinguishes between two
+    /// `custom_openai:*` deployments at the same dashboard.
+    #[tracing::instrument(
+        name = "provider.chat",
+        skip_all,
+        fields(provider = %self.name(), model = %self.model),
+    )]
     fn chat(
         &self,
         req: ChatRequest,

--- a/crates/forge-providers/src/openai/mod.rs
+++ b/crates/forge-providers/src/openai/mod.rs
@@ -73,6 +73,14 @@ impl OpenAiProvider {
 }
 
 impl Provider for OpenAiProvider {
+    /// F-682: see [`crate::anthropic::AnthropicProvider::chat`] for the
+    /// full instrumentation rationale; same shape, different provider
+    /// label.
+    #[tracing::instrument(
+        name = "provider.chat",
+        skip_all,
+        fields(provider = "openai", model = %self.model),
+    )]
     fn chat(
         &self,
         req: ChatRequest,

--- a/crates/forge-providers/src/pricing.rs
+++ b/crates/forge-providers/src/pricing.rs
@@ -67,6 +67,14 @@ impl PriceTable {
     /// The compile-time–embedded table from `data/prices.toml`. Panics on a
     /// malformed in-tree file (a release blocker — caught by the
     /// `embedded_table_parses` test below).
+    ///
+    /// Backed by a process-lifetime `OnceLock` so the TOML parse runs
+    /// at most once per process. Every subsequent call returns the
+    /// same `&'static PriceTable` reference — there is no per-call
+    /// allocation, no per-call parse, and no lock contention beyond
+    /// the OnceLock's one-time initialization fence. Safe to call
+    /// from any thread, including the hot per-tick pricing path that
+    /// runs on every provider chunk.
     pub fn embedded() -> &'static Self {
         static TABLE: OnceLock<PriceTable> = OnceLock::new();
         TABLE.get_or_init(|| {

--- a/crates/forge-providers/src/runtime.rs
+++ b/crates/forge-providers/src/runtime.rs
@@ -147,6 +147,25 @@ impl Provider for SwappableProvider {
         // holds Arc-backed state and can outlive any subsequent swap.
         // This is the contract that lets the next turn use the new inner
         // without disturbing the in-flight stream.
+        //
+        // Why clone the entire `RuntimeProvider` rather than borrow
+        // `&self.inner` into the future:
+        //
+        // 1. `parking_lot::RwLockReadGuard<'_, RuntimeProvider>` is not
+        //    `Send`. Holding it across an `.await` would refuse to compile
+        //    — the future has to be `Send` to satisfy the trait return
+        //    bound (`+ Send`).
+        //
+        // 2. `RuntimeProvider::Clone` is *cheap*: every variant wraps an
+        //    `Arc<ConcreteProvider>`, so the clone is a per-variant
+        //    refcount bump, not a deep copy of provider state (HTTP
+        //    client, API key bytes, model name).
+        //
+        // 3. Holding the snapshot decouples the in-flight chat from any
+        //    future swap: a `provider:changed` event mid-stream replaces
+        //    `self.inner` but the captured `Arc` keeps the previous inner
+        //    alive until the stream finishes. Swap-during-stream cannot
+        //    yank the network connection out from under an active turn.
         let snapshot: RuntimeProvider = self.inner.read().clone();
         async move { snapshot.chat(req).await }
     }

--- a/crates/forge-session/src/sandbox/level2.rs
+++ b/crates/forge-session/src/sandbox/level2.rs
@@ -59,6 +59,11 @@ pub use forge_oci::ContainerLimits;
 /// impl in the workspace today is `PodmanRuntime`; if a second
 /// implementation is added the safety net would need a small
 /// abstraction (e.g. each impl supplies its own teardown argv).
+///
+/// TODO(F-682, issue #718): refactor into a per-impl shutdown command
+/// when the second container runtime lands. Tracker explicitly defers
+/// the change until then — adding the abstraction now would be
+/// speculative scaffolding with one consumer.
 const DROP_CLEANUP_BINARY: &str = "podman";
 
 /// Render [`ContainerLimits`] into the argv fragment that would be

--- a/crates/forge-session/src/sidecar/mod.rs
+++ b/crates/forge-session/src/sidecar/mod.rs
@@ -982,12 +982,29 @@ impl SupervisorTask {
                 }
                 None
             }
-            SidecarMessage::Heartbeat(_) => {
+            SidecarMessage::Heartbeat(hb) => {
                 // F-608 step 4: heartbeat-watchdog deferred — the
                 // EOF-on-read path catches an unresponsive child via
                 // its TCP-style RST. A 5-second silence watchdog lands
                 // when we wire ResourceMonitor to surface stuck
                 // sidecars in step 9.
+                //
+                // F-682: surface `pending_turns > 0` at trace level so
+                // a stuck-mid-turn sidecar is visible in triage. Trace
+                // (not warn or debug) because heartbeats fire at 1 Hz
+                // and `pending_turns > 0` is the *normal* state for
+                // the entire duration of every turn — anything louder
+                // would drown the log. Operators who suspect a stuck
+                // child enable `RUST_LOG=forge_session::sidecar=trace`
+                // and read the per-second cadence to confirm.
+                if hb.pending_turns > 0 {
+                    tracing::trace!(
+                        target: "forge_session::sidecar",
+                        instance_id = %self.instance_id,
+                        pending_turns = hb.pending_turns,
+                        "sidecar heartbeat: turn in flight"
+                    );
+                }
                 None
             }
             SidecarMessage::ToolCallApprovalRequest(_) => {

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -51,7 +51,12 @@
 //! `command`. The success path is silent. See `tests/ipc_authz_tracing.rs`
 //! for the schema contract.
 //!
-//! ## Error-message prefix style (F-673)
+//! ## Error handling (F-673)
+//!
+//! Two complementary patterns govern how `*_ipc.rs` Tauri commands
+//! shape the strings they return to the webview.
+//!
+//! ### Standardized prefix (default)
 //!
 //! Every outer error path returned from a `*_ipc.rs` Tauri command must
 //! begin with a command-named constant prefix of the form
@@ -59,14 +64,32 @@
 //! Format the wrapped error as `format!("{COMMAND_ERROR}{e}")`. This keeps
 //! the dashboard's end-user error surface and the server-side log filter
 //! consistent across modules — a glance at the prefix tells you which
-//! command produced the error.
+//! command produced the error. New error paths must use this style.
 //!
-//! **Exception.** Bare `e.to_string()` (or shared infrastructure constants
-//! like `LABEL_MISMATCH_ERROR`) is acceptable for IPC-infrastructure
-//! errors — bridge state lookups, Tauri-managed `State<'_, _>` access,
-//! window-label checks — where the surrounding code makes the source
-//! unambiguous. New error paths in a `*_ipc.rs` command body must follow
-//! the prefix rule.
+//! ### When bare `.to_string()` is acceptable (exception)
+//!
+//! Bare `e.to_string()` (or shared infrastructure constants like
+//! `LABEL_MISMATCH_ERROR`) is acceptable in three narrow cases where
+//! the *origin of the failure is unambiguous from context*, and where
+//! routing the same error through every command's prefix would add
+//! noise without adding signal:
+//!
+//! 1. **Tauri-managed state access** — `state.try_state::<T>()` /
+//!    `State<'_, _>` lookup failures. The error is produced by the
+//!    Tauri runtime itself; the command name is already on the
+//!    invocation log.
+//! 2. **Bridge state lookups** — calls into the cached `BridgeState`
+//!    (e.g. `cached_workspace_root`). The error type already names
+//!    its own subsystem; double-prefixing reads as `cmd: bridge:
+//!    <message>`, which is verbose without disambiguating.
+//! 3. **Window-label authz checks** — `require_window_label*` returns
+//!    a fixed-shape `LABEL_MISMATCH_ERROR` constant. Every command
+//!    rejects with the same string, on purpose: it is the label-
+//!    authentication failure mode, not a per-command condition.
+//!
+//! Anywhere outside those three cases a bare `.to_string()` is a
+//! style regression — wrap the error in the command's prefix
+//! constant.
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/crates/forge-shell/src/memory_ipc.rs
+++ b/crates/forge-shell/src/memory_ipc.rs
@@ -18,6 +18,21 @@
 //! The same store the F-601 `memory.write` tool uses, so an agent and a
 //! human editing the same file see consistent results.
 //!
+//! # Workspace-root validation invariant (F-349)
+//!
+//! Every command body that accepts a webview-supplied `workspace_root`
+//! parameter MUST call `crate::ipc::resolve_workspace_root_for_command`
+//! **before** any filesystem operation that uses the path. The resolver
+//! ignores the webview-supplied value for `session-*` callers (consults
+//! the server-side cache populated at `session_hello` time) and validates
+//! the value against the workspaces registry for `dashboard` callers.
+//! Skipping the call — or running an `fs::read` / `fs::write` against
+//! the raw `workspace_root` before the resolver returns — re-opens the
+//! F-122 trust hole: a compromised `session-*` webview could supply any
+//! writable path and the command would happily honour it. The resolver
+//! is the only sanctioned trust boundary; everything downstream must use
+//! its returned `PathBuf`.
+//!
 //! # Authorization
 //!
 //! Every command requires the dashboard window label. A session window

--- a/crates/forge-shell/src/transcript_ipc.rs
+++ b/crates/forge-shell/src/transcript_ipc.rs
@@ -12,6 +12,20 @@
 //! `session-{id}` window. Other session windows are rejected — a
 //! session-A webview has no business reading session-B's transcript.
 //!
+//! # Workspace-root validation invariant (F-349)
+//!
+//! `export_transcript` accepts a webview-supplied `workspace_root` and
+//! MUST call `crate::ipc::resolve_workspace_root_for_command` before
+//! any filesystem operation that uses the path. The resolver ignores
+//! the supplied value for `session-*` callers (consulting the
+//! server-side cache populated at `session_hello`) and validates it
+//! against the workspaces registry for `dashboard` callers. Reading
+//! the raw `workspace_root` before the resolver returns re-opens the
+//! F-122 trust hole — a compromised webview could exfiltrate any
+//! `events.jsonl` it could path-construct. Every downstream `events.jsonl`
+//! lookup must use the resolver's returned `PathBuf`, never the
+//! webview value directly.
+//!
 //! # Path safety
 //!
 //! `session_id` is validated against the canonical


### PR DESCRIPTION
Closes forge-ide/forge#718

## Summary

Phase 3 quality-hygiene tracker: 16 actionable cleanup items (#17 deferred per the tracker's own brief) bundled into one PR for review economy. Mostly doc-comments + a handful of small wiring changes (tracing, type alias, supervisor log, three integration tests).

## Items addressed (per crate)

### forge-core
- [x] `SessionUsage::zero()` — clarified `Some(Money::usd(0))` is *known* zero vs `None` is *missing-price* sentinel
- [x] Extracted `OpenKeyMap = HashMap<String, bool>` type alias; reused as the inner map of `CatalogSettings::enabled` and directly as `MemorySettings::enabled` (the brief mentioned a doubly-nested alias, but `MemorySettings` is single-level — this alias matches the actual shape both structs share)
- [x] `EventSink::emit` — documented fatal-vs-recoverable contract: `Err` is turn-terminal; recoverable failures must be absorbed inside the sink

### forge-shell
- [x] `memory_ipc.rs` and `transcript_ipc.rs` — added F-349 workspace-root invariant header (resolver is the only sanctioned trust boundary; bypassing it re-opens the F-122 hole). Other `*_ipc.rs` modules don't accept `workspace_root`, so the header isn't applicable to them
- [x] `ipc.rs` — promoted "Error-message prefix style" to "Error handling" with explicit enumeration of the three narrow cases where bare `.to_string()` is acceptable (Tauri `State<>`, `BridgeState` lookups, label-authz constants)

### forge-ipc
- [x] `PROTO_VERSION` / `SCHEMA_VERSION` — documented bump rationale: additive variants like `SwitchProvider` do NOT require a bump; only framing-contract or payload-shape drift does
- [x] `sidecar.rs` — added "Future work" doc-comment recommending a centralized builder/factory for `SidecarHello` / `RunTurn` / `Credentials`. Deliberately deferred (real refactor, out of scope for a doc cleanup) per the brief
- [x] `pending_turns` — wired the supervisor's `Heartbeat` arm to emit `tracing::trace!` when `>0` so a stuck-mid-turn child is visible in triage. Trace level (not warn/debug) because heartbeats fire at 1 Hz and `pending_turns > 0` is the *normal* in-turn state — anything louder would drown the log

### forge-providers
- [x] `Provider` trait — explained the `impl Future` (not `dyn`) choice and the `RuntimeProvider` enum-dispatch escape hatch
- [x] `StreamErrorKind` — documented the asymmetry with `SseError::Transport` (kind is `Copy`/payload-free; the descriptive transport string lives on the sibling `ChatChunk::Error.message`)
- [x] `PriceTable::embedded` — noted the `OnceLock` lazy-cache pattern so callers can rely on a process-lifetime `&'static` reference
- [x] `SwappableProvider::chat` — expanded the inline comment on why `RuntimeProvider` is cloned before the async block (`RwLockReadGuard` is `!Send`; the clone is a per-variant `Arc` bump; the captured snapshot decouples in-flight streams from later `swap()`)
- [x] `#[tracing::instrument(name = "provider.chat", skip_all, fields(provider, model))]` on Anthropic / OpenAI / CustomOpenAI / Ollama `chat()` for ops latency attribution

### forge-oci
- [x] Container lifecycle tracing — `tracing::info!` on success / `tracing::warn!` on recoverable error for `pull` / `create` / `start` / `exec` / `stop` / `remove`
- [x] `parse_size_first` — `tracing::debug!` on parse failure (filtering the expected `"-- / --"` placeholder) so podman-version skew is visible
- [x] Three `#[ignore]`-gated integration tests in `podman_integration.rs`: failed pull (nonexistent image → `CommandFailed`), failed exec (stopped container → nonzero exit + stderr), malformed runtime JSON (`parse_stats` → `InvalidJson`)

### Deferred
- [ ] **#17 — `Level2Session::DROP_CLEANUP_BINARY`**: the tracker explicitly says "when the second runtime lands". No code change here; added a `TODO(F-682, #718)` comment so the refactor surfaces when the second runtime arrives. Adding the abstraction now would be speculative scaffolding with one consumer.

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (zero failures)
- [x] `just check-rust` passes (rustdoc gate clean — no broken/private intra-doc links)
- New `#[ignore]`-gated tests run with `cargo test -p forge-oci -- --ignored` against a real rootless podman; not exercised in CI.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)