### PR TITLE
[#702] forge-session: pgid recycle check, byte-budget tool-call overhead, pause-event ordering

### DIFF
--- a/crates/forge-session/src/byte_budget.rs
+++ b/crates/forge-session/src/byte_budget.rs
@@ -39,6 +39,32 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Default aggregate byte budget per session: 500 MiB. See module docs.
 pub const DEFAULT_BUDGET_BYTES: u64 = 500 * 1024 * 1024;
 
+/// Per-tool-call fixed envelope written to the event log alongside the
+/// tool's actual payload bytes.
+///
+/// Each tool invocation emits at minimum a `ToolCallStarted` event whose
+/// JSON envelope adds framing around the caller-supplied `args` payload:
+/// the discriminant tag (`"type":"tool_call_started"`), the `id`, `msg`,
+/// `tool`, `at`, and `parallel_group` keys plus the trailing newline the
+/// event log appends. The pinning test
+/// `per_tool_call_overhead_matches_serializer` (in this module's
+/// `#[cfg(test)] mod tests`) measures the
+/// minimum-shape envelope live: 16-byte ULID ids, a single-char tool
+/// name, `args: {}`, an epoch timestamp, and `parallel_group: None`
+/// serialize to ~162 bytes minus the `"args":{}` payload. The constant
+/// is pinned at a conservative floor below that (so longer-id real
+/// emissions never undershoot the gate) and is asserted as a
+/// lower-bound by the test. Subtracting `n * overhead` from the
+/// remaining budget is therefore a strict floor: live envelopes pay
+/// at least this much and usually more.
+///
+/// The `is_exhausted_with_overhead` gate folds this in:
+/// `consumed + n_tool_calls * PER_TOOL_CALL_OVERHEAD_BYTES >= limit`
+/// trips refusal earlier than the naive payload-only check, preventing
+/// a long-running session from out-running the budget purely through
+/// tool-call framing on chatty-but-tiny tools.
+pub const PER_TOOL_CALL_OVERHEAD_BYTES: u64 = 128;
+
 /// Monotonic per-session counter of bytes consumed by tool results.
 ///
 /// `Ordering::Relaxed` is sufficient for both the load and the
@@ -76,6 +102,32 @@ impl ByteBudget {
     /// will be refused.
     pub fn is_exhausted(&self) -> bool {
         self.consumed() >= self.limit
+    }
+
+    /// Overhead-aware variant of [`Self::is_exhausted`]. Counts
+    /// `n_tool_calls * PER_TOOL_CALL_OVERHEAD_BYTES` against the
+    /// remaining headroom in addition to the payload bytes already
+    /// charged via [`Self::charge`]. Returns `true` when the projected
+    /// total — payload plus per-call envelopes — would meet or exceed
+    /// the limit.
+    ///
+    /// Use this at the dispatch boundary when the number of in-flight
+    /// or already-emitted tool calls is known; use [`Self::is_exhausted`]
+    /// when only the raw payload aggregate matters.
+    pub fn is_exhausted_with_overhead(&self, n_tool_calls: u64) -> bool {
+        let overhead = n_tool_calls.saturating_mul(PER_TOOL_CALL_OVERHEAD_BYTES);
+        self.consumed().saturating_add(overhead) >= self.limit
+    }
+
+    /// Remaining headroom after subtracting the per-tool-call envelope
+    /// overhead for `n_tool_calls` already-emitted (or projected) calls.
+    /// Saturates at zero — callers treat zero as "no further work is
+    /// safe".
+    pub fn remaining_with_overhead(&self, n_tool_calls: u64) -> u64 {
+        let overhead = n_tool_calls.saturating_mul(PER_TOOL_CALL_OVERHEAD_BYTES);
+        self.limit
+            .saturating_sub(self.consumed())
+            .saturating_sub(overhead)
     }
 
     /// Record `bytes` against the budget. Saturating add prevents
@@ -147,5 +199,87 @@ mod tests {
     fn default_is_500_mib() {
         assert_eq!(ByteBudget::default().limit(), 500 * 1024 * 1024);
         assert_eq!(DEFAULT_BUDGET_BYTES, 500 * 1024 * 1024);
+    }
+
+    /// Pin the per-tool-call envelope estimate against the live
+    /// `Event::ToolCallStarted` serializer. The serialized envelope
+    /// of a minimum-shape event (single-byte ids, empty `args: {}`,
+    /// `parallel_group: None`) minus the `"args":{}` bytes is a
+    /// concrete lower-bound on the framing every real tool call
+    /// pays. The constant must be at or below that floor — over-
+    /// estimating would short-circuit valid sessions, but under-
+    /// estimating by a small fixed amount is fine (the gate is a
+    /// conservative floor, not a tight bound).
+    ///
+    /// If this test fails because the event shape grew, recompute
+    /// the constant from the printed `envelope_minus_args_bytes`
+    /// number and update the doc comment to match.
+    #[test]
+    fn per_tool_call_overhead_matches_serializer() {
+        use chrono::{DateTime, Utc};
+        use forge_core::ids::{MessageId, ToolCallId};
+        use forge_core::Event;
+        use serde_json::json;
+
+        let event = Event::ToolCallStarted {
+            id: ToolCallId::new(),
+            msg: MessageId::new(),
+            tool: "t".to_string(),
+            args: json!({}),
+            at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+            parallel_group: None,
+        };
+        let envelope = serde_json::to_vec(&event).expect("event serializes");
+        let args_bytes = serde_json::to_vec(&json!({}))
+            .expect("args serialize")
+            .len() as u64;
+        let envelope_minus_args = (envelope.len() as u64).saturating_sub(args_bytes);
+
+        // Lower-bound the constant so a real event's framing always
+        // dominates the estimate. Add a small safety margin
+        // (the trailing newline the event log appends, plus any
+        // tag-key drift that adds <=10 bytes).
+        assert!(
+            PER_TOOL_CALL_OVERHEAD_BYTES <= envelope_minus_args,
+            "PER_TOOL_CALL_OVERHEAD_BYTES ({PER_TOOL_CALL_OVERHEAD_BYTES}) overshoots \
+             empirical envelope ({envelope_minus_args} bytes for a minimum-shape \
+             ToolCallStarted). Lower the constant.",
+        );
+        // And don't let the constant drift to zero — the gate would
+        // silently become a no-op. Const-block assert so clippy
+        // doesn't flag the constant comparison as always-true.
+        const _: () = assert!(
+            PER_TOOL_CALL_OVERHEAD_BYTES >= 64,
+            "PER_TOOL_CALL_OVERHEAD_BYTES must remain non-trivial \
+             (at least 64 bytes of framing).",
+        );
+    }
+
+    #[test]
+    fn is_exhausted_with_overhead_counts_tool_call_framing() {
+        let b = ByteBudget::new(1_000);
+        b.charge(500);
+        // 500 bytes of payload + 0 tool calls of overhead = 500 ≪ 1000.
+        assert!(!b.is_exhausted_with_overhead(0));
+        // Now add enough tool-call envelopes to cross the line.
+        // remaining headroom = 500 → div_ceil over the per-call overhead.
+        let n = (1_000u64 - 500).div_ceil(PER_TOOL_CALL_OVERHEAD_BYTES);
+        assert!(
+            b.is_exhausted_with_overhead(n),
+            "{n} envelopes ({} bytes) should saturate 500-byte headroom",
+            n * PER_TOOL_CALL_OVERHEAD_BYTES,
+        );
+        // One fewer should not trip the gate.
+        assert!(!b.is_exhausted_with_overhead(n - 1));
+    }
+
+    #[test]
+    fn remaining_with_overhead_saturates_at_zero() {
+        let b = ByteBudget::new(1_000);
+        b.charge(900);
+        assert_eq!(b.remaining_with_overhead(0), 100);
+        // 1 envelope eats 180 bytes; 100 remaining → saturates at 0.
+        assert_eq!(b.remaining_with_overhead(1), 0);
+        assert_eq!(b.remaining_with_overhead(u64::MAX), 0);
     }
 }

--- a/crates/forge-session/src/sandbox.rs
+++ b/crates/forge-session/src/sandbox.rs
@@ -200,9 +200,34 @@ pub const BASE_ENV_WHITELIST: &[&str] = &["PATH", "HOME", "LANG", "LC_ALL"];
 /// Shared registry of live sandboxed children scoped to a session. On session
 /// shutdown, [`ChildRegistry::kill_all`] sends `SIGKILL` to every tracked
 /// process group so that stray descendants do not survive the daemon.
+///
+/// On Linux, each entry pairs the pgid with the leader pid's
+/// `/proc/<pid>/stat` field-22 start-time, captured at insert time.
+/// [`ChildRegistry::kill_all`] re-reads the start-time before issuing
+/// `killpg` and skips any entry whose leader has been reaped and the pgid
+/// recycled — otherwise the `killpg` would target an unrelated process
+/// group. Mirrors the F-655 / F-656 `(dev, ino)` pattern used for daemon
+/// socket identity. Non-Linux builds do not sandbox; the registry stores
+/// the bare pgid and `kill_all` is a no-op.
 #[derive(Default, Clone)]
 pub struct ChildRegistry {
+    #[cfg(target_os = "linux")]
+    entries: Arc<Mutex<Vec<RegisteredPgid>>>,
+    #[cfg(not(target_os = "linux"))]
     pgids: Arc<Mutex<Vec<i32>>>,
+}
+
+/// Linux entry: pgid paired with the leader pid's recorded start-time so
+/// [`ChildRegistry::kill_all`] can refuse a `killpg` after pgid recycling.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy)]
+struct RegisteredPgid {
+    pgid: i32,
+    /// Leader pid's `/proc/<pid>/stat` field 22 at insertion time. `None`
+    /// when the probe failed (e.g. leader exited between spawn and
+    /// insert): treat as "unknown identity" and skip the kill rather
+    /// than risk hitting a recycled pgid.
+    starttime: Option<u64>,
 }
 
 impl ChildRegistry {
@@ -212,26 +237,84 @@ impl ChildRegistry {
 
     /// Register a pgid. The caller is expected to deregister it via
     /// [`ChildRegistry::remove`] once the child exits cleanly.
+    ///
+    /// On Linux this also probes `/proc/<pgid>/stat` to record the leader
+    /// pid's start-time so [`Self::kill_all`] can detect pgid recycling.
+    /// A probe failure is non-fatal — the entry is still recorded with a
+    /// `None` start-time, and [`Self::kill_all`] will skip it rather than
+    /// risk killing a recycled pgid.
     pub fn insert(&self, pgid: i32) {
-        self.pgids.lock().unwrap().push(pgid);
+        #[cfg(target_os = "linux")]
+        {
+            let starttime = crate::starttime::read_process_starttime(pgid).ok();
+            self.entries
+                .lock()
+                .unwrap()
+                .push(RegisteredPgid { pgid, starttime });
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            self.pgids.lock().unwrap().push(pgid);
+        }
+    }
+
+    /// Linux-only test seam: register a pgid with an explicit recorded
+    /// start-time, bypassing the `/proc/<pgid>/stat` probe. Exists so
+    /// `kill_all` can be exercised against a known-good or known-stale
+    /// identity without racing the kernel.
+    #[cfg(all(target_os = "linux", test))]
+    pub(crate) fn insert_with_starttime(&self, pgid: i32, starttime: Option<u64>) {
+        self.entries
+            .lock()
+            .unwrap()
+            .push(RegisteredPgid { pgid, starttime });
     }
 
     /// Deregister a pgid.
     pub fn remove(&self, pgid: i32) {
-        let mut guard = self.pgids.lock().unwrap();
-        if let Some(idx) = guard.iter().position(|p| *p == pgid) {
-            guard.swap_remove(idx);
+        #[cfg(target_os = "linux")]
+        {
+            let mut guard = self.entries.lock().unwrap();
+            if let Some(idx) = guard.iter().position(|e| e.pgid == pgid) {
+                guard.swap_remove(idx);
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let mut guard = self.pgids.lock().unwrap();
+            if let Some(idx) = guard.iter().position(|p| *p == pgid) {
+                guard.swap_remove(idx);
+            }
         }
     }
 
-    /// Send `SIGKILL` to every tracked process group and clear the registry.
+    /// Send `SIGKILL` to every tracked process group and clear the
+    /// registry.
+    ///
+    /// Each entry is verified against `/proc/<pgid>/stat` field 22
+    /// immediately before the `killpg`: a mismatch (or a missing
+    /// `/proc` entry) means the leader pid has been reaped and the
+    /// kernel may have recycled the pgid for an unrelated process.
+    /// In that case the `killpg` is suppressed and the entry is
+    /// dropped — the alternative would be sending `SIGKILL` to a
+    /// stranger.
     #[cfg(target_os = "linux")]
     pub fn kill_all(&self) {
-        let mut guard = self.pgids.lock().unwrap();
-        for pgid in guard.drain(..) {
+        let mut guard = self.entries.lock().unwrap();
+        for entry in guard.drain(..) {
+            if !leader_identity_matches(entry.pgid, entry.starttime) {
+                tracing::warn!(
+                    target: "forge_session::sandbox",
+                    pgid = entry.pgid,
+                    recorded_starttime = ?entry.starttime,
+                    "skipping killpg: leader pid has been reaped \
+                     and pgid may be recycled",
+                );
+                continue;
+            }
             // SAFETY: killpg is async-signal-safe and takes no Rust references.
             unsafe {
-                libc::killpg(pgid, libc::SIGKILL);
+                libc::killpg(entry.pgid, libc::SIGKILL);
             }
         }
     }
@@ -244,12 +327,41 @@ impl ChildRegistry {
 
     #[cfg(test)]
     pub fn len(&self) -> usize {
-        self.pgids.lock().unwrap().len()
+        #[cfg(target_os = "linux")]
+        {
+            self.entries.lock().unwrap().len()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            self.pgids.lock().unwrap().len()
+        }
     }
 
     #[cfg(test)]
     pub fn is_empty(&self) -> bool {
-        self.pgids.lock().unwrap().is_empty()
+        #[cfg(target_os = "linux")]
+        {
+            self.entries.lock().unwrap().is_empty()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            self.pgids.lock().unwrap().is_empty()
+        }
+    }
+}
+
+/// Linux: confirm `/proc/<pgid>/stat` field 22 still matches
+/// `recorded`. `recorded == None` means the insert-time probe failed,
+/// which we treat as "identity unknown — refuse to kill" (the
+/// conservative bias for a security-hygiene gate).
+#[cfg(target_os = "linux")]
+fn leader_identity_matches(pgid: i32, recorded: Option<u64>) -> bool {
+    let Some(recorded) = recorded else {
+        return false;
+    };
+    match crate::starttime::read_process_starttime(pgid) {
+        Ok(current) => current == recorded,
+        Err(_) => false,
     }
 }
 
@@ -1150,6 +1262,105 @@ mod tests {
             "expected SIGKILL, got {status:?}"
         );
         assert!(!process_alive(pgid));
+    }
+
+    #[tokio::test]
+    async fn registry_kill_all_skips_pgid_with_mismatched_starttime() {
+        // Simulates the pgid-recycle case: an entry recorded with a
+        // start-time that does not match the live `/proc/<pid>/stat`.
+        // `kill_all` must skip the killpg rather than send SIGKILL to
+        // a stranger that happens to hold the same pgid now.
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = ChildRegistry::new();
+
+        let mut sb = SandboxedCommand::new("/bin/sh", tmp.path());
+        sb.command_mut()
+            .arg("-c")
+            .arg("sleep 30")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+
+        // Spawn WITHOUT the registry so the real insert path doesn't
+        // capture an accurate start-time; we then manually register
+        // the pgid with a deliberately-wrong recorded start-time.
+        let sandboxed = sb.spawn().unwrap();
+        let pgid = sandboxed.pgid();
+        registry.insert_with_starttime(pgid, Some(u64::MAX));
+        assert!(process_alive(pgid), "child {pgid} should be alive");
+
+        registry.kill_all();
+        assert!(registry.is_empty(), "entries are drained even when skipped");
+        // Mismatched start-time means killpg was suppressed: the child
+        // must still be alive a moment later.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            process_alive(pgid),
+            "child {pgid} must survive a starttime-mismatched kill_all",
+        );
+
+        // Clean up: cancel the sleep child explicitly so the test exits.
+        unsafe {
+            libc::killpg(pgid, libc::SIGKILL);
+        }
+        let mut child = sandboxed.into_child();
+        let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+    }
+
+    #[tokio::test]
+    async fn registry_kill_all_kills_when_starttime_matches() {
+        // The matching-identity path: a normally-registered child has
+        // its real start-time captured at insert time, so `kill_all`
+        // sees a match and proceeds with `killpg`. This is the
+        // existing F-055 / F-149 contract — the recycle gate must not
+        // regress it.
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = ChildRegistry::new();
+
+        let mut sb = SandboxedCommand::new("/bin/sh", tmp.path());
+        sb.command_mut()
+            .arg("-c")
+            .arg("sleep 30")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        sb.with_registry(registry.clone());
+
+        let sandboxed = sb.spawn().unwrap();
+        let _pgid = sandboxed.pgid();
+        assert_eq!(registry.len(), 1);
+
+        registry.kill_all();
+
+        let mut child = sandboxed.into_child();
+        let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("child did not exit after registry.kill_all()")
+            .unwrap();
+        use std::os::unix::process::ExitStatusExt;
+        assert_eq!(
+            status.signal(),
+            Some(libc::SIGKILL),
+            "matching-identity entry must still get SIGKILL: {status:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn registry_kill_all_skips_entry_with_no_recorded_starttime() {
+        // An entry whose insert-time probe failed (recorded `None`)
+        // is treated as "identity unknown — refuse to kill" so we
+        // never SIGKILL a possibly-recycled pgid on the basis of
+        // missing evidence.
+        let registry = ChildRegistry::new();
+        // pgid 1 (init) is always alive, so a kill would actually
+        // hit something if the gate let it through. The `None`
+        // start-time must suppress that.
+        registry.insert_with_starttime(1, None);
+        registry.kill_all();
+        assert!(registry.is_empty());
+        // pid 1 is owned by root in any sane environment; this
+        // assertion exists to document intent rather than catch
+        // a fault (we expect EPERM on the suppressed code path
+        // anyway).
+        assert!(process_alive(1));
     }
 
     #[tokio::test]

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -1640,23 +1640,24 @@ async fn handle_connection<P: Provider + 'static>(
                     }
 
                     Some(IpcMessage::PauseSession(_)) => {
-                        // F-603: pause request. `Session::try_pause` flips
-                        // the in-memory `Paused` flag and returns whether
-                        // it performed the `Running → Paused` transition.
-                        // Only emit `Event::SessionPaused` on a real
-                        // transition — pause-while-paused is idempotent
-                        // and falls through to a `debug!` log per the DoD
-                        // (NOT an error). Effect on the orchestrator: the
-                        // next iteration of `run_request_loop` parks at
-                        // `Session::wait_if_paused`; any in-flight step
-                        // (model stream, tool call) finishes first.
-                        if session.try_pause() {
-                            if let Err(e) = session
-                                .emit(forge_core::Event::SessionPaused {
-                                    at: chrono::Utc::now(),
-                                })
-                                .await
-                            {
+                        // F-603 / F-666: pause request. The state-flip
+                        // and the `Event::SessionPaused` emission run
+                        // under a single lock inside the session so a
+                        // concurrent resume cannot interleave their
+                        // events out-of-order relative to the actual
+                        // state transitions. Idempotency contract is
+                        // unchanged: pause-while-paused returns `false`
+                        // and emits no event.
+                        match session.pause_and_emit_if_transitioned().await {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                tracing::debug!(
+                                    target: "forge_session::server",
+                                    session_id = %session_id,
+                                    "PauseSession: already paused (no-op)",
+                                );
+                            }
+                            Err(e) => {
                                 tracing::warn!(
                                     target: "forge_session::server",
                                     session_id = %session_id,
@@ -1664,30 +1665,26 @@ async fn handle_connection<P: Provider + 'static>(
                                     "failed to emit SessionPaused",
                                 );
                             }
-                        } else {
-                            tracing::debug!(
-                                target: "forge_session::server",
-                                session_id = %session_id,
-                                "PauseSession: already paused (no-op)",
-                            );
                         }
                     }
 
                     Some(IpcMessage::ResumeSession(_)) => {
-                        // F-603: resume request. `Session::try_resume`
-                        // clears the `Paused` flag and (on a real
-                        // transition) wakes any orchestrator parked at
-                        // the pause checkpoint via
-                        // `Notify::notify_waiters`. Idempotency mirrors
-                        // pause: redundant resume falls through to a
-                        // `debug!` log and emits no event.
-                        if session.try_resume() {
-                            if let Err(e) = session
-                                .emit(forge_core::Event::SessionResumed {
-                                    at: chrono::Utc::now(),
-                                })
-                                .await
-                            {
+                        // F-603 / F-666: resume request. Companion to
+                        // the pause path above — the state-flip,
+                        // `notify_waiters`, and `Event::SessionResumed`
+                        // emission run under the same lock so consumer
+                        // ordering matches transition ordering even
+                        // under concurrent pause/resume traffic.
+                        match session.resume_and_emit_if_transitioned().await {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                tracing::debug!(
+                                    target: "forge_session::server",
+                                    session_id = %session_id,
+                                    "ResumeSession: not paused (no-op)",
+                                );
+                            }
+                            Err(e) => {
                                 tracing::warn!(
                                     target: "forge_session::server",
                                     session_id = %session_id,
@@ -1695,12 +1692,6 @@ async fn handle_connection<P: Provider + 'static>(
                                     "failed to emit SessionResumed",
                                 );
                             }
-                        } else {
-                            tracing::debug!(
-                                target: "forge_session::server",
-                                session_id = %session_id,
-                                "ResumeSession: not paused (no-op)",
-                            );
                         }
                     }
 

--- a/crates/forge-session/src/session.rs
+++ b/crates/forge-session/src/session.rs
@@ -232,6 +232,13 @@ impl Session {
     /// pause/resume events appear in the event log in the same order
     /// as the corresponding state transitions. Wakes any orchestrator
     /// parked on `wait_if_paused` only on a real transition.
+    ///
+    /// F-653: uses `notify_one` (not `notify_waiters`) so a resume that
+    /// lands *before* the orchestrator reaches the checkpoint retains
+    /// a permit — the next `notified()` consumes it without parking,
+    /// avoiding the dropped-permit deadlock that
+    /// `pause_resume_burst_before_turn_does_not_deadlock_or_leak_step`
+    /// pins.
     pub async fn resume_and_emit_if_transitioned(&self) -> Result<bool, SessionError> {
         let _guard = self.pause_emit_lock.lock().await;
         if self
@@ -241,7 +248,7 @@ impl Session {
         {
             return Ok(false);
         }
-        self.resume_notify.notify_waiters();
+        self.resume_notify.notify_one();
         self.emit(Event::SessionResumed { at: Utc::now() }).await?;
         Ok(true)
     }

--- a/crates/forge-session/src/session.rs
+++ b/crates/forge-session/src/session.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use chrono::Utc;
 use forge_core::{Event, EventLog, EventSink};
 use tokio::sync::{broadcast, Mutex, Notify};
 
@@ -71,6 +72,17 @@ pub struct Session {
     /// checkpoint would not park, and a tool effect could fire after
     /// `SessionPaused` was acknowledged on the wire.
     pause_epoch: Arc<AtomicU64>,
+    /// F-666 hygiene: serialises the state-flip and the event emission for
+    /// pause/resume. Without this lock, two concurrent pause/resume
+    /// callers could win the atomic CAS in one order but reach
+    /// `Session::emit` (which awaits the underlying log mutex) in the
+    /// opposite order — consumers replaying the event stream would see
+    /// `Paused`/`Resumed` events out of sequence with the actual state
+    /// transitions. `pause_and_emit_if_transitioned` /
+    /// `resume_and_emit_if_transitioned` hold this lock across both
+    /// steps so the observable order is "transition → event"
+    /// monotonically.
+    pause_emit_lock: Arc<Mutex<()>>,
     /// F-603: paired with `paused`. The orchestrator's pause checkpoint
     /// awaits this `Notify` while the flag is set; `try_resume` calls
     /// `notify_one` to wake it. F-653: switched from `notify_waiters` to
@@ -124,6 +136,7 @@ impl Session {
             parallel_group_seq: Arc::new(AtomicU32::new(1)),
             paused: Arc::new(AtomicBool::new(false)),
             pause_epoch: Arc::new(AtomicU64::new(0)),
+            pause_emit_lock: Arc::new(Mutex::new(())),
             resume_notify: Arc::new(Notify::new()),
             interrupt_requested: Arc::new(AtomicBool::new(false)),
             interrupt_capture: Arc::new(Mutex::new(None)),
@@ -185,6 +198,52 @@ impl Session {
     /// arrived.
     pub fn pause_epoch(&self) -> u64 {
         self.pause_epoch.load(Ordering::SeqCst)
+    }
+
+    /// F-666 hygiene: atomically perform the `Running → Paused`
+    /// transition **and** emit `Event::SessionPaused` under a single
+    /// lock. Replaces the previous "call `try_pause` then conditionally
+    /// `emit` from the caller" pattern — that pattern let two callers'
+    /// events appear in the event log out of order relative to their
+    /// state transitions (the CAS winner could lose the race to the
+    /// log mutex). Returns `true` when this call performed the
+    /// transition and emitted the event; `false` when the session was
+    /// already paused (idempotent no-op; no event emitted).
+    ///
+    /// F-653: also bumps `pause_epoch` on transition so the
+    /// orchestrator's pause checkpoint catches a quick pause/resume
+    /// cycle that completed before the next step boundary.
+    pub async fn pause_and_emit_if_transitioned(&self) -> Result<bool, SessionError> {
+        let _guard = self.pause_emit_lock.lock().await;
+        if self
+            .paused
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Ok(false);
+        }
+        self.pause_epoch.fetch_add(1, Ordering::SeqCst);
+        self.emit(Event::SessionPaused { at: Utc::now() }).await?;
+        Ok(true)
+    }
+
+    /// F-666 hygiene: companion to [`Self::pause_and_emit_if_transitioned`]
+    /// for the `Paused → Running` transition. Holds the same lock so
+    /// pause/resume events appear in the event log in the same order
+    /// as the corresponding state transitions. Wakes any orchestrator
+    /// parked on `wait_if_paused` only on a real transition.
+    pub async fn resume_and_emit_if_transitioned(&self) -> Result<bool, SessionError> {
+        let _guard = self.pause_emit_lock.lock().await;
+        if self
+            .paused
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Ok(false);
+        }
+        self.resume_notify.notify_waiters();
+        self.emit(Event::SessionResumed { at: Utc::now() }).await?;
+        Ok(true)
     }
 
     /// F-603: observe the pause flag without mutating it. Used in tests
@@ -697,6 +756,111 @@ mod tests {
             result.is_none(),
             "await must yield None on deadline expiry (no orchestrator publish)",
         );
+    }
+
+    // ---------- F-666 hygiene: pause/resume event ordering under lock ----------
+
+    #[tokio::test]
+    async fn pause_and_emit_if_transitioned_emits_event_under_lock() {
+        let (_dir, session) = fresh_session().await;
+        let mut rx = session.event_tx.subscribe();
+
+        assert!(session.pause_and_emit_if_transitioned().await.unwrap());
+        let (_, ev) = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("event arrives")
+            .expect("subscriber alive");
+        assert!(
+            matches!(ev, Event::SessionPaused { .. }),
+            "expected SessionPaused, got {ev:?}",
+        );
+
+        // Idempotent: redundant pause must not emit a second event.
+        assert!(!session.pause_and_emit_if_transitioned().await.unwrap());
+        assert!(rx.try_recv().is_err(), "no second event on no-op pause");
+
+        assert!(session.resume_and_emit_if_transitioned().await.unwrap());
+        let (_, ev) = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("event arrives")
+            .expect("subscriber alive");
+        assert!(
+            matches!(ev, Event::SessionResumed { .. }),
+            "expected SessionResumed, got {ev:?}",
+        );
+    }
+
+    /// F-666: hammer pause/resume from many tasks at once and assert
+    /// the event stream alternates `Paused, Resumed, Paused, Resumed,
+    /// …` strictly. Pre-fix, the state-flip CAS and the `emit` log-
+    /// mutex acquisition were separable, so two callers could see
+    /// their events arrive in the opposite order from their
+    /// transitions.
+    #[tokio::test]
+    async fn concurrent_pause_resume_events_match_transition_order() {
+        let (_dir, session) = fresh_session().await;
+        let mut rx = session.event_tx.subscribe();
+
+        // 50 cycles of pause/resume issued from independent tasks.
+        // We serialize each cycle (resume must observe a prior pause)
+        // but the *emission* path is contended across tasks.
+        let cycles = 50;
+        let mut tasks = Vec::new();
+        for _ in 0..cycles {
+            let s = Arc::clone(&session);
+            tasks.push(tokio::spawn(async move {
+                // Spin until the pause transition lands (a concurrent
+                // resumer may have flipped us back to Running already).
+                while !s.pause_and_emit_if_transitioned().await.unwrap() {
+                    tokio::task::yield_now().await;
+                }
+                while !s.resume_and_emit_if_transitioned().await.unwrap() {
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+
+        // Drain all 2N events; assert strict alternation.
+        let mut prev_was_paused: Option<bool> = None;
+        let mut paused = 0;
+        let mut resumed = 0;
+        for _ in 0..(cycles * 2) {
+            let (_, ev) = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+                .await
+                .expect("event arrives")
+                .expect("subscriber alive");
+            match ev {
+                Event::SessionPaused { .. } => {
+                    assert!(
+                        prev_was_paused != Some(true),
+                        "two consecutive SessionPaused events — state/emit \
+                         interleaved out of order",
+                    );
+                    prev_was_paused = Some(true);
+                    paused += 1;
+                }
+                Event::SessionResumed { .. } => {
+                    assert!(
+                        prev_was_paused != Some(false),
+                        "two consecutive SessionResumed events — state/emit \
+                         interleaved out of order",
+                    );
+                    assert!(
+                        prev_was_paused == Some(true),
+                        "SessionResumed before any SessionPaused",
+                    );
+                    prev_was_paused = Some(false);
+                    resumed += 1;
+                }
+                other => panic!("unexpected event {other:?}"),
+            }
+        }
+        assert_eq!(paused, cycles);
+        assert_eq!(resumed, cycles);
+        assert!(!session.is_paused(), "final state must be Running");
     }
 
     #[tokio::test]

--- a/crates/forge-session/src/starttime.rs
+++ b/crates/forge-session/src/starttime.rs
@@ -30,6 +30,27 @@
 
 use anyhow::Result;
 
+/// Read the starttime token for an arbitrary pid on Linux.
+///
+/// Mirrors [`read_self_starttime`] but targets `/proc/<pid>/stat` instead
+/// of `/proc/self/stat` so callers can verify a recorded leader pid has
+/// not been reaped and recycled (see `sandbox::ChildRegistry::kill_all`).
+/// Linux-only because the pid-reuse mitigation it backs is itself
+/// Linux-only (cgroup-paired killpg); macOS/Windows sandboxes do not
+/// use this path.
+#[cfg(target_os = "linux")]
+pub fn read_process_starttime(pid: libc::pid_t) -> Result<u64> {
+    let path = format!("/proc/{pid}/stat");
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            anyhow::bail!("no such process {pid} (/proc/{pid}/stat missing)");
+        }
+        Err(e) => anyhow::bail!("failed to read /proc/{pid}/stat: {e}"),
+    };
+    linux::parse_proc_stat_starttime(&contents)
+}
+
 /// Return a `u64` that uniquely identifies this process across its
 /// lifetime on the current host. The shape is platform-dependent; see
 /// the module docs.

--- a/crates/forge-session/src/tools/mod.rs
+++ b/crates/forge-session/src/tools/mod.rs
@@ -299,7 +299,7 @@ pub(crate) async fn invoke_with_budget(
     ctx: &ToolCtx,
 ) -> serde_json::Value {
     if let Some(budget) = ctx.byte_budget.as_ref() {
-        if budget.is_exhausted() {
+        if budget.is_exhausted_with_overhead(1) {
             return serde_json::json!({
                 "error": format!(
                     "session byte budget exceeded: {}/{} bytes",
@@ -313,7 +313,7 @@ pub(crate) async fn invoke_with_budget(
     let result = tool.invoke(args, ctx).await;
 
     if let Some(budget) = ctx.byte_budget.as_ref() {
-        budget.charge(result_byte_cost(&result));
+        budget.charge(result_byte_cost(&result) + crate::byte_budget::PER_TOOL_CALL_OVERHEAD_BYTES);
     }
 
     result

--- a/crates/forge-session/tests/byte_budget.rs
+++ b/crates/forge-session/tests/byte_budget.rs
@@ -104,15 +104,19 @@ async fn dispatcher_short_circuits_after_budget_exhaustion() {
     let mut d = ToolDispatcher::new();
     d.register(Box::new(FsReadTool)).unwrap();
 
-    // Budget too small to cover even one full read — first call exhausts it.
-    let budget = Arc::new(ByteBudget::new(1));
+    // Budget sized so the first 100 KiB read completes (its result_byte_cost
+    // plus the per-tool-call envelope overhead lands at the limit) but the
+    // pre-check on the second call sees `consumed + overhead >= limit` and
+    // short-circuits. Picks the file size as the budget so the first
+    // charge clearly exhausts the headroom.
+    let budget = Arc::new(ByteBudget::new(100 * 1024));
     let ctx = ToolCtx {
         allowed_paths: vec![allowed],
         byte_budget: Some(budget.clone()),
         ..ToolCtx::default()
     };
 
-    // First call: tool may execute (post-decrement model) and return content.
+    // First call: tool runs and consumes the budget.
     let _ = d
         .dispatch("fs.read", &json!({ "path": &path }), &ctx)
         .await


### PR DESCRIPTION
## Summary

Three independent low-severity hardenings from the Phase 3 security hygiene tracker (#702). Touches three files plus their two collaborators (`starttime.rs`, `server.rs`).

- **`sandbox::ChildRegistry` pgid kill verifies recorded leader start-time before `killpg`.** Records `/proc/<pgid>/stat` field 22 at insert time on Linux; refuses the kill on mismatch (leader reaped → pgid may be recycled). Same `(dev, ino)`-style identity pattern F-655/F-656 used for the daemon socket. `starttime::read_process_starttime` extracted as a Linux-only public helper. Non-Linux behavior unchanged.
- **`byte_budget` accounts for per-tool-call event-log envelope.** New `PER_TOOL_CALL_OVERHEAD_BYTES = 128` constant, pinned by a test that serializes a minimum-shape `Event::ToolCallStarted` (~162 bytes minus `args` payload) and asserts the constant stays at or below that floor. `is_exhausted_with_overhead` / `remaining_with_overhead` helpers count `n * overhead` against the remaining ceiling.
- **`Session` pause/resume events emitted under a lock.** New `pause_and_emit_if_transitioned` / `resume_and_emit_if_transitioned` methods hold a `pause_emit_lock` across the state flip and the event emission so two concurrent pause/resume callers can't have their events arrive on the event stream in the opposite order from their transitions. IPC handlers in `server.rs` routed onto the new methods. Distinct from SEC-13 (wait-checkpoint race) per the issue note.

## Definition of Done

- [x] Item 1: pgid kill verifies starttime; tests cover starttime mismatch, missing recorded starttime, and the matching-identity happy path
- [x] Item 2: budget accounts for tool-call overhead; pinning test ties the constant to live `serde_json::to_vec(&Event::ToolCallStarted)` math
- [x] Item 3: pause/resume event emission inside the lock; concurrent-pause/resume test asserts strict event/transition alternation over 50 cycles
- [x] `cargo test --workspace` clean
- [x] `just check-rust` clean (fmt + clippy + rustdoc gate)

## Test plan

- [x] `cargo test -p forge-session --lib sandbox::` (38 passed including the three new starttime tests)
- [x] `cargo test -p forge-session --lib byte_budget` (9 passed including the new pinning + overhead-math tests)
- [x] `cargo test -p forge-session --lib session::` (11 passed including the new concurrent ordering test)
- [x] `cargo test --workspace` (full suite green)
- [x] `just check-rust` (fmt + clippy + RUSTDOCFLAGS="-D warnings" cargo doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)