### PR TITLE
[#702] forge-oci podman polish: strict RFC-3339, type-checked detect, container ID validation, Stats error vs absent, sandbox drop absolute-path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,7 @@ name = "forge-oci"
 version = "0.3.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/forge-oci/Cargo.toml
+++ b/crates/forge-oci/Cargo.toml
@@ -14,6 +14,10 @@ test-support = []
 
 [dependencies]
 async-trait = "0.1"
+# Strict RFC-3339 parsing for `podman logs --timestamps` prefixes (used
+# by `parse_podman_log_line`). `default-features = false` strips the
+# clock/localization features we don't need.
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/forge-oci/src/podman.rs
+++ b/crates/forge-oci/src/podman.rs
@@ -159,12 +159,18 @@ impl ContainerRuntime for PodmanRuntime {
                 source,
             })?;
 
-        let rootless = parsed
-            .get("host")
-            .and_then(|h| h.get("security"))
-            .and_then(|s| s.get("rootless"))
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+        // Drill down with explicit type checks so a malformed payload
+        // (e.g. `host` returned as a string, `security` returned as a
+        // list, `rootless` returned as a number) fails with a typed
+        // `InvalidJson` instead of silently collapsing to "rootless
+        // unavailable". Each step distinguishes "key absent" (still a
+        // typed error — the schema is load-bearing) from "key present
+        // but wrong shape".
+        let rootless = extract_rootless(&parsed).map_err(|reason| OciError::InvalidJson {
+            tool: PODMAN,
+            subcommand: "info",
+            source: <serde_json::Error as serde::de::Error>::custom(reason),
+        })?;
 
         if !rootless {
             return Err(OciError::RootlessUnavailable {
@@ -256,6 +262,24 @@ impl ContainerRuntime for PodmanRuntime {
                 args: args.iter().map(|s| s.to_string()).collect(),
                 exit_code: outcome.exit_code,
                 stderr: "podman create returned empty container id".to_string(),
+            });
+        }
+        // Podman emits a 64-char lowercase hex container id. Reject
+        // anything else so a corrupted / wrapper-prefixed stdout cannot
+        // leak through to `start` / `exec` / `rm` and cause a
+        // hard-to-diagnose podman error or, worse, hit a different
+        // container with a coincidentally-matching short id.
+        if !is_valid_container_id(&id) {
+            return Err(OciError::CommandFailed {
+                tool: PODMAN,
+                args: args.iter().map(|s| s.to_string()).collect(),
+                exit_code: outcome.exit_code,
+                stderr: format!(
+                    "podman create returned malformed container id (expected 64-char \
+                     lowercase hex, got {} chars: {:?})",
+                    id.len(),
+                    id
+                ),
             });
         }
         tracing::info!(
@@ -397,9 +421,19 @@ impl ContainerRuntime for PodmanRuntime {
         //   - `mem_usage`: string like `"178.3MB / 67.31GB"` (we surface only
         //     the first number)
         //   - `pids`: string or integer
-        // Missing/transitional fields are surfaced as `None` rather than
-        // failing the call — see `parse_size_first` for the `"-- / --"`
-        // placeholder podman emits while a container is mid-state.
+        //
+        // We distinguish two cases on each field:
+        //   1. **Absent / null** — `Ok(None)` on the matching `Stats`
+        //      field. Podman omits fields for containers in transitional
+        //      states (just-created, exited), and the `"-- / --"`
+        //      placeholder for `mem_usage` is a documented podman convention
+        //      we treat the same way.
+        //   2. **Present but unparseable** — `Err(OciError::InvalidJson)`.
+        //      Surfacing the error means version-skew or schema drift in
+        //      podman bubbles up to the caller instead of being silently
+        //      reported as "metric missing", which previously hid genuine
+        //      breakage behind a `None` that looks identical to "container
+        //      starting up".
         let parsed: serde_json::Value =
             serde_json::from_slice(raw).map_err(|source| OciError::InvalidJson {
                 tool: PODMAN,
@@ -413,21 +447,125 @@ impl ContainerRuntime for PodmanRuntime {
             .unwrap_or(serde_json::Value::Null);
 
         Ok(Stats {
-            cpu_percent: entry
-                .get("cpu_percent")
-                .and_then(|v| v.as_str())
-                .and_then(parse_percent),
-            memory_bytes: entry
-                .get("mem_usage")
-                .and_then(|v| v.as_str())
-                .and_then(parse_size_first),
-            pids: entry.get("pids").and_then(|v| match v {
-                serde_json::Value::String(s) => s.parse().ok(),
-                serde_json::Value::Number(n) => n.as_u64(),
-                _ => None,
-            }),
+            cpu_percent: parse_optional_field(&entry, "cpu_percent", parse_cpu_percent_field)?,
+            memory_bytes: parse_optional_field(&entry, "mem_usage", parse_mem_usage_field)?,
+            pids: parse_optional_field(&entry, "pids", parse_pids_field)?,
         })
     }
+}
+
+/// Read an optional Stats field. Absent / `null` → `Ok(None)`. Present
+/// → delegate to `parser`, which returns `Ok(Some(_))` for a successful
+/// parse, `Ok(None)` for a documented placeholder podman emits while a
+/// container is mid-state, and `Err(reason)` for anything else (schema
+/// drift, version skew). The `Err` path is wrapped in the same
+/// [`OciError::InvalidJson`] variant the surrounding `parse_stats` uses
+/// so callers get one typed error covering both "blob is not JSON" and
+/// "blob is JSON but doesn't match the podman stats schema".
+fn parse_optional_field<T>(
+    entry: &serde_json::Value,
+    field: &'static str,
+    parser: impl FnOnce(&serde_json::Value) -> Result<Option<T>, String>,
+) -> Result<Option<T>, OciError> {
+    let value = match entry.get(field) {
+        None => return Ok(None),
+        Some(serde_json::Value::Null) => return Ok(None),
+        Some(v) => v,
+    };
+    parser(value).map_err(|reason| OciError::InvalidJson {
+        tool: PODMAN,
+        subcommand: "stats",
+        source: <serde_json::Error as serde::de::Error>::custom(format!(
+            "stats field {field:?}: {reason}"
+        )),
+    })
+}
+
+fn parse_cpu_percent_field(v: &serde_json::Value) -> Result<Option<f64>, String> {
+    let Some(s) = v.as_str() else {
+        return Err(format!("expected string, got {v}"));
+    };
+    parse_percent(s).map(Some).ok_or_else(|| {
+        format!("could not parse {s:?} as a podman percent string (expected e.g. \"1.35%\")")
+    })
+}
+
+fn parse_mem_usage_field(v: &serde_json::Value) -> Result<Option<u64>, String> {
+    let Some(s) = v.as_str() else {
+        return Err(format!("expected string, got {v}"));
+    };
+    // Podman emits `"-- / --"` for containers mid-transition. That is
+    // a documented placeholder, not a schema drift — keep it as
+    // `Ok(None)` so callers see "metric missing" rather than an error
+    // every time they sample a just-created container.
+    if s.trim() == "-- / --" {
+        return Ok(None);
+    }
+    parse_size_first(s).map(Some).ok_or_else(|| {
+        format!("could not parse {s:?} as a podman mem_usage string (expected e.g. \"178.3MB / 67.31GB\")")
+    })
+}
+
+fn parse_pids_field(v: &serde_json::Value) -> Result<Option<u64>, String> {
+    match v {
+        serde_json::Value::String(s) => s
+            .parse::<u64>()
+            .map(Some)
+            .map_err(|e| format!("could not parse pids string {s:?} as u64: {e}")),
+        serde_json::Value::Number(n) => n
+            .as_u64()
+            .map(Some)
+            .ok_or_else(|| format!("pids number {n} is not a non-negative u64")),
+        other => Err(format!(
+            "expected string or non-negative number, got {other}"
+        )),
+    }
+}
+
+/// Extract the `host.security.rootless` boolean from a `podman info --format
+/// json` payload with explicit type checks at each step.
+///
+/// Returns `Err(reason)` if any intermediate node is missing or the wrong
+/// shape so the caller can surface a typed `InvalidJson` error. A previous
+/// `and_then` chain collapsed every malformed-shape case into "rootless =
+/// false" via `unwrap_or(false)`, which masked schema drift behind the
+/// existing `RootlessUnavailable` error.
+fn extract_rootless(parsed: &serde_json::Value) -> Result<bool, String> {
+    let Some(host) = parsed.get("host") else {
+        return Err("podman info: missing top-level `host` object".to_string());
+    };
+    if !host.is_object() {
+        return Err(format!(
+            "podman info: expected `host` to be an object, got {host}"
+        ));
+    }
+    let Some(security) = host.get("security") else {
+        return Err("podman info: missing `host.security` object".to_string());
+    };
+    if !security.is_object() {
+        return Err(format!(
+            "podman info: expected `host.security` to be an object, got {security}"
+        ));
+    }
+    let Some(rootless) = security.get("rootless") else {
+        return Err("podman info: missing `host.security.rootless` field".to_string());
+    };
+    rootless.as_bool().ok_or_else(|| {
+        format!("podman info: expected `host.security.rootless` to be a boolean, got {rootless}")
+    })
+}
+
+/// Validate a podman container id from `podman create` stdout. Real
+/// podman emits exactly 64 lowercase hex characters (the truncated form
+/// `--format '{{.ID}}'` would surface 12 chars, but our argv passes no
+/// such flag — we get the full form). Anything else is a schema-drift
+/// or wrapper signal; reject so callers see a typed error rather than
+/// a downstream `start` / `exec` / `rm` failure against a bogus id.
+fn is_valid_container_id(id: &str) -> bool {
+    id.len() == 64
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
 #[async_trait]
@@ -504,12 +642,18 @@ impl ContainerLogs for PodmanRuntime {
 
 /// Parse one `podman logs --timestamps` line into a [`LogLine`]. Podman's
 /// timestamp prefix is RFC-3339 followed by a single space; everything
-/// after the first space is the original line text. Lines without a
-/// recognisable timestamp prefix are returned with `timestamp = None` so
-/// the caller never silently drops them.
+/// after the first space is the original line text.
+///
+/// The first whitespace-delimited token is validated against strict
+/// RFC-3339 via [`chrono::DateTime::parse_from_rfc3339`]. If the token
+/// is not a valid RFC-3339 timestamp the entire `raw` line is returned
+/// as the log message with `timestamp = None` — the previous heuristic
+/// (`contains('T') && contains('-')`) would silently misparse any line
+/// whose first word happened to contain both characters (e.g. a path
+/// like `/etc/foo-bar.conf T=1`) and strip the first token.
 fn parse_podman_log_line(stream: &str, raw: &str) -> LogLine {
     if let Some((maybe_ts, rest)) = raw.split_once(' ') {
-        if maybe_ts.contains('T') && maybe_ts.contains('-') {
+        if chrono::DateTime::parse_from_rfc3339(maybe_ts).is_ok() {
             return LogLine {
                 stream: stream.to_string(),
                 line: rest.to_string(),
@@ -693,7 +837,10 @@ mod tests {
     #[tokio::test]
     async fn create_returns_handle_from_stdout() {
         let runner = RecordingRunner::new();
-        runner.push(StubResponse::ok_stdout(b"abc1234deadbeef\n".to_vec()));
+        // Podman emits a 64-char lowercase hex container id. The
+        // post-`create` validator requires this exact shape.
+        let id_bytes = format!("{SHA}\n");
+        runner.push(StubResponse::ok_stdout(id_bytes.into_bytes()));
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
@@ -702,7 +849,7 @@ mod tests {
             .create(&img, &["echo", "hi"], &SecurityOpts::permissive())
             .await
             .unwrap();
-        assert_eq!(h.id, "abc1234deadbeef");
+        assert_eq!(h.id, SHA);
 
         let calls = calls.lock().unwrap();
         // SecurityOpts::permissive emits zero flags, keeping the
@@ -729,7 +876,8 @@ mod tests {
         // `create_does_not_apply_caller_flags_as_runtime_flags`; this unit
         // test pins the *positional* invariant the safety story rests on.
         let runner = RecordingRunner::new();
-        runner.push(StubResponse::ok_stdout(b"abc1234\n".to_vec()));
+        let id_bytes = format!("{SHA}\n");
+        runner.push(StubResponse::ok_stdout(id_bytes.into_bytes()));
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
@@ -1345,7 +1493,7 @@ mod tests {
         // the IMAGE positional, where podman would treat it as the
         // in-container command) fails the test loudly.
         let runner = RecordingRunner::new();
-        runner.push(StubResponse::ok_stdout(b"abc1234\n".to_vec()));
+        runner.push(StubResponse::ok_stdout(format!("{SHA}\n").into_bytes()));
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
@@ -1396,7 +1544,7 @@ mod tests {
         // through review. The order is documented on
         // `SecurityOpts::to_create_flags`.
         let runner = RecordingRunner::new();
-        runner.push(StubResponse::ok_stdout(b"abc1234\n".to_vec()));
+        runner.push(StubResponse::ok_stdout(format!("{SHA}\n").into_bytes()));
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
@@ -1451,7 +1599,7 @@ mod tests {
         // SecurityOpts::permissive expects a clean argv with no
         // hardening flags interleaved.
         let runner = RecordingRunner::new();
-        runner.push(StubResponse::ok_stdout(b"abc1234\n".to_vec()));
+        runner.push(StubResponse::ok_stdout(format!("{SHA}\n").into_bytes()));
         let calls = runner.calls.clone();
 
         let runtime = rt(runner);
@@ -1478,5 +1626,331 @@ mod tests {
         assert_eq!(l.stream, "stderr");
         assert_eq!(l.line, "plain output");
         assert_eq!(l.timestamp, None);
+    }
+
+    // ── #702: strict RFC-3339 in parse_podman_log_line ───────────────
+
+    #[test]
+    fn parse_podman_log_line_rejects_non_rfc3339_first_token() {
+        // The old heuristic accepted any first token containing both
+        // 'T' and '-', so a path like `/etc/foo-bar.conf` followed by
+        // text was misread as a timestamp and the rest of the line was
+        // silently truncated. With strict RFC-3339 the whole line is
+        // preserved as the message.
+        let l = parse_podman_log_line("stdout", "/etc/foo-bar.conf T=1 some message");
+        assert_eq!(l.stream, "stdout");
+        assert_eq!(l.line, "/etc/foo-bar.conf T=1 some message");
+        assert_eq!(l.timestamp, None);
+    }
+
+    #[test]
+    fn parse_podman_log_line_accepts_real_rfc3339_with_offset() {
+        // RFC-3339 admits both 'Z' and explicit offsets — both must
+        // parse cleanly so podman emissions across host TZs round-trip.
+        let l = parse_podman_log_line("stdout", "2025-04-26T10:00:00+02:00 hello");
+        assert_eq!(l.line, "hello");
+        assert_eq!(l.timestamp.as_deref(), Some("2025-04-26T10:00:00+02:00"));
+    }
+
+    #[test]
+    fn parse_podman_log_line_treats_almost_rfc3339_as_message() {
+        // Looks similar to RFC-3339 (has 'T' and '-') but is missing
+        // the timezone — chrono::parse_from_rfc3339 rejects this, so
+        // the whole token is treated as part of the message.
+        let l = parse_podman_log_line("stdout", "2025-04-26T10:00:00 hello");
+        assert_eq!(l.line, "2025-04-26T10:00:00 hello");
+        assert_eq!(l.timestamp, None);
+    }
+
+    // ── #702: type-checked detect JSON drill-down ────────────────────
+
+    #[tokio::test]
+    async fn detect_reports_invalid_json_when_host_is_wrong_type() {
+        // `host` is a string instead of an object. The old `.and_then`
+        // chain swallowed this and collapsed to `rootless=false`,
+        // surfacing as a misleading `RootlessUnavailable`. The new code
+        // surfaces it as `InvalidJson` — schema drift, not "rootless
+        // off".
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"podman version 5.0\n".to_vec()));
+        runner.push(StubResponse::ok_stdout(
+            br#"{"host":"not an object"}"#.to_vec(),
+        ));
+        let err = rt(runner).detect().await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                OciError::InvalidJson {
+                    tool: "podman",
+                    subcommand: "info",
+                    ..
+                }
+            ),
+            "expected InvalidJson, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn detect_reports_invalid_json_when_security_is_wrong_type() {
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"podman version 5.0\n".to_vec()));
+        runner.push(StubResponse::ok_stdout(
+            br#"{"host":{"security":["unexpected","array"]}}"#.to_vec(),
+        ));
+        let err = rt(runner).detect().await.unwrap_err();
+        assert!(matches!(
+            err,
+            OciError::InvalidJson {
+                tool: "podman",
+                subcommand: "info",
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn detect_reports_invalid_json_when_rootless_is_not_bool() {
+        // `rootless` is a string, not a boolean — the old code
+        // collapsed this to `false` and reported `RootlessUnavailable`.
+        // The new code reports schema drift.
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"podman version 5.0\n".to_vec()));
+        runner.push(StubResponse::ok_stdout(
+            br#"{"host":{"security":{"rootless":"true"}}}"#.to_vec(),
+        ));
+        let err = rt(runner).detect().await.unwrap_err();
+        assert!(matches!(
+            err,
+            OciError::InvalidJson {
+                tool: "podman",
+                subcommand: "info",
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn detect_reports_invalid_json_when_rootless_key_absent() {
+        // The key is structurally missing entirely. This is also schema
+        // drift relative to the documented podman `info` payload, so
+        // surface it as InvalidJson rather than silently collapsing to
+        // "rootless unavailable".
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"podman version 5.0\n".to_vec()));
+        runner.push(StubResponse::ok_stdout(
+            br#"{"host":{"security":{}}}"#.to_vec(),
+        ));
+        let err = rt(runner).detect().await.unwrap_err();
+        assert!(matches!(
+            err,
+            OciError::InvalidJson {
+                tool: "podman",
+                subcommand: "info",
+                ..
+            }
+        ));
+    }
+
+    // ── #702: container ID format validation in `create` ─────────────
+
+    #[test]
+    fn is_valid_container_id_accepts_64_char_lowercase_hex() {
+        // 64 lowercase hex chars — what real podman emits.
+        assert!(is_valid_container_id(SHA));
+    }
+
+    #[test]
+    fn is_valid_container_id_rejects_short_id() {
+        assert!(!is_valid_container_id("abc1234"));
+        // Truncated 12-char form podman would emit with --format '{{.ID}}'
+        // (we don't pass that flag, so we reject it here defensively).
+        assert!(!is_valid_container_id("abc1234deadbe"));
+    }
+
+    #[test]
+    fn is_valid_container_id_rejects_uppercase_hex() {
+        // Podman's container ids are lowercase. An uppercase id is a
+        // wrapper / parsing artefact, not real podman output.
+        let upper: String = SHA.chars().map(|c| c.to_ascii_uppercase()).collect();
+        assert!(!is_valid_container_id(&upper));
+    }
+
+    #[test]
+    fn is_valid_container_id_rejects_non_hex_chars() {
+        // 64 chars but contains a non-hex character.
+        let mut bad = String::from(SHA);
+        bad.replace_range(0..1, "g");
+        assert_eq!(bad.len(), 64);
+        assert!(!is_valid_container_id(&bad));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_malformed_container_id_from_podman_stdout() {
+        // `podman create` returned a short / non-hex id. The new
+        // validator must surface this as CommandFailed rather than
+        // hand it back as a usable handle that would then misbehave
+        // in `start` / `exec` / `rm`.
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(b"not-a-container-id\n".to_vec()));
+        let runtime = rt(runner);
+        let img = alpine_pinned();
+        let err = runtime
+            .create(&img, &["sh"], &SecurityOpts::permissive())
+            .await
+            .unwrap_err();
+        match err {
+            OciError::CommandFailed { stderr, .. } => {
+                assert!(
+                    stderr.contains("malformed container id"),
+                    "expected malformed-id message, got {stderr:?}"
+                );
+            }
+            other => panic!("expected CommandFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_container_id_with_uppercase_hex() {
+        // 64 chars but uppercase — defensive rejection so wrapper /
+        // schema-drift sources surface immediately.
+        let upper_id: String = SHA.chars().map(|c| c.to_ascii_uppercase()).collect();
+        let runner = RecordingRunner::new();
+        runner.push(StubResponse::ok_stdout(
+            format!("{upper_id}\n").into_bytes(),
+        ));
+        let runtime = rt(runner);
+        let img = alpine_pinned();
+        let err = runtime
+            .create(&img, &["sh"], &SecurityOpts::permissive())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OciError::CommandFailed { .. }));
+    }
+
+    // ── #702: Stats parsing — Err vs absent ──────────────────────────
+
+    #[test]
+    fn parse_stats_returns_none_for_absent_fields() {
+        // Container is mid-transition: podman emits the entry with no
+        // metrics yet. `None` is the correct surface — caller renders
+        // "metric pending" rather than "metric broken".
+        let runtime = PodmanRuntime::new();
+        let stats = runtime.parse_stats(b"[{\"id\":\"xyz\"}]").unwrap();
+        assert_eq!(stats.cpu_percent, None);
+        assert_eq!(stats.memory_bytes, None);
+        assert_eq!(stats.pids, None);
+    }
+
+    #[test]
+    fn parse_stats_returns_none_for_explicit_null_fields() {
+        // Same shape as "absent", but the field is present with `null`.
+        // Podman has emitted both forms across versions; both are the
+        // documented "no data yet" signal, not an error.
+        let runtime = PodmanRuntime::new();
+        let stats = runtime
+            .parse_stats(br#"[{"cpu_percent":null,"mem_usage":null,"pids":null}]"#)
+            .unwrap();
+        assert_eq!(stats.cpu_percent, None);
+        assert_eq!(stats.memory_bytes, None);
+        assert_eq!(stats.pids, None);
+    }
+
+    #[test]
+    fn parse_stats_treats_mem_usage_placeholder_as_none() {
+        // Documented podman placeholder for mid-state containers.
+        // Predates this change; preserved so the dashboards continue to
+        // render "metric pending" instead of an error every time a
+        // container is just-starting.
+        let runtime = PodmanRuntime::new();
+        let stats = runtime
+            .parse_stats(br#"[{"mem_usage":"-- / --"}]"#)
+            .unwrap();
+        assert_eq!(stats.memory_bytes, None);
+    }
+
+    #[test]
+    fn parse_stats_errors_on_unparseable_cpu_percent_string() {
+        // Field is present but unparseable — schema drift, not "no
+        // data". The old code returned `None` here, masking the drift.
+        let runtime = PodmanRuntime::new();
+        let err = runtime
+            .parse_stats(br#"[{"cpu_percent":"banana"}]"#)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OciError::InvalidJson {
+                tool: "podman",
+                subcommand: "stats",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_stats_errors_on_cpu_percent_wrong_type() {
+        // Field is the wrong JSON type entirely (number instead of
+        // string). Surface as a typed error so the caller can log /
+        // alert on schema skew rather than silently dropping a metric.
+        let runtime = PodmanRuntime::new();
+        let err = runtime
+            .parse_stats(br#"[{"cpu_percent":1.35}]"#)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OciError::InvalidJson {
+                tool: "podman",
+                subcommand: "stats",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_stats_errors_on_unparseable_mem_usage_string() {
+        // String shape diverges from `"178.3MB / 67.31GB"` and is not
+        // the `"-- / --"` placeholder — schema drift.
+        let runtime = PodmanRuntime::new();
+        let err = runtime
+            .parse_stats(br#"[{"mem_usage":"definitely not a size"}]"#)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OciError::InvalidJson {
+                tool: "podman",
+                subcommand: "stats",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_stats_errors_on_unparseable_pids_string() {
+        let runtime = PodmanRuntime::new();
+        let err = runtime
+            .parse_stats(br#"[{"pids":"not a number"}]"#)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OciError::InvalidJson {
+                tool: "podman",
+                subcommand: "stats",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_stats_errors_on_pids_wrong_type() {
+        // pids as an array — wrong type entirely.
+        let runtime = PodmanRuntime::new();
+        let err = runtime.parse_stats(br#"[{"pids":[1,2]}]"#).unwrap_err();
+        assert!(matches!(
+            err,
+            OciError::InvalidJson {
+                tool: "podman",
+                subcommand: "stats",
+                ..
+            }
+        ));
     }
 }

--- a/crates/forge-session/src/sandbox/level2.rs
+++ b/crates/forge-session/src/sandbox/level2.rs
@@ -40,6 +40,7 @@
 //! those handles. The `Arc` carries the same dyn-trait surface area and is
 //! cheaper than re-detecting / re-warming per step.
 
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -54,17 +55,76 @@ use forge_oci::{ContainerHandle, ContainerRuntime, ImageRef, OciError, SecurityO
 /// strict preset (2 cpus, 4 GiB, 1024 pids, no swap).
 pub use forge_oci::ContainerLimits;
 
-/// Binary used by [`Level2Session::drop`]'s panic-safety net to reap
-/// a leaked container. Hardcoded because the only `ContainerRuntime`
-/// impl in the workspace today is `PodmanRuntime`; if a second
-/// implementation is added the safety net would need a small
-/// abstraction (e.g. each impl supplies its own teardown argv).
+/// Binary name used by [`Level2Session::drop`]'s panic-safety net to
+/// reap a leaked container. Hardcoded because the only
+/// `ContainerRuntime` impl in the workspace today is `PodmanRuntime`;
+/// if a second implementation is added the safety net would need a
+/// small abstraction (e.g. each impl supplies its own teardown argv).
+///
+/// The bare name is only used to *resolve* the absolute path at
+/// session-creation time via [`resolve_drop_cleanup_binary`]. The
+/// resolved [`PathBuf`] is stored on the session and used by
+/// [`Level2Session::drop`]; the unwind path never re-walks `PATH`,
+/// which protects the cleanup from a `PATH` mutation, working-
+/// directory change, or sandbox-induced PATH scrub between session
+/// creation and drop.
 ///
 /// TODO(F-682, issue #718): refactor into a per-impl shutdown command
 /// when the second container runtime lands. Tracker explicitly defers
 /// the change until then — adding the abstraction now would be
 /// speculative scaffolding with one consumer.
 const DROP_CLEANUP_BINARY: &str = "podman";
+
+/// Walk `PATH` once and return the absolute path of the
+/// `DROP_CLEANUP_BINARY`. Symlinks are *not* canonicalised — we want
+/// the same binary the rest of the host invokes via PATH lookup, even
+/// if it lives behind `/usr/bin/podman -> /usr/local/bin/podman`.
+///
+/// Returns `None` if `PATH` is unset, empty, or does not contain a
+/// regular file with the binary name. Callers fall back to a
+/// PATH-relative spawn in that case and log a warning — the host is
+/// already in an unusual state if we get here, but Drop is best-effort
+/// and we should not panic in the unwind path.
+fn resolve_drop_cleanup_binary() -> Option<PathBuf> {
+    resolve_on_path(DROP_CLEANUP_BINARY)
+}
+
+/// Tiny dep-free PATH walker. Returns the first entry whose
+/// `{entry}/{binary}` is a regular file. Mirrors how
+/// `std::process::Command::new("podman")` resolves `podman` at spawn
+/// time, but captures the result eagerly so a subsequent `PATH`
+/// mutation cannot change which binary is chosen.
+fn resolve_on_path(binary: &str) -> Option<PathBuf> {
+    // Reject paths that already look absolute or contain a path
+    // separator — those would either bypass PATH lookup (so we have
+    // nothing to resolve) or attempt to escape the lookup, neither of
+    // which fits the "find a bare command name" contract.
+    if binary.is_empty() || binary.contains('/') {
+        return None;
+    }
+    let path_var = std::env::var_os("PATH")?;
+    for entry in std::env::split_paths(&path_var) {
+        if entry.as_os_str().is_empty() {
+            continue;
+        }
+        let candidate = entry.join(binary);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    // We only need a "the binary exists and is regular" predicate —
+    // `std::process::Command::spawn` will surface the precise reason
+    // (mode bits, ENOEXEC, etc.) if it fails. Symlinks resolve through
+    // `metadata` (not `symlink_metadata`) so a typical `/usr/bin/podman
+    // -> /usr/local/bin/podman` arrangement is accepted.
+    std::fs::metadata(path)
+        .map(|m| m.is_file())
+        .unwrap_or(false)
+}
 
 /// Render [`ContainerLimits`] into the argv fragment that would be
 /// inserted between `podman create` and the IMAGE positional.
@@ -156,6 +216,15 @@ pub struct Level2Session {
     image: ImageRef,
     handle: ContainerHandle,
     limits: ContainerLimits,
+    /// Absolute path of the cleanup binary, resolved once at
+    /// [`Self::create`] time. [`Self::drop`] uses this verbatim so
+    /// the unwind path never re-walks `PATH` — a `PATH` mutation, CWD
+    /// change, or sandbox-imposed environment scrub between session
+    /// creation and drop cannot redirect the cleanup at a different
+    /// `podman` binary (or, worse, leave it unresolvable). `None`
+    /// when no `podman` was found on `PATH` at create time; Drop then
+    /// falls back to the bare-name spawn and logs a warning.
+    cleanup_binary: Option<PathBuf>,
     /// Set by [`Level2Session::teardown`]; checked by
     /// [`Level2Session::drop`] so an explicit clean shutdown skips the
     /// `podman rm -f` panic-safety fire-and-forget.
@@ -223,11 +292,27 @@ impl Level2Session {
             }
             return Err(start_err);
         }
+        // Resolve `podman` once now, while the runtime environment is
+        // still in the shape that successfully ran `pull → create →
+        // start`. Drop must not re-walk PATH at unwind time — that
+        // would race with `PATH` mutations, sandbox env scrubs, or a
+        // CWD change that altered the lookup. We log (not panic) if
+        // resolution fails because Drop is best-effort.
+        let cleanup_binary = resolve_drop_cleanup_binary();
+        if cleanup_binary.is_none() {
+            tracing::warn!(
+                binary = DROP_CLEANUP_BINARY,
+                "Level 2 panic-safety teardown could not resolve absolute path at session \
+                 creation; falling back to PATH-relative spawn at drop time — container leak \
+                 risk if PATH is mutated before drop"
+            );
+        }
         Ok(Self {
             runtime,
             image,
             handle,
             limits: effective_limits,
+            cleanup_binary,
             teardown_done: AtomicBool::new(false),
         })
     }
@@ -328,10 +413,16 @@ impl Drop for Level2Session {
     ///   `teardown_done` and the Drop impl becomes a no-op. The Drop
     ///   path is for the cases where `teardown` could not run
     ///   (panic, early `?`, task cancellation).
-    /// - **Hardcoded `podman`.** Today there is exactly one
-    ///   `ContainerRuntime` impl in the workspace. If a second one
-    ///   ships, this Drop should grow a tiny abstraction (each impl
-    ///   exposing its own teardown argv).
+    /// - **Absolute path resolved at create time.** Spawning by bare
+    ///   binary name re-walks `PATH` at unwind time, which races with
+    ///   `PATH` mutations, sandbox env scrubs, and CWD changes
+    ///   between session creation and drop. We resolve `podman` once
+    ///   in [`Self::create`] and use the captured [`PathBuf`] here so
+    ///   the cleanup is anchored to the binary the rest of the
+    ///   session was running against. If resolution failed at create
+    ///   time we fall back to PATH-relative spawn (preserving the old
+    ///   behaviour) and emit a warning — the same situation that
+    ///   would have failed `runtime.pull` upstream anyway.
     /// - **Errors are swallowed.** A failing `spawn` here would mean
     ///   `podman` is missing or the cleanup couldn't be launched —
     ///   both situations that already imply a leaked container we
@@ -342,7 +433,14 @@ impl Drop for Level2Session {
             return;
         }
         let argv = drop_cleanup_argv(&self.handle);
-        match std::process::Command::new(DROP_CLEANUP_BINARY)
+        // Prefer the absolute path captured at create time; fall back
+        // to the bare name only when resolution failed. Production
+        // callers go through the absolute-path branch.
+        let mut command = match self.cleanup_binary.as_ref() {
+            Some(abs) => std::process::Command::new(abs),
+            None => std::process::Command::new(DROP_CLEANUP_BINARY),
+        };
+        match command
             .args(argv.iter().map(String::as_str))
             // Detach: we are a fire-and-forget guard, not a wait()er.
             .stdin(std::process::Stdio::null())
@@ -359,7 +457,7 @@ impl Drop for Level2Session {
                 tracing::warn!(
                     error = %e,
                     container_id = %self.handle.id,
-                    binary = DROP_CLEANUP_BINARY,
+                    binary = ?self.cleanup_binary.as_deref().unwrap_or_else(|| Path::new(DROP_CLEANUP_BINARY)),
                     "Level 2 panic-safety teardown could not spawn 'podman rm -f'; \
                      container may leak — invoke `podman rm -f <id>` manually"
                 );
@@ -703,6 +801,174 @@ mod tests {
         session.disable_drop_cleanup();
     }
 
+    // ── #702: drop-cleanup binary resolved to absolute path ──────────
+
+    /// Serialize the env-mutation tests below — std::env is process-
+    /// global and cargo runs tests in parallel within a binary by
+    /// default. Without this lock concurrent `set_var("PATH", ...)`
+    /// calls race and the resolve-on-path assertions flake.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn resolve_on_path_finds_binary_in_first_matching_path_entry() {
+        // Place a fake `podman` (an executable file at a known path)
+        // in a temp dir, point `PATH` at that dir, and assert
+        // `resolve_on_path` returns the absolute path. This pins the
+        // "look up PATH at create time" contract independently of
+        // whether a real podman exists on the test host.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        use std::io::Write;
+        let tmp = tempfile::tempdir().unwrap();
+        let binary_path = tmp.path().join("podman");
+        // Empty file is sufficient — `resolve_on_path` checks
+        // existence + regular-file, not executability.
+        let mut f = std::fs::File::create(&binary_path).unwrap();
+        f.write_all(b"").unwrap();
+
+        let prev = std::env::var_os("PATH");
+        std::env::set_var("PATH", tmp.path());
+        let got = resolve_on_path("podman");
+        match prev {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+        assert_eq!(got, Some(binary_path));
+    }
+
+    #[test]
+    fn resolve_on_path_returns_none_when_binary_absent() {
+        // PATH points only at an empty dir. The function must return
+        // `None` rather than panicking or producing a partial path.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("PATH");
+        std::env::set_var("PATH", tmp.path());
+        let got = resolve_on_path("this-binary-does-not-exist-anywhere");
+        match prev {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn resolve_on_path_rejects_inputs_that_contain_a_separator() {
+        // The contract is "find a bare binary name on PATH"; anything
+        // with a `/` is either already absolute or is trying to
+        // escape PATH lookup. Both should short-circuit to None so
+        // the bare-name fallback in Drop is not silently bypassed.
+        assert!(resolve_on_path("/usr/bin/podman").is_none());
+        assert!(resolve_on_path("./podman").is_none());
+        assert!(resolve_on_path("").is_none());
+    }
+
+    // The two async tests below hold the `ENV_LOCK` across an
+    // `.await` because the awaited future (`Level2Session::create`)
+    // reads `PATH` synchronously inside `resolve_drop_cleanup_binary`
+    // and must see the staged value. An async mutex would defeat the
+    // purpose — std::env is process-global, so the lock has to serialise
+    // every test that mutates it, including the awaiting ones. Clippy's
+    // `await_holding_lock` would normally flag this; we silence it
+    // because the lock is test-only and the held duration is short.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn create_resolves_cleanup_binary_to_absolute_path() {
+        // The session must capture an absolute `podman` PathBuf at
+        // create time so Drop is not re-walking PATH at unwind. We
+        // stage a fake `podman` in a temp dir and point PATH at it
+        // for the duration of `create`. The captured path must equal
+        // the staged absolute path.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        use std::io::Write;
+        let tmp = tempfile::tempdir().unwrap();
+        let podman = tmp.path().join("podman");
+        std::fs::File::create(&podman)
+            .unwrap()
+            .write_all(b"")
+            .unwrap();
+
+        let prev_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", tmp.path());
+
+        let mock: Arc<MockRuntime> = Arc::new(MockRuntime::default());
+        let runtime: Arc<dyn ContainerRuntime> = mock.clone();
+        let session = Level2Session::create(runtime, alpine(), ContainerLimits::default())
+            .await
+            .unwrap();
+        // Disarm Drop before restoring PATH so the panic-safety net
+        // (which would now have an absolute path to a fake `podman`)
+        // doesn't spawn against the empty file.
+        session.disable_drop_cleanup();
+        let captured = session.cleanup_binary.clone();
+
+        match prev_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+
+        let captured = captured.expect(
+            "Level2Session::create must resolve `podman` to an absolute path when it is on PATH",
+        );
+        assert_eq!(captured, podman);
+        assert!(
+            captured.is_absolute(),
+            "captured cleanup binary path must be absolute (got {captured:?})"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn drop_path_mutation_does_not_change_cleanup_target() {
+        // The whole point of resolving once at create time: a
+        // PATH mutation between `create` and `drop` must not change
+        // which binary the cleanup spawns. We verify by capturing the
+        // resolved path, mutating PATH to point somewhere else, and
+        // confirming the captured path is unchanged.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        use std::io::Write;
+        let tmp_a = tempfile::tempdir().unwrap();
+        let podman_a = tmp_a.path().join("podman");
+        std::fs::File::create(&podman_a)
+            .unwrap()
+            .write_all(b"")
+            .unwrap();
+
+        let prev_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", tmp_a.path());
+
+        let mock: Arc<MockRuntime> = Arc::new(MockRuntime::default());
+        let runtime: Arc<dyn ContainerRuntime> = mock.clone();
+        let session = Level2Session::create(runtime, alpine(), ContainerLimits::default())
+            .await
+            .unwrap();
+        session.disable_drop_cleanup();
+
+        // After `create`, point PATH at an entirely different dir
+        // that has its own `podman`. The session must still hold the
+        // *original* resolved path.
+        let tmp_b = tempfile::tempdir().unwrap();
+        let podman_b = tmp_b.path().join("podman");
+        std::fs::File::create(&podman_b)
+            .unwrap()
+            .write_all(b"")
+            .unwrap();
+        std::env::set_var("PATH", tmp_b.path());
+
+        let captured = session.cleanup_binary.clone();
+
+        match prev_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+
+        let captured = captured.expect("create must resolve cleanup binary");
+        assert_eq!(
+            captured, podman_a,
+            "cleanup binary must not follow PATH mutations after create"
+        );
+        assert_ne!(captured, podman_b);
+    }
+
     // ── F-655: container leak on start failure ──────────────────────
 
     #[tokio::test]
@@ -1023,8 +1289,15 @@ mod tests {
         let recorder = RecordingRunner::new();
         // pull → empty success
         recorder.push(StubResponse::ok_stdout(b"".to_vec()));
-        // create → returns container id on stdout
-        recorder.push(StubResponse::ok_stdout(b"abc123\n".to_vec()));
+        // create → returns container id on stdout. Must be the 64-char
+        // lowercase hex shape real podman emits; the #702 validator in
+        // `PodmanRuntime::create` rejects anything else with a
+        // CommandFailed.
+        const FAKE_CONTAINER_ID: &str =
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        recorder.push(StubResponse::ok_stdout(
+            format!("{FAKE_CONTAINER_ID}\n").into_bytes(),
+        ));
         // start → empty success
         recorder.push(StubResponse::ok_stdout(b"".to_vec()));
         // exec → stdout + exit 0


### PR DESCRIPTION
Refs forge-ide/forge#702 — tackles five low-severity items from the Phase 3 security-hygiene tracker in a single PR.

## Summary

| Item | File | Behaviour change |
|------|------|------------------|
| 1 | `crates/forge-oci/src/podman.rs` (`parse_podman_log_line`) | Heuristic `contains('T') && contains('-')` replaced with strict `chrono::DateTime::parse_from_rfc3339`. Non-conforming first tokens (e.g. `/etc/foo-bar.conf T=1`) keep the full raw line as the message instead of silently truncating. |
| 2 | `crates/forge-oci/src/podman.rs` (`PodmanRuntime::detect`) | `.and_then` chain replaced with explicit `is_object` / `is_bool` drill-down. Malformed `podman info` payloads now surface as `OciError::InvalidJson` instead of collapsing to `RootlessUnavailable`. |
| 3 | `crates/forge-oci/src/podman.rs` (`PodmanRuntime::create`) | Container id from podman stdout validated as 64-char lowercase hex; anything else returns `OciError::CommandFailed` with a descriptive stderr so corrupt output cannot reach `start` / `exec` / `rm`. |
| 4 | `crates/forge-oci/src/podman.rs` (`PodmanRuntime::parse_stats`) | "Field absent / null / `-- / --` placeholder" → `Ok(None)`; "field present but unparseable" → `Err(OciError::InvalidJson)`. Schema drift no longer hides behind a `None` indistinguishable from "container starting up". |
| 5 | `crates/forge-session/src/sandbox/level2.rs` (`Level2Session::drop`) | Cleanup binary's absolute path resolved once at session creation via a small dep-free PATH walker and stored on the session. Drop spawns the captured `PathBuf`, not the bare `podman` name, so PATH mutations / sandbox env scrubs / CWD changes between create and unwind cannot redirect or break the cleanup. |

Adds `chrono = { version = \"0.4\", default-features = false, features = [\"std\"] }` to `forge-oci`. No new dep for the PATH walker.

## Test plan

- `cargo test --workspace` passes (all-features as well)
- `cargo clippy --all-targets -- -D warnings` passes
- `just check-rust` passes (includes `RUSTDOCFLAGS=-D warnings cargo doc`)
- New unit coverage in both crates:
  - `parse_podman_log_line_rejects_non_rfc3339_first_token`, `parse_podman_log_line_accepts_real_rfc3339_with_offset`, `parse_podman_log_line_treats_almost_rfc3339_as_message`
  - `detect_reports_invalid_json_when_host_is_wrong_type`, `..._security_is_wrong_type`, `..._rootless_is_not_bool`, `..._rootless_key_absent`
  - `is_valid_container_id_*` (4 cases) + `create_rejects_malformed_container_id_from_podman_stdout`, `create_rejects_container_id_with_uppercase_hex`
  - `parse_stats_returns_none_for_absent_fields`, `..._explicit_null_fields`, `..._mem_usage_placeholder_as_none`, `parse_stats_errors_on_unparseable_cpu_percent_string`, `..._cpu_percent_wrong_type`, `..._unparseable_mem_usage_string`, `..._unparseable_pids_string`, `..._pids_wrong_type`
  - `resolve_on_path_finds_binary_in_first_matching_path_entry`, `..._returns_none_when_binary_absent`, `..._rejects_inputs_that_contain_a_separator`, `create_resolves_cleanup_binary_to_absolute_path`, `drop_path_mutation_does_not_change_cleanup_target`
- Existing tests that synthesised short container ids (`abc123`, `abc1234`, `abc1234deadbeef`) updated to use realistic 64-char lowercase hex so they exercise the new validator's accept path.

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)