### PR TITLE
[#702] forge-shell validators: container ID dot-prefix, provider_id empty suffix, agent_id whitespace

### DIFF
--- a/crates/forge-shell/src/containers_ipc.rs
+++ b/crates/forge-shell/src/containers_ipc.rs
@@ -257,6 +257,17 @@ pub fn validate_container_id(container_id: &str) -> Result<(), String> {
             MAX_CONTAINER_ID_BYTES
         ));
     }
+    // Leading `.` and `-` are explicitly rejected, mirroring the F-628
+    // ImageRef hardening: a dot-prefix would alias a hidden filesystem
+    // entry if the id ever escapes argv into a path, and a dash-prefix
+    // collides with `podman <cmd> -<flag>` argv conventions. The body
+    // charset below rejects `.` outright anyway, but the explicit guard
+    // yields a clearer error for the common mis-paste.
+    if let Some(first) = container_id.chars().next() {
+        if first == '.' || first == '-' {
+            return Err(format!("container_id must not start with {first:?}"));
+        }
+    }
     // Container IDs from podman are 64-char hex; podman container *names*
     // accept `[a-zA-Z0-9][a-zA-Z0-9_.-]*`. Our allowlist is a deliberate
     // superset of the hex-id form and a subset of the name form (we omit
@@ -517,6 +528,34 @@ mod tests {
     fn validate_container_id_accepts_named_id() {
         assert!(validate_container_id("forge-session-abc").is_ok());
         assert!(validate_container_id("forge_sandbox_1").is_ok());
+    }
+
+    #[test]
+    fn validate_container_id_rejects_leading_dot() {
+        // Dot is already outside the body charset, but the explicit
+        // leading-dot guard yields a clearer error and parallels the
+        // F-628 ImageRef hardening that just merged.
+        let err = validate_container_id(".abc").unwrap_err();
+        assert!(
+            err.contains("must not start with"),
+            "expected leading-dot rejection, got: {err}",
+        );
+        assert!(validate_container_id(".").is_err());
+        assert!(validate_container_id(".hidden").is_err());
+    }
+
+    #[test]
+    fn validate_container_id_rejects_leading_dash() {
+        // Hyphen is in the body charset (so `"-abc"` would otherwise sneak
+        // past), but a leading dash collides with `podman <cmd> -<flag>`
+        // argv conventions — mirror the F-628 ImageRef rule.
+        let err = validate_container_id("-abc").unwrap_err();
+        assert!(
+            err.contains("must not start with"),
+            "expected leading-dash rejection, got: {err}",
+        );
+        assert!(validate_container_id("-").is_err());
+        assert!(validate_container_id("--flag").is_err());
     }
 
     #[test]

--- a/crates/forge-shell/src/memory_ipc.rs
+++ b/crates/forge-shell/src/memory_ipc.rs
@@ -137,6 +137,15 @@ pub fn validate_agent_id(agent_id: &str) -> Result<(), String> {
             MAX_AGENT_ID_BYTES
         ));
     }
+    // Reject explicitly — silent strip-and-accept would let `" agent"` and
+    // `"agent "` route to the same file as `"agent"`, indistinguishable in
+    // the UI but split in any downstream id comparison. The body charset
+    // already excludes whitespace, but an explicit guard yields a clearer
+    // error than "must contain only [A-Za-z0-9_-]" for the common
+    // copy-paste mishap.
+    if agent_id.chars().any(char::is_whitespace) {
+        return Err("agent_id must not contain whitespace".to_string());
+    }
     if !agent_id
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
@@ -546,6 +555,25 @@ mod tests {
                 "expected acceptance for {good:?}",
             );
         }
+    }
+
+    #[test]
+    fn validate_agent_id_rejects_whitespace_padded_ids() {
+        // Silent stripping would let `" agent"` and `"agent "` route to the
+        // same file as `"agent"` — visually distinct, behaviourally aliased.
+        // Reject explicitly so the caller sees the mismatch.
+        for bad in [" agent", "agent ", " agent ", "\tagent", "agent\n"] {
+            let err = validate_agent_id(bad)
+                .err()
+                .unwrap_or_else(|| panic!("expected rejection for {bad:?}"));
+            assert!(
+                err.contains("whitespace"),
+                "expected whitespace-specific error for {bad:?}, got: {err}",
+            );
+        }
+        // Happy path still passes.
+        validate_agent_id("agent").unwrap();
+        validate_agent_id("my-agent_42").unwrap();
     }
 
     #[test]

--- a/crates/forge-shell/src/providers_ipc.rs
+++ b/crates/forge-shell/src/providers_ipc.rs
@@ -243,6 +243,27 @@ pub fn validate_provider_id(provider_id: &str) -> Result<(), String> {
             MAX_PROVIDER_ID_BYTES
         ));
     }
