### PR TITLE
[#702] forge-session tools: reject NUL in shell.exec env, validate agent.spawn agent_name

### DIFF
--- a/crates/forge-session/src/tools/agent_spawn.rs
+++ b/crates/forge-session/src/tools/agent_spawn.rs
@@ -31,7 +31,7 @@
 use std::sync::Arc;
 
 use super::{get_required_str, Tool, ToolCtx};
-use forge_agents::{AgentDef, AgentScope, SpawnContext};
+use forge_agents::{validate_agent_name, AgentDef, AgentScope, SpawnContext};
 use forge_core::{ApprovalPreview, Event};
 
 pub struct AgentSpawnTool;
@@ -58,6 +58,19 @@ impl Tool for AgentSpawnTool {
             Ok(s) => s.to_owned(),
             Err(e) => return serde_json::json!({ "error": e.to_string() }),
         };
+        // Length cap + charset gate. `forge_agents::validate_agent_name` is
+        // the canonical rule used at parse time for `.agents/*.md` stems —
+        // reusing it here keeps the IPC entry point and the on-disk loader
+        // in lockstep (64-byte cap, ASCII alphanumeric + `_`/`-`, no path
+        // separators, no leading `.`, no whitespace). A name that the
+        // loader would reject must also be rejected at spawn time so a
+        // forged provider call cannot drive a hostile resolve against
+        // `resolve_def`.
+        if let Err(e) = validate_agent_name(&agent_name) {
+            return serde_json::json!({
+                "error": format!("tool.{}: invalid agent_name: {}", Self::NAME, e),
+            });
+        }
         // F-137 follow-up to F-134: forward `prompt` through `SpawnContext`
         // onto the registered child instance so a step-executor can seed the
         // child's first user turn with the parent's input. Pre-F-137 the arg
@@ -565,5 +578,115 @@ mod tests {
             err,
             crate::tools::ToolError::DuplicateName(ref n) if n == "agent.spawn"
         ));
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_agent_name() {
+        // `validate_agent_name` caps at 64 bytes. 65 should fail loud rather
+        // than reach `resolve_def` and silently miss.
+        let oversized = "a".repeat(forge_agents::MAX_AGENT_NAME_BYTES + 1);
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        let result = d
+            .dispatch(
+                "agent.spawn",
+                &json!({ "agent_name": oversized, "prompt": "hi" }),
+                &ToolCtx::default(),
+            )
+            .await
+            .unwrap();
+
+        let err = result["error"].as_str().unwrap_or_default();
+        assert!(
+            err.contains("invalid agent_name") && err.contains("too large"),
+            "expected size-cap rejection, got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_agent_name_with_forbidden_chars() {
+        // Path separators, '..', leading '.', and arbitrary punctuation must
+        // all be rejected at the tool entry point, mirroring the parse-time
+        // rule for `.agents/*.md` stems.
+        let bad_names = [
+            "../escape",
+            "child/sub",
+            "child\\sub",
+            ".hidden",
+            "name!",
+            "naïve", // non-ASCII
+        ];
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        for bad in bad_names {
+            let result = d
+                .dispatch(
+                    "agent.spawn",
+                    &json!({ "agent_name": bad, "prompt": "hi" }),
+                    &ToolCtx::default(),
+                )
+                .await
+                .unwrap();
+            let err = result["error"].as_str().unwrap_or_default();
+            assert!(
+                err.contains("invalid agent_name"),
+                "must reject {bad:?}, got: {result}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_agent_name_with_whitespace() {
+        let bad_names = [" leading", "trailing ", "mid space", "tab\tname"];
+
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        for bad in bad_names {
+            let result = d
+                .dispatch(
+                    "agent.spawn",
+                    &json!({ "agent_name": bad, "prompt": "hi" }),
+                    &ToolCtx::default(),
+                )
+                .await
+                .unwrap();
+            let err = result["error"].as_str().unwrap_or_default();
+            assert!(
+                err.contains("invalid agent_name") && err.contains("whitespace"),
+                "must reject whitespace in {bad:?}, got: {result}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn accepts_valid_agent_name() {
+        // A well-formed name must pass the validator and fall through to the
+        // "agent runtime not configured" branch (since no ctx is wired in).
+        // Asserting that branch fires proves the validator didn't misfire.
+        let mut d = ToolDispatcher::new();
+        d.register(Box::new(AgentSpawnTool)).unwrap();
+
+        for ok in ["child", "code-reviewer", "agent_42", "Aa-Bb_99"] {
+            let result = d
+                .dispatch(
+                    "agent.spawn",
+                    &json!({ "agent_name": ok, "prompt": "hi" }),
+                    &ToolCtx::default(),
+                )
+                .await
+                .unwrap();
+            assert!(
+                result["error"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("agent runtime not configured"),
+                "valid agent_name {ok:?} must not trip the validator; got: {result}"
+            );
+        }
     }
 }

--- a/crates/forge-session/src/tools/shell_exec.rs
+++ b/crates/forge-session/src/tools/shell_exec.rs
@@ -188,10 +188,12 @@ async fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value
     sb.command_mut().stdin(std::process::Stdio::null());
 
     if let Some(env_obj) = args.get("env").and_then(|v| v.as_object()) {
-        for (k, v) in env_obj {
-            if let Some(val) = v.as_str() {
-                sb.allow_env(k, val);
-            }
+        let pairs = match validate_env(env_obj) {
+            Ok(pairs) => pairs,
+            Err(e) => return serde_json::json!({ "error": e }),
+        };
+        for (k, v) in pairs {
+            sb.allow_env(k, v);
         }
     }
 
@@ -269,4 +271,83 @@ async fn run_linux(args: &serde_json::Value, ctx: &ToolCtx) -> serde_json::Value
     // killpg on an already-reaped pgid returns ESRCH) and on timeout
     // (drop sends SIGKILL to the pgid and removes it from the registry).
     result
+}
+
+/// Reject any env key or value containing an embedded NUL byte (`\0`).
+///
+/// POSIX `execve` terminates `argv` / `envp` entries at the first NUL, so a
+/// caller-supplied env value carrying an embedded `\0` would silently truncate
+/// the child's view of that variable — a confused-deputy primitive against
+/// downstream tools that read process env. Fail loud with the offending
+/// variable name; do not silently strip.
+///
+/// Returns the validated `(key, value)` pairs in the input's iteration order
+/// so the caller can forward them to `allow_env` without re-parsing.
+pub(crate) fn validate_env(
+    env_obj: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<(&str, &str)>, String> {
+    let mut pairs = Vec::with_capacity(env_obj.len());
+    for (k, v) in env_obj {
+        if k.contains('\0') {
+            return Err(format!("shell.exec: env key contains NUL byte: {k:?}"));
+        }
+        let Some(val) = v.as_str() else { continue };
+        if val.contains('\0') {
+            return Err(format!("shell.exec: env value for '{k}' contains NUL byte"));
+        }
+        pairs.push((k.as_str(), val));
+    }
+    Ok(pairs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_env;
+    use serde_json::json;
+
+    fn env_map(v: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        v.as_object().unwrap().clone()
+    }
+
+    #[test]
+    fn rejects_nul_in_env_value() {
+        let env = env_map(json!({ "FOO": "ba\0r" }));
+        let err = validate_env(&env).unwrap_err();
+        assert!(
+            err.contains("NUL") && err.contains("FOO"),
+            "error must name the offending variable: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_nul_in_env_key() {
+        let mut env = serde_json::Map::new();
+        env.insert("BA\0D".to_string(), json!("ok"));
+        let err = validate_env(&env).unwrap_err();
+        assert!(err.contains("NUL"), "error must mention NUL: {err}");
+        assert!(err.contains("key"), "error must say the key is bad: {err}");
+    }
+
+    #[test]
+    fn accepts_clean_env() {
+        let env = env_map(json!({ "FOO": "bar", "BAZ": "qux" }));
+        let pairs = validate_env(&env).expect("clean env must pass");
+        assert_eq!(pairs.len(), 2);
+        for (k, v) in pairs {
+            assert!(matches!(k, "FOO" | "BAZ"));
+            assert!(matches!(v, "bar" | "qux"));
+        }
+    }
+
+    #[test]
+    fn skips_non_string_values_without_failing() {
+        // Pre-existing contract: non-string values are silently ignored (the
+        // old loop did `if let Some(val) = v.as_str()`). Preserve that —
+        // NUL validation only applies to the values we would actually
+        // forward.
+        let env = env_map(json!({ "FOO": "bar", "N": 42 }));
+        let pairs = validate_env(&env).expect("non-string values must be skipped");
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0], ("FOO", "bar"));
+    }
 }


### PR DESCRIPTION
Tackles two items from the Phase 3 security-hygiene tracker (#702).

## Summary

- **shell.exec env**: reject any key or value containing an embedded `\0`. POSIX `execve` truncates `argv`/`envp` at the first NUL, so an embedded NUL would silently truncate the child's view of the variable — fail loud with the offending variable name rather than silently strip.
- **agent.spawn agent_name**: enforce length cap (64 bytes) and charset rule (`[A-Za-z0-9_-]`, no path separators, no leading `.`, no whitespace) by delegating to `forge_agents::validate_agent_name`. This is the canonical rule used at parse time for `.agents/*.md` stems, so the IPC entry point and the on-disk loader stay in lockstep.

Each validator rejects the bad cases with a clear error message and leaves valid cases untouched.

## Test plan

- New unit tests in `crates/forge-session/src/tools/shell_exec.rs`:
  - `rejects_nul_in_env_value`
  - `rejects_nul_in_env_key`
  - `accepts_clean_env`
  - `skips_non_string_values_without_failing`
- New unit tests in `crates/forge-session/src/tools/agent_spawn.rs`:
  - `rejects_oversized_agent_name`
  - `rejects_agent_name_with_forbidden_chars`
  - `rejects_agent_name_with_whitespace`
  - `accepts_valid_agent_name`
- `cargo test --workspace` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `just check-rust` passes (clippy + RUSTDOCFLAGS=-D warnings doc)

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

Refs forge-ide/forge#702