### PR TITLE
[F-699 followup] Phase 3 frontend tooling: 6 lint/CI items

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Forge pre-commit hook (F-699 follow-up #820, item 3).
+#
+# Runs the design-token gate when the commit touches CSS or TSX files
+# under `web/`. Skip-if-nothing-relevant means commits that don't touch
+# styles run instantly. Activate locally with:
+#   git config core.hooksPath .githooks
+#
+# CI runs the same gate via `just check-web`, so the hook is purely a
+# developer-ergonomics shortcut. Disable temporarily with `git commit
+# --no-verify` if you need to land a WIP commit.
+
+set -euo pipefail
+
+# Files staged for commit, filtered to the surfaces check-tokens covers.
+# Diff is empty on initial commit; in that case skip the hook.
+mapfile -t staged < <(git diff --cached --name-only --diff-filter=ACMR \
+  | grep -E '^(web/.*\.(css|tsx)|docs/design/token-reference\.md)$' \
+  || true)
+
+if [ "${#staged[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "pre-commit: node not on PATH; skipping check-tokens (CI will catch drift)." >&2
+  exit 0
+fi
+
+# Repo-relative; works the same whether the user is at the repo root or
+# inside a worktree because git already constrained CWD.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+node "${REPO_ROOT}/scripts/check-tokens.mjs"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+Forge PR template. Keep the summary concise; the description's value is
+in `why`, not `what` (the diff already covers what changed).
+-->
+
+## Summary
+
+<!-- 1-3 bullets describing the intent and the surfaces touched. -->
+
+## Definition of Done
+
+<!-- Mirror the issue's DoD checklist; tick each item as it lands. -->
+
+- [ ] …
+
+## Test plan
+
+<!-- Bulleted list of the commands / manual checks that prove the change
+     works. CI mirrors `just check-rust` / `just check-web` / `just
+     test-rust` / `just test-web`; spell out anything beyond that. -->
+
+- [ ] …
+
+## Frontend checklist
+
+<!-- Skip if this PR is backend-only. Otherwise tick each that applies. -->
+
+- [ ] If this PR adds or changes a frontend component, it has a paired
+      entry under `docs/ui-specs/` (or extends an existing spec).
+- [ ] Design tokens: no raw hex / px in component CSS or inline styles —
+      `pnpm check-tokens` is clean.
+- [ ] No raw `<button>` outside `web/packages/design/` — `pnpm
+      check-raw-buttons` is clean.
+- [ ] Voice & terminology: copy follows `docs/design/voice-terminology.md`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,9 +254,19 @@ jobs:
       - name: pnpm audit
         run: pnpm audit --audit-level moderate
 
-      - name: Web checks (typecheck + token drift)
+      - name: Web checks (typecheck + token drift + raw buttons)
         working-directory: .
         run: just check-web
+
+      # F-699 follow-up #820: voice-terminology helper. Informational
+      # only — `check-voice.mjs` always exits 0 and the step is
+      # `continue-on-error: true` so a transient phrasing nit never
+      # blocks a PR. Findings show up in the workflow summary for
+      # human triage. Promote to gating once the corpus is clean.
+      - name: Voice-terminology drift (informational)
+        working-directory: .
+        continue-on-error: true
+        run: just check-voice
 
       - name: Build
         run: pnpm -r build

--- a/docs/frontend/generation-pipelines.md
+++ b/docs/frontend/generation-pipelines.md
@@ -47,16 +47,40 @@ updating both simultaneously.
 
 ---
 
-### Drafted sibling — raw-`<button>` check (F-398, disabled)
+### Sibling gates wired into `just check-web`
 
-`scripts/check-raw-buttons.mjs` mirrors the token-check pattern for raw
-`<button>` JSX under `web/packages/app/src/`. It is **not wired into
-`just check-web`** today because the primitives it steers toward
-(`Button` / `IconButton` / `Tab+Tabs` / `MenuItem` in `@forge/design`)
-ship in Phase 3. Activate it in the final migration PR per
-[`button-primitives-migration.md`](button-primitives-migration.md) §"Migration
-PRs — PR 4". Unit tests live at `scripts/check-raw-buttons.test.mjs` and run
-via `node scripts/check-raw-buttons.test.mjs`.
+Two more node-script gates run alongside `check-tokens.mjs`:
+
+- **`scripts/check-raw-buttons.mjs`** — forbids raw `<button>` JSX
+  outside `web/packages/design/`. Steers consumers to the design
+  primitives (`Button` / `IconButton` / `Tab+Tabs` / `MenuItem`).
+  Allowlist of row/card/popover sites lives in the script itself; new
+  sites should adopt a primitive instead of growing the list. Run
+  locally via `pnpm check-raw-buttons`. Unit tests:
+  `scripts/check-raw-buttons.test.mjs` (`node scripts/check-raw-buttons.test.mjs`).
+
+- **`scripts/check-voice.mjs`** (informational) — greps `.tsx` / `.md`
+  surfaces for vocabulary that conflicts with
+  [voice-terminology.md](../design/voice-terminology.md). Always exits
+  0 today — findings print to stdout for human triage. CI surfaces
+  them via a `continue-on-error` step. Promote to gating once the
+  corpus is clean. Run locally via `pnpm check-voice` or
+  `just check-voice`. Unit tests: `scripts/check-voice.test.mjs`
+  (`node scripts/check-voice.test.mjs`).
+
+### Local pre-commit hook (optional)
+
+A pre-commit hook at `.githooks/pre-commit` runs `check-tokens.mjs`
+when staged files include CSS or TSX under `web/`. Activate locally
+with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook is a developer-ergonomics shortcut — CI runs the same gate
+via `just check-web`, so opting out costs you a CI round-trip but
+nothing more.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -66,11 +66,20 @@ check-rust:
     cargo clippy --workspace --all-targets -- -D warnings
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
 
-# Web lane: typecheck + design-token drift gate.
+# Web lane: typecheck + design-token drift gate + raw-button gate.
 # Mirrors the pnpm lint steps in the `frontend` job. Assumes deps installed.
+# `check-voice` is informational and lives in its own recipe; promote
+# it into this lane once the corpus is clean (F-699 follow-up #820).
 check-web:
     cd web && pnpm -r typecheck
     cd web && pnpm check-tokens
+    cd web && pnpm check-raw-buttons
+
+# Voice-terminology helper (F-699 follow-up #820, item 6). Informational:
+# always exits 0, prints findings for human triage. Promote into
+# `check-web` once the corpus is clean.
+check-voice:
+    cd web && pnpm check-voice
 
 # Markdown link-rot gate (F-705). Offline lane only — mirrors the
 # `internal-links` job in .github/workflows/link-check.yml. The

--- a/scripts/check-raw-buttons.mjs
+++ b/scripts/check-raw-buttons.mjs
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
-// Raw-`<button>` drift check — DRAFTED, DISABLED (F-398).
+// Raw-`<button>` drift check — ACTIVE (F-699 follow-up #820, item 4).
 //
-// Purpose: once `@forge/design` ships `Button` / `IconButton` / `Tab+Tabs` /
-// `MenuItem` primitives (Phase 3), forbid raw `<button>` inside
-// `web/packages/app/src/` outside the allowlisted row/card-as-button sites.
+// Forbids raw `<button>` JSX inside `web/packages/app/src/` outside the
+// allowlisted row/card/popover sites where the content shape isn't cleanly
+// expressible through a `@forge/design` primitive (Button / IconButton /
+// Tab / MenuItem).
 //
-// State today: DRAFTED and NOT WIRED into CI. The primitives don't exist yet,
-// so activating this rule would fail the build against the existing 44 raw
-// sites. This file exists so the lint is committed and reviewable alongside
-// the migration plan; Phase-3 migration PR 4 (cleanup) flips the switch.
+// History: drafted disabled in F-398 alongside the migration plan; flipped
+// active in #820 once the Phase 3 primitives shipped. The allowlist tracks
+// the residual sites where a primitive doesn't fit yet — those are tracked
+// for migration in a sibling cleanup issue, not blocked by this rule.
 //
-// To activate in Phase 3:
-//   1. Delete or shrink the `ALLOWLIST` below to only true row/card-as-button
-//      files (rows 1, 14, 18, 19, 27 from the F-398 catalog).
-//   2. Add `node scripts/check-raw-buttons.mjs` to `justfile`'s `check-web`
-//      recipe, after `pnpm check-tokens`.
-//   3. Add a `pnpm check-raw-buttons` script to `web/package.json`.
+// Skips:
+//   - `.test.tsx` and `*.test.ts` files (tests legitimately reference
+//     raw `<button>` strings, e.g. asserting "this used to be a raw
+//     button and now isn't").
+//   - Files whose path matches an entry in `ALLOWLIST` (relative to
+//     `web/packages/app/src/`).
 //
 // Migration plan: `docs/frontend/button-primitives-migration.md`.
 // Tests:         `scripts/check-raw-buttons.test.mjs` (unit-tested on fixtures).
@@ -24,18 +25,25 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
 
 // Allowlist of files that legitimately render a raw `<button>` because the
-// content shape (row, card, tree item) isn't cleanly expressible through a
-// primitive. Sourced from the F-398 catalog's row/card-as-button callout.
+// content shape (row, card, tree item, popover-internal action) isn't
+// cleanly expressible through a primitive yet. Migration to design
+// primitives is tracked in a sibling cleanup issue.
 //
 // Paths are relative to the repo root, using forward slashes.
 export const ALLOWLIST = [
-  'web/packages/app/src/shell/StatusBar.tsx',               // row 1 — bg-agent badge
-  'web/packages/app/src/components/BranchMetadataPopover.tsx', // row 14 — variant rows
-  'web/packages/app/src/routes/AgentMonitor.tsx',           // rows 18, 19 — agent row, trace step
-  'web/packages/app/src/routes/Dashboard/SessionsPanel.tsx', // row 27 — session card
+  'web/packages/app/src/shell/StatusBar.tsx',                  // bg-agent badge row
+  'web/packages/app/src/components/BranchMetadataPopover.tsx', // variant rows
+  'web/packages/app/src/routes/AgentMonitor.tsx',              // agent row + trace step
+  'web/packages/app/src/routes/Dashboard/SessionsPanel.tsx',   // session card
+  // F-699 follow-up #820 baseline — row/card/popover sites still
+  // pending design-primitive migration:
+  'web/packages/app/src/components/ContextChip.tsx',           // chip-internal retry
+  'web/packages/app/src/components/SubAgentBanner.tsx',        // state chip
+  'web/packages/app/src/components/SubAgentDetailsPopover.tsx',// popover footer action
+  'web/packages/app/src/routes/Session/ChatPane.tsx',          // tool-call card "show more"
 ];
 
-/** Recursively yield absolute paths of `.tsx` files under `dir`. */
+/** Recursively yield absolute paths of non-test `.tsx` files under `dir`. */
 function* walkTsx(dir) {
   let entries;
   try {
@@ -48,7 +56,11 @@ function* walkTsx(dir) {
     const full = resolve(dir, entry.name);
     if (entry.isDirectory()) {
       yield* walkTsx(full);
-    } else if (entry.isFile() && entry.name.endsWith('.tsx')) {
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith('.tsx') &&
+      !entry.name.endsWith('.test.tsx')
+    ) {
       yield full;
     }
   }
@@ -79,10 +91,16 @@ export function scanTsxSources({ root, allowlist = [] }) {
     const rel = relative(root, file).split('\\').join('/');
     if (suppressed.has(rel)) continue;
     const source = readFileSync(file, 'utf-8');
+    // Strip `//` line comments before scanning so prose mentions of
+    // `<button>` in comments aren't flagged. Block comments and string
+    // literals are out of scope for now — JSX `<button` inside a string
+    // literal is implausible and the rule has explicit unit-test
+    // coverage for the cases we care about.
+    const scanSource = source.replace(/^\s*\/\/.*$/gm, '');
     rawButton.lastIndex = 0;
     let m;
-    while ((m = rawButton.exec(source)) !== null) {
-      const upto = source.slice(0, m.index);
+    while ((m = rawButton.exec(scanSource)) !== null) {
+      const upto = scanSource.slice(0, m.index);
       const line = upto.split('\n').length;
       findings.push({ file: rel, line });
     }

--- a/scripts/check-raw-buttons.test.mjs
+++ b/scripts/check-raw-buttons.test.mjs
@@ -88,6 +88,26 @@ test('does not false-positive on a string containing the word button', async () 
   if (findings.length !== 0) throw new Error(`expected 0 findings, got ${findings.length}: ${JSON.stringify(findings)}`);
 });
 
+test('skips .test.tsx files (tests legitimately reference raw <button>)', async () => {
+  const findings = await runRule({
+    files: {
+      'web/packages/app/src/components/Foo.test.tsx':
+        "it('was a raw button', () => { render(() => <button>x</button>); });\n",
+    },
+  });
+  if (findings.length !== 0) throw new Error(`expected 0 findings, got ${findings.length}: ${JSON.stringify(findings)}`);
+});
+
+test('skips // line comments that mention <button>', async () => {
+  const findings = await runRule({
+    files: {
+      'web/packages/app/src/components/Foo.tsx':
+        '// state chip is a <button> that wraps the popover\nexport const Foo = () => <span>x</span>;\n',
+    },
+  });
+  if (findings.length !== 0) throw new Error(`expected 0 findings, got ${findings.length}: ${JSON.stringify(findings)}`);
+});
+
 let failed = 0;
 for (const { name, fn } of cases) {
   try {

--- a/scripts/check-tokens.mjs
+++ b/scripts/check-tokens.mjs
@@ -24,6 +24,53 @@ const tsxScanRoots = [
   resolve(repoRoot, 'web/packages/design/src'),
 ];
 
+// Scope for the CSS-side typography scan (F-699 follow-up #820, item 1).
+// We flag bare `font-size: <N>px` and `line-height: <N>px` declarations —
+// the two CSS properties where pixel literals most often drift from the
+// typography scale. Static contexts where px is intentional (border-width,
+// margin, padding, transform) are *not* covered: those have their own
+// design-time conventions and the false-positive rate would dominate.
+const cssScanRoots = [
+  resolve(repoRoot, 'web/packages/app/src'),
+  resolve(repoRoot, 'web/packages/design/src'),
+];
+
+// Pre-existing violations baseline (F-699 follow-up #820). 29 files at the
+// time of landing the rule; cleanup is tracked separately so this PR can
+// ship the gate without an unrelated style migration. Do NOT add new
+// entries — fix the violation instead, or use a typography token.
+const cssTypographyAllowlist = new Set([
+  'web/packages/app/src/commands/CommandPalette.css',
+  'web/packages/app/src/components/ApprovalPrompt/ApprovalPrompt.css',
+  'web/packages/app/src/components/ApprovalPrompt/WhitelistedPill.css',
+  'web/packages/app/src/components/BranchMetadataPopover.css',
+  'web/packages/app/src/components/BranchSelectorStrip.css',
+  'web/packages/app/src/components/catalog/CatalogPane.css',
+  'web/packages/app/src/components/ContextChip.css',
+  'web/packages/app/src/components/ContextPicker.css',
+  'web/packages/app/src/components/dashboard/ContainersSection.css',
+  'web/packages/app/src/components/dashboard/CredentialsSection.css',
+  'web/packages/app/src/components/dashboard/MemorySection.css',
+  'web/packages/app/src/components/dashboard/ProvidersSection.css',
+  'web/packages/app/src/components/RerunPopover.css',
+  'web/packages/app/src/components/SubAgentBanner.css',
+  'web/packages/app/src/components/SubAgentDetailsPopover.css',
+  'web/packages/app/src/components/usage/UsagePane.css',
+  'web/packages/app/src/panes/EditorPane.css',
+  'web/packages/app/src/panes/TerminalPane.css',
+  'web/packages/app/src/routes/AgentMonitor.css',
+  'web/packages/app/src/routes/Catalog.css',
+  'web/packages/app/src/routes/Dashboard/ProviderPanel.css',
+  'web/packages/app/src/routes/Dashboard/SessionsPanel.css',
+  'web/packages/app/src/routes/Session/ChatPane.css',
+  'web/packages/app/src/routes/Session/CompactButton.css',
+  'web/packages/app/src/routes/Session/PaneHeader.css',
+  'web/packages/app/src/routes/Session/SessionWindow.css',
+  'web/packages/app/src/shell/FilesSidebar.css',
+  'web/packages/app/src/shell/StatusBar.css',
+  'web/packages/design/src/components/forge-button.css',
+]);
+
 /**
  * Extract `--name: value;` declarations from a CSS string, preserving
  * original order and normalising whitespace inside values.
@@ -102,6 +149,25 @@ function* walkTsx(dir) {
   }
 }
 
+/** Recursively yield absolute paths of `.css` files under `dir`. */
+function* walkCss(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkCss(full);
+    } else if (entry.isFile() && entry.name.endsWith('.css')) {
+      yield full;
+    }
+  }
+}
+
 /**
  * Yield every JSX `style={...}` block body (the text between the outer
  * braces) as `{ body, offset }` where `offset` is the start index in the
@@ -161,6 +227,44 @@ for (const root of tsxScanRoots) {
           `raw hex in inline style (use tokens.css or a CSS class): ${rel}:${line} — ${hexMatch[0]}`,
         );
       }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// F-699 follow-up #820 (item 1): scan component CSS for raw `font-size: <N>px`
+// and `line-height: <N>px`. These are the two declarations where pixel
+// drift hurts the typography scale; other px declarations (border-width,
+// margin, transform) are intentional and out of scope.
+//
+// Skip token files (the design package owns the source of truth for sizing
+// custom properties) and skip declarations sourced from a CSS variable —
+// `font-size: var(--type-body)` resolves to a px value at runtime, but the
+// literal text is not a raw px. We match the literal `<N>px` *only* on the
+// right-hand side of `font-size:` / `line-height:`.
+// ---------------------------------------------------------------------------
+
+// Boundary `(?<![-a-zA-Z])` keeps us from false-positiving on hyphenated
+// custom properties like `--my-font-size: 13px;` (those are sizing tokens
+// in their own right, not bare declarations).
+const cssTypographyPxRe = /(?<![-a-zA-Z])(font-size|line-height)\s*:\s*\d+(?:\.\d+)?px\b/g;
+
+for (const root of cssScanRoots) {
+  for (const file of walkCss(root)) {
+    const rel = relative(repoRoot, file).split('\\').join('/');
+    // Tokens.css is the source of truth for sizing custom properties — px
+    // literals here define the scale that other files consume.
+    if (rel.endsWith('/tokens.css')) continue;
+    if (cssTypographyAllowlist.has(rel)) continue;
+    const source = readFileSync(file, 'utf-8');
+    cssTypographyPxRe.lastIndex = 0;
+    let m;
+    while ((m = cssTypographyPxRe.exec(source)) !== null) {
+      const upto = source.slice(0, m.index);
+      const line = upto.split('\n').length;
+      errors.push(
+        `raw ${m[1]} px in CSS (use a typography token): ${rel}:${line} — ${m[0]}`,
+      );
     }
   }
 }

--- a/scripts/check-voice.mjs
+++ b/scripts/check-voice.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Voice-terminology drift check (F-699 follow-up #820, item 6).
+//
+// Greps user-facing TSX/MD/MDX strings for vocabulary that violates
+// `docs/design/voice-terminology.md`. The canonical vocabulary table lives
+// there; this script is a tripwire, not the source of truth.
+//
+// Initial mode: INFORMATIONAL. The script always exits 0. Findings print
+// to stdout in `file:line:col — <offender> (<reason>)` form so a CI run
+// can surface them without blocking merges. Promote to a gating check
+// (exit non-zero on findings) once the corpus is clean.
+//
+// Scope:
+//   - `.tsx`, `.ts`, `.md`, `.mdx` under `web/packages/app/src` and `docs/`.
+//   - Skip generated artifacts (`web/packages/ipc/src/generated/`),
+//     `node_modules`, `dist`, and the voice-terminology doc itself
+//     (it lists the forbidden words verbatim by design).
+//
+// Heuristic precision is deliberately low — the rule prefers false
+// positives that prompt a human review over false negatives that let
+// drift sneak in. Exclusions live below per offender.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+
+const scanRoots = [
+  resolve(repoRoot, 'web/packages/app/src'),
+  resolve(repoRoot, 'web/packages/design/src'),
+  resolve(repoRoot, 'docs/design'),
+  resolve(repoRoot, 'docs/frontend'),
+  resolve(repoRoot, 'docs/ui-specs'),
+  resolve(repoRoot, 'docs/product'),
+];
+
+const skipPathSegments = [
+  'node_modules',
+  'dist',
+  'generated',
+];
+
+const skipFileBasenames = new Set([
+  // The vocabulary doc itself lists every forbidden word verbatim. Scanning
+  // it would yield only self-references.
+  'voice-terminology.md',
+]);
+
+/** Recursively yield absolute paths of source files under `dir`. */
+function* walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    if (skipPathSegments.includes(entry.name)) continue;
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(full);
+    } else if (entry.isFile()) {
+      if (skipFileBasenames.has(entry.name)) continue;
+      const ext = entry.name.match(/\.([a-z]+)$/i)?.[1];
+      if (ext && ['tsx', 'ts', 'md', 'mdx'].includes(ext.toLowerCase())) {
+        yield full;
+      }
+    }
+  }
+}
+
+/**
+ * Vocabulary rules. Each entry has:
+ *   - `pattern` — RegExp (must use `g` flag)
+ *   - `reason`  — human-readable rationale shown next to the offender
+ *   - `allow`   — optional predicate `(line, file) => boolean`; truthy
+ *                 means the match is intentional and should be skipped
+ *
+ * The patterns intentionally match prose, not identifiers — matches
+ * inside imports, IPC type names, or symbol literals get filtered by the
+ * `allow` predicates per rule.
+ */
+const rules = [
+  {
+    name: 'model-as-ui-noun',
+    // "AI model" / "the model" — UI vocabulary forbids these (use
+    // "AI provider" / "provider"). Identifier surfaces (`provider.model`,
+    // `model_id`, `modelId`) are data, not UI copy, and stay allowed.
+    pattern: /\b(?:AI model|the model|LLM)\b/g,
+    reason: 'voice-terminology: use "AI provider" / "provider" (not "AI model" / "LLM" / "the model")',
+    allow: () => false,
+  },
+  {
+    name: 'conversation-as-ui-noun',
+    // "conversation" — Forge UI vocabulary uses "session" or "chat". The
+    // word is fine inside long-form design docs that *describe* the
+    // conversational UI; we narrow to TSX strings (UI copy) only.
+    pattern: /\bconversations?\b/gi,
+    reason: 'voice-terminology: use "session" or "chat" (not "conversation") in UI surfaces',
+    allow: (_line, file) => !file.endsWith('.tsx'),
+  },
+  {
+    name: 'plugin-server',
+    // "plugin server" / "tool server" — voice doc reserves "MCP server".
+    pattern: /\b(?:plugin server|tool server)\b/gi,
+    reason: 'voice-terminology: use "MCP server" (not "plugin server" / "tool server")',
+    allow: () => false,
+  },
+  {
+    name: 'helper-or-assistant-for-subagent',
+    // "helper" / "child AI" / "assistant" as a synonym for sub-agent.
+    // "assistant" is broad and frequently legitimate (e.g. ARIA labels,
+    // accessibility text, agent-role enum). We restrict to phrases that
+    // clearly substitute for "sub-agent".
+    pattern: /\b(?:child AI|helper agent|AI assistant)\b/gi,
+    reason: 'voice-terminology: use "sub-agent" (not "child AI" / "helper agent" / "AI assistant")',
+    allow: () => false,
+  },
+];
+
+/** 1-based (line, col) for an offset in `source`. */
+function locate(source, offset) {
+  let line = 1;
+  let col = 1;
+  for (let i = 0; i < offset; i += 1) {
+    if (source[i] === '\n') {
+      line += 1;
+      col = 1;
+    } else {
+      col += 1;
+    }
+  }
+  return { line, col };
+}
+
+const findings = [];
+
+for (const root of scanRoots) {
+  let exists = false;
+  try {
+    exists = statSync(root).isDirectory();
+  } catch {
+    exists = false;
+  }
+  if (!exists) continue;
+  for (const file of walk(root)) {
+    const rel = relative(repoRoot, file).split('\\').join('/');
+    const source = readFileSync(file, 'utf-8');
+    for (const rule of rules) {
+      rule.pattern.lastIndex = 0;
+      let m;
+      while ((m = rule.pattern.exec(source)) !== null) {
+        const { line, col } = locate(source, m.index);
+        const lineText = source.split('\n')[line - 1] ?? '';
+        if (rule.allow(lineText, rel)) continue;
+        findings.push({ file: rel, line, col, match: m[0], reason: rule.reason, rule: rule.name });
+      }
+    }
+  }
+}
+
+if (findings.length === 0) {
+  console.log('ok: no voice-terminology drift detected');
+  process.exit(0);
+}
+
+// Informational mode: print and exit 0. The CI step that calls us is
+// `continue-on-error: true` until the corpus is clean; flip both this
+// exit and the CI step in a follow-up once the count drops to 0.
+console.log(`voice-terminology findings (${findings.length} — informational, non-gating):`);
+for (const f of findings) {
+  console.log(`  ${f.file}:${f.line}:${f.col} — "${f.match}" (${f.rule}: ${f.reason})`);
+}
+process.exit(0);

--- a/scripts/check-voice.test.mjs
+++ b/scripts/check-voice.test.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Tests for check-voice.mjs.
+//
+// Tests scope: drive the script with a fixture file in the repo's scan
+// roots, capture stdout, then clean up. Informational mode means the
+// script always exits 0; the assertion target is the printed findings.
+
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = resolve(here, 'check-voice.mjs');
+const repoRoot = resolve(here, '..');
+const scanRoot = resolve(repoRoot, 'web/packages/app/src');
+
+/** Run the script and return { status, stdout, stderr }. */
+function run() {
+  return spawnSync('node', [script], { cwd: repoRoot, encoding: 'utf-8' });
+}
+
+const cases = [];
+function test(name, fn) { cases.push({ name, fn }); }
+
+test('exits 0 even when findings present (informational mode)', () => {
+  const fixture = resolve(scanRoot, '__voice_test_fixture__.tsx');
+  writeFileSync(fixture, 'export const X = () => <p>The model is ready</p>;\n');
+  try {
+    const result = run();
+    if (result.status !== 0) throw new Error(`expected exit 0, got ${result.status}`);
+  } finally {
+    rmSync(fixture, { force: true });
+  }
+});
+
+test('flags "AI model" in TSX prose', () => {
+  const fixture = resolve(scanRoot, '__voice_aimodel_fixture__.tsx');
+  writeFileSync(fixture, 'export const X = () => <p>Choose your AI model</p>;\n');
+  try {
+    const result = run();
+    if (!result.stdout.includes('__voice_aimodel_fixture__.tsx')) {
+      throw new Error(`expected fixture in stdout, got:\n${result.stdout}`);
+    }
+    if (!result.stdout.includes('AI model')) {
+      throw new Error(`expected "AI model" match in stdout, got:\n${result.stdout}`);
+    }
+  } finally {
+    rmSync(fixture, { force: true });
+  }
+});
+
+test('flags "conversation" in TSX prose', () => {
+  const fixture = resolve(scanRoot, '__voice_conv_fixture__.tsx');
+  writeFileSync(fixture, 'export const X = () => <p>Start a new conversation</p>;\n');
+  try {
+    const result = run();
+    if (!result.stdout.includes('__voice_conv_fixture__.tsx')) {
+      throw new Error(`expected fixture in stdout, got:\n${result.stdout}`);
+    }
+  } finally {
+    rmSync(fixture, { force: true });
+  }
+});
+
+test('does not flag "conversation" in design-doc prose (.md outside TSX)', () => {
+  // The conversation rule is TSX-only; long-form design docs may use the
+  // word descriptively without violating UI voice.
+  const fixture = resolve(repoRoot, 'docs/design/__voice_md_fixture__.md');
+  writeFileSync(fixture, '# Note\n\nThe conversation is a UI affordance.\n');
+  try {
+    const result = run();
+    // The fixture path may show up with other rule matches; assert that
+    // the conversation rule specifically did NOT fire.
+    const lines = result.stdout.split('\n');
+    const offending = lines.filter(
+      (l) => l.includes('__voice_md_fixture__.md') && l.includes('conversation-as-ui-noun'),
+    );
+    if (offending.length !== 0) {
+      throw new Error(`expected conversation rule to skip .md, got:\n${offending.join('\n')}`);
+    }
+  } finally {
+    rmSync(fixture, { force: true });
+  }
+});
+
+test('flags "plugin server"', () => {
+  const fixture = resolve(scanRoot, '__voice_pluginsrv_fixture__.tsx');
+  writeFileSync(fixture, 'export const X = () => <p>Connect a plugin server</p>;\n');
+  try {
+    const result = run();
+    if (!result.stdout.includes('__voice_pluginsrv_fixture__.tsx')) {
+      throw new Error(`expected fixture in stdout, got:\n${result.stdout}`);
+    }
+  } finally {
+    rmSync(fixture, { force: true });
+  }
+});
+
+test('does not flag identifier surfaces like provider.model', () => {
+  const fixture = resolve(scanRoot, '__voice_ident_fixture__.tsx');
+  writeFileSync(
+    fixture,
+    'export const X = (props: { provider: { model: string } }) => <p>{props.provider.model}</p>;\n',
+  );
+  try {
+    const result = run();
+    const offending = result.stdout
+      .split('\n')
+      .filter((l) => l.includes('__voice_ident_fixture__.tsx'));
+    if (offending.length !== 0) {
+      throw new Error(`expected no findings for identifier surface, got:\n${offending.join('\n')}`);
+    }
+  } finally {
+    rmSync(fixture, { force: true });
+  }
+});
+
+let failed = 0;
+for (const { name, fn } of cases) {
+  try {
+    fn();
+    console.log(`ok: ${name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL: ${name}`);
+    console.error(`  ${err.message}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} test(s) failed`);
+  process.exit(1);
+}
+console.log(`\n${cases.length} tests passed`);

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,9 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "typecheck": "pnpm -r typecheck",
-    "check-tokens": "node ../scripts/check-tokens.mjs"
+    "check-tokens": "node ../scripts/check-tokens.mjs",
+    "check-raw-buttons": "node ../scripts/check-raw-buttons.mjs",
+    "check-voice": "node ../scripts/check-voice.mjs"
   },
   "pnpm": {
     "overrides": {

--- a/web/packages/app/src/check-tokens.test.ts
+++ b/web/packages/app/src/check-tokens.test.ts
@@ -79,4 +79,55 @@ describe('scripts/check-tokens.mjs', () => {
       unlinkSync(fixture);
     }
   });
+
+  // F-699 followup (#820, item 1): the CSS-side scan must flag bare
+  // `font-size: <N>px` and `line-height: <N>px` declarations. Component
+  // CSS should reach for the typography tokens (or `rem`) instead of
+  // hardcoded pixel sizes — those are the two declarations where px
+  // most often drifts, while `border-width: 1px` etc. are intentional.
+  it('exits non-zero when a non-allowlisted .css contains a raw font-size px', () => {
+    const fixture = resolve(
+      repoRoot,
+      'web/packages/app/src/__f699_rawfontsize_fixture__.css',
+    );
+    writeFileSync(fixture, '.x { font-size: 13px; }\n');
+    try {
+      const result = spawnSync('node', [script], { cwd: repoRoot, encoding: 'utf-8' });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr + result.stdout).toMatch(/__f699_rawfontsize_fixture__\.css/);
+      expect(result.stderr + result.stdout).toMatch(/13px/);
+    } finally {
+      unlinkSync(fixture);
+    }
+  });
+
+  it('exits non-zero when a non-allowlisted .css contains a raw line-height px', () => {
+    const fixture = resolve(
+      repoRoot,
+      'web/packages/app/src/__f699_rawlineheight_fixture__.css',
+    );
+    writeFileSync(fixture, '.y { line-height: 20px; }\n');
+    try {
+      const result = spawnSync('node', [script], { cwd: repoRoot, encoding: 'utf-8' });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr + result.stdout).toMatch(/__f699_rawlineheight_fixture__\.css/);
+      expect(result.stderr + result.stdout).toMatch(/20px/);
+    } finally {
+      unlinkSync(fixture);
+    }
+  });
+
+  it('does not flag border-width or margin px in CSS — only font-size / line-height', () => {
+    const fixture = resolve(
+      repoRoot,
+      'web/packages/app/src/__f699_borderpx_fixture__.css',
+    );
+    writeFileSync(fixture, '.z { border-width: 1px; margin-bottom: 4px; padding: 8px; }\n');
+    try {
+      const result = spawnSync('node', [script], { cwd: repoRoot, encoding: 'utf-8' });
+      expect(result.status).toBe(0);
+    } finally {
+      unlinkSync(fixture);
+    }
+  });
 });


