### PR TITLE
[chore] Extend ChatChunk::ToolCall with provider tool-use id for round-trip

### DIFF
--- a/crates/forge-providers/benches/ollama_stream.rs
+++ b/crates/forge-providers/benches/ollama_stream.rs
@@ -107,7 +107,11 @@ fn legacy_parse_line(line: &str) -> Option<ChatChunk> {
                 .get("arguments")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null);
-            return Some(ChatChunk::ToolCall { name, args });
+            return Some(ChatChunk::ToolCall {
+                id: String::new(),
+                name,
+                args,
+            });
         }
     }
 

--- a/crates/forge-providers/src/anthropic/translate.rs
+++ b/crates/forge-providers/src/anthropic/translate.rs
@@ -288,13 +288,9 @@ impl<'a> Serialize for AnthropicToolResultMessage<'a> {
 /// starting block. The accumulator tracks the active tool-use block by its
 /// index; when the matching `content_block_stop` arrives it parses the
 /// accumulated `partial_json` chunks into a structured `args` value and
-/// emits the [`ChatChunk::ToolCall`].
-///
-/// TODO(post-F-583): [`ChatChunk::ToolCall`] does not currently carry the
-/// Anthropic-assigned `id` (`toolu_…`). Once the round-trip back to Anthropic
-/// requires the id (so the assistant message can reference it as
-/// `tool_use_id` on the follow-up `tool_result`), extend `ChatChunk::ToolCall`
-/// with an `id` field and surface it here.
+/// emits the [`ChatChunk::ToolCall`] — preserving the Anthropic-assigned
+/// `toolu_…` id captured at `content_block_start` so callers can
+/// reference it as `tool_use_id` on the follow-up `tool_result`.
 #[derive(Default)]
 pub struct AnthropicEventAccumulator {
     /// Block index → in-progress tool_use block.
@@ -306,6 +302,11 @@ pub struct AnthropicEventAccumulator {
 
 struct ToolUseInProgress {
     index: u64,
+    /// Anthropic-assigned `toolu_…` id from `content_block_start`.
+    /// Surfaced on the emitted [`ChatChunk::ToolCall`] so the orchestrator
+    /// can round-trip it back as `tool_use_id` on the matching
+    /// `tool_result`.
+    id: String,
     name: String,
     /// Accumulated `partial_json` strings from `input_json_delta` events.
     args_buf: String,
@@ -335,6 +336,11 @@ impl AnthropicEventAccumulator {
         };
         let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
         if block_type == "tool_use" {
+            let id = block
+                .get("id")
+                .and_then(|i| i.as_str())
+                .unwrap_or("")
+                .to_string();
             let name = block
                 .get("name")
                 .and_then(|n| n.as_str())
@@ -342,6 +348,7 @@ impl AnthropicEventAccumulator {
                 .to_string();
             self.active_tool_use = Some(ToolUseInProgress {
                 index,
+                id,
                 name,
                 args_buf: String::new(),
             });
@@ -400,6 +407,7 @@ impl AnthropicEventAccumulator {
                     serde_json::from_str(&active.args_buf).unwrap_or(json!({}))
                 };
                 return vec![ChatChunk::ToolCall {
+                    id: active.id,
                     name: active.name,
                     args,
                 }];
@@ -651,6 +659,7 @@ mod tests {
         assert_eq!(
             chunks,
             vec![ChatChunk::ToolCall {
+                id: "toolu_01".into(),
                 name: "get_weather".into(),
                 args: json!({"city": "sf"}),
             }]

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -113,7 +113,17 @@ pub enum ChatBlock {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChatChunk {
     TextDelta(String),
+    /// A complete tool call emitted by the provider.
+    ///
+    /// `id` is the provider-assigned identifier (Anthropic `toolu_…`,
+    /// OpenAI `call_…`) needed to round-trip a `ChatBlock::ToolResult`
+    /// back to that provider — the assistant message that initiated the
+    /// tool use carries the id, and the user-role tool result references
+    /// it. Providers that do not surface an id on the wire (Ollama,
+    /// `MockProvider`) emit an empty string; the orchestrator falls back
+    /// to its own internal id in that case.
     ToolCall {
+        id: String,
         name: String,
         args: serde_json::Value,
     },
@@ -202,6 +212,12 @@ enum RawChunk {
 
 #[derive(Deserialize)]
 struct RawToolCall {
+    /// Optional in the NDJSON mock shape. Real providers (Anthropic,
+    /// OpenAI) always carry an id; the mock shape predates the field
+    /// and falls back to an empty string so the orchestrator's
+    /// internal id is used for round-trip.
+    #[serde(default)]
+    id: String,
     name: String,
     args: serde_json::Value,
 }
@@ -215,6 +231,7 @@ fn parse_ndjson(content: &str) -> Result<Vec<ChatChunk>> {
             Ok(match raw {
                 RawChunk::Delta { delta } => ChatChunk::TextDelta(delta),
                 RawChunk::ToolCall { tool_call } => ChatChunk::ToolCall {
+                    id: tool_call.id,
                     name: tool_call.name,
                     args: tool_call.args,
                 },

--- a/crates/forge-providers/src/ollama.rs
+++ b/crates/forge-providers/src/ollama.rs
@@ -579,7 +579,11 @@ pub fn parse_line_bytes(line: &[u8]) -> Option<ChatChunk> {
     // be discarded by the text-delta branch below.
     if let Some(first) = message.tool_calls.into_iter().next() {
         if let Some(func) = first.function {
+            // Ollama's wire shape does not assign an id to tool calls;
+            // emit an empty string so the orchestrator falls back to
+            // its own internal id for round-trip.
             return Some(ChatChunk::ToolCall {
+                id: String::new(),
                 name: func.name.into_owned(),
                 args: func.arguments,
             });
@@ -1342,6 +1346,7 @@ mod tests {
         assert_eq!(
             parse_line(line),
             Some(ChatChunk::ToolCall {
+                id: String::new(),
                 name: "fs.read".into(),
                 args: serde_json::json!({"path": "/tmp/x"}),
             })

--- a/crates/forge-providers/src/openai/translate.rs
+++ b/crates/forge-providers/src/openai/translate.rs
@@ -305,14 +305,11 @@ impl<'a> Serialize for OpenAiAssistantOrUserMessage<'a> {
 /// 2. The literal `data: [DONE]` line arrives as an event whose `data`
 ///    payload is exactly `b"[DONE]"`.
 /// 3. On `[DONE]`, the accumulator first emits any tracked tool calls in
-///    `index` order, then emits [`ChatChunk::Done`] with the cached reason
-///    (defaulting to `"stop"` if none was seen).
-///
-/// TODO(post-F-584): [`ChatChunk::ToolCall`] does not currently carry the
-/// OpenAI-assigned `id` (`call_…`). Once the round-trip back to OpenAI requires
-/// the id (so the assistant message can reference it as `tool_call_id` on the
-/// follow-up `tool` message), extend `ChatChunk::ToolCall` with an `id` field
-/// and surface it here. (Mirrors the same TODO on the Anthropic accumulator.)
+///    `index` order — preserving the OpenAI-assigned `call_…` id captured
+///    on the first delta for each `index` — then emits [`ChatChunk::Done`]
+///    with the cached reason (defaulting to `"stop"` if none was seen).
+///    Callers reference that id as `tool_call_id` on the follow-up
+///    `role: "tool"` message.
 #[derive(Default)]
 pub struct OpenAiEventAccumulator {
     /// In-progress tool calls keyed by their delta `index`.
@@ -323,6 +320,11 @@ pub struct OpenAiEventAccumulator {
 
 struct ToolCallInProgress {
     index: u64,
+    /// OpenAI-assigned `call_…` id from the first delta for this index.
+    /// Surfaced on the emitted [`ChatChunk::ToolCall`] so the orchestrator
+    /// can round-trip it back as `tool_call_id` on the matching
+    /// `role: "tool"` message.
+    id: String,
     name: String,
     args_buf: String,
 }
@@ -382,12 +384,22 @@ impl OpenAiEventAccumulator {
             None => {
                 self.tool_calls.push(ToolCallInProgress {
                     index,
+                    id: String::new(),
                     name: String::new(),
                     args_buf: String::new(),
                 });
                 self.tool_calls.last_mut().expect("just pushed")
             }
         };
+
+        // First delta for an index carries the `call_…` id; later deltas
+        // typically omit it. Only overwrite when non-empty so a stray
+        // `"id": ""` does not clobber.
+        if let Some(id) = delta.get("id").and_then(|i| i.as_str()) {
+            if !id.is_empty() {
+                entry.id = id.to_string();
+            }
+        }
 
         if let Some(name) = delta
             .get("function")
@@ -421,6 +433,7 @@ impl OpenAiEventAccumulator {
                 serde_json::from_str(&tc.args_buf).unwrap_or(json!({}))
             };
             out.push(ChatChunk::ToolCall {
+                id: tc.id,
                 name: tc.name,
                 args,
             });
@@ -702,12 +715,14 @@ mod tests {
             ))
             .is_empty());
 
-        // [DONE] sentinel: emit the tool call, then Done.
+        // [DONE] sentinel: emit the tool call (carrying the `call_…` id
+        // captured on the first delta), then Done.
         let chunks = acc.consume(&ev("[DONE]"));
         assert_eq!(
             chunks,
             vec![
                 ChatChunk::ToolCall {
+                    id: "call_abc".into(),
                     name: "get_weather".into(),
                     args: json!({"city": "sf"}),
                 },
@@ -767,10 +782,12 @@ mod tests {
             chunks,
             vec![
                 ChatChunk::ToolCall {
+                    id: "call_a".into(),
                     name: "a".into(),
                     args: json!({}),
                 },
                 ChatChunk::ToolCall {
+                    id: "call_b".into(),
                     name: "b".into(),
                     args: json!({}),
                 },

--- a/crates/forge-providers/tests/anthropic.rs
+++ b/crates/forge-providers/tests/anthropic.rs
@@ -47,7 +47,12 @@ async fn parse_events_yields_text_and_tool_call_and_done() {
         vec![
             ChatChunk::TextDelta("Hello".into()),
             ChatChunk::TextDelta(" world".into()),
+            // Regression: the Anthropic-assigned `toolu_…` id captured at
+            // `content_block_start` must round-trip end-to-end so the
+            // orchestrator can reference it as `tool_use_id` on the
+            // follow-up `tool_result`.
             ChatChunk::ToolCall {
+                id: "toolu_01".into(),
                 name: "get_weather".into(),
                 args: serde_json::json!({"city": "sf"}),
             },
@@ -91,7 +96,9 @@ async fn chat_round_trip_yields_expected_chunks() {
         vec![
             ChatChunk::TextDelta("Hello".into()),
             ChatChunk::TextDelta(" world".into()),
+            // Regression: id preserved across the full HTTP-mock round-trip.
             ChatChunk::ToolCall {
+                id: "toolu_01".into(),
                 name: "get_weather".into(),
                 args: serde_json::json!({"city": "sf"}),
             },

--- a/crates/forge-providers/tests/mock_provider.rs
+++ b/crates/forge-providers/tests/mock_provider.rs
@@ -31,7 +31,36 @@ async fn streams_tool_call_chunks() {
 
     assert_eq!(chunks.len(), 1);
     match &chunks[0] {
-        ChatChunk::ToolCall { name, args } => {
+        ChatChunk::ToolCall { id, name, args } => {
+            // The mock NDJSON shape did not carry an id in this script;
+            // the optional field defaults to an empty string.
+            assert!(id.is_empty(), "id defaults to empty when absent: {id:?}");
+            assert_eq!(name, "fs.read");
+            assert_eq!(args["path"], "README.md");
+        }
+        other => panic!("expected ToolCall, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn streams_tool_call_with_explicit_id_preserves_id() {
+    // Mock NDJSON callers can opt into an explicit id; it must round-trip
+    // onto the emitted [`ChatChunk::ToolCall`] so headless tests can
+    // exercise the same wire-id round-trip path as the real providers.
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(
+        file,
+        r#"{{"tool_call":{{"id":"toolu_xyz","name":"fs.read","args":{{"path":"README.md"}}}}}}"#
+    )
+    .unwrap();
+
+    let provider = MockProvider::new(file.path());
+    let chunks: Vec<ChatChunk> = provider.stream().await.unwrap().collect().await;
+
+    assert_eq!(chunks.len(), 1);
+    match &chunks[0] {
+        ChatChunk::ToolCall { id, name, args } => {
+            assert_eq!(id, "toolu_xyz");
             assert_eq!(name, "fs.read");
             assert_eq!(args["path"], "README.md");
         }

--- a/crates/forge-providers/tests/ollama.rs
+++ b/crates/forge-providers/tests/ollama.rs
@@ -63,7 +63,12 @@ async fn chat_streams_text_tool_call_and_done() {
         vec![
             ChatChunk::TextDelta("Hel".into()),
             ChatChunk::TextDelta("lo".into()),
+            // Ollama's wire shape carries no tool-call id; the chunk
+            // surfaces an empty string so the orchestrator falls back to
+            // its own internal id when constructing the round-trip
+            // assistant `ChatBlock::ToolCall` / user `ChatBlock::ToolResult`.
             ChatChunk::ToolCall {
+                id: String::new(),
                 name: "fs.read".into(),
                 args: serde_json::json!({"path": "/x"}),
             },

--- a/crates/forge-providers/tests/openai.rs
+++ b/crates/forge-providers/tests/openai.rs
@@ -47,7 +47,12 @@ async fn parse_events_yields_text_and_tool_call_and_done() {
         vec![
             ChatChunk::TextDelta("Hello".into()),
             ChatChunk::TextDelta(" world".into()),
+            // Regression: the OpenAI-assigned `call_…` id captured on the
+            // first delta for an index must round-trip end-to-end so the
+            // orchestrator can reference it as `tool_call_id` on the
+            // follow-up `role: "tool"` message.
             ChatChunk::ToolCall {
+                id: "call_abc".into(),
                 name: "get_weather".into(),
                 args: serde_json::json!({"city": "sf"}),
             },
@@ -91,7 +96,9 @@ async fn chat_round_trip_yields_expected_chunks() {
         vec![
             ChatChunk::TextDelta("Hello".into()),
             ChatChunk::TextDelta(" world".into()),
+            // Regression: id preserved across the full HTTP-mock round-trip.
             ChatChunk::ToolCall {
+                id: "call_abc".into(),
                 name: "get_weather".into(),
                 args: serde_json::json!({"city": "sf"}),
             },

--- a/crates/forge-providers/tests/openai_custom.rs
+++ b/crates/forge-providers/tests/openai_custom.rs
@@ -41,6 +41,7 @@ fn expected_chunks() -> Vec<ChatChunk> {
         ChatChunk::TextDelta("Hello".into()),
         ChatChunk::TextDelta(" world".into()),
         ChatChunk::ToolCall {
+            id: "call_abc".into(),
             name: "get_weather".into(),
             args: serde_json::json!({"city": "sf"}),
         },

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -643,11 +643,16 @@ pub(crate) async fn run_request_loop<P: Provider>(
                         .await?;
                 }
 
-                ChatChunk::ToolCall { name, args } => {
+                ChatChunk::ToolCall {
+                    id: provider_id,
+                    name,
+                    args,
+                } => {
                     pending_calls.push(PendingToolCall {
                         name,
                         args,
                         call_id: ToolCallId::new(),
+                        provider_id,
                     });
                 }
 
@@ -884,7 +889,35 @@ pub(crate) async fn run_request_loop<P: Provider>(
 struct PendingToolCall {
     name: String,
     args: serde_json::Value,
+    /// Orchestrator-internal id used to correlate `ToolCall*` events,
+    /// approval-channel keys, and tool steps. Independent of any
+    /// provider-supplied id — events stay on the local wire and never
+    /// flow back to the provider.
     call_id: ToolCallId,
+    /// Provider-assigned id (Anthropic `toolu_…`, OpenAI `call_…`)
+    /// captured from [`ChatChunk::ToolCall`]. Used as the round-trip
+    /// id on the assistant [`ChatBlock::ToolCall`] and matching user
+    /// [`ChatBlock::ToolResult`] so the provider can correlate the
+    /// follow-up `tool_result` / `role: "tool"` message back to the
+    /// original tool use. Empty for providers that do not carry an id
+    /// on the wire (Ollama, mock); the orchestrator falls back to
+    /// `call_id` in that case via [`PendingToolCall::round_trip_id`].
+    provider_id: String,
+}
+
+impl PendingToolCall {
+    /// The id to thread back to the provider on the assistant
+    /// `ChatBlock::ToolCall` and matching `ChatBlock::ToolResult`.
+    /// Prefer the provider-supplied id when present so the provider can
+    /// correlate the round-trip; fall back to the orchestrator's
+    /// internal id for providers (Ollama, mock) that surface none.
+    fn round_trip_id(&self) -> String {
+        if self.provider_id.is_empty() {
+            self.call_id.to_string()
+        } else {
+            self.provider_id.clone()
+        }
+    }
 }
 
 /// F-599: outcome of dispatching the buffered tool batch for one model
@@ -1229,13 +1262,14 @@ async fn dispatch_tool_calls(
                     })
                     .await?;
 
+                let block_id = pc.round_trip_id();
                 tc_blocks.push(ChatBlock::ToolCall {
-                    id: pc.call_id.to_string(),
+                    id: block_id.clone(),
                     name: pc.name.clone(),
                     args: pc.args.clone(),
                 });
                 tr_blocks.push(ChatBlock::ToolResult {
-                    id: pc.call_id.to_string(),
+                    id: block_id,
                     result,
                 });
             }
@@ -1414,13 +1448,14 @@ async fn dispatch_tool_calls(
                     })
                     .await?;
 
+                let block_id = pc.round_trip_id();
                 tc_blocks.push(ChatBlock::ToolCall {
-                    id: pc.call_id.to_string(),
+                    id: block_id.clone(),
                     name: pc.name.clone(),
                     args: pc.args.clone(),
                 });
                 tr_blocks.push(ChatBlock::ToolResult {
-                    id: pc.call_id.to_string(),
+                    id: block_id,
                     result,
                 });
             }


### PR DESCRIPTION
Closes forge-ide/forge#625

## Summary
- Add `id: String` to `ChatChunk::ToolCall { id, name, args }` so providers can surface their wire-assigned tool-use id.
- AnthropicProvider preserves the `toolu_*` id from `content_block_start` through `content_block_stop` emission; post-F-583 TODO removed.
- OpenAIProvider preserves the `call_*` id from the first delta carrying it through `[DONE]` reassembly; post-F-584 TODO removed.
- Orchestrator threads the provider id through `PendingToolCall` and uses it as the round-trip id on the assistant `ChatBlock::ToolCall` and matching user `ChatBlock::ToolResult`. Falls back to the internal `ToolCallId` for Ollama / mock paths that surface no id.
- Internal `ToolCallId` stays untouched — it still backs local event correlation, approval-channel keys, and tool steps, independent of any provider id.

## Test plan
- `cargo test --workspace` passes (incl. new regression tests asserting `toolu_01` and `call_abc` round-trip end-to-end through wiremock-backed integration tests for both providers).
- `cargo fmt --check` passes.
- `cargo clippy --workspace --all-targets -- -D warnings` passes.
- `RUSTDOCFLAGS=-D warnings cargo doc -p forge-providers -p forge-session --no-deps` passes (forge-term rustdoc errors are pre-existing on `main` and unrelated).

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Generated with [Claude Code](https://claude.com/claude-code)