### PR TITLE
[chore] Gate forge-oci RecordingRunner / StubResponse / RecordedCalls behind test-support feature

### DIFF
--- a/crates/forge-oci/Cargo.toml
+++ b/crates/forge-oci/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[features]
+# Re-exports the `RecordingRunner` / `StubResponse` / `RecordedCalls` /
+# `RecordedCall` mock-runner toolkit so downstream crates can drive
+# `PodmanRuntime::with_runner` from their own tests without spawning a
+# real `podman`. Off by default to keep the published API surface
+# focused on production types.
+test-support = []
+
 [dependencies]
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
@@ -14,3 +22,14 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+# F-626: integration test consumes the `RecordingRunner` mock toolkit
+# which is gated on the `test-support` feature. `required-features`
+# tells cargo to skip the target on plain `cargo test -p forge-oci`
+# (which does not enable the feature) instead of failing to compile.
+# CI exercises the integration test via `cargo test --all-features`
+# / `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`.
+[[test]]
+name = "podman_integration"
+path = "tests/podman_integration.rs"
+required-features = ["test-support"]

--- a/crates/forge-oci/README.md
+++ b/crates/forge-oci/README.md
@@ -20,13 +20,26 @@ Container lifecycle for agent isolation. Defines the [`ContainerRuntime`] trait 
 ## Testing
 
 - Unit tests cover argv-shaping for every method via the `RecordingRunner` mock — no `podman` binary required.
-- Integration test `tests/podman_integration.rs` is `cfg(target_os = "linux")` and `#[ignore]`-gated, so CI's default `cargo test` skips it cleanly. Run locally with rootless podman configured:
+- Integration test `tests/podman_integration.rs` is `cfg(target_os = "linux")` and `#[ignore]`-gated, so CI's default `cargo test` skips it cleanly. It also requires the `test-support` feature (see below) because it consumes the mock-runner toolkit; cargo skips compiling the target on plain `cargo test -p forge-oci`. Run locally with rootless podman configured:
 
   ```sh
-  cargo test -p forge-oci -- --ignored
+  cargo test -p forge-oci --features test-support -- --ignored
   ```
 
   It pulls `docker.io/library/alpine:3.19`, runs `echo hello`, asserts stdout, and verifies cleanup via `podman inspect`. The test fails loudly when podman is missing or misconfigured rather than auto-skipping (which would mask CI regressions).
+
+### `test-support` feature
+
+`forge-oci` re-exports its mock-runner toolkit (`RecordingRunner`, `StubResponse`, `RecordedCalls`, `RecordedCall`) only when the `test-support` Cargo feature is enabled. The default published API surface ships just the production runtime types (`PodmanRuntime`, `CommandRunner`, `TokioCommandRunner`, `CommandOutcome`, the `signature` module).
+
+Downstream crates that drive `PodmanRuntime::with_runner` from their own tests opt in via dev-dependencies:
+
+```toml
+[dev-dependencies]
+forge-oci = { path = "../forge-oci", features = ["test-support"] }
+```
+
+Cargo unifies dev-dep features additively into test/bench builds only, so the production library build still sees the lean default API.
 
 ## Further reading
 

--- a/crates/forge-oci/src/lib.rs
+++ b/crates/forge-oci/src/lib.rs
@@ -9,6 +9,22 @@
 //! agent execution model — including the supply-chain story (digest pinning
 //! and signature verification) that [`ImageRef`] and
 //! [`signature::SignatureVerifier`] enforce.
+//!
+//! ## Cargo features
+//!
+//! - `test-support` *(off by default)* — re-exports the `RecordingRunner`
+//!   mock-runner toolkit (`RecordingRunner`, `StubResponse`, `RecordedCalls`,
+//!   `RecordedCall`) so downstream crates can drive
+//!   [`PodmanRuntime::with_runner`] from their own tests without spawning a
+//!   real `podman`. Production builds leave this off so the published API
+//!   surface stays focused on the runtime types.
+//!
+//!   Enable from a downstream crate's `Cargo.toml`:
+//!
+//!   ```toml
+//!   [dev-dependencies]
+//!   forge-oci = { path = "../forge-oci", features = ["test-support"] }
+//!   ```
 
 #![deny(missing_docs)]
 
@@ -17,10 +33,9 @@ mod runner;
 pub mod signature;
 
 pub use podman::PodmanRuntime;
-pub use runner::{
-    CommandOutcome, CommandRunner, RecordedCall, RecordedCalls, RecordingRunner, StubResponse,
-    TokioCommandRunner,
-};
+pub use runner::{CommandOutcome, CommandRunner, TokioCommandRunner};
+#[cfg(any(test, feature = "test-support"))]
+pub use runner::{RecordedCall, RecordedCalls, RecordingRunner, StubResponse};
 pub use signature::{
     CosignVerifier, NoopVerifier, SignaturePolicy, SignatureVerifier, VerificationError,
 };

--- a/crates/forge-oci/src/runner.rs
+++ b/crates/forge-oci/src/runner.rs
@@ -2,12 +2,15 @@
 //! can be unit-tested without an actual `podman` binary on the host.
 //!
 //! Production wiring uses [`TokioCommandRunner`]; tests use