### PR DESCRIPTION
Closes forge-ide/forge#820. Sibling cleanup tracked in forge-ide/forge#823.

## Summary

Six tooling items split off from #735 (F-699):

- **`scripts/check-tokens.mjs` extended** — flags bare `font-size: <N>px` and `line-height: <N>px` declarations in component CSS. Pre-existing 29-file baseline lives in `cssTypographyAllowlist`; new violations fail the gate.
- **`scripts/check-raw-buttons.mjs` activated** — was drafted-disabled (F-398); now wired into `just check-web` via `pnpm check-raw-buttons`. Skips `.test.tsx` + `// line comments`. Residual row/card/popover sites in `ALLOWLIST`.
- **`scripts/check-voice.mjs` (new)** — informational greppable check for vocabulary that conflicts with `docs/design/voice-terminology.md` ("AI model" / "LLM" / "the model", "conversation" in TSX, "plugin server", sub-agent synonyms). Always exits 0; CI surfaces findings via `continue-on-error: true`.
- **`.githooks/pre-commit`** — plain shell hook running `check-tokens.mjs` on staged CSS / TSX. Opt-in: `git config core.hooksPath .githooks`. No husky / lefthook dep.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — new template with a frontend checklist that pairs `docs/ui-specs/` adoption with the three gates and voice-terminology.
- **CI wired** — `frontend` job now runs `check-raw-buttons` (gating, via `just check-web`) and `check-voice` (non-gating, `continue-on-error: true`).

