### PR TITLE
[Phase 3.1] Group A: V1 UI spec foundations

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -396,3 +396,88 @@ All component values resolve to the tokens declared in the YAML frontmatter and 
 - **Don't** reduce opacity to indicate disabled state on interactive elements, and don't use the same color for text and background.
 - **Do** maintain WCAG AA contrast (4.5:1) for body text.
 - **Don't** drop below AA for any surface other than the status bar (the documented exception).
+
+## Layout primitives
+
+V1 dashboard primitives. Each primitive resolves to the tokens in `web/packages/design/src/tokens.css`; component CSS references them via `var(--token)`, never raw values.
+
+### Layout grid
+
+A 12-column grid drives the dashboard body. Columns are equal fractions of the container; gutters and side padding are token-driven so card edges align with hero padding above.
+
+- **Track:** `grid-template-columns: repeat(12, 1fr)`
+- **Gap:** `var(--sp-4)` between cells, `var(--sp-6)` between row stacks
+- **Outer padding:** `var(--sp-6) var(--sp-8)` (vertical / horizontal)
+- **Span helpers:** `col-4`, `col-6`, `col-8`, `col-12` map to `grid-column: span N`
+
+V1 card layouts use `col-8 / col-4` for the primary row (Sessions / Providers), `col-6 / col-6` for the secondary row (Usage / Workspace toggles), and `col-12` for full-bleed rows (Containers). Sub-12 widths require an ADR.
+
+### Hero block
+
+The dashboard header. A two-column grid: headline + status sentence on the left, dual CTAs on the right, aligned to the baseline.
+
+- **Container:** `padding: var(--sp-8)`, bottom border `1px solid var(--color-border-1)`
+- **Track:** `grid-template-columns: 1fr auto`, `gap: var(--sp-6)`, `align-items: end`
+- **Headline:** `font-family: var(--font-display)`, weight 800, uppercase, `letter-spacing: 0.02em`, `line-height: 0.95`. Inline `<em>` keeps the brand word in `var(--color-ember-400)` with `font-style: normal`. <!-- TODO: add token --type-display-hero (40px) -->
+- **Status sentence:** `font-family: var(--font-body)`, `color: var(--color-text-secondary)`, `max-width: 560px`, `margin-top: var(--sp-3)` <!-- TODO: add token --type-body-hero (15px) -->
+- **CTA cluster:** `display: flex`, `gap: var(--sp-2)`. Exactly two actions — a ghost secondary (e.g. "Attach to session") and an ember primary (e.g. "New session"). Primary always trails so it lands at the right edge.
+
+### KPI tile
+
+A metric card: label, large value with optional unit, and a delta line. Used in the Usage card on the dashboard and in the Usage view header row.
+
+- **Container:** `background: var(--color-surface-2)`, `border: 1px solid var(--color-border-1)`, `border-radius: var(--r-lg)`, `padding: var(--sp-5)`, `position: relative`
+- **Accent rail:** a `48px × 2px` strip pinned to the top-left corner via `::before`, colored by variant:
+  - default → `var(--color-ember-400)`
+  - `ok` → `var(--color-success)`
+  - `warn` → `var(--color-warning)`
+  - `info` → `var(--color-info)`
+- **Label:** `font-family: var(--font-mono)`, `font-size: var(--type-mono-xs)`, `color: var(--color-text-secondary)`, uppercase, `letter-spacing: 0.22em`
+- **Value:** `font-family: var(--font-display)`, weight 800, `letter-spacing: 0.02em`, `margin-top: var(--sp-2)`. Inline `<small>` unit reverts to `var(--font-mono)`, `var(--color-text-secondary)`. <!-- TODO: add token --type-display-kpi (34px) and --type-display-kpi-unit (16px) -->
+- **Delta:** `font-family: var(--font-mono)`, `font-size: var(--type-mono-sm)`, `margin-top: var(--sp-2)`. Direction colors the row — `delta.up` (more spend/tokens) → `var(--color-warning)`; `delta.dn` (less spend, more output) → `var(--color-success)`.
+
+### Spark chart
+
+A 7-day micro-trend rendered inline in the Usage card. Inline SVG, no axes, no labels — context comes from the surrounding KPI numbers.
+
+- **Container:** `height: 60px`, `padding: 0 var(--sp-4) var(--sp-4)`; SVG fills the box with `preserveAspectRatio="none"`
+- **viewBox:** `0 0 320 60`
+- **Line:** `stroke: var(--color-ember-400)`, `stroke-width: 1.5`, `fill: none`
+- **Area fill:** vertical `linearGradient` from `var(--color-ember-400)` at 35% alpha to 0% alpha — declared as a stop with `stop-color="#ff4a12"` because SVG `stop-color` does not accept CSS custom properties in V1 <!-- TODO: add token --color-ember-400-rgb so the gradient can be expressed as rgba(var(--color-ember-400-rgb), 0.35) -->
+- **Day dots:** `circle r="2"` filled with `var(--color-ember-400)`, one per data point. The latest point uses `r="2.5"` and a `1px` white stroke to read as the current day.
+
+### Toggle switch
+
+A binary control used in row lists (workspace toggles on Skills / MCP / Agents). On/off is the only state; in-between (loading) is communicated by the parent row's status chip, not the toggle.
+
+- **Track:** `28px × 16px`, `border-radius: 8px`, `background: var(--color-border-1)` (off) / `var(--color-ember-900)` (on) <!-- TODO: add token --sp-toggle-track-w (28px), --sp-toggle-track-h (16px) -->
+- **Thumb:** `12px × 12px` circle, `top: 2px`, `left: 2px` → `14px` when on. Background: `var(--color-text-tertiary)` (off) / `var(--color-ember-400)` (on) <!-- TODO: add token --sp-toggle-thumb (12px) -->
+- **Transition:** `transition: all var(--ease)` on both track background and thumb position
+- **Hit target:** the parent row, not the 28px track — toggle is a visual indicator of a row-level affordance
+
+### Status pill
+
+A compact state label used in session rows, provider cards, and the chat composer. Variant binds the foreground color; the background stays transparent so the pill reads as inline metadata, not as a chip.
+
+- **Typography:** `font-family: var(--font-mono)`, `font-size: var(--type-mono-xxs)`, `letter-spacing: 0.06em`, lowercase
+- **Layout:** `display: flex`, `align-items: center`, `gap: var(--sp-2)`. A leading `6px` `border-radius: 50%` pulse dot inherits color from the pill (`background: currentColor`); the dot animates with the shared `pulse` keyframes (1.6s, 1 → 0.4 → 1 opacity) when the variant is live.
+- **Variants:**
+  - `streaming` → `var(--color-ember-200)` (amber), animated dot
+  - `awaiting approval` → `var(--color-warning)`, animated dot
+  - `done` → `var(--color-success)`, static dot
+  - `idle` → `var(--color-text-secondary)`, no dot
+  - `ready` → `var(--color-success)` with the live-dot glow (`box-shadow: 0 0 6px rgba(61, 220, 132, 0.5)`)
+  - `auth` → `var(--color-error)` with the error live-dot glow (`box-shadow: 0 0 6px rgba(255, 74, 18, 0.5)`)
+
+The glow on `ready` / `auth` reuses the system's single network-connectivity glow rule — no new glow tokens.
+
+### Status bar
+
+The strip pinned to the bottom of every shell view. Always Ember 400, always 22px tall — the documented brand-exception surface.
+
+- **Container:** `height: 22px`, `flex-shrink: 0`, `display: flex`, `align-items: center`, `padding: 0 var(--sp-3)`, `gap: var(--sp-4)`, `background: var(--color-ember-400)`, `color: var(--color-text-inverted)`
+- **Typography:** `font-family: var(--font-mono)`, `font-size: var(--type-mono-xxs)`, `letter-spacing: 0.05em`
+- **Slots:** left slot owns the Forge mark, branch, session count, active provider, and streaming state; right slot is `margin-left: auto` and owns the cost meter, range, and container status
+- **Separator:** literal `·` dot at `opacity: 0.5` between adjacent groups; group-internal items use `gap: var(--sp-2)`
+- **Live dot:** `6px × 6px` circle, `background: var(--color-text-inverted)`, `opacity: 0.9`, sits next to the streaming label — never glows on this surface (glow is reserved for elevated MCP indicators)
+- **Agent badges:** when present, render on a solid `var(--color-surface-2)` chip with `border-radius: 10px` (`pill`) so they clear WCAG AA against the Ember background independently of the bar exception

--- a/docs/design/component-principles.md
+++ b/docs/design/component-principles.md
@@ -49,3 +49,15 @@ The ember-400 × white pairing computes to ~3.35:1 contrast — below WCAG AA 4.
 ### Code blocks
 
 Code blocks use `#050709` background (slightly darker than `iron-900`) to create depth. The header bar shows language and copy/insert actions. Highlighted lines use a left border of `ember-400` with `rgba(255,74,18,0.07)` background.
