### PR TITLE
[#628] ImageRef::parse rejects image segments starting with '-'

### DIFF
--- a/crates/forge-oci/src/lib.rs
+++ b/crates/forge-oci/src/lib.rs
@@ -161,6 +161,19 @@ impl ImageRef {
 
     /// Parse an image reference. See type-level docs for the accepted
     /// shapes and the allowlist semantics.
+    ///
+    /// # Rejections
+    ///
+    /// In addition to the digest and allowlist checks, `parse` rejects
+    /// any reference where the registry, name, or tag segment begins
+    /// with `-`. `to_image_string()` emits those segments verbatim into
+    /// the IMAGE positional of `podman create [...] IMAGE [COMMAND]`,
+    /// where a leading `-` would let podman parse the IMAGE token as a
+    /// runtime flag (`-v`, `-e`, `--privileged`, ...). The F-595
+    /// hardening pinned the *positional layout* of the rendered argv
+    /// but not the *content* of the IMAGE positional itself, so issue
+    /// #628 closes that vector at parse time. Returns
+    /// [`OciError::InvalidImageRef`].
     pub fn parse(input: &str) -> Result<Self, OciError> {
         let trimmed = input.trim();
         if trimmed.is_empty() {
@@ -207,6 +220,23 @@ impl ImageRef {
         // expects, but the F-643 supply-chain check below still rejects
         // the reference if it has no digest AND is not allowlisted.
         let tag = tag.unwrap_or_else(|| "latest".to_string());
+
+        // #628 flag-injection guard: `to_image_string()` emits these
+        // segments verbatim into the IMAGE positional of `podman create
+        // [...] IMAGE [COMMAND]`. A leading `-` on any segment lets
+        // podman parse the IMAGE token as a runtime flag (`-v`, `-e`,
+        // `--privileged`, ...). Reject before the supply-chain check so
+        // a digest-pinned ref with a poisoned segment still fails on
+        // the dash, not on the unrelated allowlist.
+        if name.starts_with('-')
+            || registry.as_deref().is_some_and(|r| r.starts_with('-'))
+            || tag.starts_with('-')
+        {
+            return Err(OciError::InvalidImageRef {
+                input: input.to_string(),
+                reason: "image segments must not begin with '-'",
+            });
+        }
 
         // Supply-chain guard: a reference with no digest is only safe if the
         // *canonical* registry-qualified path matches the first-party
@@ -969,6 +999,58 @@ mod tests {
             ImageRef::parse(&format!("alpine@{SHA}")),
             Err(OciError::InvalidDigest { .. })
         ));
+    }
+
+    // ── #628: reject image segments that begin with `-` ─────────────
+    //
+    // `to_image_string()` emits the parsed segments verbatim into the
+    // IMAGE positional of `podman create [...] IMAGE [COMMAND]`. A
+    // leading `-` on any segment would let podman misinterpret the
+    // IMAGE token as a flag (`-v`, `-e`, `--privileged`, etc.). The
+    // F-595 B1 hardening pinned the *positional layout* but not the
+    // *content* of the IMAGE positional itself, so we reject at parse
+    // time on every segment — registry, name, tag — regardless of
+    // whether the reference is digest-pinned (a digest-pinned ref
+    // still renders the registry/name on the wire).
+
+    #[test]
+    fn image_ref_rejects_name_starting_with_dash() {
+        // Worst case from the threat model: `-v/host:/container:latest`
+        // would render verbatim into IMAGE and podman would parse `-v`
+        // as the volume flag. Reject before it ever reaches the argv.
+        let err = ImageRef::parse("-v/host:/container:latest").unwrap_err();
+        assert!(
+            matches!(err, OciError::InvalidImageRef { .. }),
+            "expected InvalidImageRef, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn image_ref_rejects_registry_starting_with_dash() {
+        // A `-` registry is structurally identical to the name case but
+        // walks a different parser branch (the `head.contains('.')` arm
+        // of the registry split). Cover it explicitly so a future
+        // refactor of that branch can't silently re-open the hole.
+        // We use a digest-pinned form to bypass the F-643 tag-only
+        // guard and prove the dash check fires first.
+        let err = ImageRef::parse(&format!("-evil.io/myorg/myapp@sha256:{SHA}")).unwrap_err();
+        assert!(
+            matches!(err, OciError::InvalidImageRef { .. }),
+            "expected InvalidImageRef, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn image_ref_rejects_tag_starting_with_dash() {
+        // A leading-dash tag would render as `name:-v` on the wire and
+        // podman *also* parses that as a flag because it's part of the
+        // single IMAGE token. Use the allowlisted first-party path so
+        // the F-643 guard doesn't intercept first.
+        let err = ImageRef::parse("oci.io/forge/rust-tools:-v").unwrap_err();
+        assert!(
+            matches!(err, OciError::InvalidImageRef { .. }),
+            "expected InvalidImageRef, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/forge-oci/tests/podman_integration.rs
+++ b/crates/forge-oci/tests/podman_integration.rs
@@ -656,6 +656,85 @@ async fn exec_against_stopped_container_surfaces_nonzero_exit() {
     let _ = runtime.remove(&h).await;
 }
 
+/// Empirical justification for the issue #628 parse-time rejection:
+/// proves that real podman *would* misinterpret a leading-dash IMAGE
+/// positional as a runtime flag if `ImageRef::parse` ever stopped
+/// rejecting it.
+///
+/// We bypass the parser deliberately and shell out to `podman create`
+/// with the offending IMAGE token directly. The expected failure shape
+/// is podman complaining about an unknown flag (e.g. `-v` needs a
+/// value, `-evil.io/...` is not recognized) — *not* "invalid image
+/// reference" or "image not found". If a future podman release
+/// changes its argv grammar to terminate flag parsing earlier, this
+/// test will fail loudly so the parse-time rejection can be
+/// re-evaluated.
+#[test]
+#[ignore = "requires rootless podman on PATH (run with --ignored)"]
+fn podman_misinterprets_leading_dash_image_as_flag() {
+    // Use a name-segment dash because that is the worst-case from the
+    // threat model (`-v/host:/container:latest` would smuggle a
+    // bind-mount). Whatever podman emits to stderr, the exit code
+    // must be non-zero AND the message must reference flag/argument
+    // parsing — not a registry/digest/image-not-found error, which
+    // would mean podman accepted the token as IMAGE and only failed
+    // when it tried to pull.
+    let out = std::process::Command::new("podman")
+        .args([
+            "create",
+            "--rm",
+            // Leading-dash IMAGE positional. If podman parses this as
+            // IMAGE the failure will surface at pull time with a
+            // registry/digest error; if it parses as a flag we get an
+            // argv error. We assert the latter.
+            "-v/host:/container:latest",
+        ])
+        .output()
+        .expect("podman must be on PATH for --ignored runs");
+
+    assert!(
+        !out.status.success(),
+        "podman create must reject the leading-dash IMAGE; \
+         got success with stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    // Podman's argv parser (cobra) emits one of these phrases when it
+    // mis-parses a leading-dash token as a flag. Cross-version we
+    // accept any of them; what matters is that the failure is at the
+    // argv layer, NOT at the registry/pull layer. A registry/pull
+    // error (e.g. "manifest unknown", "image not found", "no such
+    // image") would mean podman accepted the dash IMAGE — exactly the
+    // condition issue #628 closes.
+    let argv_layer_phrases = [
+        "unknown flag",
+        "unknown shorthand flag",
+        "needs an argument",
+        "invalid argument",
+        "flag needs an argument",
+        "unknown command",
+    ];
+    let registry_layer_phrases = [
+        "manifest unknown",
+        "image not found",
+        "no such image",
+        "pull access denied",
+    ];
+    assert!(
+        argv_layer_phrases.iter().any(|p| stderr.contains(p)),
+        "expected an argv-layer parse failure (one of {argv_layer_phrases:?}); \
+         got stderr={stderr:?}"
+    );
+    assert!(
+        !registry_layer_phrases.iter().any(|p| stderr.contains(p)),
+        "podman accepted the leading-dash IMAGE and failed at the \
+         registry layer ({registry_layer_phrases:?}) — issue #628's \
+         premise is violated; got stderr={stderr:?}"
+    );
+}
+
 /// `parse_stats` against a malformed JSON body returned by a future
 /// podman version (or a registry-injected payload, hypothetically)
 /// must surface `OciError::InvalidJson` rather than panicking or


### PR DESCRIPTION
Closes forge-ide/forge#628

## Summary
- `ImageRef::parse` now rejects any reference where the registry, name, or tag begins with `-`. Returns `OciError::InvalidImageRef`.
- Closes a podman flag-injection vector: `to_image_string()` emits the parsed segments verbatim into the IMAGE positional of `podman create [...] IMAGE [COMMAND]`, and a leading `-` would let podman parse the IMAGE token as a runtime flag (`-v`, `-e`, `--privileged`, ...). The F-595 hardening pinned the *positional layout* of the rendered argv but not the *content* of the IMAGE positional itself.
- Layered on top of F-643 (digest pinning): the dash check fires before the supply-chain guard, so a digest-pinned ref with a poisoned segment fails on the dash, not on the unrelated allowlist.

## Tests
- Three new unit tests cover name-, registry-, and tag-segment rejection (the registry case uses a digest-pinned form to bypass F-643's tag-only guard; the tag case uses the allowlisted `oci.io/forge/` namespace for the same reason).
- One new `#[ignore]`-gated integration test (`podman_misinterprets_leading_dash_image_as_flag`) shells out to real `podman create` with `-v/host:/container:latest` as the IMAGE positional and asserts podman fails at the **argv-parsing layer** (`unknown flag` / `needs an argument`), not at the registry layer (`manifest unknown` / `image not found`). If a future podman release ever terminates flag parsing earlier, the test fails loudly so the parse-time rejection can be re-evaluated.
- Doc comment on `ImageRef::parse` calls out the new rejection.

## Test plan
- `cargo fmt --check` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (full suite green; default run skips the new `#[ignore]`-gated podman test)
- `cargo clippy --all-targets -- -D warnings` passes
- `just check-rust` passes (including `RUSTDOCFLAGS=-D warnings cargo doc`)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).