## Trade-off note

The issue body suggested a custom ESLint rule for the inline-style-px JSX check (item 2). The existing `check-tokens.mjs` already scans `.tsx` inline `style={...}` blocks for raw px / hex (F-389 lineage), so a parallel ESLint setup would duplicate the surface and introduce a heavyweight infra dep the workspace doesn't otherwise carry. Item 2 is satisfied by the existing TSX-side scan; documented in `docs/frontend/generation-pipelines.md`.

## Definition of Done

- [x] Each item lands as configured tooling (not just "we considered it") — see Summary above.
- [x] Each new check is wired into CI / local dev flow with documentation:
  - `check-raw-buttons` → `just check-web` (gating) → CI `frontend` job
  - `check-voice` → `just check-voice` (informational) → CI `frontend` job (`continue-on-error`)
  - Pre-commit hook → `.githooks/pre-commit` + opt-in instructions in `docs/frontend/generation-pipelines.md`
  - PR template → `.github/PULL_REQUEST_TEMPLATE.md`

## Pre-existing-violation policy

- `font-size` / `line-height` px in CSS: 176 violations across 29 files — **widespread**, allowlisted as a baseline; cleanup tracked in #823.
- Raw `<button>` outside design package: 4 residual sites added to `ALLOWLIST` (row/card/popover content shapes); design-primitive migration to be tracked separately.
- Voice-terminology: 23 informational findings; non-gating until cleanup lands.

## Test plan

- `node scripts/check-tokens.mjs` — clean (65 tokens match)
- `node scripts/check-raw-buttons.mjs` — clean (no raw `<button>` outside allowlist)
- `node scripts/check-raw-buttons.test.mjs` — 7/7 passing
- `node scripts/check-voice.mjs` — exits 0; prints 23 informational findings
- `node scripts/check-voice.test.mjs` — 6/6 passing
- `pnpm --filter app exec vitest run src/check-tokens.test.ts` — 7/7 passing (CSS + TSX assertions)
- `just check-web` — clean (typecheck + check-tokens + check-raw-buttons)
- `just check-rust` — clean (fmt, check, clippy, rustdoc)
- `pnpm -r test` — 1241/1241 passing

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)