### PR TITLE
[#702] forge-shell IPC: sanitize fetch_url errors + validate allowed-hosts + size-cap session_switch_provider

### DIFF
--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -3081,6 +3081,12 @@ pub async fn session_switch_provider<R: Runtime>(
         &format!("session-{session_id}"),
         "session_switch_provider",
     )?;
+    // Tracker #702: size-cap + non-empty guard, matching every other
+    // provider IPC (`set_active_provider`, credential commands). Without
+    // this, a webview could submit an arbitrarily long `provider_id`
+    // and force the daemon to allocate / log it before the resolver
+    // rejects it.
+    crate::providers_ipc::validate_provider_id(&provider_id)?;
     state
         .bridge
         .switch_provider(&session_id, provider_id)
@@ -3324,19 +3330,83 @@ impl AllowedHostsState {
             .clone()
     }
 
-    /// Replace the allowlist wholesale. Whitespace is trimmed off each
-    /// entry; empty entries are dropped. Case-insensitive matching runs
-    /// inside `context_fetch::enforce_url_policy`, so the stored form
-    /// keeps the user-visible casing.
-    pub fn replace(&self, hosts: Vec<String>) {
-        let cleaned: Vec<String> = hosts
-            .into_iter()
-            .map(|h| h.trim().to_string())
-            .filter(|h| !h.is_empty())
-            .collect();
+    /// Replace the allowlist wholesale. Each entry is trimmed of
+    /// surrounding whitespace and then validated against RFC 1123
+    /// hostname rules (alphanumeric + hyphen + dot, ≤ 253 bytes, ≤
+    /// 63-byte labels, no leading/trailing hyphen per label). Invalid
+    /// entries surface as `Err` — silent filtering used to mask
+    /// malformed inputs that would never match a real host, tracked
+    /// as part of #702.
+    /// Case-insensitive matching runs inside
+    /// `context_fetch::enforce_url_policy`, so the stored form keeps
+    /// the user-visible casing.
+    pub fn replace(&self, hosts: Vec<String>) -> Result<(), String> {
+        let mut cleaned: Vec<String> = Vec::with_capacity(hosts.len());
+        for host in hosts {
+            let trimmed = host.trim().to_string();
+            validate_hostname(&trimmed)?;
+            cleaned.push(trimmed);
+        }
         let mut guard = self.hosts.lock().expect("allowed hosts state poisoned");
         *guard = cleaned;
+        Ok(())
     }
+}
+
+/// Validate an allowed-host entry against RFC 1123 hostname rules.
+///
+/// Tracker #702 / `AllowedHostsState::replace`. Rules:
+///
+/// - Non-empty after trim.
+/// - ≤ 253 bytes overall.
+/// - Each dot-separated label is non-empty, ≤ 63 bytes, starts and
+///   ends with `[a-zA-Z0-9]`, and contains only `[a-zA-Z0-9-]`.
+/// - No wildcards, path characters, control characters, or whitespace.
+///
+/// Returns a single error message starting with `"invalid host"` so
+/// the caller's surface stays consistent across reject reasons —
+/// callers (and tests) match on the prefix, not the specific reason.
+fn validate_hostname(host: &str) -> Result<(), String> {
+    if host.is_empty() {
+        return Err("invalid host: empty".to_string());
+    }
+    if host.len() > 253 {
+        return Err(format!(
+            "invalid host: {} bytes exceeds 253-byte hostname cap",
+            host.len()
+        ));
+    }
+    for label in host.split('.') {
+        if label.is_empty() {
+            return Err("invalid host: empty label (leading/trailing/consecutive dot)".to_string());
+        }
+        if label.len() > 63 {
+            return Err(format!(
+                "invalid host: label '{label}' exceeds 63-byte limit"
+            ));
+        }
+        let bytes = label.as_bytes();
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if !first.is_ascii_alphanumeric() {
+            return Err(format!(
+                "invalid host: label '{label}' must start with [a-zA-Z0-9]"
+            ));
+        }
+        if !last.is_ascii_alphanumeric() {
+            return Err(format!(
+                "invalid host: label '{label}' must end with [a-zA-Z0-9]"
+            ));
+        }
+        for b in bytes {
+            if !(b.is_ascii_alphanumeric() || *b == b'-') {
+                return Err(format!(
+                    "invalid host: label '{label}' contains disallowed character"
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Tauri-managed client pool for the context fetcher. One client per App,
@@ -3433,8 +3503,45 @@ pub async fn context_fetch_url<R: Runtime>(
     let client = fetch_state.client_for(&hosts)?;
     let ok = crate::context_fetch::fetch_url(&client, &url, &hosts)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(sanitize_fetch_url_error)?;
     Ok(FetchedUrl::from(ok))
+}
+
+/// Tracker #702: collapse a [`crate::context_fetch::FetchUrlError`] to a
+/// generic wire message and log the detailed reason internally.
+///
+/// The detailed `FetchUrlError` variants leak which gate fired (scheme,
+/// userinfo, host-not-on-allowlist, link-local IP, port, transport
+/// failure). A hostile webview could use that to probe internal
+/// network topology — what IP ranges resolve as private, which host
+/// patterns are on the allowlist. We keep the detail in `tracing` for
+/// operators and return one of two generic messages on the wire:
+///
+/// - `"URL not allowed by policy"` for any policy violation
+///   (invalid URL / scheme / userinfo / host / IP / port).
+/// - `"fetch failed"` for transport-layer failures (timeout, refused
+///   connect, non-2xx status).
+fn sanitize_fetch_url_error(err: crate::context_fetch::FetchUrlError) -> String {
+    use crate::context_fetch::FetchUrlError;
+    let (public, category): (&str, &str) = match &err {
+        FetchUrlError::InvalidUrl { .. }
+        | FetchUrlError::SchemeNotAllowed { .. }
+        | FetchUrlError::UserinfoPresent
+        | FetchUrlError::MissingHost
+        | FetchUrlError::HostNotAllowed { .. }
+        | FetchUrlError::BlockedIpRange { .. }
+        | FetchUrlError::PortNotAllowed { .. } => ("URL not allowed by policy", "policy"),
+        FetchUrlError::TransportFailed { .. } | FetchUrlError::HttpStatus { .. } => {
+            ("fetch failed", "transport")
+        }
+    };
+    tracing::warn!(
+        target: "forge_shell::ipc::context_fetch",
+        category = category,
+        error = %err,
+        "context_fetch_url rejected",
+    );
+    format!("context_fetch_url: {public}")
 }
 
 /// Replace the server-side URL allowlist. The webview's settings panel
@@ -3457,7 +3564,7 @@ pub async fn set_context_allowed_hosts<R: Runtime>(
     for h in &hosts {
         require_size("host", h, MAX_ALLOWED_HOST_BYTES)?;
     }
-    allowed.replace(hosts);
+    allowed.replace(hosts)?;
     Ok(())
 }
 

--- a/crates/forge-shell/tests/ipc_context_fetch.rs
+++ b/crates/forge-shell/tests/ipc_context_fetch.rs
@@ -21,6 +21,8 @@
 
 #![cfg(feature = "webview-test")]
 
+mod common;
+
 use forge_shell::bridge::SessionConnections;
 use forge_shell::ipc::{
     build_invoke_handler, manage_context_fetch, AllowedHostsState, BridgeState,
@@ -139,6 +141,11 @@ async fn context_fetch_url_rejects_host_not_on_server_allowlist() {
     // the target host" contract — even a DNS-resolving, publicly
     // reachable hostname is rejected if the server hasn't allowlisted
     // it.
+    //
+    // Tracker #702: the user-facing message is generic — "URL not
+    // allowed by policy" — so the rejection reason doesn't leak which
+    // gate fired. The detailed reason is captured in `tracing` (see
+    // `context_fetch_url_logs_detailed_reason_on_policy_reject`).
     let app = make_app();
     // Server-side allowlist intentionally left empty.
     let window = make_session_window(&app, TEST_SESSION);
@@ -151,18 +158,26 @@ async fn context_fetch_url_rejects_host_not_on_server_allowlist() {
         }),
     );
     assert!(
-        err.contains("not on allowed-hosts list") || err.contains("not allowed"),
-        "expected host-not-allowed; got: {err}"
+        err.contains("URL not allowed by policy"),
+        "expected sanitized policy rejection; got: {err}"
+    );
+    assert!(
+        !err.contains("docs.rs") && !err.contains("allowed-hosts list"),
+        "sanitized error must not leak host or policy detail; got: {err}"
     );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn context_fetch_url_rejects_file_scheme() {
     let app = make_app();
-    // Seed the allowlist so the scheme check — not the host check —
-    // is the authority that refuses.
+    // Seed the allowlist with a valid hostname (post-#702 the setter
+    // rejects path-shaped strings outright). The scheme check fires
+    // before any host lookup, so the seeded value doesn't matter for
+    // this assertion — only that the setter accepts it.
     let allowed = app.state::<AllowedHostsState>();
-    allowed.replace(vec!["/etc/passwd".to_string()]);
+    allowed
+        .replace(vec!["example.com".to_string()])
+        .expect("seed allowlist");
     let window = make_session_window(&app, TEST_SESSION);
     let err = invoke_err(
         &window,
@@ -172,9 +187,10 @@ async fn context_fetch_url_rejects_file_scheme() {
             "url": "file:///etc/passwd",
         }),
     );
+    // Sanitized message — does not leak which gate fired.
     assert!(
-        err.contains("scheme") || err.contains("not allowed"),
-        "expected scheme rejection; got: {err}"
+        err.contains("URL not allowed by policy"),
+        "expected sanitized policy rejection; got: {err}"
     );
 }
 
@@ -183,9 +199,16 @@ async fn context_fetch_url_rejects_link_local_ip_literal() {
     // SSRF vector: AWS IMDS link-local. Even if the user had
     // misguidedly allowlisted `169.254.169.254` as a string, the
     // IP-class block rejects it before any transport I/O.
+    //
+    // Tracker #702: the rejection message is now generic — the
+    // specific "link-local" classification stays in `tracing`, not
+    // in the wire response, so a hostile webview cannot probe which
+    // IP class triggered the block.
     let app = make_app();
     let allowed = app.state::<AllowedHostsState>();
-    allowed.replace(vec!["169.254.169.254".to_string()]);
+    allowed
+        .replace(vec!["169.254.169.254".to_string()])
+        .expect("seed allowlist");
     let window = make_session_window(&app, TEST_SESSION);
     let err = invoke_err(
         &window,
@@ -196,8 +219,12 @@ async fn context_fetch_url_rejects_link_local_ip_literal() {
         }),
     );
     assert!(
-        err.contains("link-local") || err.contains("blocked"),
-        "expected IP-range rejection; got: {err}"
+        err.contains("URL not allowed by policy"),
+        "expected sanitized policy rejection; got: {err}"
+    );
+    assert!(
+        !err.contains("link-local") && !err.contains("169.254"),
+        "sanitized error must not leak IP-class detail; got: {err}"
     );
 }
 
@@ -224,17 +251,18 @@ async fn context_fetch_url_rejects_oversize_url() {
 #[tokio::test(flavor = "multi_thread")]
 async fn set_context_allowed_hosts_replaces_the_list() {
     // `set_context_allowed_hosts` overwrites the server-side list
-    // verbatim (post-trim, post-filter-empty). A subsequent
-    // `context_fetch_url` whose host is NOT on the list returns the
-    // host-not-allowed error, confirming the setter is authoritative.
+    // verbatim (post-trim). A subsequent `context_fetch_url` whose
+    // host is NOT on the list returns the sanitized policy-violation
+    // error, confirming the setter is authoritative.
     let app = make_app();
     let session_window = make_session_window(&app, TEST_SESSION);
 
-    // Seed from the session window (session-* is accepted).
+    // Seed from the session window (session-* is accepted). Surrounding
+    // whitespace is trimmed; the trimmed form is what lands on the list.
     invoke_ok(
         &session_window,
         "set_context_allowed_hosts",
-        serde_json::json!({ "hosts": ["docs.rs", "  ", ""] }),
+        serde_json::json!({ "hosts": ["  docs.rs  "] }),
     );
     let allowed = app.state::<AllowedHostsState>();
     assert_eq!(allowed.snapshot(), vec!["docs.rs".to_string()]);
@@ -251,7 +279,8 @@ async fn set_context_allowed_hosts_replaces_the_list() {
         vec!["only.example.com".to_string()]
     );
 
-    // A URL for the *previous* allowlist entry must now be rejected.
+    // A URL for the *previous* allowlist entry must now be rejected
+    // with the sanitized policy-violation message.
     let err = invoke_err(
         &session_window,
         "context_fetch_url",
@@ -261,8 +290,8 @@ async fn set_context_allowed_hosts_replaces_the_list() {
         }),
     );
     assert!(
-        err.contains("not on allowed-hosts") || err.contains("not allowed"),
-        "expected host-not-allowed after replacement; got: {err}"
+        err.contains("URL not allowed by policy"),
+        "expected sanitized policy rejection after replacement; got: {err}"
     );
 }
 
@@ -295,5 +324,191 @@ async fn set_context_allowed_hosts_rejects_oversize_list() {
     assert!(
         err.contains("payload too large") && err.contains("hosts"),
         "expected list-length cap; got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tracker #702: hostname validation on `AllowedHostsState::replace`
+//
+// RFC 1123 host rules: alphanumeric, hyphens, dots; non-empty; ≤253 bytes;
+// each label ≤63 bytes and not starting/ending with a hyphen; no wildcards
+// or path characters. Invalid entries are `Err` — never silently filtered.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_context_allowed_hosts_rejects_empty_entry() {
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    let err = invoke_err(
+        &window,
+        "set_context_allowed_hosts",
+        serde_json::json!({ "hosts": ["good.example.com", ""] }),
+    );
+    assert!(
+        err.contains("invalid host") || err.contains("empty"),
+        "expected empty-entry rejection; got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_context_allowed_hosts_rejects_whitespace_only_entry() {
+    // Whitespace-only entries used to be silently filtered. Per #702
+    // they are now explicit errors.
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    let err = invoke_err(
+        &window,
+        "set_context_allowed_hosts",
+        serde_json::json!({ "hosts": ["   "] }),
+    );
+    assert!(
+        err.contains("invalid host"),
+        "expected whitespace-only rejection; got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_context_allowed_hosts_rejects_path_chars() {
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    let err = invoke_err(
+        &window,
+        "set_context_allowed_hosts",
+        serde_json::json!({ "hosts": ["/etc/passwd"] }),
+    );
+    assert!(
+        err.contains("invalid host"),
+        "expected path-char rejection; got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_context_allowed_hosts_rejects_wildcard() {
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    let err = invoke_err(
+        &window,
+        "set_context_allowed_hosts",
+        serde_json::json!({ "hosts": ["*.example.com"] }),
+    );
+    assert!(
+        err.contains("invalid host"),
+        "expected wildcard rejection; got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_context_allowed_hosts_rejects_control_char() {
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    let err = invoke_err(
+        &window,
+        "set_context_allowed_hosts",
+        serde_json::json!({ "hosts": ["bad\u{0007}.example.com"] }),
+    );
+    assert!(
+        err.contains("invalid host"),
+        "expected control-char rejection; got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_context_allowed_hosts_rejects_leading_hyphen_label() {
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    let err = invoke_err(
+        &window,
+        "set_context_allowed_hosts",
+        serde_json::json!({ "hosts": ["-bad.example.com"] }),
+    );
+    assert!(
+        err.contains("invalid host"),
+        "expected leading-hyphen rejection; got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_context_allowed_hosts_rejects_overlong_hostname() {
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    // 254-byte hostname (max is 253). Made of 5-char labels so no
+    // single label exceeds 63 bytes — isolates the total-length gate.
+    let labels: Vec<String> = (0..50).map(|i| format!("lab{:02}", i)).collect();
+    let host = labels.join("."); // 50 * 6 - 1 = 299 bytes; well over 253.
+    let err = invoke_err(
+        &window,
+        "set_context_allowed_hosts",
+        serde_json::json!({ "hosts": [host] }),
+    );
+    // Either the per-entry size cap or the hostname-validity gate
+    // rejects — both qualify. The list-length cap is irrelevant here.
+    assert!(
+        err.contains("invalid host") || err.contains("payload too large"),
+        "expected overlong-hostname rejection; got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_fetch_url_logs_detailed_reason_on_policy_reject() {
+    // Tracker #702: the wire response is sanitized to a generic
+    // "URL not allowed by policy" — but the detailed reason (here the
+    // IP-class block on the AWS IMDS link-local address) must still
+    // reach `tracing` so operators can debug without re-running.
+    let _g = common::capture_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    common::install_capture_subscriber();
+    let _ = common::drain_capture();
+
+    let app = make_app();
+    let allowed = app.state::<AllowedHostsState>();
+    allowed
+        .replace(vec!["169.254.169.254".to_string()])
+        .expect("seed allowlist");
+    let window = make_session_window(&app, TEST_SESSION);
+    let err = invoke_err(
+        &window,
+        "context_fetch_url",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "url": "http://169.254.169.254/latest/meta-data/",
+        }),
+    );
+    assert_eq!(err, "context_fetch_url: URL not allowed by policy");
+
+    let logs = common::drain_capture();
+    assert!(
+        logs.contains("forge_shell::ipc::context_fetch"),
+        "expected tracing target, got: {logs}"
+    );
+    assert!(logs.contains("WARN"), "expected WARN level, got: {logs}");
+    assert!(
+        logs.contains("link-local"),
+        "expected detailed reason in tracing, got: {logs}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_context_allowed_hosts_accepts_valid_hostnames() {
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    invoke_ok(
+        &window,
+        "set_context_allowed_hosts",
+        serde_json::json!({ "hosts": [
+            "docs.rs",
+            "sub-domain.example.com",
+            "127.0.0.1",  // IP literal — parses as labels of digits.
+            "a",          // single-label hostname.
+        ] }),
+    );
+    assert_eq!(
+        app.state::<AllowedHostsState>().snapshot(),
+        vec![
+            "docs.rs".to_string(),
+            "sub-domain.example.com".to_string(),
+            "127.0.0.1".to_string(),
+            "a".to_string(),
+        ]
     );
 }

--- a/crates/forge-shell/tests/ipc_session_switch_provider.rs
+++ b/crates/forge-shell/tests/ipc_session_switch_provider.rs
@@ -1,0 +1,124 @@
+//! Tracker #702: `session_switch_provider` must size-cap `provider_id`.
+//!
+//! Other provider IPCs (e.g. `set_active_provider`) already validate
+//! through `crate::providers_ipc::validate_provider_id`, which rejects
+//! empty IDs and anything past `MAX_PROVIDER_ID_BYTES` (128 bytes). The
+//! finding noted `session_switch_provider` lacked the same guard; this
+//! test pins the new wiring.
+
+#![cfg(feature = "webview-test")]
+
+use forge_shell::bridge::SessionConnections;
+use forge_shell::ipc::{build_invoke_handler, BridgeState};
+use tauri::test::{get_ipc_response, mock_builder, mock_context, noop_assets, INVOKE_KEY};
+use tauri::Manager;
+
+const TEST_SESSION: &str = "abcdef0123456789";
+
+fn make_app() -> tauri::App<tauri::test::MockRuntime> {
+    let app = mock_builder()
+        .invoke_handler(build_invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("build mock Tauri app");
+    app.manage(BridgeState::new(SessionConnections::new()));
+    app
+}
+
+fn make_session_window(
+    app: &tauri::App<tauri::test::MockRuntime>,
+    session_id: &str,
+) -> tauri::WebviewWindow<tauri::test::MockRuntime> {
+    tauri::WebviewWindowBuilder::new(
+        app,
+        format!("session-{session_id}"),
+        tauri::WebviewUrl::App("index.html".into()),
+    )
+    .build()
+    .expect("mock session window")
+}
+
+fn invoke_err(
+    window: &tauri::WebviewWindow<tauri::test::MockRuntime>,
+    cmd: &str,
+    payload: serde_json::Value,
+) -> String {
+    let res = get_ipc_response(
+        window,
+        tauri::webview::InvokeRequest {
+            cmd: cmd.into(),
+            callback: tauri::ipc::CallbackFn(0),
+            error: tauri::ipc::CallbackFn(1),
+            url: "http://tauri.localhost".parse().unwrap(),
+            body: tauri::ipc::InvokeBody::Json(payload),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    );
+    match res {
+        Ok(ok) => panic!("expected error, got Ok: {ok:?}"),
+        Err(serde_json::Value::String(s)) => s,
+        Err(other) => other.to_string(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_switch_provider_rejects_empty_provider_id() {
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    let err = invoke_err(
+        &window,
+        "session_switch_provider",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "providerId": "",
+        }),
+    );
+    assert!(
+        err.contains("provider_id is empty"),
+        "expected empty-rejection, got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_switch_provider_rejects_oversize_provider_id() {
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    // `validate_provider_id` enforces `MAX_PROVIDER_ID_BYTES` (128). Use
+    // 256 to clear that cap with comfortable headroom.
+    let huge = "x".repeat(256);
+    let err = invoke_err(
+        &window,
+        "session_switch_provider",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "providerId": huge,
+        }),
+    );
+    assert!(
+        err.contains("provider_id too large"),
+        "expected size-cap rejection, got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_switch_provider_passes_validation_for_realistic_id() {
+    // Valid `provider_id` clears validation. The downstream bridge call
+    // then fails because no UDS connection is registered for the test
+    // session — that's the "no active connection" surface, not the
+    // size/empty guard. Pinning this distinguishes the validator from
+    // the bridge in case either error string drifts.
+    let app = make_app();
+    let window = make_session_window(&app, TEST_SESSION);
+    let err = invoke_err(
+        &window,
+        "session_switch_provider",
+        serde_json::json!({
+            "sessionId": TEST_SESSION,
+            "providerId": "anthropic",
+        }),
+    );
+    assert!(
+        !err.contains("provider_id is empty") && !err.contains("provider_id too large"),
+        "validator should accept 'anthropic'; got: {err}"
+    );
+}


### PR DESCRIPTION
Tackles three Phase-3 security-hygiene items from tracker forge-ide/forge#702 — all in `crates/forge-shell/src/ipc.rs`, so they ship as one PR.

## Summary

- **`context_fetch_url` error sanitization** (`ipc.rs:3315-3317`). The previous wire response was `e.to_string()` on the underlying `FetchUrlError`, which leaked which gate fired (scheme, userinfo, host-not-on-allowlist, link-local IP, blocked-IP-range, port). New helper `sanitize_fetch_url_error` collapses every policy variant to a single generic `"URL not allowed by policy"` (and `"fetch failed"` for transport variants) and emits a `tracing::warn!` at target `forge_shell::ipc::context_fetch` carrying the detailed reason so operators can still debug. A hostile renderer can no longer probe internal allowlist contents or which IP class triggered the block.
- **`AllowedHostsState::replace` hostname validation** (`ipc.rs:3212-3220`). `replace` now returns `Result<(), String>` and validates each entry against RFC 1123 rules (alphanumeric + hyphen + dot, non-empty after trim, ≤253 bytes overall, ≤63-byte labels, no leading/trailing hyphen per label). Invalid entries — empty strings, whitespace-only, control characters, wildcards, path separators — return `Err` with an `"invalid host: …"` prefix rather than being silently filtered. `set_context_allowed_hosts` propagates the `Err`.
- **`session_switch_provider` size cap** (`ipc.rs:2954-2970`). Now invokes `providers_ipc::validate_provider_id` before forwarding to the bridge — same empty-string + 128-byte cap every other provider IPC enforces.

## Test plan

- New tests in `crates/forge-shell/tests/ipc_context_fetch.rs`:
  - 8 hostname-validation cases (empty / whitespace / path-chars / wildcard / control-char / leading-hyphen / overlong / accepts-valid).
  - `context_fetch_url_logs_detailed_reason_on_policy_reject` — tracing capture asserts the public message is generic while `link-local` lands in `tracing`.
  - 4 existing tests updated to expect the sanitized public message.
- New `crates/forge-shell/tests/ipc_session_switch_provider.rs`:
  - Rejects empty `provider_id`.
  - Rejects oversize `provider_id`.
  - Realistic `provider_id` (`"anthropic"`) clears the validator (bridge then errors downstream — pinned to distinguish validator vs. bridge failure).
- `cargo test --workspace` — clean.
- `cargo clippy --all-targets --workspace -- -D warnings` — clean.
- `just check-rust` (CI rustdoc gate, `RUSTDOCFLAGS=-D warnings cargo doc`) — clean.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol). Tracker #702 stays open — only these three boxes get ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)