+    // `custom_openai:<name>` ids must carry a non-empty, charset-clean
+    // suffix. The bare prefix (`custom_openai:`) and whitespace-only
+    // suffixes would otherwise pass the size cap and reach
+    // `is_known_provider_id` / `apply_setting_update`, where they alias
+    // an empty map key or surprise the downstream display. Mirror the
+    // catalog/credential id shape used elsewhere in the repo.
+    if let Some(suffix) = provider_id.strip_prefix(CUSTOM_OPENAI_PREFIX) {
+        if suffix.is_empty() || suffix.chars().all(char::is_whitespace) {
+            return Err(format!(
+                "provider_id {CUSTOM_OPENAI_PREFIX}<name> must have a non-empty name"
+            ));
+        }
+        if !suffix
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(format!(
+                "provider_id {CUSTOM_OPENAI_PREFIX}<name> name must contain only [A-Za-z0-9_-]"
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -587,5 +608,57 @@ mod tests {
     fn validate_provider_id_accepts_realistic_slugs() {
         validate_provider_id("anthropic").expect("anthropic");
         validate_provider_id("custom_openai:together").expect("custom_openai:together");
+    }
+
+    #[test]
+    fn validate_provider_id_rejects_custom_openai_empty_suffix() {
+        let err = validate_provider_id("custom_openai:").unwrap_err();
+        assert!(
+            err.contains("custom_openai"),
+            "expected custom_openai-specific error, got: {err}",
+        );
+    }
+
+    #[test]
+    fn validate_provider_id_rejects_custom_openai_whitespace_suffix() {
+        for bad in ["custom_openai: ", "custom_openai:\t", "custom_openai:   "] {
+            let err = validate_provider_id(bad)
+                .err()
+                .unwrap_or_else(|| panic!("expected rejection for {bad:?}"));
+            assert!(
+                err.contains("custom_openai"),
+                "expected custom_openai-specific error for {bad:?}, got: {err}",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_provider_id_rejects_custom_openai_bad_charset() {
+        // The first `:` is the prefix separator; a second `:` or any
+        // other non-allowlist byte in the suffix must trip the charset
+        // guard.
+        for bad in [
+            "custom_openai:foo:bar",
+            "custom_openai:foo/bar",
+            "custom_openai:foo bar",
+            "custom_openai:foo.bar",
+        ] {
+            assert!(
+                validate_provider_id(bad).is_err(),
+                "expected rejection for {bad:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_provider_id_accepts_custom_openai_named_suffix() {
+        for good in [
+            "custom_openai:vllm",
+            "custom_openai:together-ai",
+            "custom_openai:my_endpoint",
+            "custom_openai:Endpoint1",
+        ] {
+            validate_provider_id(good).unwrap_or_else(|e| panic!("{good:?}: {e}"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Three sibling validator tightenings from the Phase 3 security-hygiene tracker (#702). Single PR, three checkboxes ticked.

- **`validate_container_id` (`crates/forge-shell/src/containers_ipc.rs`)** — explicit leading-`.` and leading-`-` rejection. Dot was already excluded by the body charset; the explicit guard gives a clearer error and closes the leading-`-` gap that the existing charset allowed through. Parallels the F-628 ImageRef rule that just merged.
- **`validate_provider_id` (`crates/forge-shell/src/providers_ipc.rs`)** — `custom_openai:` with empty / whitespace-only / charset-dirty suffix is now rejected at the IPC boundary instead of reaching `is_known_provider_id` and `apply_setting_update` as an empty map key.
- **`validate_agent_id` (`crates/forge-shell/src/memory_ipc.rs`)** — explicit whitespace rejection. Whitespace was already excluded by the body charset, but the dedicated guard surfaces a clearer error than "must contain only [A-Za-z0-9_-]" for the common `" agent"` / `"agent "` copy-paste mishap. "Reject" over "strip" so visually-distinct ids cannot alias the same downstream file.

## Test plan

- [x] `cargo test --workspace` (clean — 7 new unit tests; 0 regressions)
- [x] `just check-rust` (clippy + rustdoc gate clean)
- [x] Each rejection has a dedicated unit test (`*_rejects_leading_dot`, `*_rejects_leading_dash`, `*_rejects_custom_openai_empty_suffix`, `*_rejects_custom_openai_whitespace_suffix`, `*_rejects_custom_openai_bad_charset`, `*_accepts_custom_openai_named_suffix`, `*_rejects_whitespace_padded_ids`)
- [x] Happy-path cases preserved (existing `accepts_*` tests untouched + new positive coverage)

Closes the three IPC-validator checkboxes on tracker issue #702. The remaining items on that tracker are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)