-//! [`RecordingRunner`] (or any custom `CommandRunner`) to capture argv arrays
-//! and stub responses.
+//! `RecordingRunner` (or any custom `CommandRunner`) to capture argv arrays
+//! and stub responses. The mock toolkit (`RecordingRunner`, `StubResponse`,
+//! `RecordedCalls`, `RecordedCall`) is gated behind the `test-support`
+//! feature flag so downstream crates only see it in their dev builds.
 //!
 //! [`PodmanRuntime`]: crate::PodmanRuntime
 
 use async_trait::async_trait;
+#[cfg(any(test, feature = "test-support"))]
 use std::sync::{Arc, Mutex};
 use tokio::process::Command;
 
@@ -55,7 +58,16 @@ impl CommandRunner for TokioCommandRunner {
     }
 }
 
+// ── Test-only mock toolkit ─────────────────────────────────────────────
+//
+// Gated on `cfg(any(test, feature = "test-support"))` so the published
+// API surface of `forge-oci` (default features) carries only the
+// production runner. Downstream crates that drive
+// `PodmanRuntime::with_runner` from their own tests opt in via
+// `forge-oci = { ..., features = ["test-support"] }`.
+
 /// One pre-canned response for a [`RecordingRunner`].
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Debug, Clone)]
 pub struct StubResponse {
     /// Optional argv-prefix the call must match. `None` matches anything.
@@ -64,6 +76,7 @@ pub struct StubResponse {
     pub outcome: CommandOutcome,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl StubResponse {
     /// Always-successful stdout response, regardless of argv.
     pub fn ok_stdout(stdout: impl Into<Vec<u8>>) -> Self {
@@ -91,9 +104,11 @@ impl StubResponse {
 }
 
 /// One recorded invocation: the program name and the argv it was called with.
+#[cfg(any(test, feature = "test-support"))]
 pub type RecordedCall = (String, Vec<String>);
 
 /// Shared, mutex-guarded log of every call a [`RecordingRunner`] has seen.
+#[cfg(any(test, feature = "test-support"))]
 pub type RecordedCalls = Arc<Mutex<Vec<RecordedCall>>>;
 
 /// Test-only runner that records every invocation and returns canned
@@ -103,6 +118,7 @@ pub type RecordedCalls = Arc<Mutex<Vec<RecordedCall>>>;
 /// - Each `run` call pops the front of the configured response queue.
 /// - If the queue is empty, returns a successful empty outcome.
 /// - Every call (program, argv) is recorded for later assertion.
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Debug, Default, Clone)]
 pub struct RecordingRunner {
     responses: Arc<Mutex<std::collections::VecDeque<StubResponse>>>,
@@ -111,6 +127,7 @@ pub struct RecordingRunner {
     pub calls: RecordedCalls,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl RecordingRunner {
     /// Empty runner — every call returns an empty success outcome.
     pub fn new() -> Self {
@@ -128,6 +145,7 @@ impl RecordingRunner {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 #[async_trait]
 impl CommandRunner for RecordingRunner {
     async fn run(&self, program: &str, args: &[&str]) -> std::io::Result<CommandOutcome> {

--- a/crates/forge-session/Cargo.toml
+++ b/crates/forge-session/Cargo.toml
@@ -75,6 +75,11 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support", "async_tokio"] }
 forge-cli = { path = "../forge-cli" }
+# F-626: the level2 sandbox tests drive `PodmanRuntime::with_runner`
+# through forge-oci's mock-runner toolkit. Cargo unifies dev-dep
+# features additively into test/bench builds only, so the production
+# library build still sees the lean default-features API surface.
+forge-oci = { path = "../forge-oci", features = ["test-support"] }
 # F-586: enable the `RuntimeProvider::Mock` variant for the
 # `provider_swap` integration test. Production binaries leave this off.
 forge-providers = { path = "../forge-providers", features = ["testing"] }


### PR DESCRIPTION
Closes forge-ide/forge#626

## Summary

- Adds a `test-support` Cargo feature to `forge-oci` (default off) that gates the mock-runner toolkit (`RecordingRunner`, `StubResponse`, `RecordedCalls`, `RecordedCall`) behind `cfg(any(test, feature = "test-support"))`.
- Default published API surface now ships only the production runtime types: `PodmanRuntime`, `CommandRunner`, `TokioCommandRunner`, `CommandOutcome`, plus the `signature` module.
- `forge-oci`'s own unit tests reach the symbols via the internal `crate::runner::*` path (unchanged); the integration test target is pinned with `required-features = ["test-support"]` so plain `cargo test -p forge-oci` skips compilation rather than failing.
- `forge-session` opts in via dev-dependencies (`forge-oci = { path = "../forge-oci", features = ["test-support"] }`) so its level2 sandbox tests still compile. Cargo unifies dev-dep features into test/bench builds only, so the production library build sees the lean default API.
- Documented in the `forge-oci` crate-level doc-comment and in `crates/forge-oci/README.md`.

Option A (`#[cfg(test)]`-gate) was rejected during scoping because both `forge-oci`'s integration test and `forge-session`'s level2 sandbox tests are external test binaries that link `forge-oci` as a regular dependency — `cfg(test)` would not make the symbols visible to either. Option B (feature flag) was the only viable path per the issue.

## Test plan

- `cargo fmt --check` passes
- `cargo check --workspace --all-targets` passes
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` passes
- API-surface invariant verified by an out-of-tree scratch crate: depending on `forge-oci` without the feature produces `error[E0425]: cannot find type `RecordingRunner` in crate `forge_oci`` with the rustc note pointing at the `cfg`. The same scratch crate with `features = ["test-support"]` compiles cleanly.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)