+
+### Layout primitives
+
+V1 dashboard primitives are specified in [DESIGN.md §Layout primitives](../../DESIGN.md#layout-primitives). Each primitive binds to tokens in [Token Reference](token-reference.md); component CSS resolves to those tokens via `var(--token)`.
+
+- **Layout grid** — 12-column track, `var(--sp-4)` gap, `var(--sp-6) var(--sp-8)` outer padding. Spans: `col-4`, `col-6`, `col-8`, `col-12`.
+- **Hero block** — headline + status sentence + dual CTAs. Ghost secondary leads, ember primary trails.
+- **KPI tile** — `surface-2` card with a 2px top-left accent rail. Variants bind to `ember-400` / `success` / `warning` / `info`.
+- **Spark chart** — 60px micro-trend on `ember-400` line + alpha-gradient fill. Latest day-dot is haloed `1px` white.
+- **Toggle switch** — 28×16 track on `border-1` / `ember-900`, 12px thumb on `text-tertiary` / `ember-400`.
+- **Status pill** — `mono-xxs` label + 6px pulse dot. Variants: `streaming` (ember-200), `awaiting approval` (warning), `done` (success), `idle` (text-secondary), `ready` (success + glow), `auth` (error + glow).
+- **Status bar** — 22px Ember 400 strip with left/right slots, mono-xxs text, `·` separators. The brand-exception surface — never re-colored.

--- a/docs/product/v1-ui-completeness.md
+++ b/docs/product/v1-ui-completeness.md
@@ -1,0 +1,44 @@
+# V1 UI completeness
+
+## Purpose
+
+Forge V1 ships when an operator can complete every workflow below from the UI alone — no terminal, no hand-edited TOML, no shelling into `forge_cli`. This document is the acceptance gate: each row pins a user-facing workflow to the ui-spec section that delivers it, so reviewers can verify the end-to-end promise without re-reading every spec.
+
+## Acceptance gate
+
+| Workflow | Trigger | Spec section | Acceptance evidence |
+| --- | --- | --- | --- |
+| Open workspace | Dashboard hero `+ New session` with no cached workspace, or `Browse` inside the new-session form | [new-session-flow.md §Empty-workspace branch](../ui-specs/new-session-flow.md#empty-workspace-branch) | Native directory picker confirms; selected absolute path prefills `workspace_root` and caches for subsequent spawns. |
+| Spawn new session | Dashboard hero `+ New session` | [new-session-flow.md](../ui-specs/new-session-flow.md), [dashboard.md §Hero block](../ui-specs/dashboard.md#hero-block) | `session_start` IPC returns a `session_id`; Session window opens in `v-fresh` state. |
+| Attach to existing session | Dashboard hero `Attach to session` (F-727) | [dashboard.md §Hero block](../ui-specs/dashboard.md#hero-block) | Attach picker enumerates detached sessions; selection hands off to the existing Session window. |
+| Add provider | Providers route `+ Add provider` | [providers-page.md §Add provider](../ui-specs/providers-page.md#add-provider) | `add_provider` IPC (F-730) persists the new entry; provider appears in the list and on the dashboard Providers card without restart. |
+| Edit provider | Providers row `Edit` | [providers-page.md §Edit/Remove](../ui-specs/providers-page.md#editremove) | `update_provider` IPC (F-731) writes back; row reflects the change. |
+| Remove provider | Providers row `Remove` (with destructive-action confirmation) | [providers-page.md §Edit/Remove](../ui-specs/providers-page.md#editremove) | `remove_provider` IPC (F-732) succeeds; row disappears; dependent sessions surface the absence verbatim. |
+| Enter and test credential | Providers row credential field + `Test connection` | [providers-page.md §Credential entry](../ui-specs/providers-page.md#credential-entry), [§Test connection](../ui-specs/providers-page.md#test-connection) | Write-only credential IPC (per [credentials-section.md](../ui-specs/credentials-section.md)) lands the secret; `test_provider_connection` (F-733) returns `ready` or the verbatim error. |
+| Add MCP server | Catalog `+ Add MCP server` | [catalog.md §Add MCP server](../ui-specs/catalog.md#add-mcp-server) | Modal accepts stdio or http variant; validation passes; new entry appears in the MCP tab and in the Enabled card. |
+| Toggle skill enabled | Catalog row toggle (Skills tab) | [catalog.md §Enablement toggles](../ui-specs/catalog.md#enablement-toggles) | Toggle round-trips through the catalog enablement IPC; dashboard Enabled card reflects the new state. |
+| Toggle MCP server enabled | Catalog row toggle (MCP tab) | [catalog.md §Enablement toggles](../ui-specs/catalog.md#enablement-toggles) | Same contract as skills; dashboard Enabled card mirrors. |
+| Toggle agent enabled | Catalog row toggle (Agents tab) or dashboard Enabled card row | [catalog.md §Enablement toggles](../ui-specs/catalog.md#enablement-toggles), [dashboard.md §Enabled card](../ui-specs/dashboard.md#enabled-card) | Toggle from either surface (F-724) persists; the other surface re-renders the same truth on the next `WORKSPACE_CONFIG_CHANGED_EVENT`. |
+| View usage (7D / 30D / MTD) | Dashboard Usage card selector | [dashboard.md §Usage card](../ui-specs/dashboard.md#usage-card), [usage.md](../ui-specs/usage.md) | `usage_summary` IPC (F-722) returns the windowed totals; KPI tiles and spark chart render. |
+| Manage containers (stop / logs / prune) | Dashboard Containers card row actions, or Containers route | [dashboard.md §Containers card](../ui-specs/dashboard.md#containers-card), [containers-section.md](../ui-specs/containers-section.md) | Per-row `Stop` / `Logs` and header `Prune` invoke the existing podman IPC; verbatim runtime errors surface inline. |
+| First-run dashboard (no state) | Cold launch with no providers, no sessions, no enabled assets | [dashboard.md](../ui-specs/dashboard.md), [dashboard.md §Hero block](../ui-specs/dashboard.md#hero-block) (empty state) | Hero status sentence reads the empty-state copy; each card paints its empty placeholder pointing at the remediation route (F-737). |
+
+## Out of scope (V1)
+
+Mirrored from the Phase 3.1 milestone description:
+
+- **Skill authoring UI.** Editing `.md` skill files remains a CLI / editor workflow.
+- **Agent definition authoring UI.** Same — authoring agents is not in the V1 UI surface.
+- **Workspace creation flow.** Opening Forge in a directory is the workspace-select gesture; there is no in-product "new workspace" dialog.
+
+## Cross-spec references
+
+- [dashboard.md](../ui-specs/dashboard.md)
+- [app-shell.md](../ui-specs/app-shell.md)
+- [new-session-flow.md](../ui-specs/new-session-flow.md)
+- [providers-page.md](../ui-specs/providers-page.md)
+- [credentials-section.md](../ui-specs/credentials-section.md)
+- [catalog.md](../ui-specs/catalog.md)
+- [containers-section.md](../ui-specs/containers-section.md)
+- [usage.md](../ui-specs/usage.md)
+- [forge-mocks.html](../forge-mocks.html)

--- a/docs/ui-specs/app-shell.md
+++ b/docs/ui-specs/app-shell.md
@@ -1,0 +1,254 @@
+# App Shell
+
+> Unified chrome ([F-709](https://github.com/forge-ide/forge/issues/709)) — the activity bar, primary-nav sidebar, and status bar that V1 mounts on every route. [F-716](https://github.com/forge-ide/forge/issues/716) extracts the shell from the Session window so Dashboard, Catalog, Usage, and Providers receive it too.
+
+---
+
+## Purpose
+
+A single chrome surface that survives route changes. Today the shell elements (`ActivityBar`, primary nav, `StatusBar`) only mount inside the Session window — every other route renders bare. F-716 will lift these into a route-agnostic layout component; this spec is the contract that work implements.
+
+The shell owns the three persistent surfaces that frame every route: the **Activity bar** (vertical route switcher), the **Sidebar** (primary navigation with count badges), and the **Status bar** (workspace breadcrumb on the left, provider / streaming / runtime on the right). Route content slots between Sidebar and Status bar.
+
+## Where
+
+The shell wraps every top-level route — Dashboard, Session, Catalog (Skills / MCP servers / Agents), Usage, Providers, Settings. It mounts above the router outlet so navigating between routes never unmounts the chrome. Component paths after F-716:
+
+- `web/packages/app/src/shell/AppShell.tsx` — new root layout (F-716).
+- `web/packages/app/src/shell/ActivityBar.tsx` — existing, lifted out of `SessionWindow`.
+- `web/packages/app/src/shell/StatusBar.tsx` — existing, lifted out of `SessionWindow`.
+- `web/packages/app/src/shell/Sidebar.tsx` — new primary-nav sidebar (F-716).
+
+> **Not** `web/packages/app/src/shell/FilesSidebar.tsx`. That component is the **workspace file tree** ([`shell.md §2`](./shell.md#2-session-window-shell)), shown only inside the Session route in the activity-bar-driven sidebar slot. The Sidebar described in this spec is a different surface — fixed primary navigation, always mounted, identical on every route. Sessions render *both*: the primary-nav Sidebar at 240px, then the FilesSidebar inside the session viewport.
+
+## Size
+
+```
+┌─ 44 ─┬─ 240 ─┬─────── route content (flex) ──────────┐
+│      │       │                                       │
+│  AB  │  SB   │              <Outlet/>                │
+│      │       │                                       │
+├──────┴───────┴───────────────────────────────────────┤
+│ status bar — 22                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+- Activity bar: `44px` fixed width, full viewport height minus the status bar.
+- Sidebar: `240px` fixed width, full viewport height minus the status bar.
+- Status bar: `22px` fixed height, spans the full viewport width — the brand-exception surface ([`component-principles.md §Status bar`](../design/component-principles.md#status-bar)).
+
+---
+
+## Activity bar
+
+A vertical strip of icon buttons that switch the top-level route. Implementation lives at `web/packages/app/src/shell/ActivityBar.tsx`.
+
+### Anatomy
+
+```
+┌──┐
+│⌂ │  Dashboard       ← selected (background + ember accent rail)
+│▣ │  Session
+│★ │  Catalog
+│∑ │  Usage
+│◆ │  Providers
+│  │
+│  │  (spacer)
+│  │
+│⚙ │  Settings        ← pinned to the bottom
+└──┘
+```
+
+Each item is a 28×28 `IconButton` centered in the 44px track. The selected item paints `background: var(--color-surface-2)` and renders a 2px `var(--color-ember-400)` accent rail on its left edge (`::before`), matching the `.activity-bar button.active` pattern in `docs/forge-mocks.html`. Hover paints `var(--color-surface-3)`. Disabled items keep visual chrome but no hover; never reduce opacity to signal disabled per [`component-principles.md §Buttons`](../design/component-principles.md#buttons).
+
+### Items
+
+Top stack — route switchers in order:
+
+1. **Dashboard** → `/`
+2. **Session** → `/session/<id>` (disabled when no active session)
+3. **Catalog** → `/catalog` (Skills / MCP servers / Agents tabs)
+4. **Usage** → `/usage`
+5. **Providers** → `/providers`
+
+Bottom (pinned via `margin-top: auto`):
+
+6. **Settings** → `/settings`
+
+Tooltip format: `<Label> (<shortcut>)` — e.g. `Dashboard (Cmd/Ctrl+Shift+D)`. Shortcuts land with F-716; until then the label alone surfaces.
+
+### States
+
+- **Loading.** Not applicable. The activity bar is route metadata, not data — it renders instantly from the static `ACTIVITIES` list.
+- **Empty.** Not applicable. The list is fixed at six items.
+- **Error.** Not applicable. Navigation failures are surfaced by the route content, not by re-coloring the bar.
+- **Ready.** The icon stack above. Selected item paints with the accent rail; the rest render in `var(--color-text-secondary)`.
+
+### Tokens
+
+- Track: `width: 44px`, `background: var(--color-surface-1)`, `border-right: 1px solid var(--color-border-1)`.
+- Item: `width: 28px`, `height: 28px`, `color: var(--color-text-secondary)` (default) / `var(--color-text-primary)` (active).
+- Accent rail (active): `2px` × full item height, `background: var(--color-ember-400)`.
+- Icon stroke: `1.7px`, `viewBox="0 0 24 24"`, `stroke="currentColor"` so theme color cascades.
+
+---
+
+## Sidebar
+
+A 240px fixed primary-nav rail. Distinct from `FilesSidebar.tsx` (see callout in §Where). Implementation lands as `web/packages/app/src/shell/Sidebar.tsx` in F-716.
+
+### Anatomy
+
+```
+┌────────────────────────┐
+│ ▲ Forge                │  ← brand block
+│   any ai. one editor.  │
+├────────────────────────┤
+│ WORKSPACE              │  ← group label (mono-xs)
+│ ▣ Sessions          2  │  ← active row (ember rail + surface-2)
+│ ⌒ Recent            7  │
+│ ⎇ Git               6  │
+│                        │
+│ AI                     │
+│ ◆ Providers         4  │
+│ ★ Skills           12  │
+│ ⚙ MCP servers       6  │
+│ ☉ Agents            9  │
+│                        │
+│ SYSTEM                 │
+│ ⎈ Containers        3  │
+│ ∑ Usage                │
+│ ⚙ Settings             │
+└────────────────────────┘
+```
+
+### Nav contract
+
+Order is fixed. Every group label is mono-xs uppercase `var(--color-text-secondary)` per [`component-principles.md §Inputs`](../design/component-principles.md#inputs) labels. Each row is a `<a>` with `aria-current="page"` when its route matches.
+
+| Group | Item | Route | Badge source |
+|---|---|---|---|
+| Workspace | **Sessions** | `/` (sessions tab) | active session count |
+| Workspace | **Recent** | `/recent` | last-7-day session count |
+| Workspace | **Git** | `/git` | changed-file count for active workspace |
+| AI | **Providers** | `/providers` | configured provider count |
+| AI | **Skills** | `/catalog/skills` | enabled-for-workspace count |
+| AI | **MCP servers** | `/catalog/mcp` | enabled-for-workspace count |
+| AI | **Agents** | `/catalog/agents` | enabled-for-workspace count |
+| System | **Containers** | `/containers` | active sandbox count ([`containers-section.md`](./containers-section.md)) |
+| System | **Usage** | `/usage` | — |
+| System | **Settings** | `/settings` | — |
+
+Count badges render as `<span class="sidebar__count">` to the right of the row, `font-family: var(--font-mono)`, `font-size: var(--type-mono-xxs)`, `color: var(--color-text-tertiary)`. Zero-count rows render the row but suppress the badge — not `0`.
+
+### States
+
+- **Loading.** Brand block + group labels + nav rows paint immediately; badges render `—` (em dash, `var(--color-text-tertiary)`) until their data source resolves. Rows remain clickable during this window — the route they navigate to owns its own loading state.
+- **Empty.** Not applicable as a sidebar-level state. Individual count badges suppress when the count is zero (see above). The nav contract itself is fixed and never empty.
+- **Error.** Per-badge fail-silent: if a badge's data source rejects, the badge renders `—` and the route content surfaces the error. The sidebar never paints `role="alert"` — chrome failures must not steal focus from the route.
+- **Ready.** Rows render with their counts; the active row paints `background: var(--color-surface-2)` and a 2px `var(--color-ember-400)` left rail (matching the activity bar's selected treatment).
+
+### Verbatim copy
+
+- Brand wordmark: `Forge`
+- Brand tagline: `any ai. one editor.`
+- Group labels: `WORKSPACE`, `AI`, `SYSTEM`
+- Row labels (in order): `Sessions`, `Recent`, `Git`, `Providers`, `Skills`, `MCP servers`, `Agents`, `Containers`, `Usage`, `Settings`
+- Zero-state badge: row renders with no badge element (not `0`, not `—` — em dash is reserved for loading)
+- Loading badge: `—`
+
+### Tokens
+
+- Track: `width: 240px`, `background: var(--color-surface-1)`, `border-right: 1px solid var(--color-border-1)`.
+- Row: `padding: var(--sp-2) var(--sp-3)`, `gap: var(--sp-2)`, `color: var(--color-text-secondary)`.
+- Row hover: `background: var(--color-surface-2)`, `color: var(--color-text-primary)`.
+- Row active: `background: var(--color-surface-2)`, 2px `var(--color-ember-400)` left rail via `::before`.
+- Group label: `font-family: var(--font-mono)`, `font-size: var(--type-mono-xs)`, `letter-spacing: 0.2em`, `color: var(--color-text-secondary)`, `padding: var(--sp-3) var(--sp-3) var(--sp-1)`.
+- Count badge: `font-family: var(--font-mono)`, `font-size: var(--type-mono-xxs)`, `color: var(--color-text-tertiary)`, `margin-left: auto`.
+
+---
+
+## Status bar
+
+The 22px Ember 400 strip pinned to the bottom of every route. Implementation lives at `web/packages/app/src/shell/StatusBar.tsx`. The brand-exception surface — never re-colored, never themed ([`component-principles.md §Status bar`](../design/component-principles.md#status-bar)).
+
+### Anatomy
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ ▲ forge · ~/code/acme-api · session #a3f1 · anthropic · sonnet-4.5 · │
+│                              streaming ●     $0.23 · 60.3k tok · 7d  │
+│                                                       · podman up   │
+└──────────────────────────────────────────────────────────────────────┘
+   └──── left slot ────┘                         └──── right slot ────┘
+```
+
+### Slots
+
+- **Left slot** — workspace breadcrumb. Forge mark, then the route-appropriate path:
+  - Dashboard: `forge · <workspace-name> · <branch>`
+  - Session: `forge · <session-name> · <workspace-path> · #<8-char id>`
+  - Catalog: `forge · catalog · <section>` (skills / mcp / agents)
+  - Usage: `forge · usage · <range>`
+  - Providers: `forge · providers`
+  - Settings: `forge · settings · <section>`
+- **Right slot** — provider pill, streaming pill, runtime stats. `margin-left: auto`. Segments:
+  - Provider pill: `<provider> · <model>` (e.g. `anthropic · sonnet-4.5`)
+  - Streaming pill: `streaming` + 6px live dot, or `idle` (no dot), or `awaiting approval`
+  - Runtime stats: `$<spend> · <tokens> tok · <range>` (Dashboard / Usage) or `ln <N> · col <N> · <lang> · lsp <state>` (Session editor focus)
+  - Sandbox: `sandbox: <kind>` (Session only)
+
+Adjacent groups are separated by a literal `·` at `opacity: 0.5`. Group-internal items use `gap: var(--sp-2)`.
+
+### States
+
+- **Loading.** First mount paints the slots with placeholder copy: left renders `forge · …`; right renders `idle` and suppresses the provider pill until the provider store resolves. No skeleton primitives — the strip is mono text, not a card.
+- **Empty.** Not applicable. The status bar always has at least the Forge mark and route label in the left slot.
+- **Error.** A provider-side failure (auth expired, runtime down) paints the streaming pill as `auth` (`var(--color-error)`, error live-dot glow per the [`status pill`](../design/component-principles.md#layout-primitives) `auth` variant). Background-agent IPC failures are logged to `console.error` and do not surface on the bar — chrome must not steal focus from the route's own error state.
+- **Ready.** All slots populated as in the anatomy above. The streaming pill animates its dot when the variant is live (`streaming`, `awaiting approval`). The background-agent badge appears in the right slot when count > 0, rendered on a `var(--color-surface-2)` chip to clear WCAG AA independently of the Ember background.
+
+### Verbatim copy
+
+- Forge mark: rendered via `<svg><use href="#forge-mark"/></svg>` — no text alternative needed (the wordmark `forge` follows immediately).
+- Loading left slot: `forge · …`
+- Idle streaming pill: `idle`
+- Streaming pill: `streaming`
+- Awaiting-approval pill: `awaiting approval`
+- Auth-error pill: `auth`
+- Background-agent badge: `<count> bg`
+- Empty-provider state (no provider configured): omit the provider pill entirely — do not render `no provider`.
+
+### Tokens
+
+Per [`DESIGN.md §Layout primitives → Status bar`](../../DESIGN.md#layout-primitives):
+
+- Container: `height: 22px`, `flex-shrink: 0`, `display: flex`, `align-items: center`, `padding: 0 var(--sp-3)`, `gap: var(--sp-4)`, `background: var(--color-ember-400)`, `color: var(--color-text-inverted)`.
+- Typography: `font-family: var(--font-mono)`, `font-size: var(--type-mono-xxs)`, `letter-spacing: 0.05em`.
+- Separator: literal `·` at `opacity: 0.5`.
+- Live dot: `6px × 6px`, `background: var(--color-text-inverted)`, `opacity: 0.9`. Never glows on this surface.
+- Agent-badge chip: `background: var(--color-surface-2)`, `border-radius: 10px` (pill), `padding: 0 var(--sp-2)` — clears WCAG AA against the Ember background.
+
+### Brand-exception
+
+The Ember 400 × white pairing computes to ~3.35:1 — below WCAG AA 4.5:1 for normal text. This is an accepted exception, pinned by `web/packages/app/src/shell/StatusBar.css.test.ts`. Interactive controls (the background-agent badge) render on an iron chip so they clear AA independently. Do not re-color the bar under any theme.
+
+---
+
+## Doesn't do
+
+- Does not host route content. The shell is chrome; the router outlet between Sidebar and StatusBar owns content.
+- Does not mount the workspace file tree. `FilesSidebar` is session-internal and lives inside the Session route, not in this spec.
+- Does not surface route-specific banners (e.g. the container-runtime banner). Those belong to the route — see [`containers-section.md §First-run banner`](./containers-section.md#first-run-banner).
+- Does not animate route transitions. Chrome stays static; only the outlet swaps.
+
+## Cross-spec references
+
+- [`dashboard.md`](./dashboard.md) — Dashboard route content that mounts inside this shell.
+- [`shell.md`](./shell.md) — Session-window chrome (title bar, files sidebar, tab bar). The Session route extends this app shell with its own internal layout.
+- [`containers-section.md`](./containers-section.md) — Containers route content; its sidebar nav badge surfaces the active sandbox count.
+- [`usage.md`](./usage.md) — Usage route content.
+- [`providers-section.md`](./providers-section.md) — Providers route content.
+- [`catalog.md`](./catalog.md) — Catalog route (Skills / MCP servers / Agents tabs).
+- [`session-roster.md`](./session-roster.md) — Sessions row used inside the Dashboard's primary card and reachable from the Sidebar's `Sessions` row.
+- [`../design/component-principles.md`](../design/component-principles.md) — interaction-state contract (loading / empty / error / ready) and the status-bar brand exception.
+- [`../../DESIGN.md#layout-primitives`](../../DESIGN.md#layout-primitives) — token bindings for the status bar and other V1 primitives.

--- a/docs/ui-specs/catalog.md
+++ b/docs/ui-specs/catalog.md
@@ -34,7 +34,8 @@ Fills the catalog window. Single column — header (title + search) on top, tab 
 ### Header
 
 - Title: `Catalog` (display font).
-- Search: `<input type="search">` filtering across the active tab. Placeholder: `Filter skills, MCP, agents…`. Aria-label: `Filter catalog entries`.
+- Search: `<input type="search">` filtering across the active tab. Placeholder: `Filter skills, MCP, agents…`. Aria-label: `Filter catalog entries`. See [§Search and filters](#search-and-filters).
+- On the MCP tab the header also carries a primary `+ Add server` button that opens the modal documented in [§Add MCP server](#add-mcp-server). The other two tabs omit it — skills and agents are filesystem-only.
 
 ### Tabs
 
@@ -44,38 +45,166 @@ Three tabs. Each carries a count badge that reflects the *post-filter* row count
 
 Rows are grouped by their `scope`: `Session-wide`, `Agent · <id>`, or `Provider · <id>`. Group label is rendered as an `<h3>`. Each row carries:
 
-- **Body:** `name` (the roster id) + an optional `meta` line (provider's `model`, agent's `background` / `foreground`, empty string for skills / MCP).
-- **Toggle:** `role="switch"` `<input type="checkbox">` with the `enabled` / `disabled` text label adjacent.
+- **Body:** `name` (the roster id) + an optional `meta` line (provider's `model`, agent's `background` / `foreground`, MCP server's `kind` + transport detail).
+- **Toggle:** the inline switch documented in [§Enablement toggles](#enablement-toggles).
 
 ## Live data
 
 Each kind owns its own `createResource`, so a slow / failing skill loader does not block the MCP and Agents tabs from rendering. The active-tab badge counts re-derive from the filtered row list.
 
+## Search and filters
+
+A single search box plus a strip of filter chips sits below the header on every tab. Both feed the same client-side predicate; the predicate runs against the in-memory roster — no IPC roundtrip per keystroke.
+
+- **Search input:** `<input type="search">`, placeholder reflects the active tab (`Search <N> <kind>…`, e.g. `Search 9 MCP servers…`). Matches case-insensitively on `name` and on the row's `meta` line.
+- **Filter chips:** rendered as `role="radiogroup"` with `aria-label="Catalog filters"`. Each chip is `role="radio"`. Selecting one clears the others — chips are *not* additive (single-axis filter; `Enabled` and `Workspace` are mutually-exclusive intents, not stackable).
+- **Chip set:**
+
+  | Chip        | Tabs           | Predicate                                                 |
+  |-------------|----------------|-----------------------------------------------------------|
+  | `All`       | all            | `true` (default)                                          |
+  | `Enabled`   | all            | `catalog.enabled.<kind>.<id> !== false`                   |
+  | `Workspace` | all            | `row.scope.tier === "workspace"`                          |
+  | `User`      | all            | `row.scope.tier === "user"`                               |
+  | `stdio`     | MCP only       | `row.kind === "stdio"`                                    |
+  | `http`      | MCP only       | `row.kind === "http"`                                     |
+
+  The `stdio` / `http` chips are rendered only when the MCP tab is active; switching off MCP collapses them out and resets the chip selection to `All` if either was active.
+
+- **Empty + search-miss:** when the active chip + search query exclude every row but the underlying roster is non-empty, the panel renders the search-miss empty state (see [§States](#states)) with the verbatim message `No matches`. The chip selection is *not* cleared automatically — the user can see which filter zeroed the list.
+
+## Add MCP server
+
+A modal launched from the `+ Add server` button on the MCP tab header. Captures the transport-discriminated shape that lands in `.mcp.json`. The modal is the only writer to that file from inside Forge — skills and agents stay filesystem-only.
+
+### Form structure
+
+```
+┌─ Add MCP server ──────────────────────────────────────┐
+│ Name           [______________________]               │
+│ Scope          ( ) Workspace   ( ) User               │
+│ Transport      ( ) stdio       ( ) http               │
+│                                                       │
+│ ── if stdio ──────────────────────────────────────────│
+│ Command        [______________________]               │
+│ Arguments      [______________________]  + add arg    │
+│                                                       │
+│ ── if http ───────────────────────────────────────────│
+│ URL            [https://_____________]                │
+│ Headers        [name] [value]            + add header │
+│                                                       │
+│ Credential     [••••••••••••••••••••]  (write-only)   │
+│                                                       │
+│                              [ CANCEL ]  [ ADD ]      │
+└───────────────────────────────────────────────────────┘
+```
+
+Renders as a focus-trapped `role="dialog" aria-modal="true"` with heading `Add MCP server`. `Escape` cancels; the focus trap matches the [containers logs flyout pattern](./containers-section.md#logs-flyout).
+
+### Fields
+
+| Field        | Type                                       | Required             | Notes                                                                                                          |
+|--------------|--------------------------------------------|----------------------|----------------------------------------------------------------------------------------------------------------|
+| `name`       | text                                       | yes                  | Unique within the chosen scope. Matches `^[a-z0-9][a-z0-9_-]*$`.                                              |
+| `scope`      | radio (`workspace` / `user`)               | yes                  | Determines target file (`<workspace>/.mcp.json` or `~/.mcp.json`).                                            |
+| `kind`       | radio (`stdio` / `http`)                   | yes                  | Discriminates the `ServerKind` variant per `crates/forge-mcp/src/lib.rs`.                                     |
+| `command`    | text                                       | yes when `stdio`     | Executable path or command name. Required-not-empty.                                                          |
+| `args`       | repeatable text                            | no                   | One per row; empty rows are dropped before submit.                                                            |
+| `url`        | text                                       | yes when `http`      | Validated as a URL with `http` or `https` scheme.                                                             |
+| `headers`    | repeatable `(name, value)`                 | no                   | Header `name` must match `^[A-Za-z0-9_-]+$`. Duplicate names are rejected client-side.                        |
+| `credential` | password                                   | no                   | Write-only. Persisted via the credential store, not into `.mcp.json`. Never read back into the form on edit. |
+
+### Validation
+
+Schema validation mirrors the agentskills.io / universal MCP loader at `crates/forge-mcp/src/lib.rs` (`McpServerSpec::try_from` via `build_server_kind`, `StrictFields::Reject`):
+
+- `stdio` rejects any of `url`, `headers`.
+- `http` rejects any of `command`, `args`, `env`.
+- Unknown top-level keys are rejected (`#[serde(deny_unknown_fields)]`).
+
+Client-side validation fires on submit and per-field on blur; the same shape is re-validated in the daemon. Errors render inline under the offending field, using the input error border token (`--color-ember-400`, per [`component-principles.md §Inputs`](../design/component-principles.md#inputs)).
+
+### IPC contract
+
+The modal is the only caller of the `add_mcp_server` Tauri command (introduced by F-734).
+
+```
+Input  ← {
+  kind:       "stdio" | "http",
+  name:       string,
+  scope:      "workspace" | "user",
+  command?:   string,      // stdio only
+  args?:      string[],    // stdio only
+  url?:       string,      // http only
+  headers?:   { [name: string]: string },  // http only
+  credential?: string,
+}
+
+Output → { id: string }      // verbatim daemon-assigned id on success
+Error  → string              // verbatim error detail, per the F-673 IPC convention
+                             //   (see crates/forge-shell/src/ipc.rs)
+```
+
+Daemon-side guarantees:
+
+- `name` is unique within `scope` (re-checked under a lock; the modal's pre-flight is advisory).
+- `credential`, if present, is stored via the credential store keyed by the assigned `id`; it never lands in `.mcp.json` and is never returned on subsequent `list_mcp` reads.
+- A rejection surfaces as a `role="alert"` line inside the modal carrying `add_mcp_server failed: <detail>`. The modal stays open so the user can fix the input.
+
+On success the modal closes, the MCP-tab `createResource` refetches, and the toast `MCP server "<name>" added` (info, 5 s auto-dismiss) confirms.
+
+## Enablement toggles
+
+Every row on every tab carries an inline toggle. The toggle is a [DESIGN.md §Toggle switch](../../DESIGN.md#toggle-switch) primitive — a 28×16 track with a 12px thumb on `--color-ember-400` (on) / `--color-text-tertiary` (off).
+
+- **Wire:** each toggle calls `set_setting` with a key shaped `catalog.enabled.<kind>.<id>`:
+  - `catalog.enabled.skills.<id>` for skills,
+  - `catalog.enabled.mcp.<id>` for MCP servers,
+  - `catalog.enabled.agents.<id>` for agents.
+
+  The value is a boolean; absent keys default to `true`. Scope is settled by `set_setting`'s own `level` argument (`workspace` for workspace-scoped rosters, `user` otherwise) — the catalog inherits the row's `scope.tier`. This is the same IPC F-735 wires.
+
+- **Semantics:** `role="switch" aria-checked="true|false"`. Click and Space both toggle. Hit target is the parent row (per the design primitive), not just the 28px track. The aria-label inverts the current state — `Enable <name>` when off, `Disable <name>` when on — to describe what the click *will* do.
+- **Failure:** if `set_setting` rejects, the toggle reverts to its pre-click position and the section-level `catalog__action-error` line surfaces with the prefix `set_setting failed: <detail>` (verbatim daemon detail).
+- **Cross-surface effect:** the `@`-picker and any roster consumer reads these same keys to filter; toggling here affects every downstream consumer immediately. See [`context-picker.md`](./context-picker.md).
+
 ## States
 
-Per tab, four states distinct (and the per-tab error never collapses into the per-tab empty placeholder):
+Every interactive surface here renders all four `docs/design/component-principles.md` states distinctly. Per-tab error never collapses into the per-tab empty placeholder.
 
-- **Loading.** Skeleton placeholder per [`dashboard.md §D.5.1`](./dashboard.md#d51-loading-state-primitives-f-684) — four `block`-variant row-shaped skeletons inside the active tab. Loading is per-tab — switching tabs while one is mid-load doesn't restart the others.
-- **Empty (zero entries across all scopes).** Per-kind copy:
-  - Skills: title `No skills installed`, hint `Drop a SKILL.md under .skills/<name>/ in your workspace or ~/.skills/.`
-  - MCP: title `No MCP servers configured`, hint `Add a server entry to .mcp.json in your workspace or ~/.mcp.json.`
-  - Agents: title `No agents defined`, hint `Add a definition under .agents/<name>.md in your workspace or ~/.agents/.`
-- **Empty (search miss).** When the kind has rows but the current filter excludes them all: title `No matches`, hint `Nothing in <kind label> matches "<query>".`
-- **Error.** A `role="alert"` block with heading `<KIND LABEL> UNAVAILABLE` and the verbatim error detail. Distinct from empty — a `list_*` rejection must never collapse into the no-entries placeholder. (Reading `resource()` in the `errored` state re-throws inside Solid's reactive scope — the panel gates on `resource.state` to surface the error cleanly.)
-- **Ready.** The grouped row list above.
+### Tab panel
 
-A separate `role="alert"` `catalog__action-error` line surfaces above the panel when a `setSetting` toggle call rejects; it carries the `set_setting failed: <detail>` prefix so the user can tell "I can't read the catalog" from "I tried to toggle and it failed".
+| State                    | Render                                                                                                                                                                                                          |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Loading**              | Four `block`-variant row-shaped skeletons per [`dashboard.md §D.5.1`](./dashboard.md#d51-loading-state-primitives-f-684). Per-tab — switching tabs while one is mid-load doesn't restart the others.            |
+| **Empty (zero rows)**    | Per-kind copy. Skills: `No skills installed` / `Drop a SKILL.md under .skills/<name>/ in your workspace or ~/.skills/.` · MCP: `No MCP servers configured` / `Add a server entry to .mcp.json in your workspace or ~/.mcp.json, or use + Add server.` · Agents: `No agents defined` / `Add a definition under .agents/<name>.md in your workspace or ~/.agents/.` |
+| **Empty (filter miss)**  | Title `No matches`, hint `Nothing in <kind label> matches "<query>"` when a search query is set, or `No <kind label> match the "<chip>" filter.` when only a chip is active. Chip selection stays as the user left it. |
+| **Error**                | `role="alert"` block, heading `<KIND LABEL> UNAVAILABLE`, verbatim daemon detail. Reading `resource()` in the `errored` state re-throws inside Solid's reactive scope — the panel gates on `resource.state` to surface the error cleanly. |
+| **Ready**                | The grouped row list documented in [§Tab panel](#tab-panel).                                                                                                                                                    |
+
+A separate `role="alert"` `catalog__action-error` line surfaces above the panel when a `set_setting` toggle call rejects; it carries the `set_setting failed: <detail>` prefix so the user can tell "I can't read the catalog" from "I tried to toggle and it failed".
+
+### Add MCP server modal
+
+| State        | Render                                                                                                                                                                                       |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Idle**     | Empty form. Default scope = the currently-active scope tab (workspace if a workspace is open, else user). Default transport = `stdio`. Primary `ADD` button enabled iff required fields filled. |
+| **Submitting** | `ADD` button shows `Adding…` and is disabled. All inputs are disabled. No skeleton — the modal is itself the loading affordance.                                                            |
+| **Error**    | `role="alert"` inline line above the action row, carrying `add_mcp_server failed: <detail>`. The form re-enables; focus moves to the alert. Field-level validation errors render under the offending input with the input error border (`--color-ember-400`). |
+| **Success**  | Modal closes; MCP tab refetches; toast `MCP server "<name>" added` (info variant, 5 s auto-dismiss) appears.                                                                                  |
 
 ## Copy
 
 - Window title: `Catalog`
-- Search placeholder: `Filter skills, MCP, agents…`
+- Search placeholder: `Filter skills, MCP, agents…` (per-tab variant: `Search <N> <kind>…`).
 - Tab labels: `Skills`, `MCP`, `Agents` (badge: integer count).
-- Toggle labels: `enabled` / `disabled` (lowercase — switch state, not button verb).
+- Filter chips: `All`, `Enabled`, `Workspace`, `User`, `stdio`, `http` (last two: MCP only).
 - Toggle aria-label: `Enable <name>` / `Disable <name>` (the inverse of the current state — what the click *will* do).
 - Group labels: `Session-wide` / `Agent · <id>` / `Provider · <id>`.
-- Action-error prefix: `set_setting failed: <detail>`.
-- Empty + search-miss copy: see States.
+- Add-server button: `+ Add server` (MCP tab only).
+- Modal title: `Add MCP server`. Modal buttons: `ADD` / `CANCEL`. Submitting label: `Adding…`. Success toast: `MCP server "<name>" added`.
+- Action-error prefixes: `set_setting failed: <detail>`, `add_mcp_server failed: <detail>`.
+- Empty + filter-miss copy: see [§States](#states).
 
 ## Color & typography
 
@@ -96,11 +225,18 @@ A separate `role="alert"` `catalog__action-error` line surfaces above the panel 
 - [`dashboard.md §D.5.1`](./dashboard.md#d51-loading-state-primitives-f-684) — skeleton primitive contract (F-684).
 - [`providers-section.md`](./providers-section.md) — provider discovery lives there; the catalog deliberately does *not* expose providers as a top-level tab.
 - [`context-picker.md`](./context-picker.md) — composer-time `@`-picker that filters its results by these `catalog.enabled.*` flags.
+- [`containers-section.md §Logs flyout`](./containers-section.md#logs-flyout) — focus-trapped modal pattern reused by the add-MCP-server modal.
+- [`component-principles.md §Inputs`](../design/component-principles.md#inputs) — input borders + error border token used by the add-MCP form.
+- [`DESIGN.md §Toggle switch`](../../DESIGN.md#toggle-switch) — the primitive every catalog row toggle renders as.
+- `crates/forge-mcp/src/lib.rs` — `McpServerSpec` / `ServerKind` (`Stdio` / `Http`) — authoritative shape mirrored by the add-MCP form.
+- `crates/forge-agents/src/skill_loader.rs` — agentskills.io reference loader.
+- `crates/forge-shell/src/ipc.rs` — the `set_setting` command and the F-673 verbatim-error IPC convention.
 - `docs/frontend/architecture.md §9.2` — the `settings` store and the `setSetting` IPC.
 
 ## Doesn't do
 
-- Does not install or remove assets — the catalog is a discovery + toggle surface. Adding a skill / MCP server / agent is a filesystem edit; the catalog refreshes on the next mount.
+- Does not install or remove skills or agents. Those are filesystem-only — the catalog refreshes on the next mount. MCP servers *are* writable from inside the catalog via [§Add MCP server](#add-mcp-server); the inverse (delete) stays a filesystem edit until a future revision.
 - Does not surface providers as a top-level tab. Provider discovery is the Dashboard's `<ProvidersSection>` (per [F-586](https://github.com/forge-ide/forge/issues/604)). Catalog rows still attach to a `Provider` scope when the asset is provider-scoped, but the *primary* axis is the three asset kinds.
 - Does not preview a skill's body or an agent's definition. That's a future "details" pane; v1 keeps the surface scannable.
-- Does not let the user edit `.mcp.json` inline. MCP edits stay in the user's editor of choice.
+- Does not let the user *edit* an existing MCP server inline. Edits stay in the user's editor of choice; the modal is add-only in v1.
+- Does not stack filter chips. The chip strip is single-select on a single axis — combining `Workspace` and `stdio` is a v-next ask.

--- a/docs/ui-specs/containers-section.md
+++ b/docs/ui-specs/containers-section.md
@@ -1,42 +1,54 @@
 # Containers Section
 
-> Dashboard section ([F-597](https://github.com/forge-ide/forge/issues/615)) — active sandbox containers + first-run runtime banner + tail-style logs flyout.
+> Dashboard section ([F-597](https://github.com/forge-ide/forge/issues/615)) — active sandbox containers rendered as full-width rows on the dashboard's container card, with header runtime stats and inline per-row controls.
 
 ---
 
 ## Purpose
 
-Surface the Level-2 sandbox containers Forge sessions create, let the operator stop / remove them outside of session teardown, and tail their logs without dropping to a terminal. Sessions register containers via `ContainerRegistryState::register`; this section is the read-and-control surface.
+Surface the Level-2 sandbox containers Forge sessions create, let the operator stop them or open a terminal inline, and aggregate runtime stats in the card header. Sessions register containers via `ContainerRegistryState::register`; this section is the read-and-control surface.
 
 ## Where
 
-`<ContainersSection>` mounts inside the Dashboard root, anchored at id `containers-section`. The accompanying `<ContainerRuntimeBanner>` mounts at the top of the Dashboard when `detect_container_runtime` reports the runtime is missing / broken / rootless-unavailable. Component path: `web/packages/app/src/components/dashboard/ContainersSection.tsx`.
+`<ContainersSection>` mounts inside the Dashboard root as the `col-12` card on the secondary row, anchored at id `containers-section`. The accompanying `<ContainerRuntimeBanner>` mounts at the top of the Dashboard when `detect_container_runtime` reports the runtime is missing / broken / rootless-unavailable. Component path: `web/packages/app/src/components/dashboard/ContainersSection.tsx`.
 
 ## Size
 
-Fills the dashboard column width. Vertically scrolling row list — bounded only by the active-container count. The logs flyout is a focus-trapped overlay, sized ≈ 80% of viewport.
+Spans the full 12-column dashboard width (see `DESIGN.md §Layout grid`). Body is a vertically stacking row list — bounded only by the active-container count. The card head and body share the dashboard card chrome; no overlay surfaces.
 
 ## Structure
 
 ### Section
 
 ```
-┌─ CONTAINERS ───────────────────────────────────────────────┐
-│ ┌─ a3f1c2b4d5e6  ghcr.io/forge/sandbox:debian12 ───────┐   │
-│ │ session: 8c2a1f0e            12m ago                 │   │
-│ │                              [LOGS] [STOP] [REMOVE]  │   │
-│ └──────────────────────────────────────────────────────┘   │
-│ ┌─ b1c8e0f2a93d  …                          [stopped] ─┐   │
-│ │ session: 4f9d2e7a            1h ago                  │   │
-│ │                              [LOGS]    —    [REMOVE] │   │
-│ └──────────────────────────────────────────────────────┘   │
-└────────────────────────────────────────────────────────────┘
+┌─ CONTAINERS  3 running · 2.4 GB · podman ──────────── [Prune] [Logs] ─┐
+│ ●  refactor-sandbox-a3f1                                              │
+│    sha256:8b9f… · mounts: ~/code/acme-api:ro                          │
+│    oci.io/forge/rust-tools:0.3.1    cpu 0.8 · ram 412M   [term] [stop]│
+│ ●  docs-preview                                                       │
+│    sha256:2c0e… · ports: 4173:80                                      │
+│    oci.io/forge/node-preview:20     cpu 0.1 · ram 96M    [term] [stop]│
+│ ◐  pg-test-db                                                         │
+│    sha256:5a1d… · idle 14m                                            │
+│    docker.io/library/postgres:16    cpu 0.0 · ram 51M    [term] [stop]│
+└───────────────────────────────────────────────────────────────────────┘
 ```
 
-Row anatomy:
-- **Head:** 12-char container id (full id surfaced in `title` tooltip), image ref, optional `stopped` pip (color-warn) when the container exited but hasn't been removed yet.
-- **Meta:** session id (8-char), relative `started_at` (`<60s` → `Ns ago`, `<1h` → `Nm ago`, `<24h` → `Nh ago`, otherwise an ISO date).
-- **Actions:** `LOGS` toggle, `STOP` (disabled when `stopped`), `REMOVE` (primary — destructive but the container is already isolated).
+### Header meta
+
+The card head carries two clusters separated by `margin-left: auto`:
+- **Left:** the `CONTAINERS` label plus an aggregate stats line — running count, total RAM, runtime name, joined by `·` — rendered in `var(--font-mono)` at `var(--type-mono-xxs)` in `var(--color-text-tertiary)`. Pattern: `<n> running · <total-ram> · <runtime>`. Singular collapses (`1 running`); zero suppresses the stats line entirely (only the label remains).
+- **Right:** two header actions — `Prune` (ghost; clears stopped + dangling containers via the runtime adapter) and `Logs` (ghost; opens the full-runtime log stream — see §Logs below). Both use the `btn-ghost` variant from `DESIGN.md` (small chip sizing: compact horizontal padding, `var(--type-mono-xs)`).
+
+### Row layout
+
+Each container is one full-width row inside the card body, no per-row card chrome. Row track: `auto 1fr auto auto auto` with `gap: var(--sp-3)`, vertical padding `var(--sp-2) var(--sp-4)`, and a `1px solid var(--color-border-1)` bottom border (suppressed on `:last-child`). Cells, left to right:
+
+1. **Liveness dot.** A `live-dot` pip — `var(--color-success)` for running, `var(--color-warn)` for `stopped` / `unhealthy`. Pulses when running (shared `pulse` keyframes from `DESIGN.md §Status pill`).
+2. **Identity stack.** Two stacked lines: container name (medium weight, body type) on top; image digest plus a short context fragment (mount, port, or idle-for) on the second line in `var(--font-mono)` at `11px` (`--type-mono-xs`) in `var(--color-text-tertiary)`. Full digest surfaces in `title`.
+3. **Image ref.** `var(--font-mono)`, `--type-mono-xs`, `var(--color-text-primary)` — registry-qualified image tag.
+4. **Resource readout.** `var(--font-mono)` at `10px` (`--type-mono-xxs`), `var(--color-text-secondary)`. Format: `cpu <n.n> · ram <Mn|Gn>`. Zero CPU collapses to `cpu 0.0` (it disambiguates idle from missing data).
+5. **Actions.** A 4px-gap flex of two `btn-ic` icon buttons — `term` (drops the operator into the container via the session terminal pane) then `stop` (disabled when the container is already stopped). Both carry `aria-label` and a `title` tooltip; no destructive-confirm prompt at this tier — stop is reversible via session resume.
 
 ### First-run banner
 
@@ -48,36 +60,52 @@ Row anatomy:
 └────────────────────────────────────────────────────────────┘
 ```
 
-Anchored above the container list. Dismissable via "Don't show again" — persists `dashboard.container_banner_dismissed = true` in user-tier settings ([F-151](https://github.com/forge-ide/forge/issues/296)) so the banner stays gone across launches.
+Anchored above the container card. Dismissable via "Don't show again" — persists `dashboard.container_banner_dismissed = true` in user-tier settings ([F-151](https://github.com/forge-ide/forge/issues/296)) so the banner stays gone across launches.
 
-### Logs flyout
+### Logs
 
-Toggled by the row's `LOGS` button. Renders a focus-trapped `role="dialog" aria-modal="true"` with:
-- Header: `LOGS — <12-char id>` plus a `CLOSE` button.
-- Body: `<pre>` log pane that paints stdout / stderr lines, stderr in `--color-warn`. Streams via `containerLogs` polling on a 2 s interval; bounded buffer of 1000 lines; tail of 200 on first poll.
-- Window-level `Escape` closes (so the focus trap can't swallow it).
+The header `Logs` action opens a full-runtime log pane (no longer a focus-trapped flyout per row). It renders inline beneath the row list when toggled, framed by the same card chrome:
+- Header: `LOGS — <runtime>` plus a `CLOSE` action that collapses the pane.
+- Body: `<pre>` log pane that paints stdout / stderr lines, stderr in `var(--color-warn)`. Streams via `containerLogs` polling on a 2 s interval; bounded buffer of 1000 lines; tail of 200 on first open. Stream is multiplexed across all running containers; each line is prefixed with the originating container's 12-char id in `var(--color-text-tertiary)`.
+
+Per-row inline log toggles were removed when row actions were trimmed to `term` and `stop`; the header `Logs` action is the only entry point.
+
+## Actions
+
+Action contract summary:
+
+| Action       | Where       | Behavior                                                                                          |
+|--------------|-------------|---------------------------------------------------------------------------------------------------|
+| `Prune`      | card head   | Invokes the runtime adapter's `prune` — stopped containers and dangling images cleared in one go. |
+| `Logs`       | card head   | Toggles the inline multiplexed log pane.                                                          |
+| `term`       | per-row     | Opens a terminal in the host session bound to the container.                                      |
+| `stop`       | per-row     | Stops the container. Disabled when the row is already `stopped`. Emits `CONTAINERS_CHANGED_EVENT`. |
+
+There is no per-row `remove` in V1 — removal happens via `Prune` (sweeping stopped containers) or via session teardown. Surfacing `remove` per-row returns when destructive-confirmation lands (F-689) so the irreversible action gates behind a prompt.
 
 ## Live data
 
-Refreshes are event-driven, not timer-driven: the section subscribes to the `CONTAINERS_CHANGED_EVENT` Tauri event bus, which `stop_container` / `remove_container` / session teardown all emit. Local `STOP` / `REMOVE` clicks also issue an inline `refetch()` so the row updates within the same tick.
+Refreshes are event-driven, not timer-driven: the section subscribes to the `CONTAINERS_CHANGED_EVENT` Tauri event bus, which `stop_container` / `prune_containers` / session teardown all emit. Local `stop` and header `Prune` clicks also issue an inline `refetch()` so rows update within the same tick. The header meta line (running count, total RAM) recomputes off the same query result — no separate stats fetch.
 
 ## States
 
 The section renders all four `docs/design/component-principles.md` states distinctly:
 
-- **Loading.** Skeleton placeholder per [`dashboard.md §D.5.1`](./dashboard.md#d51-loading-state-primitives-f-684) — three `block`-variant skeletons sized to row height.
-- **Empty.** `// no active sandbox containers. They appear here when a session uses Level-2 isolation.` placeholder, mono 11px, `--color-text-tertiary`.
-- **Error.** A `role="alert"` `containers-section__error` line above the list when the most recent action (`stopContainer` / `removeContainer`) rejects, carrying the verbatim error detail. List read failures degrade silently to an empty list — the banner already covers the runtime-unavailable case so a runtime-side rejection never surfaces twice.
+- **Loading.** Skeleton placeholder per [`dashboard.md §D.5.1`](./dashboard.md#d51-loading-state-primitives-f-684) — three `block`-variant skeletons sized to the new full-width row height (identity stack + image + resources + actions cells). The card head paints immediately with the `CONTAINERS` label only; the meta stats line is held until the first paint resolves so the count never flashes from `0` to `n`. The `Prune` / `Logs` header actions render disabled while loading.
+- **Empty.** `No active sandbox containers. They appear here when a session uses Level-2 isolation.` rendered as a single full-row placeholder, `var(--font-mono)` at `11px` in `var(--color-text-tertiary)`. The header meta line collapses (label only); `Prune` / `Logs` render disabled.
+- **Error.** A `role="alert"` `containers-section__error` line above the row list when the most recent action (`stopContainer` / `pruneContainers`) rejects, carrying the verbatim error detail. List read failures degrade silently to an empty list — the banner already covers the runtime-unavailable case so a runtime-side rejection never surfaces twice.
 - **Ready.** The row list above.
 
-The flyout has its own loading state — first poll paints into an empty `<pre>` with no skeleton (logs are append-only mono text, the empty buffer is itself the loading affordance). A polling rejection surfaces as a `role="alert"` line inside the flyout without closing it.
+The inline log pane has its own loading state — first poll paints into an empty `<pre>` with no skeleton (logs are append-only mono text, the empty buffer is itself the loading affordance). A polling rejection surfaces as a `role="alert"` line inside the pane without collapsing it.
 
 ## Copy
 
 - Section label: `CONTAINERS`
+- Header meta pattern: `<n> running · <total-ram> · <runtime>` (e.g. `3 running · 2.4 GB · podman`)
 - Empty: `No active sandbox containers. They appear here when a session uses Level-2 isolation.`
-- Stopped pip: `stopped`
-- Action buttons: `LOGS` / `CLOSE LOGS`, `STOP`, `REMOVE`, `CLOSE`
+- Stopped liveness affordance: pip-only (no text label); `aria-label="stopped"` on the dot.
+- Header actions: `Prune`, `Logs` / `Close logs`
+- Per-row actions (icon, tooltip only): terminal icon → `Open terminal`; stop icon → `Stop container`
 - Banner headline (one of, by `RuntimeStatus.kind`):
   - `Container runtime ready` (`available` — never rendered; the banner suppresses)
   - `Container runtime not installed (<tool>)` (`missing`)
@@ -86,29 +114,38 @@ The flyout has its own loading state — first poll paints into an empty `<pre>`
   - `Container runtime probe failed` (`unknown`)
 - Banner detail: per status — see component for verbatim copy. Truncated reason strings cap at 160 chars.
 - Banner CTA: `DON'T SHOW AGAIN` / `See install instructions`.
-- Logs title: `LOGS — <12-char id>` (mono, em dash with single space either side).
+- Inline log pane title: `LOGS — <runtime>` (mono, em dash with single space either side).
 
 ## Color & typography
 
-- Stopped pip: `--color-warn` text on `--color-surface-2`.
-- Stderr log lines: `--color-warn` text. Stdout: `--color-text-primary`.
-- Log pane font: `--font-mono` 11px. Timestamp prefix: `--color-text-tertiary`.
-- Banner icon: `--color-warn`. Banner is `role="alert"` — semantically assertive even though sessions still fall back to Level-1 (per [F-596](https://github.com/forge-ide/forge/issues/614)).
+- Liveness dot: `var(--color-success)` running, `var(--color-warn)` stopped / unhealthy. Pulse via the shared `pulse` keyframes.
+- Stderr log lines: `var(--color-warn)` text. Stdout: `var(--color-text-primary)`.
+- Log pane font: `var(--font-mono)` at `--type-mono-xs`. Container-id prefix: `var(--color-text-tertiary)`.
+- Row dividers: `1px solid var(--color-border-1)` between rows; no border on the last row.
+- Header meta line: `var(--font-mono)` at `--type-mono-xxs`, `var(--color-text-tertiary)`.
+- Banner icon: `var(--color-warn)`. Banner is `role="alert"` — semantically assertive even though sessions still fall back to Level-1 (per [F-596](https://github.com/forge-ide/forge/issues/614)).
 
 ## Keyboard
 
-- Tab inside the row list — natural document order: row → row.
-- Inside the logs flyout — focus is trapped by `useFocusTrap`. `Escape` closes (window-level handler).
-- The `<pre>` log pane is `tabindex={0}` so screen-reader users can focus and scroll it directly.
+- Tab inside the card head — `Prune` → `Logs` → first row.
+- Tab inside the row list — natural document order, row by row, hitting `term` then `stop` per row.
+- Inline log pane — focusable region; the `<pre>` log pane is `tabindex={0}` so screen-reader users can focus and scroll it directly. `Escape` while focused inside the pane collapses it.
 
 ## Destructive-action contract
 
-`STOP` and `REMOVE` are inline buttons today — Forge's destructive-confirmation pattern is being introduced for this section in F-689. Until F-689 lands, the buttons fire immediately on click; the cgroup teardown is itself bounded and idempotent. When F-689 ships, this spec is updated to require a confirm step on `REMOVE` — `STOP` stays single-step (a stopped container can be re-started via session resume; removal is the irreversible step).
+Per-row `stop` is single-step — a stopped container can be re-started via session resume, so the action is reversible at the session tier. Header `Prune` is irreversible (it removes stopped containers and dangling images in one sweep); a confirm step gates it once destructive-confirmation lands (F-689). Until F-689 ships, `Prune` fires immediately on click; the runtime adapter's prune is itself bounded and idempotent.
 
 ## Cross-spec references
 
-- [`dashboard.md`](./dashboard.md) — root-window layout; the runtime banner sits above the providers section.
+<a id="container-card-on-dashboard"></a>
+
+### Container card on dashboard
+
+The container card is the `col-12` cell on the dashboard's secondary row (see [`dashboard.md`](./dashboard.md)). The dashboard spec defers its anatomy here; this section owns the header meta, row layout, and action contract. The skeleton entry in [`dashboard.md §D.5.1`](./dashboard.md#d51-loading-state-primitives-f-684) tracks the row shape defined above.
+
+- [`dashboard.md`](./dashboard.md) — root-window layout; the runtime banner sits above the providers section, and the container card is the `col-12` row beneath the Usage / Workspace toggles.
 - [`dashboard.md §D.5.1`](./dashboard.md#d51-loading-state-primitives-f-684) — skeleton primitive contract.
+- [`DESIGN.md` §Layout primitives](../../DESIGN.md) — `Layout grid` (12-col / `col-12` span), `Status pill` (pulse keyframes), and `Status bar` (container-status slot) tokens consumed here.
 - `docs/architecture/isolation-model.md` — Level-2 / Level-1 isolation model and the `forge-oci` runtime adapter.
 - `docs/dev/sandbox-limits.md` — per-tool limits the sandbox enforces.
 
@@ -116,5 +153,5 @@ The flyout has its own loading state — first poll paints into an empty `<pre>`
 
 - Does not let the user *create* a container directly — sessions own that. The Dashboard surface is read + control.
 - Does not stream logs server-push — it polls every 2 s. A future revision may swap to a Tauri event channel; the row contract stays the same.
-- Does not let the user `exec` into a container. Manual triage is a deliberate non-goal — sessions own the workflow.
 - Does not surface non-Level-2 sandboxes (cgroup-only Level-1) in this list. Those are session-internal.
+- Does not expose per-row `remove` in V1 — see §Actions. Removal is `Prune` (sweep) or session teardown.

--- a/docs/ui-specs/credentials-section.md
+++ b/docs/ui-specs/credentials-section.md
@@ -1,109 +1,95 @@
-# Credentials Section
+# Credentials IPC Reference
 
-> Dashboard section ([F-588](https://github.com/forge-ide/forge/issues/606)) — per-provider credential management with rotation confirmation and a security-conscious form contract.
+> **Note**: As of V1, credential entry happens in the full-page `/providers` route (see [`providers-page.md`](./providers-page.md)).
+> This file is retained as the authoritative IPC reference for the credential commands
+> (`login_provider`, `logout_provider`, `has_credential`). The dashboard credentials card is removed.
 
 ---
 
 ## Purpose
 
-Let the user store, rotate, and remove provider credentials without leaving the Dashboard. The section is the authoritative surface for credential state — every other view (the providers grid, the first-run banner) reflects `has_credential` as a hint and links here when remediation is needed.
+Define the wire contract every UI surface uses to read and mutate per-provider credential state. The IPC layer is the single source of truth — every consumer (the `/providers` page, the first-run banner copy, the new-session picker's `has_credential` hint) calls these commands rather than reaching into the keyring directly.
 
 ## Where
 
-`<CredentialsSection>` mounts inside the Dashboard root, anchored at id `credentials-section` so the first-run banner can deep-link to it. Component path: `web/packages/app/src/components/dashboard/CredentialsSection.tsx`.
+Lives wherever provider credentials are entered (currently [`providers-page.md`](./providers-page.md)) and wherever a "credential present?" hint is rendered (the dashboard Providers card status pill, the new-session picker). Backed by `crates/forge-shell/src/credentials_ipc.rs`.
 
-## Size
+## Commands
 
-Fills the dashboard column width. Single column of rows — one row per provider in `CREDENTIAL_PROVIDERS`. No internal scrolling; the row count is small and bounded.
+Every command in this section follows the F-673 standard: the outer error string returned to the webview begins with `<command_name>: `, where `<command_name>` matches the wire name of the Tauri command. See `crates/forge-shell/src/ipc.rs` "Error handling (F-673)" header for the canonical rationale.
 
-## Structure
+All three commands are authz-gated to the `dashboard` window label via `crate::ipc::require_window_label`. A session window invoking any of them is rejected before validation runs.
 
-```
-┌─ CREDENTIALS ──────────────────────────────────────────────┐
-│ ✓ Anthropic   ANTHROPIC_API_KEY                  [LOGOUT]  │
-│ Replace key  [••••••••••••]                      [ROTATE]  │
-│                                                            │
-│ ⚠ OpenAI      OPENAI_API_KEY                               │
-│ Add key      [           ]                       [STORE]   │
-└────────────────────────────────────────────────────────────┘
-```
-
-### Row anatomy
-
-- **Indicator + label row.** `✓` (stored) or `⚠` (missing) icon, provider display name, env-var hint (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY` …), and a `LOGOUT` button when a credential is present.
-- **Form row.** `<input type="password">` plus a primary action whose label flips between `STORE` (no credential yet) and `ROTATE` (replacing one).
-- **Error row.** A `role="alert"` line under the form when the most recent submit / logout call rejected.
-
-### Rotation confirmation
-
-Submitting the form when a credential is already stored opens a modal:
+### `login_provider` (F-587)
 
 ```
-┌────────────────────────────────────────────┐
-│ REPLACE STORED KEY?                        │
-├────────────────────────────────────────────┤
-│ A credential for <Provider> is already     │
-│ stored. Replacing it overwrites the        │
-│ keyring entry — the previous key cannot    │
-│ be recovered.                              │
-├────────────────────────────────────────────┤
-│                          [CANCEL] [REPLACE]│
-└────────────────────────────────────────────┘
+input:  { provider_id: string, key: string }
+output: ()
+error:  "login_provider: <reason>"
 ```
 
-The modal is a focus-trapped `role="dialog" aria-modal="true"` with a window-level `Escape` handler. Logout is reversible (re-enter the key) and stays single-step — no modal.
+Writes `key` to the active credential store under `provider_id`. Validation rejects empty `provider_id`, empty `key`, `provider_id` longer than `MAX_PROVIDER_ID_BYTES`, and `key` longer than `MAX_API_KEY_BYTES` (8 KiB). The inbound `key` is wrapped in `secrecy::SecretString` immediately so downstream `Debug` / `format!` calls redact it. Storage semantics are overwrite-on-write — the previous entry is replaced unconditionally; callers that need rotation confirmation gate it at the UI layer (see [`providers-page.md` §Credential entry](./providers-page.md)).
 
-## States
+### `logout_provider` (F-587)
 
-Per row, four states cleanly separated:
+```
+input:  { provider_id: string }
+output: ()
+error:  "logout_provider: <reason>"
+```
 
-- **Loading.** First read of `has_credential` — the row paints with the indicator's neutral fallback (treated as missing). Probe failure does not crash the row; it degrades to "no stored credential" so the user can still type a key and recover.
-- **Empty / no credential.** `⚠` indicator (color-warn), `Add key` form label, `STORE` action.
-- **Stored.** `✓` indicator (color-ok), `Replace key` form label, `ROTATE` action, plus the `LOGOUT` button. Replacing requires the rotation-confirm modal.
-- **Pending.** While a `loginProvider` / `logoutProvider` IPC is in flight, both buttons report `aria-busy=true`, the input is `disabled`, and the action's label stays the same — no spinner copy.
-- **Error.** `role="alert"` line under the form with the verbatim IPC rejection message. The line clears on the next user action.
+Removes the credential entry for `provider_id` from the active store. Idempotent — removing an absent entry resolves `Ok(())`. Validation rejects empty / oversized `provider_id`. The keyring write is irreversible from the IPC surface (no undo); reversibility is only via a subsequent `login_provider` with a freshly-typed key.
 
-## Copy
+### `has_credential` (F-587)
 
-- Section label: `CREDENTIALS`
-- Indicator labels (aria-label only): `Credential stored for <Provider>` / `No credential for <Provider>`
-- Form labels: `Replace key` / `Add key`
-- Buttons: `STORE`, `ROTATE`, `LOGOUT` (uppercase, mono, matches the project's destructive / write-style action discipline).
-- Rotation modal title: `REPLACE STORED KEY?` (uppercase question — same voice as `CLEAR MEMORY?` in `memory-section.md`).
-- Rotation body: verbatim — "A credential for <strong>{providerLabel}</strong> is already stored. Replacing it overwrites the keyring entry — the previous key cannot be recovered."
-- Rotation buttons: `CANCEL`, `REPLACE`.
+```
+input:  { provider_id: string }
+output: bool
+error:  "has_credential: <reason>"
+```
 
-## Color & typography
+Presence probe. Returns `true` iff the active store reports a credential entry for `provider_id`. Never returns the value — the IPC contract is strictly write-only once stored. Validation matches `logout_provider`'s. Probe failure is propagated to the caller verbatim (the renderer typically degrades to "no stored credential" so the user can still type a key and recover).
 
-- Stored indicator: `--color-ok`. Missing indicator: `--color-warn`.
-- Env-var hint: `--font-mono`, `--color-text-tertiary` — the hint is reference, not interactive.
-- Action buttons follow `@forge/design` `Button` variants: `ghost` for `LOGOUT` and `CANCEL`, `primary` (ember accent) for `STORE` / `ROTATE` / `REPLACE`.
+## Error format
+
+The F-673 contract for each command:
+
+- `login_provider: <reason>` — validation failures, keyring write failures.
+- `logout_provider: <reason>` — validation failures, keyring delete failures.
+- `has_credential: <reason>` — validation failures, keyring read failures.
+
+`<reason>` is the verbatim store-layer error string (no stripping, no rewrapping). UI surfaces echo the message into a `role="alert"` line per `docs/design/component-principles.md` four-state rule.
+
+## Keyring integration
+
+Production wiring is `LayeredStore<KeyringStore, EnvFallbackStore>` — the OS keyring is primary, the environment is read-only fallback for `get`/`has`. Tests substitute `MemoryStore`. The store boundary is `forge_core::Credentials`; the IPC layer holds an `Arc<dyn Credentials>` in `CredentialsState` and never inspects the concrete backend. See `docs/architecture/credentials.md` for the backend contract (rotation-overwrite invariant, env-fallback read semantics, platform cfg-gating of `KeyringStore`).
 
 ## Security contract
 
-The section is the canonical implementation of Forge's credential UX rules. Reviewers should treat any drift as a security issue:
+The IPC layer is the canonical enforcement point for Forge's credential rules. Reviewers should treat any drift as a security issue:
 
-- The typed value lives only in the row's local `draft()` signal and the `<input type="password">`'s browser-DOM state.
-- The signal is cleared the moment the IPC call resolves — success or rejection — and on rotation cancel. No ambient terminal state can hold the secret.
-- No `aria-label`, log line, or rendered DOM string ever echoes the key.
-- The DOM never contains a rendered key — only the password input ever holds the typed value.
+- The inbound `key` is wrapped in `SecretString` before any downstream call. No long-lived `String` copy is taken.
+- Tracing fields never carry the value — only `provider_id` and outcome (`hit`, `miss`, `error_kind`). This holds at every level, including `trace!`.
+- No command returns the stored value. `has_credential` is the only read surface and yields a `bool`.
+- The dashboard-only authz gate ensures session windows cannot reach the credential surface.
 
-## Keyboard
+## Destructive-action contract
 
-- Tab — moves focus from indicator → input → action button → next row.
-- Enter inside the input — submits the form (same path as clicking `STORE` / `ROTATE`).
-- Escape inside the rotation modal — cancels (matches `WAI-ARIA APG Dialog` pattern; the listener is window-level so the focus trap can't swallow the keystroke).
+`logout_provider` is destructive — the keyring entry is gone after a successful call and the user must re-enter the key to restore it. Callers gate the invocation behind a user-facing confirm appropriate to their surface (the `/providers` page chains it inside the `REMOVE PROVIDER?` modal; see [`providers-page.md` §Edit/Remove](./providers-page.md)). The IPC itself does not prompt — confirmation is a UI concern.
+
+`login_provider` is single-step at the wire level but overwrites unconditionally; rotation confirmation (when an entry is already present) is gated at the UI layer per [`providers-page.md` §Credential entry](./providers-page.md).
 
 ## Cross-spec references
 
-- [`providers-section.md`](./providers-section.md) — the neighbouring section whose card "credential" hint is sourced from `has_credential`.
-- [`dashboard.md`](./dashboard.md) — first-run `<CredentialBanner>` lives at the top of the dashboard and deep-links to `#credentials-section`.
-- `docs/architecture/credentials.md` — backend keyring contract (referenced for the rotation-overwrite invariant).
-- `docs/design/component-principles.md` — four-state rule.
+- [`providers-page.md`](./providers-page.md) — primary consumer; the `/providers` page is the only UI surface that opens the credential input field. Chains `login_provider` / `logout_provider` from its Add / Edit / Remove flows.
+- [`providers-section.md`](./providers-section.md) — the dashboard Providers card; reads `has_credential` (via the higher-level `provider_status` aggregate) for the readiness pill.
+- [`dashboard.md`](./dashboard.md) — the Providers card's status sentence references credential readiness in plain prose.
+- `docs/architecture/credentials.md` — backend keyring contract (rotation-overwrite invariant, env-fallback read semantics).
+- `docs/design/component-principles.md` — four-state rule and destructive-action contract honored by UI callers.
 
 ## Doesn't do
 
-- Does not surface keyless providers (e.g. Ollama). Adding them would surface a "missing key" indicator for a provider that does not need one.
+- Does not surface keyless providers (e.g. Ollama). Callers should suppress the credential field for any provider whose `credential_required` flag is unset.
 - Does not let the user *view* a stored key. The IPC contract is one-way once stored — only `has_credential` is queryable.
 - Does not export / back up keys. The user's keyring is the system of record.
-- Does not own provider activation — that's [`providers-section.md`](./providers-section.md).
+- Does not own provider activation or configuration — that's [`providers-page.md`](./providers-page.md) and [`providers-section.md`](./providers-section.md).

--- a/docs/ui-specs/dashboard.md
+++ b/docs/ui-specs/dashboard.md
@@ -1,100 +1,355 @@
 # Dashboard
 
-> Root window of the desktop app — surfaces the active provider and the session roster so the user can pick up where they left off or start something new.
+> Root window of the desktop app ([F-708](https://github.com/forge-ide/forge/issues/708)) — the V1 dashboard renders the app shell, a hero block with dual CTAs, and a 12-column grid of five cards (Sessions, Providers, Usage, Enabled, Containers).
 
 ---
 
-## D. Dashboard
+## Purpose
 
-**Purpose.** First view in the Dashboard window. Confirms the local environment is wired up (provider reachable, models discoverable) and lets the user re-enter an existing session or read what's been archived.
+First view in the Dashboard window. Confirms the workspace state at a glance (active sessions, configured providers, recent usage, enabled extensions, sandbox containers) and gives the operator one click to attach to an existing session or spawn a new one.
 
-**Where.** Root route (`/`) of the Dashboard window. There is exactly one Dashboard window per app instance.
+## Where
 
-**Size.** Fills the window. Min-height `100vh`. Single-column layout, content-driven height.
+Root route (`/`) of the Dashboard window. There is exactly one Dashboard window per app instance. Mounted inside the [app shell](./app-shell.md): the Activity bar and Sidebar frame the route on the left, the Status bar pins to the bottom, and `<Dashboard/>` renders into the router outlet between them.
 
-### D.1 Structure
+Component path: `web/packages/app/src/routes/Dashboard/Dashboard.tsx`.
+
+## Size
+
+Fills the outlet. Hero block sits at the top with `padding: var(--sp-8)`; the grid below uses the `DESIGN.md §Layout grid` 12-column track with `var(--sp-6) var(--sp-8)` outer padding and `var(--sp-4)` cell gaps. Content-driven height — the page scrolls when the grid exceeds the viewport.
+
+## Structure
 
 ```
-┌───────────────────────────────────────────────┐
-│ Forge — Dashboard                             │ ← title, ember
-├───────────────────────────────────────────────┤
-│ ┌── PROVIDER · ollama ────────────────────┐   │
-│ │ ● http://localhost:11434                 │   │
-│ │ [SHOW MODELS — 4 models]   [REFRESH]     │   │
-│ └─────────────────────────────────────────┘   │
-├───────────────────────────────────────────────┤
-│ [active 03] [archived 12]                     │
-│ ┌─────────────┐ ┌─────────────┐ ┌──────────┐  │
-│ │ session     │ │ session     │ │ session  │  │
-│ │ specimen    │ │ specimen    │ │ specimen │  │
-│ └─────────────┘ └─────────────┘ └──────────┘  │
-└───────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│  app shell — activity bar · sidebar · status bar                     │
+├──────────────────────────────────────────────────────────────────────┤
+│  HERO                                                                │
+│  Welcome back.                                                       │
+│  Forge something.                            [Attach] [+ New session]│
+│  Two sessions active. One agent paused awaiting approval. …          │
+├──────────────────────────────────────────────────────────────────────┤
+│  ┌──────────────────────────── col-8 ────────────────┐ ┌── col-4 ──┐ │
+│  │ Sessions          active · 2 archived · 14        │ │ Providers │ │
+│  │ ● refactor-payment-service          streaming     │ │           │ │
+│  │ ● doc-site-rewrite          awaiting approval     │ │ Anthropic │ │
+│  │ ● test-harness-migration              done        │ │ OpenAI    │ │
+│  │ ● sql-query-optimizer                 idle        │ │ Ollama    │ │
+│  └───────────────────────────────────────────────────┘ │ Mistral   │ │
+│                                                        └───────────┘ │
+│  ┌──────────────── col-6 ─────────────┐ ┌────────── col-6 ──────────┐│
+│  │ Usage · last 7 days       7D 30D MTD│ │ Enabled · workspace      ││
+│  │ $18.42       4.2M         1.1M      │ │ typescript-review    on  ││
+│  │ spend        tokens in    tokens out│ │ postgres-schemata    on  ││
+│  │ ──sparkline──────────────────────── │ │ github               on  ││
+│  └─────────────────────────────────────┘ └───────────────────────────┘│
+│  ┌─────────────────────────── col-12 ──────────────────────────────┐ │
+│  │ Containers  3 running · 2.4 GB · podman          [Prune] [Logs] │ │
+│  │ ● refactor-sandbox-a3f1     oci.io/forge/rust-tools  [term][stop]│ │
+│  │ ● docs-preview              oci.io/forge/node-preview [term][stop]│ │
+│  │ ◐ pg-test-db                postgres:16              [term][stop]│ │
+│  └─────────────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
-Top-to-bottom: title → provider panel → sessions panel. No tab bar, no sidebar, no pane splits — the Dashboard is intentionally a single flat surface.
+Reading order, top to bottom: app shell chrome → hero → primary row (Sessions / Providers) → secondary row (Usage / Enabled) → full-bleed row (Containers).
 
-### D.2 Title
+## App shell
 
-- Text: `Forge — Dashboard` (em dash, single space either side)
-- Font: `--font-display` (Barlow Condensed)
-- Size: 2rem
-- Color: `--color-text-ember`
-- Margin: `0 0 var(--sp-3) 0`
+The Dashboard does not render its own chrome — see [`app-shell.md`](./app-shell.md). The Activity bar paints `Dashboard` as the active route, the Sidebar paints the `Sessions` row as `aria-current="page"`, and the Status bar's left slot renders `forge · <workspace-name> · <branch>` while the right slot renders the active provider / streaming / cost segments. Route content slots between Sidebar and Status bar.
 
-### D.3 Spacing & background
+## Hero block
 
-- Page padding: `var(--sp-8)` on all sides
-- Background: `--color-bg`
-- Body color: `--color-text-primary`
-- Body font: `--font-body`
+A two-column hero — see `DESIGN.md §Hero block`. Headline on the left, CTA cluster on the right, aligned to the baseline.
 
-### D.4 Composition
+### Anatomy
 
-The Dashboard renders three children in order: `<h1>` title, `<ProviderPanel/>`, `<SessionsPanel/>`. Both panels self-source their data via Tauri commands (`provider_status`, `session_list`) and own their own loading and empty states.
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ Welcome back.                                                       │
+│ Forge something.                          [Attach] [+ New session]  │
+│                                                                     │
+│ Two sessions active. One agent paused awaiting approval.            │
+│ Anthropic and local Ollama connected — OpenAI awaiting credentials. │
+└─────────────────────────────────────────────────────────────────────┘
+```
 
-- **Provider panel** — see `web/packages/app/src/routes/Dashboard/ProviderPanel.tsx`. Shows the configured provider (Phase 1: ollama, hardcoded), reachability indicator, base URL, expandable model list, and a `REFRESH` action that re-probes. When unreachable, renders an `ECONNREFUSED <host>` line and a `START OLLAMA` CTA. Provider identity color follows `ai-patterns.md` — Ollama is `steel`.
-- **Sessions panel** — industrial-ledger specimen cards grouped by `active` / `archived` tabs. Card click dispatches `open_session` and reopens the Session window. Cards show subject, persistence badge, state pip, provider chip, and a relative `last event` timestamp.
+- **Headline.** Two lines. First line `Welcome back.` in `var(--color-text-primary)`. Second line `<em>Forge</em> something.` with the brand word in `var(--color-ember-400)` (inline `<em>`, `font-style: normal`). Display font, weight 800, uppercase, `letter-spacing: 0.02em`.
+- **Status sentence.** A single rendered paragraph beneath the headline summarizing the workspace state. Body font, `var(--color-text-secondary)`, `max-width: 560px`. The sentence is templated from live data: active-session count, paused-agent count, provider readiness summary.
+- **CTA cluster.** Exactly two buttons, `gap: var(--sp-2)`, primary on the right:
+  - `Attach to session` — ghost secondary. Opens the attach picker (F-727). Disabled when there are zero active sessions.
+  - `+ New session` — ember primary, leading `+` glyph (12px). Opens the new-session flow (F-726) — see new-session-flow.md when it lands. Always enabled.
 
-### D.5 States
+### States
 
-The Dashboard itself has no global loading or error state — it always renders the title and both panels. The panels each handle their own state per `component-principles.md`'s four-state rule (loading / error / empty / ready):
+| State    | Trigger                            | Visual                                                     | Verbatim copy                                                                                  |
+| -------- | ---------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| loading  | workspace summary pending          | headline + buttons paint immediately; status sentence renders as `forge · …` placeholder | `forge · …`                                                                                    |
+| empty    | zero sessions, zero providers      | headline + buttons paint; status sentence narrates the empty state | `No sessions yet. Configure a provider to get started.`                                        |
+| error    | workspace summary rejects          | status sentence collapses to the verbatim error fragment; CTAs remain enabled | `Couldn't load workspace status.`                                                              |
+| ready    | summary resolves                   | full hero — headline, status sentence, two CTAs            | `Welcome back.` / `Forge something.` / `Two sessions active. One agent paused awaiting approval. Anthropic and local Ollama connected — OpenAI awaiting credentials.` |
 
-- **Provider panel — loading:** placeholder line `ollama · probing` (noun + state per `voice-terminology.md` §8) while `provider_status` resolves.
-- **Provider panel — unreachable:** error line + remediation hint + `START OLLAMA` CTA.
-- **Sessions panel — loading:** placeholder line `sessions · probing` while `session_list` resolves.
-- **Sessions panel — empty (active tab):** `// no active sessions`.
-- **Sessions panel — empty (archived tab):** `// archive is empty`.
-- **Sessions panel — fetch failure:** visible error block with heading `SESSIONS UNAVAILABLE`, the verbatim error detail (preserved exactly per `voice-terminology.md` §8 "show technical identifiers verbatim"), and a `RETRY` button that re-invokes `session_list`. The error state is distinct from empty — the `session_list` rejection must not collapse to `// no active sessions`.
+## Grid
 
-### D.5.1 Loading-state primitives (F-684)
+The dashboard body uses the `DESIGN.md §Layout grid` 12-column track. Card spans:
 
-Per `docs/design/ai-patterns.md` §"Interaction states", every fetching
-surface paints a **skeleton or the streaming cursor — never plain "loading…"
-text, never a spinner**. The dashboard sections all surface multi-row /
-grid layouts, so they use skeletons (the streaming cursor is reserved for
-inline assistant output in `ChatPane`).
+| Row       | Card                  | Span    | Notes                                                                            |
+| --------- | --------------------- | ------- | -------------------------------------------------------------------------------- |
+| primary   | [Sessions](#sessions-card)        | `col-8` | Left, primary surface — most-recent sessions inline.                              |
+| primary   | [Providers](#providers-card)      | `col-4` | Right, secondary surface — provider readiness at a glance.                        |
+| secondary | [Usage](#usage-card)              | `col-6` | KPI tile + spark chart over the last range.                                       |
+| secondary | [Enabled](#enabled-card)          | `col-6` | Workspace-enabled skills, MCP servers, agents.                                    |
+| third     | [Containers](#containers-card)    | `col-12`| Full-bleed sandbox container card. Body owned by [`containers-section.md#container-card-on-dashboard`](./containers-section.md#container-card-on-dashboard). |
 
-| Section            | Choice    | Shape                                                  |
-|--------------------|-----------|--------------------------------------------------------|
-| Providers          | skeleton  | 4 card-shaped placeholders on the live `auto-fill, minmax(220px, 1fr)` grid |
-| Containers         | skeleton  | 3 row-shaped block placeholders matching the row gap   |
-| Catalog (per tab)  | skeleton  | 4 row-shaped block placeholders inside the active tab  |
-| Usage              | skeleton  | 1 chart placeholder + 3 table-row placeholders         |
+Sub-12 widths require an ADR per `DESIGN.md §Layout grid`.
 
-The shared `<Skeleton>` primitive lives in `@forge/design` (`variant`:
-`block` / `text` / `card`; `count` for stacked rows). It carries
-`role="status"` + `aria-busy="true"` + `aria-live="polite"` so screen
-readers register the load without spamming on every paint, and respects
-`prefers-reduced-motion` by suppressing the shimmer.
+## Sessions card
 
-### D.6 Cross-spec references
+The `col-8` primary card. Surfaces the workspace's recent sessions inline so the operator can resume a thread in one click.
 
-- `session-roster.md` *(deferred post-Phase-2)* — forward-looking spec for an in-session roster of loaded assets. No component or hosting sidebar exists in Phase 2; the Dashboard's session cards still open sessions, but those sessions do not render a roster today.
-- `ai-patterns.md` — provider accent colors used by the provider indicator and any future provider chips on session cards.
-- `provider-selector.md` — composer-time provider switching (Phase 2+). The Dashboard's provider panel is read-only status, not a switcher.
-- `layout-panes.md` — pane model used by the Session window. The Dashboard does not use the pane model.
+### Anatomy
 
-**Doesn't do.**
-- Does not start a new session inline — `forge run …` from a terminal still seeds new sessions in Phase 1; a `NEW SESSION` action arrives later.
-- Does not show usage, billing, or per-model cost — that surfaces in pane headers and the usage view.
-- Does not configure providers — provider config lives in `~/.config/forge/providers.toml`; the panel only reflects status.
+```
+┌─ SESSIONS   active · 2 | archived · 14    2 running · 5 idle    [View all] ─┐
+│ ⚒  ● refactor-payment-service  #a3f1                       streaming        │
+│      ~/code/acme-api · claude-sonnet-4.5 · 3 agents · 12m                   │
+│ ☉  ● doc-site-rewrite  #b8c0                       awaiting approval        │
+│      ~/code/docs-v2 · llama-3.3-70b · 1 agent · 41m                         │
+│ ✓  ● test-harness-migration  #77d3                             done         │
+│      ~/code/acme-api · 64 steps · $2.41 · 2h ago                            │
+│ ▣  ● sql-query-optimizer  #120e                                idle         │
+│      ~/code/analytics · gpt-4.1 · idle · yesterday                          │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Header
+
+- **Label.** `Sessions` — mono-xs uppercase, `var(--color-text-secondary)`.
+- **Tab pair.** Two segments rendered as a single mono chip group inside `var(--color-surface-3)`: `active · <n>` (selected; `var(--color-surface-2)` background) and `archived · <n>`. Switches the body list. Singular collapses (`active · 1`); zero renders `active · 0` (the chip is always present).
+- **Aggregate meta.** `<running> running · <idle> idle`, `var(--color-text-tertiary)`, mono. Suppressed when zero.
+- **Header action.** `View all` — ghost button. Navigates to the full sessions view (Sidebar → `Sessions`).
+
+### Row layout
+
+Each session is one row inside the card body, no per-row card chrome. Row track: `auto 1fr auto` with `gap: var(--sp-3)`, vertical padding `var(--sp-2) var(--sp-4)`, and a `1px solid var(--color-border-1)` bottom border (suppressed on `:last-child`). Cells:
+
+1. **Status icon.** A 16px glyph keyed to the session lifecycle — wrench (active editing), agent (sub-agent active), check (completed), sessions (idle). Color follows the lifecycle: ember for active, success for done, text-tertiary for idle, warning for awaiting approval.
+2. **Identity stack.** Two stacked lines. Line one: provider dot (`p-dot` keyed to provider id), session name (medium weight, body), and the 4-char id in mono-xs `var(--color-text-tertiary)`. Line two: `<workspace-path> · <model> · <agent-count> agents · <last-event>` in mono-xs, `var(--color-text-tertiary)`.
+3. **Status pill.** Right-aligned. Variants per `DESIGN.md §Status pill`: `streaming`, `awaiting approval`, `done`, `idle`.
+
+### Click target
+
+The full row is clickable — opens the session in the Session window (`open_session` Tauri command). Keyboard: each row is `tabindex={0}` and responds to `Enter` / `Space`.
+
+### States
+
+| State    | Trigger                              | Visual                                                                                | Verbatim copy                          |
+| -------- | ------------------------------------ | ------------------------------------------------------------------------------------- | -------------------------------------- |
+| loading  | `session_list` pending               | 4 row-shaped skeletons matching the row height (see [`dashboard.md §Loading skeletons`](#loading-skeletons)) | —                                      |
+| empty    | `session_list` ok, zero sessions     | single full-row placeholder; `View all` disabled                                       | `No active sessions yet.`              |
+| error    | `session_list` rejects               | `role="alert"` error block above the row list with verbatim error detail and a `RETRY` link; `View all` remains enabled | `Couldn't load sessions.`              |
+| ready    | `session_list` ok, sessions > 0      | populated row list (anatomy above)                                                    | —                                      |
+
+The error state is distinct from empty — a `session_list` rejection must not collapse to the empty placeholder. The verbatim error detail is preserved (per `voice-terminology.md §8` "show technical identifiers verbatim").
+
+## Providers card
+
+The `col-4` secondary card on the primary row. Mirrors the provider list from the Providers view in a condensed form — one row per provider, readiness pill on the right.
+
+### Anatomy
+
+```
+┌─ PROVIDERS                                          [Manage] ─┐
+│ ● Anthropic                                        ● ready     │
+│   sonnet-4.5 · opus-4.1                                        │
+│ ● OpenAI                                           ● auth      │
+│   credentials expired                                          │
+│ ● Ollama                                           ● ready     │
+│   llama-3.3 · qwen-2.5                                         │
+│ ● Mistral                                          ● ready     │
+│   medium-2508                                                  │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Header
+
+- **Label.** `Providers` — mono-xs uppercase, `var(--color-text-secondary)`.
+- **Header action.** `Manage` — ghost button. Navigates to the Providers route (see providers-section.md).
+
+### Row layout
+
+Each provider is one row. Track: `auto 1fr auto` with `gap: var(--sp-3)`, padding `var(--sp-3)`. Cells:
+
+1. **Provider dot.** A 10px circle filled with the provider accent (`var(--p-anthropic)`, `var(--p-openai)`, `var(--p-local)`, `var(--p-custom)` — see `docs/design/ai-patterns.md`).
+2. **Identity stack.** Two stacked lines. Line one: provider name (medium weight, body). Line two: model list or status detail in mono-xs, `var(--color-text-tertiary)` — e.g. `sonnet-4.5 · opus-4.1` or `credentials expired`.
+3. **Status pill.** `ready` (success + live-dot glow) or `auth` (error + live-dot glow) per `DESIGN.md §Status pill`.
+
+### States
+
+| State    | Trigger                                | Visual                                                          | Verbatim copy                          |
+| -------- | -------------------------------------- | --------------------------------------------------------------- | -------------------------------------- |
+| loading  | `provider_status` pending              | 4 row-shaped skeletons sized to the row height                  | —                                      |
+| empty    | `provider_status` ok, zero providers   | single full-row placeholder pointing at the Providers route     | `No providers configured.`             |
+| error    | `provider_status` rejects              | `role="alert"` error block above the row list with verbatim error detail and a `RETRY` link | `Couldn't load providers.`             |
+| ready    | `provider_status` ok, providers > 0    | populated row list (anatomy above)                              | —                                      |
+
+Per-row provider failures (single provider unreachable) surface as the `auth` pill on that row, not as a card-level error.
+
+## Usage card
+
+The `col-6` left card on the secondary row. KPI tiles for the last range plus a 7-day spark chart — see `DESIGN.md §KPI tile` and `DESIGN.md §Spark chart`.
+
+### Anatomy
+
+```
+┌─ USAGE · last 7 days                              [7D] 30D MTD ─┐
+│  $18.42         4.2M                1.1M                         │
+│  spend          tokens in           tokens out                   │
+│  ↑ 24% vs last 7d   ↑ 18%           ↑ 31%                        │
+│  ─────────────── 7-day spark line ─────────────────────────────  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Header
+
+- **Label.** `Usage · last 7 days` — mono-xs uppercase, the trailing range fragment lowercase. Range follows the selected tab.
+- **Range tabs.** Three mono chips — `7D` (default), `30D`, `MTD`. Selected chip paints `var(--color-text-primary)` on `var(--color-surface-3)`; the rest paint `var(--color-text-tertiary)` with transparent background.
+
+### Body
+
+Three KPI tiles laid out as a `repeat(3, 1fr)` grid with `gap: var(--sp-4)`. Each tile uses the `DESIGN.md §KPI tile` primitive — label, large value with optional unit, delta line.
+
+| Tile         | Format                | Delta semantic                              |
+| ------------ | --------------------- | ------------------------------------------- |
+| `spend`      | `$<value>`            | up → warning (more spend); down → success   |
+| `tokens in`  | `<value><unit>`       | up → warning; down → success                |
+| `tokens out` | `<value><unit>`       | up → success (more output); down → warning  |
+
+Beneath the KPI grid: a single `DESIGN.md §Spark chart` filling the card width, painting the same range. Latest day point renders at `r="2.5"` with a 1px white stroke.
+
+### States
+
+| State    | Trigger                       | Visual                                                                   | Verbatim copy                          |
+| -------- | ----------------------------- | ------------------------------------------------------------------------ | -------------------------------------- |
+| loading  | usage query pending           | KPI grid renders 3 tile-shaped skeletons; spark renders 1 chart-shaped skeleton | —                                |
+| empty    | usage query ok, zero events   | KPI grid renders zero-valued tiles (`$0.00`, `0`, `0`); delta lines hide; spark renders the empty-baseline path | `No usage recorded yet.`               |
+| error    | usage query rejects           | `role="alert"` error block in place of the KPI grid with a `RETRY` link; spark suppresses | `Couldn't load usage.`                 |
+| ready    | usage query ok, events > 0    | KPI tiles + spark per anatomy                                            | —                                      |
+
+The empty state renders zero-valued tiles rather than a single placeholder — the structure is informative even when the numbers are flat.
+
+## Enabled card
+
+The `col-6` right card on the secondary row. Shows the workspace's enabled skills, MCP servers, and agents in a single mini-list with inline toggles.
+
+### Anatomy
+
+```
+┌─ ENABLED · workspace                                  acme-api ─┐
+│  ★ typescript-review       on    ●——                            │
+│    skill · .forge/skills                                        │
+│  ★ postgres-schemata       on    ●——                            │
+│    skill · anthropic/official                                   │
+│  ⚙ github                  on    ●——                            │
+│    mcp · stdio · v0.9.2                                         │
+│  ⚙ sentry                  off   ——●  connecting…               │
+│    mcp · http                                                   │
+│  ☉ refactor-bot            on    ●——                            │
+│    agent · process-isolated                                     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Header
+
+- **Label.** `Enabled · workspace` — mono-xs uppercase, trailing fragment lowercase.
+- **Workspace name.** Right-aligned, mono-xs, `var(--color-text-tertiary)` — e.g. `acme-api`.
+
+### Row layout
+
+Each entry is one row. Track: `auto 1fr auto auto` with `gap: var(--sp-3)`, padding `var(--sp-2) var(--sp-3)`. Cells:
+
+1. **Kind icon.** A 14px glyph keyed to the entry type — skill, mcp, agent.
+2. **Identity stack.** Two stacked lines. Line one: entry name (medium weight, body). Line two: `<kind> · <source>` (or `<kind> · <transport> · <state>` for MCP) in mono-xs, `var(--color-text-tertiary)`.
+3. **State chip.** `on` (ember-tinted background) or `off` (text-tertiary on transparent). Mono-xxs.
+4. **Toggle.** A `DESIGN.md §Toggle switch` — the visual indicator; the row is the hit target.
+
+### States
+
+| State    | Trigger                            | Visual                                                       | Verbatim copy                          |
+| -------- | ---------------------------------- | ------------------------------------------------------------ | -------------------------------------- |
+| loading  | enabled-list pending               | 5 row-shaped skeletons                                       | —                                      |
+| empty    | enabled-list ok, zero entries      | single full-row placeholder pointing at the Catalog route    | `Nothing enabled in this workspace yet.` |
+| error    | enabled-list rejects               | `role="alert"` error block above the row list with verbatim error detail and a `RETRY` link | `Couldn't load enabled extensions.`    |
+| ready    | enabled-list ok, entries > 0       | populated row list (anatomy above)                           | —                                      |
+
+A single-row failure (e.g. MCP server stuck in `connecting…`) does not raise the card-level error — it surfaces inline on that row as the trailing `<state>` fragment in the identity stack.
+
+## Containers card
+
+The `col-12` full-bleed card on the third row. The dashboard owns the placement; the card's anatomy, header meta, row layout, states, and action contract are defined in [`containers-section.md#container-card-on-dashboard`](./containers-section.md#container-card-on-dashboard).
+
+The runtime banner (when the runtime is missing / broken / rootless-unavailable) anchors above the grid, between the hero and the primary row — see [`containers-section.md §First-run banner`](./containers-section.md#first-run-banner).
+
+## Loading skeletons
+
+Per `docs/design/ai-patterns.md §"Interaction states"`, every fetching surface paints a skeleton or the streaming cursor — never plain "loading…" text, never a spinner. The dashboard cards all surface multi-row / grid layouts, so they use skeletons (the streaming cursor is reserved for inline assistant output in `ChatPane`).
+
+| Card        | Choice    | Shape                                                                                  |
+| ----------- | --------- | -------------------------------------------------------------------------------------- |
+| Sessions    | skeleton  | 4 row-shaped block placeholders matching the row height                                |
+| Providers   | skeleton  | 4 row-shaped block placeholders                                                        |
+| Usage       | skeleton  | 3 KPI-tile placeholders + 1 chart placeholder                                          |
+| Enabled     | skeleton  | 5 row-shaped block placeholders                                                        |
+| Containers  | skeleton  | per [`containers-section.md §States`](./containers-section.md) — 3 row-shaped placeholders |
+
+The shared `<Skeleton>` primitive lives in `@forge/design` (`variant`: `block` / `text` / `card`; `count` for stacked rows). It carries `role="status"` + `aria-busy="true"` + `aria-live="polite"` so screen readers register the load without spamming on every paint, and respects `prefers-reduced-motion` by suppressing the shimmer.
+
+## Live data
+
+Card data sources subscribe to Tauri events to refresh in place — no polling timer at the page level:
+
+| Card        | Query                  | Refresh trigger                                                                |
+| ----------- | ---------------------- | ------------------------------------------------------------------------------ |
+| Sessions    | `session_list`         | `SESSIONS_CHANGED_EVENT` (session open / archive / done)                        |
+| Providers   | `provider_status`      | `PROVIDERS_CHANGED_EVENT` (credential update / reachability change)             |
+| Usage       | `usage_summary`        | `USAGE_TICK_EVENT` (debounced 5s on streaming completion)                       |
+| Enabled     | `workspace_enabled`    | `WORKSPACE_CONFIG_CHANGED_EVENT` (catalog toggle / config save)                 |
+| Containers  | `container_list`       | `CONTAINERS_CHANGED_EVENT` ([`containers-section.md §Live data`](./containers-section.md#live-data)) |
+
+## Keyboard
+
+- Tab order follows document order: hero CTAs → Sessions header → Sessions rows → Providers header → Providers rows → Usage header → Enabled rows → Containers header → Containers rows.
+- `Enter` / `Space` on a session row opens the session.
+- `Enter` on `+ New session` opens the new-session flow (see new-session-flow.md when it lands).
+- `Esc` from any focused row returns focus to the card header.
+
+## Color & typography
+
+- Card chrome: `background: var(--color-surface-1)`, `border: 1px solid var(--color-border-1)`, `border-radius: var(--r-lg)`.
+- Card header label: mono-xs uppercase, `letter-spacing: 0.22em`, `var(--color-text-secondary)`.
+- Card header meta: mono-xxs, `var(--color-text-tertiary)`.
+- Row identity name: body font, weight 500, `var(--color-text-primary)`.
+- Row identity detail: mono-xs, `var(--color-text-tertiary)`.
+- Status pills: per `DESIGN.md §Status pill` — `streaming` (ember-200, animated dot), `awaiting approval` (warning, animated dot), `done` (success, static dot), `idle` (text-secondary, no dot), `ready` (success + glow), `auth` (error + glow).
+- Provider dots: `var(--p-anthropic)`, `var(--p-openai)`, `var(--p-local)`, `var(--p-custom)` per `docs/design/ai-patterns.md`.
+
+## Cross-spec references
+
+- [`app-shell.md`](./app-shell.md) — the chrome the Dashboard mounts inside (Activity bar, Sidebar, Status bar).
+- [`containers-section.md`](./containers-section.md) — owns the `col-12` Containers card anatomy and action contract; see [`#container-card-on-dashboard`](./containers-section.md#container-card-on-dashboard).
+- [`providers-section.md`](./providers-section.md) — the full Providers route; the dashboard's Providers card links to it via the `Manage` header action. (See also providers-page.md, in flight.)
+- [`session-roster.md`](./session-roster.md) — session-internal roster; the dashboard's Sessions card opens the session window where the roster lives.
+- [`usage.md`](./usage.md) — the full Usage route; the dashboard's Usage card is a condensed surface that links into it.
+- [`catalog.md`](./catalog.md) — the full Skills / MCP / Agents catalog; the dashboard's Enabled card is the workspace-scoped slice.
+- [`provider-selector.md`](./provider-selector.md) — composer-time provider switching inside a session. The dashboard's Providers card is read-only status, not a switcher.
+- [`../design/component-principles.md`](../design/component-principles.md) — interaction-state contract (loading / empty / error / ready) every card honors.
+- [`../../DESIGN.md`](../../DESIGN.md) — `Layout grid`, `Hero block`, `KPI tile`, `Spark chart`, `Toggle switch`, `Status pill` primitives consumed by the cards above.
+- new-session-flow.md — F-726 new-session entry flow triggered by the hero `+ New session` CTA. <!-- TODO: link once new-session-flow.md lands -->
+
+## Doesn't do
+
+- Does not author skills, MCP servers, or agents — that surface lives in the Catalog route ([`catalog.md`](./catalog.md)). The Enabled card is a workspace-scoped toggle surface, not an authoring surface.
+- Does not create workspaces — workspace creation is a Settings-time concern; the dashboard reflects the active workspace's state.
+- Does not configure providers — provider config lives in `~/.config/forge/providers.toml` and the Providers route; the Providers card only reflects status.
+- Does not host the session canvas — clicking a session row opens the Session window ([`shell.md`](./shell.md)); the dashboard never embeds the chat pane.
+- Does not surface non-Level-2 sandboxes (cgroup-only Level-1) in the Containers card. Those are session-internal — see [`containers-section.md`](./containers-section.md).

--- a/docs/ui-specs/new-session-flow.md
+++ b/docs/ui-specs/new-session-flow.md
@@ -1,0 +1,168 @@
+# New Session Flow
+
+> UI-only spec ([F-710](https://github.com/forge-ide/forge/issues/710)) — session-spawn flow triggered from the dashboard hero `+ New session` CTA. Wraps the daemon spawn the existing `forge run …` CLI performs (`session_new` in `crates/forge-cli/src/main.rs`) behind a Tauri IPC command `session_start` (delivered by F-725).
+
+---
+
+## Purpose
+
+Let the operator start a Forge session from the Dashboard window without dropping to a terminal. The flow gathers the three inputs the daemon needs — workspace root, provider, agent — validates them client-side, and hands them to the `session_start` IPC. On success the Dashboard hands off to the freshly-opened Session window (the `v-fresh` blank-canvas mock in `docs/forge-mocks.html`); on failure the form re-enables and surfaces the verbatim daemon error.
+
+## Where
+
+The trigger is the `+ New session` button in the Dashboard hero (`DESIGN.md §Hero block`). The form mounts as a focus-trapped modal anchored at id `new-session-modal`, layered above the Dashboard root via the app-shell modal portal (see [`app-shell.md`](./app-shell.md)). Component path: `web/packages/app/src/components/dashboard/NewSessionModal.tsx`. The modal is the only entry point in V1 — the `Attach to session` hero CTA is a separate flow (session list re-entry) and does not pass through this spec.
+
+## Size
+
+Modal surface: `min-width: 480px`, content-driven height, capped at `max-height: 80vh` with internal scroll for the form body if the viewport is short. Mounted via the shared `<Modal>` primitive — `surface-2` card chrome, `var(--sp-6)` padding, focus trap, `Escape` dismisses, backdrop is `rgba(0,0,0,0.6)` and click-dismisses.
+
+## Trigger
+
+The Dashboard hero renders two CTAs (per the `v-dash` mock, lines 1106–1109 of `docs/forge-mocks.html`):
+
+- `Attach to session` — ghost; out of scope for this spec.
+- `+ New session` — primary, ember (`var(--color-ember-400)`); opens this modal.
+
+Activation paths:
+
+- Mouse click on `+ New session`.
+- Keyboard: `n` while the Dashboard root has focus and no input is focused (mirrors the command-palette single-key conventions documented in [`command-palette.md`](./command-palette.md)).
+
+On click, the modal opens to the `idle` state with the workspace field focused. There is no inline composer alternative — the Dashboard is intentionally flat (see [`dashboard.md`](./dashboard.md) §D.1) and inline form chrome would compete with the session roster for the same vertical band.
+
+### Empty-workspace branch
+
+When no workspace is currently open in the calling Dashboard context (the bridge's `cached_workspace_root` returns `None`), `+ New session` does **not** open the form directly. Instead it dispatches the native file picker via `tauri-plugin-dialog`'s directory-select mode, scoped to the user's home directory. Two outcomes:
+
+- **Picker confirms a directory.** The selected absolute path becomes the prefilled `workspace_root` and the modal opens to the `idle` state with focus on `provider` (the workspace field is already valid).
+- **Picker is cancelled.** Nothing further happens; no modal, no toast. The user remains on the Dashboard.
+
+When a workspace *is* already cached, `+ New session` opens the modal with `workspace_root` prefilled from the cached value and focus on `workspace_root` (so the operator can override before submitting). This is the two-step contract: pick a workspace first, then fill the form.
+
+## Form
+
+```
+┌─ NEW SESSION ───────────────────────────────────────────── [×] ─┐
+│                                                                 │
+│ WORKSPACE                                                       │
+│ [ ~/code/acme-api                                    ] [Browse] │
+│                                                                 │
+│ PROVIDER                                                        │
+│ [ anthropic                                              ▾ ]    │
+│                                                                 │
+│ AGENT                                                           │
+│ [ orchestrator                                           ▾ ]    │
+│                                                                 │
+│                                          [Cancel] [Start session]│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Fields
+
+| Field           | Type              | Default                                                  | Validation                                                                                  |
+|-----------------|-------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `workspace_root` | text + `Browse`  | cached workspace (or value chosen in the empty-workspace branch) | required; non-empty; absolute path; `Browse` re-opens the directory picker.            |
+| `provider`      | dropdown          | the `default_provider` recorded in user settings, falling back to the first `ready` entry returned by `dashboard_list_providers` | optional on the wire; the dropdown is always populated so a value is always sent.       |
+| `agent`         | dropdown          | `orchestrator`                                           | optional on the wire; populated from `list_agents`; defaults to `orchestrator` if present. |
+
+Labels use the `mono-xs` input-label style per [`component-principles.md` §Inputs](../design/component-principles.md). Inputs render with the standard token-driven borders — default `var(--color-iron-600)`, hover `var(--color-iron-300)`, focus `var(--color-ember-400)`, error `var(--color-ember-400)`.
+
+Dropdown sourcing:
+
+- **Provider list** comes from the same `dashboard_list_providers` IPC the Dashboard's Providers card uses (see the Providers section of `dashboard.md`; the standalone `providers-page.md` will own its admin chrome once authored). Entries whose status is `auth` or `error` render disabled with the verbatim status word in `var(--color-text-tertiary)` after the name — the user can see why a provider is greyed out without leaving the modal. Selecting a credential-blocked entry is impossible from the dropdown; the credential remediation lives in [`credentials-section.md`](./credentials-section.md).
+- **Agent list** comes from `list_agents`. If the call returns an empty roster the dropdown collapses to a single `orchestrator` option (the built-in fallback). If the call rejects, the dropdown renders disabled with `agents · unavailable` and the form still submits — `agent` is optional on the wire so the daemon picks `orchestrator`.
+
+### Primary / secondary actions
+
+- **Cancel** — ghost (`btn-ghost`). Closes the modal without dispatching IPC. `Escape` is the keyboard equivalent.
+- **Start session** — primary, ember (`btn-pri`). Disabled until `workspace_root` is non-empty. `Enter` while focus is inside the modal submits.
+
+The action cluster sits flush-right at the foot of the modal, matching the form-modal pattern in [`approval-prompt.md` §10.1](./approval-prompt.md) (ghost leads, primary trails; primary carries the keyboard default).
+
+## States
+
+The modal renders all four `docs/design/component-principles.md` states distinctly:
+
+| State           | Form chrome                                                                                                                          | Primary button                                  | Error region                                              |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|-----------------------------------------------------------|
+| `idle`          | All fields enabled, no skeletons. The first invalid (or first if none) field is focused.                                             | Enabled iff `workspace_root` is non-empty.       | Absent.                                                   |
+| `validating`    | Fields enabled, error region absent. Transient — typically a single tick while the client-side path check runs.                       | Disabled with the idle label.                   | Absent.                                                   |
+| `spawning`      | Fields disabled (read-only borders, `iron-600` background per the disabled-button rule — never opacity).                              | Disabled, label swaps to `Starting…`, 6px pulse dot on the leading edge. | Absent.                                                   |
+| `spawn-failed`  | Fields re-enabled, focus jumps to the field the error cites if parseable (`workspace_root` for path errors; otherwise `workspace_root` by default). | Enabled; label reverts to `Start session`.       | `role="alert"` line above the action cluster carrying the verbatim daemon string. |
+
+State badges in the header use the `mono-xxs` status-pill style ([`DESIGN.md` §Status pill](../../DESIGN.md)) — `spawning` is the `streaming` variant (ember-200, pulsing); `spawn-failed` is the `auth` variant (error + glow). `idle` and `validating` render no badge — the form itself is the affordance.
+
+The success path does not have a steady-state — when `session_start` resolves, the Dashboard window dispatches the session-window open event (the same path `open_session` walks today, see [`dashboard.md`](./dashboard.md) §D.4) and dismisses the modal. The freshly-opened Session window paints the `v-fresh` blank canvas (mocks line 1338).
+
+## IPC contract
+
+The form dispatches a single Tauri command, `session_start`, on `Start session` submit. F-725 implements it as a thin wrapper around the same daemon spawn `forge_cli::session_new` performs in `crates/forge-cli/src/main.rs` lines 144–198 — generate a `SessionId`, write a UDS socket path, exec the `forged` binary with `FORGE_SESSION_ID` / `FORGE_SOCKET_PATH` / `FORGE_WORKSPACE` env vars and `--agent` / `--provider` flags, wait for the socket to appear, return the id.
+
+### Input
+
+```ts
+type SessionStartArgs = {
+  workspace_root: string;     // absolute path; required
+  provider?: string;          // provider id from `dashboard_list_providers`; omit to use daemon default
+  agent?: string;             // agent name from `list_agents`; omit for `orchestrator`
+};
+```
+
+### Output (success)
+
+```ts
+type SessionStartOk = {
+  session_id: string;         // the `SessionId::new()` the daemon allocated
+};
+```
+
+### Output (error)
+
+A verbatim string per the F-673 standardized-prefix contract (`crates/forge-shell/src/ipc.rs` lines 54–93). The command-named prefix is `session_start: `; the wrapped daemon error follows untouched. Examples the form surfaces verbatim into `spawn-failed`:
+
+- `session_start: workspace not accessible: No such file or directory (os error 2)`
+- `session_start: provider 'openai' unavailable: credentials expired`
+- `session_start: agent 'orchestrator' not found in agent roster`
+- `session_start: forged failed to bind socket: Address already in use (os error 98)`
+
+The form does not parse, summarize, or rewrite these. They paint as-is in the error region (`var(--font-mono)`, `--type-mono-xs`, `var(--color-text-primary)` text on `var(--color-bg)` — the same treatment the Sessions panel applies to `session_list` failures per [`dashboard.md`](./dashboard.md) §D.5). Per `voice-terminology.md` §8 ("show technical identifiers verbatim"), this is the user's only signal of *what* went wrong; collapsing it loses debuggability.
+
+## Copy
+
+- Modal title: `NEW SESSION` (mono, all-caps, letter-spaced — the `--type-mono-xs` label style).
+- Field labels: `WORKSPACE`, `PROVIDER`, `AGENT`.
+- Workspace browse button: `Browse`.
+- Provider dropdown disabled-entry suffix: `<name> · <status>` (e.g. `OpenAI · auth`, `Mistral · error`).
+- Agent dropdown unavailable placeholder: `agents · unavailable`.
+- Primary action idle: `Start session`. Spawning: `Starting…`. (Ellipsis is a real `…`, not three dots.)
+- Cancel action: `Cancel`.
+- Empty-workspace picker title (passed to `tauri-plugin-dialog`): `Pick a workspace for the new session`.
+- Picker-cancelled silent path: no toast, no copy.
+- Error region prefix: none — the daemon string carries its own `session_start:` prefix.
+
+## Keyboard
+
+- `Tab` order inside the modal — `workspace_root` → `Browse` → `provider` → `agent` → `Cancel` → `Start session` → (wraps back to `workspace_root` via focus-trap).
+- `Enter` submits from any field; `Escape` cancels and closes the modal.
+- `n` on the Dashboard root opens the modal (or the empty-workspace picker first, per §Trigger).
+- The modal carries `role="dialog"` + `aria-modal="true"` + `aria-labelledby` pointing to the `NEW SESSION` title; the error region carries `role="alert"` so screen readers announce daemon failures the moment they paint.
+
+## Cross-spec references
+
+- [`dashboard.md`](./dashboard.md) — root-window layout; the hero CTAs that trigger this flow live in the dashboard's top band, and the post-spawn handoff reuses the dashboard's `open_session` dispatch.
+- [`app-shell.md`](./app-shell.md) — hosts the modal portal; the modal mounts at the shell's modal layer, not inside the Dashboard route.
+- `providers-page.md` *(authored in parallel under F-708)* — owns the long-form provider management surface; the provider dropdown's entries originate from the same `dashboard_list_providers` query the providers page renders. Until that spec lands, the read source of truth is the Providers card on the Dashboard.
+- [`credentials-section.md`](./credentials-section.md) — owns the remediation path when a provider is `auth` or `error`. The new-session form disables those provider entries; it does not relogin inline.
+- [`approval-prompt.md`](./approval-prompt.md) §10.1 — form-modal action pattern this spec mirrors (ghost cancel, ember primary, keyboard default on primary).
+- [`component-principles.md`](../design/component-principles.md) §Inputs / §Buttons — input border tokens and the button-disabled rule (`iron-600` background, never opacity).
+- [`DESIGN.md` §Hero block](../../DESIGN.md) — the trigger CTAs; [`DESIGN.md` §Status pill](../../DESIGN.md) — the `spawning` / `spawn-failed` badge variants.
+- `crates/forge-cli/src/main.rs` lines 144–198 — the existing CLI spawn path `session_start` wraps; the IPC carries no new daemon semantics, only a window-tier surface for the same call.
+- `crates/forge-shell/src/ipc.rs` lines 54–93 — the F-673 error-prefix standard the verbatim error string follows.
+
+## Doesn't do
+
+- Does not let the operator create or edit a provider entry. The dropdown is read-only; provider management lives in the providers page.
+- Does not relogin a credential-blocked provider. The entry is disabled in the dropdown; the operator routes through credentials-section to remediate.
+- Does not let the operator pick a model. Model selection happens inside the session window (see [`provider-selector.md`](./provider-selector.md)); the new-session form picks only a provider.
+- Does not retry on `spawn-failed`. The form re-enables and the operator chooses whether to amend the inputs and resubmit, or cancel. No exponential backoff, no auto-retry — the daemon failures are typically input or environment problems and a silent retry would just mask them.
+- Does not surface the in-flight `forged` startup log. The modal shows only the verbatim error string on failure; deeper diagnosis routes through the daemon log via the regular session-window log surface.

--- a/docs/ui-specs/providers-page.md
+++ b/docs/ui-specs/providers-page.md
@@ -1,0 +1,275 @@
+# Providers Page
+
+> Full-page route (F-711) — the `/providers` workspace view targeted by the dashboard Providers card's `Manage` link. Owns the configuration surface for built-in and user-defined providers: add, edit, remove, enable/disable, and a one-shot reachability probe.
+
+---
+
+## Purpose
+
+Provide a single, navigable surface for configuring every provider Forge will offer to sessions. The dashboard's Providers card ([`providers-section.md`](./providers-section.md)) is a *picker* against the active provider; this page is the *editor* behind it. Every CRUD operation that touches `[providers.*]` in user settings lands here so the dashboard card and the new-session picker can stay read-only.
+
+## Route
+
+- **Path:** `/providers` — mounted in the `Router` defined in `web/packages/app/src/App.tsx`.
+- **Shell:** renders inside the app shell (see [`app-shell.md`](./app-shell.md)); the activity-bar `Providers` icon stays active while this route is mounted.
+- **Triggered from:** the dashboard Providers card `Manage` action (F-721). Plain-text reference until `dashboard.md` is rewritten in parallel.
+- **Component path:** `web/packages/app/src/pages/ProvidersPage.tsx`.
+
+## List view
+
+```
+┌─ PROVIDERS                                          [+ Add provider] ─┐
+│ ● anthropic          built-in   ⦿ key       ● ready 142ms  [Test][Edit][Remove] │
+│ ● openai             built-in   ⚠ key       ◌ unknown      [Test][Edit][Remove] │
+│ ○ ollama             built-in              ● ready 12ms   [Test][Edit][Remove]  │
+│ ● custom_openai:vllm custom     ⦿ key       ● ready 38ms   [Test][Edit][Remove] │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### Header
+
+A page-scoped header above the row list:
+- **Left:** `Providers` title in `var(--font-display)` weight 800, uppercase, `letter-spacing: 0.02em`.
+- **Right:** `+ Add provider` primary CTA (ember) — opens the §Add provider form modal.
+
+### Row layout
+
+One full-width row per provider. Row track: `auto 1fr auto auto auto auto` with `gap: var(--sp-3)`, padding `var(--sp-2) var(--sp-4)`, and a `1px solid var(--color-border-1)` bottom border (suppressed on `:last-child`). Cells, left to right:
+
+1. **Enabled toggle.** A §Toggle switch primitive (per [`DESIGN.md` §Toggle switch](../../DESIGN.md)). Off-disabled providers are dimmed but still render every other cell. The toggle's hit target is the toggle cell only — clicking the row body does nothing.
+2. **Identity stack.** Two stacked lines: provider id (`var(--font-mono)`, `--type-mono-xs`, `var(--color-text-primary)`) on top; kind label (`built-in` or `custom_openai`) plus model id when present on the second line in `var(--font-mono)` at `--type-mono-xxs` in `var(--color-text-tertiary)`.
+3. **Credential indicator.** `⦿ key` (`--color-ok`) when stored, `⚠ key` (`--color-warn`) when required-but-missing, omitted entirely when the provider is keyless. Mirrors the dashboard card hint vocabulary so the surfaces read as one system.
+4. **Connection-status pill.** A §Status pill (per [`DESIGN.md` §Status pill](../../DESIGN.md)) reflecting the most recent `test_provider_connection` outcome — `ready` (success, with `<latency_ms>ms`), `unreachable`, `auth-required`, or `unknown` (idle). The pill collapses to `unknown` on first paint; it does not auto-probe.
+5. **Actions cluster.** Three `btn-ghost` chips with compact mono sizing: `Test`, `Edit`, `Remove`. `Remove` carries the destructive-action treatment from `docs/design/component-principles.md`.
+
+## Add provider
+
+A focus-trapped `role="dialog" aria-modal="true"` modal opened from the header CTA. Window-level `Escape` handler closes it; the focus trap can't swallow the keystroke.
+
+### Fields
+
+- **Kind** (`<select>`): built-in templates (`anthropic`, `openai`, `ollama`, …) or `custom_openai`. Kind selection drives which subsequent fields are visible.
+- **Name** (`<input>`): unique slug per provider. For built-ins, the kind itself is the canonical slug and the field is read-only with a `Hint: rename to add a second instance` affordance. For `custom_openai`, the field is required and must match `[A-Za-z0-9_-]+` (mirrors `validate_provider_id`'s suffix charset).
+- **Built-in kind fields:**
+  - `model` — default model id; pre-filled from the kind's built-in default; editable.
+  - `endpoint` — optional override; placeholder shows the built-in's canonical URL.
+- **Custom OpenAI fields:**
+  - `endpoint` — required; must parse as an `http`/`https` URL.
+  - `model` — required; non-empty.
+  - `api_version` — optional, free-text.
+- **Credential** — see §Credential entry below.
+
+### Validation
+
+- `name` is unique against the merged settings' provider keys (built-in id list + `[providers.custom_openai.*]`).
+- `endpoint` parses via `URL` constructor; non-`http`/`https` schemes are rejected before submit.
+- `credential` is non-empty when the kind's `credential_required` flag is set.
+
+### Submit
+
+`Add` → calls `add_provider` IPC. On success, the modal closes, the row list refetches, and the new row scrolls into view with a one-tick `provider-row--just-added` highlight. On failure, the modal stays open and the error renders inline above the action row (verbatim).
+
+## Credential entry
+
+Write-only by contract — the value is never echoed back to the DOM, never serialized into a row, never carried in a tracing field. The form holds the typed value in a local `draft()` signal cleared on submit-resolve or modal-close.
+
+### Field
+
+- `<input type="password" autocomplete="off" spellcheck="false">` labelled `API key`.
+- For keyless kinds the field is hidden entirely.
+- For required-key kinds with no key stored, the label reads `Add key`; when re-opening an existing provider with a key already on the keyring, the label flips to `Replace key` and the submit chip reads `ROTATE` instead of `STORE`.
+
+### Storage
+
+The underlying IPC contract — `login_provider`, `logout_provider`, `has_credential` — is defined in [`credentials-section.md`](./credentials-section.md). This page is a *caller* of those commands, not their definition surface. The Add / Edit submit flow chains `add_provider` (or `update_provider`) → `login_provider` so the row's row-side `has_credential` probe reflects the new state on the next refetch.
+
+This page is the only UI surface that opens the credential field; the dashboard's credentials card has been removed.
+
+## Test connection
+
+### Trigger
+
+The per-row `Test` chip. The button is `aria-busy=true` while a probe is in flight; clicking it again is a no-op.
+
+### Result
+
+`test_provider_connection` returns `{ ok, latency_ms?, model_count? }`. On `ok = true`, the connection-status pill renders `ready <latency_ms>ms` in `var(--color-success)`; if `model_count` is present, the row's model-id second line appends `(<n> models)` in `var(--color-text-tertiary)`. On failure, the pill flips to `unreachable` (or `auth-required` if the verbatim error begins with `test_provider_connection: auth `) and a `role="alert"` line surfaces under the row carrying the verbatim error.
+
+Failures do not block subsequent edits — a provider can be edited or removed in any state.
+
+## Edit/Remove
+
+### Edit
+
+`Edit` opens the same modal pre-populated from the current row. The `kind` field is read-only on edit — switching a provider's kind would invalidate every dependent setting. Submit calls `update_provider`; success closes the modal and triggers a refetch.
+
+If the credential field is left blank on edit, the stored key is untouched. Typing a new value flows through this page's rotation-confirm modal so the user explicitly acknowledges the keyring overwrite before `login_provider` fires (see [`credentials-section.md` §Destructive-action contract](./credentials-section.md) for the wire-level rationale).
+
+### Remove
+
+`Remove` opens a destructive confirm per `docs/design/component-principles.md` destructive-action contract:
+
+```
+┌────────────────────────────────────────────┐
+│ REMOVE PROVIDER?                           │
+├────────────────────────────────────────────┤
+│ Removing <provider-id> deletes its config  │
+│ from this workspace and clears its stored  │
+│ credential. Active sessions stay on the    │
+│ provider they started with.                │
+├────────────────────────────────────────────┤
+│                          [CANCEL] [REMOVE] │
+└────────────────────────────────────────────┘
+```
+
+On confirm:
+1. `remove_provider` IPC fires.
+2. If the removed provider was the active selection, the page clears `[providers.active]` via `set_active_provider` with an empty id (allowed under F-586 semantics — an empty active id leaves the next session to fall back to the catalog default).
+3. The keyring entry is removed in the same submit via `logout_provider` (no separate user confirmation — the destructive modal already covers it).
+4. The row list refetches; new-session pickers ([`new-session-flow.md`](./new-session-flow.md) — authored in parallel) drop the entry on their next read.
+
+## Enabled toggle
+
+Per-row §Toggle switch. Calls `set_provider_enabled` and refetches; the switch is `aria-busy=true` for the duration of the call. Disabled providers stay in the list (so the user can re-enable or remove them) but do not appear in the new-session provider picker.
+
+The disabled state is purely advisory — it does not remove the credential, does not interfere with running sessions, and does not affect `dashboard_list_providers` (the dashboard card always shows every configured provider so the user can see what's available before they spawn).
+
+## States
+
+The page renders all four `docs/design/component-principles.md` states distinctly, plus per-form / per-test sub-states.
+
+### Page level
+
+- **Loading.** Skeleton placeholder — three `block`-variant skeletons sized to the row height (toggle + identity + credential + pill + actions). The header paints immediately; the `+ Add provider` CTA renders disabled while loading.
+- **Empty.** No providers configured (post-removal of every entry): a single full-row placeholder `var(--font-mono)` at `--type-mono-xs` in `var(--color-text-tertiary)` reading `No providers configured. Add one to start a session.` plus an inline `+ Add provider` repeat of the header CTA centred in the row.
+- **Error.** A `role="alert"` line above the list reading `Couldn't load providers — <verbatim error>` with a `RETRY` link. The header CTA stays enabled — adding a provider does not require a successful list read.
+- **Ready.** The row list above.
+
+### Per-form (Add / Edit modal)
+
+- **Idle.** Modal open, fields editable, submit enabled when validation passes.
+- **Validating.** A field-level red helper line under the offending field; submit disabled until cleared.
+- **Saving.** Submit chip `aria-busy=true`; modal action row reads `Saving…`; all fields disabled.
+- **Save-failed.** Inline `role="alert"` line above the action row carrying the verbatim IPC rejection (e.g. `add_provider: name already exists`). Fields re-enable so the user can correct and retry.
+
+### Per-test (per-row probe)
+
+- **Idle.** Pill reads `unknown`; `Test` chip enabled.
+- **Probing.** Pill reads `probing` (`var(--color-text-secondary)`, animated dot via the `pulse` keyframes); `Test` chip `aria-busy=true`.
+- **Probe-ok.** Pill flips to `ready <latency_ms>ms` (`var(--color-success)`); model-id line annotates with model count when returned.
+- **Probe-failed.** Pill flips to `unreachable` or `auth-required` (`var(--color-error)`); inline `role="alert"` under the row with the verbatim error.
+
+## IPC contracts
+
+Every command in this section follows the F-673 standard: the outer error string returned to the webview begins with `<command_name>: `, where `<command_name>` matches the wire name of the Tauri command. See `crates/forge-shell/src/ipc.rs` "Error handling (F-673)" header for the canonical rationale.
+
+### `add_provider` (F-730)
+
+```
+input:  { kind: string, name: string, model?: string, endpoint?: string, api_version?: string }
+output: { provider_id: string }
+error:  "add_provider: <reason>"
+```
+
+Validates `name` against the existing provider id-set, validates `endpoint` as `http`/`https`, persists the new `[providers.custom_openai.<name>]` or built-in instance entry through `apply_setting_update`, and returns the canonical `provider_id` (e.g. `custom_openai:vllm`). Does not store the credential — chain `login_provider` from the caller for that.
+
+### `update_provider` (F-731)
+
+```
+input:  { provider_id: string, name?: string, model?: string, endpoint?: string, api_version?: string, kind?: never }
+output: { provider_id: string }
+error:  "update_provider: <reason>"
+```
+
+`kind` is intentionally absent — kind transitions are out of scope. Renames (`name` change) re-key the settings entry and migrate the keyring id by chaining a `logout_provider` of the old id and a `login_provider` of the new id when the caller passes a fresh credential. The IPC itself does not touch the keyring.
+
+### `remove_provider` (F-732)
+
+```
+input:  { provider_id: string }
+output: {}
+error:  "remove_provider: <reason>"
+```
+
+Deletes the settings entry. Clears `[providers.active]` if the removed id was active. Does not remove the keyring entry — the caller chains `logout_provider` for that so the keyring write is observable as its own IPC trace.
+
+### `set_provider_enabled` (F-733)
+
+```
+input:  { provider_id: string, enabled: bool }
+output: {}
+error:  "set_provider_enabled: <reason>"
+```
+
+Toggles the `enabled` field on the settings entry. Emits `PROVIDER_CHANGED_EVENT` so the new-session picker refreshes on the next paint.
+
+### `test_provider_connection` (F-733)
+
+```
+input:  { provider_id: string }
+output: { ok: bool, latency_ms?: number, model_count?: number }
+error:  "test_provider_connection: <reason>"
+```
+
+Issues a single low-cost probe against the provider's models endpoint (built-ins use the canonical URL; `custom_openai` uses the configured `endpoint`). Carries a 5s wall-clock deadline. `auth-required` is signalled by the verbatim error beginning `test_provider_connection: auth ` so the renderer can route the pill to its `auth-required` variant without parsing the rest of the string. Does not mutate state.
+
+### Credential-related IPCs
+
+`login_provider`, `logout_provider`, and `has_credential` are *not* defined by this page — they belong to the credential surface. See [`credentials-section.md`](./credentials-section.md) for their canonical wire format, error prefixes, and authz policy.
+
+## Copy
+
+- Page title: `Providers`
+- Header CTA: `+ Add provider`
+- Row-action chips: `Test`, `Edit`, `Remove`
+- Connection-status pills (lowercase, mono): `ready <ms>`, `unreachable`, `auth-required`, `probing`, `unknown`
+- Credential indicators: `⦿ key` (stored) / `⚠ key` (missing)
+- Empty placeholder: `No providers configured. Add one to start a session.`
+- List-error line: `Couldn't load providers — <verbatim error>` with `RETRY` link
+- Remove-confirm title: `REMOVE PROVIDER?`
+- Remove-confirm body: `Removing <strong>{providerId}</strong> deletes its config from this workspace and clears its stored credential. Active sessions stay on the provider they started with.`
+- Remove-confirm buttons: `CANCEL`, `REMOVE`
+- Add-modal title: `ADD PROVIDER`
+- Edit-modal title: `EDIT PROVIDER`
+- Modal action buttons: `CANCEL`, `STORE` (no key yet) / `ROTATE` (key present, value typed) / `SAVE` (no credential change)
+
+## Color & typography
+
+- Provider id: `var(--font-mono)`, `--type-mono-xs`, `var(--color-text-primary)`.
+- Kind + model second line: `var(--font-mono)`, `--type-mono-xxs`, `var(--color-text-tertiary)`.
+- Credential indicators: `⦿ key` → `var(--color-ok)`; `⚠ key` → `var(--color-warn)`.
+- Connection pill: per [`DESIGN.md` §Status pill](../../DESIGN.md) — `ready` uses `var(--color-success)` with the live-dot glow; `auth-required` uses `var(--color-error)` with the error live-dot glow; `unreachable` uses `var(--color-error)` static; `unknown` uses `var(--color-text-secondary)` no dot; `probing` uses `var(--color-text-secondary)` with animated `pulse` dot.
+- Row dividers: `1px solid var(--color-border-1)`; no border on the last row.
+- Toggle: per [`DESIGN.md` §Toggle switch](../../DESIGN.md) — track `var(--color-border-1)` (off) / `var(--color-ember-900)` (on); thumb `var(--color-text-tertiary)` (off) / `var(--color-ember-400)` (on).
+- Modal chrome: `var(--color-surface-2)` background, `1px solid var(--color-border-1)`, `var(--r-lg)` radius, `var(--sp-6)` padding.
+
+## Keyboard
+
+- Tab — page enters at the `+ Add provider` CTA, then each row's enabled-toggle → `Test` → `Edit` → `Remove` in document order.
+- Enter inside a row's `Edit` or `Remove` chip — invokes the action (modal opens for `Edit`; destructive confirm opens for `Remove`).
+- Space on a focused toggle — flips the enabled state.
+- Escape inside any modal — cancels (window-level handler so the focus trap can't swallow it).
+- Arrow keys do not move focus between rows — rows are not a radiogroup here (the page is the editor, not the picker; the dashboard's providers card owns radio semantics).
+
+## Destructive-action contract
+
+`Remove` is irreversible — the settings entry and the keyring entry both go in one submit. The confirm modal gates it per `docs/design/component-principles.md`. `set_provider_enabled` is single-step (toggling is reversible by toggling back). `update_provider` is single-step unless the credential is being rotated, in which case this page's rotation-confirm modal gates the `login_provider` call (see [`credentials-section.md` §Destructive-action contract](./credentials-section.md)).
+
+## Cross-spec references
+
+- [`app-shell.md`](./app-shell.md) — the page mounts inside the shell; activity-bar `Providers` icon stays active.
+- `dashboard.md` — the dashboard Providers card's `Manage` link targets `/providers`. Plain-text reference until F-721 rewrites the dashboard spec to add the link.
+- [`providers-section.md`](./providers-section.md) — the read-only dashboard card whose underlying `dashboard_list_providers` IPC reflects every change made on this page.
+- [`credentials-section.md`](./credentials-section.md) — canonical IPC reference for `login_provider`, `logout_provider`, `has_credential`.
+- `new-session-flow.md` — the new-session picker reads the provider list this page edits. Plain-text reference until the file is authored in parallel.
+- [`provider-selector.md`](./provider-selector.md) — composer-time per-turn switcher; reads the same provider list.
+- `docs/design/component-principles.md` — destructive-action contract and four-state rule.
+- `docs/architecture/credentials.md` — backend keyring contract.
+
+## Doesn't do
+
+- Does not store usage / cost data — see [`usage.md`](./usage.md).
+- Does not let the user *view* a stored key — the IPC contract is one-way (see [`credentials-section.md`](./credentials-section.md)).
+- Does not switch the active provider — that's the dashboard Providers card (see [`providers-section.md`](./providers-section.md)).
+- Does not configure session-time overrides — see [`provider-selector.md`](./provider-selector.md).
+- Does not auto-probe connection status on load — `Test` is user-driven so the page does not generate background network traffic.


### PR DESCRIPTION
## Summary

Lands the spec/docs scaffolding for Phase 3.1 — the design contract that every implementation ticket in Groups B–G will reference. No code changes.

- **F-707** DESIGN.md gains layout grid, hero block, KPI tile, spark chart, toggle switch, status pill, and status bar primitives. Each primitive names the tokens it consumes; missing tokens flagged inline as TODO. Cross-refs added to `docs/design/component-principles.md`.
- **F-708** `dashboard.md` rewritten to match `v-dash`: hero block + 12-col grid with five cards (Sessions col-8, Providers col-4, Usage col-6, Enabled col-6, Containers col-12). Each card carries a four-state matrix (loading / empty / error / ready) with verbatim copy. "Doesn't do" no longer defers new-session CTA, usage, or containers.
- **F-709** `app-shell.md` (new) describes the unified shell (ActivityBar 44px + Sidebar 240px + StatusBar 22px) mounted on every route. Disambiguates the primary-nav Sidebar from the workspace-tree `FilesSidebar`.
- **F-710** `new-session-flow.md` (new) specifies the `+ New session` modal and `session_start` IPC `{ workspace_root, provider?, agent? } → { session_id } | error`. Documents the empty-workspace two-step flow.
- **F-711** `providers-page.md` (new) specifies the `/providers` route: list view, add provider (built-in + `custom_openai`), credential entry (write-only), test connection, edit/remove, enabled toggle. Documents `add_provider` / `update_provider` / `remove_provider` / `set_provider_enabled` / `test_provider_connection` IPC contracts with the F-673 verbatim-error format.
- **F-712** `credentials-section.md` rescoped to IPC reference only (110 → 95 lines). Dashboard-card framing removed; top-of-file note explains the move to `providers-page.md`.
- **F-713** `containers-section.md` updated to mock row format: full-width rows with inline term/stop, header meta, `Prune` / `Logs` on card header (Logs no longer a flyout).
- **F-714** `catalog.md` gains §Search and filters (chips with predicates), §Add MCP server (stdio + http variants, write-only credential, schema validation), §Enablement toggles (`set_setting catalog.enabled.<kind>.<id>`).
- **F-715** `v1-ui-completeness.md` (new, under `docs/product/`) product acceptance gate: 14-workflow table mapping every V1 UI workflow to the ui-spec that delivers it. Out-of-scope mirrors the Phase 3.1 milestone.

Closes F-707, F-708, F-709, F-710, F-711, F-712, F-713, F-714, F-715.

## Verification

- `lychee --offline` across all 10 touched specs: **153 OK / 0 errors** (9 excluded per `lychee.toml`)
- `pnpm check-tokens`: **70 tokens match**
- `pnpm typecheck`: **all 4 packages pass**

## Test plan

- [ ] Reviewers confirm every spec carries the four-state contract (loading / empty / error / ready) per card / subcomponent
- [ ] Reviewers confirm IPC contracts match F-673 verbatim-error format
- [ ] Reviewers confirm cross-references resolve (lychee run in CI link-check workflow)
- [ ] Reviewers confirm "Doesn't do" sections agree with the Phase 3.1 milestone's out-of-scope list

🤖 Generated with [Claude Code](https://claude.com/claude-code)