### PR TITLE
fix(forge-session): plumb user_home through serve_with_session for MCP test isolation

### DIFF
--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -133,8 +133,11 @@ async fn main() -> Result<()> {
     // `forged` subprocesses in integration tests set `FORGE_USER_HOME_FOR_TEST`
     // to a tempdir so `load_mcp_manager` does not see the developer's real
     // `~/.mcp.json` (CI passes because `$HOME` is clean; local runs leak).
-    // Gated on `debug_assertions` so release builds never honour the
-    // override — production resolves through `dirs::home_dir()` only.
+    //
+    // Gated on `debug_assertions`: disabled in the default release profile;
+    // a profiling build with `[profile.release] debug-assertions = true`
+    // would still honour it. The `FOR_TEST` naming convention is the real
+    // safety contract — never set this env var in production.
     let user_home_override = if cfg!(debug_assertions) {
         std::env::var("FORGE_USER_HOME_FOR_TEST")
             .ok()
@@ -173,9 +176,9 @@ async fn main() -> Result<()> {
                 // F-601: typed active-agent — `None` here keeps memory off.
                 active_agent,
                 // Test isolation: `Some(tempdir)` when
-                // `FORGE_USER_HOME_FOR_TEST` is set in a debug build; `None`
-                // in release builds where the loader falls back to
-                // `dirs::home_dir()`.
+                // `FORGE_USER_HOME_FOR_TEST` is set in a build with
+                // `debug_assertions = true`; `None` otherwise, in which case
+                // `load_mcp_manager` falls back to `dirs::home_dir()`.
                 user_home_override,
             )
             .await

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -128,6 +128,22 @@ async fn main() -> Result<()> {
         .ok()
         .filter(|s| !s.trim().is_empty());
 
+    // Test-isolation seam for the user-scope `~/.mcp.json` loader (mirrors
+    // the F-743 shell-side `resolve_user_home_dir` test override). Spawned
+    // `forged` subprocesses in integration tests set `FORGE_USER_HOME_FOR_TEST`
+    // to a tempdir so `load_mcp_manager` does not see the developer's real
+    // `~/.mcp.json` (CI passes because `$HOME` is clean; local runs leak).
+    // Gated on `debug_assertions` so release builds never honour the
+    // override — production resolves through `dirs::home_dir()` only.
+    let user_home_override = if cfg!(debug_assertions) {
+        std::env::var("FORGE_USER_HOME_FOR_TEST")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+    } else {
+        None
+    };
+
     // Provider selection (F-038, F-743):
     //   1. explicit `--provider <spec>` flag, OR `FORGE_PROVIDER` env.
     //
@@ -156,6 +172,11 @@ async fn main() -> Result<()> {
                 None,
                 // F-601: typed active-agent — `None` here keeps memory off.
                 active_agent,
+                // Test isolation: `Some(tempdir)` when
+                // `FORGE_USER_HOME_FOR_TEST` is set in a debug build; `None`
+                // in release builds where the loader falls back to
+                // `dirs::home_dir()`.
+                user_home_override,
             )
             .await
         }
@@ -172,6 +193,7 @@ async fn main() -> Result<()> {
                 // F-743: Ollama is keyless; no credential pull.
                 None,
                 active_agent,
+                user_home_override,
             )
             .await
         }

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -379,8 +379,20 @@ pub fn event_log_path(session_id: &str, workspace: Option<&Path>) -> PathBuf {
 /// missing `$HOME` (extremely unusual — CI without `HOME` set) skips the
 /// user-scope file and loads workspace only. That's the fail-open path:
 /// we'd rather run with fewer servers than fail the whole session.
-async fn load_mcp_manager(workspace_path: Option<&Path>) -> Option<Arc<forge_mcp::McpManager>> {
-    let user_dir = dirs::home_dir();
+///
+/// `user_home_override` is the test-isolation seam (mirrors the F-743
+/// shell-side `resolve_user_home_dir` pattern): when `Some`, it replaces
+/// `dirs::home_dir()` so an integration test can point the user-scope
+/// `.mcp.json` loader at a tempdir instead of the developer's real
+/// `~/.mcp.json`. Production callers (`forge-session::main`) pass `None`
+/// and the platform resolver is used unchanged.
+async fn load_mcp_manager(
+    workspace_path: Option<&Path>,
+    user_home_override: Option<&Path>,
+) -> Option<Arc<forge_mcp::McpManager>> {
+    let user_dir = user_home_override
+        .map(Path::to_path_buf)
+        .or_else(dirs::home_dir);
     let merged = match workspace_path {
         Some(ws) => match (user_dir.as_deref(), forge_mcp::config::load_workspace(ws)) {
             (Some(home), ws_result) => match (forge_mcp::config::load_user_from(home), ws_result) {
@@ -655,6 +667,7 @@ pub async fn serve(path: &Path, auto_approve: bool, ephemeral: bool) -> Result<(
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -774,6 +787,13 @@ pub async fn serve_with_session<P: Provider + 'static>(
     // only safe way to give different connections in a persistent-mode
     // daemon distinct active agents.
     active_agent: Option<String>,
+    // Test-isolation seam for the user-scope `~/.mcp.json` loader (mirrors
+    // the F-743 shell-side `resolve_user_home_dir` pattern). When `Some`,
+    // `load_mcp_manager` resolves the user-scope `.mcp.json` against this
+    // directory instead of `dirs::home_dir()`, so an integration test can
+    // isolate from the developer's real `~/.mcp.json`. Production callers
+    // pass `None` and the platform resolver is used unchanged.
+    user_home_override: Option<PathBuf>,
 ) -> Result<()> {
     serve_with_session_swappable(
         path,
@@ -786,6 +806,7 @@ pub async fn serve_with_session<P: Provider + 'static>(
         session_id,
         credentials,
         active_agent,
+        user_home_override,
     )
     .await
 }
@@ -812,6 +833,10 @@ pub async fn serve_with_session_swappable<P: Provider + 'static>(
     session_id: Option<String>,
     credentials: Option<CredentialContext>,
     active_agent: Option<String>,
+    // See [`serve_with_session`] for the contract — production passes
+    // `None`; integration tests pass a tempdir path to isolate the
+    // user-scope `.mcp.json` loader from the developer's real home.
+    user_home_override: Option<PathBuf>,
 ) -> Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -901,7 +926,7 @@ pub async fn serve_with_session_swappable<P: Provider + 'static>(
     // `list_mcp_servers` / `toggle_mcp_server` / `import_mcp_config`
     // Tauri command bounces through this session's UDS so a toggle
     // affects running tool-call dispatch immediately.
-    let mcp = load_mcp_manager(workspace_path.as_deref()).await;
+    let mcp = load_mcp_manager(workspace_path.as_deref(), user_home_override.as_deref()).await;
 
     // F-371: build `session_id` before spawning the MCP state forwarder so
     // the forwarder can carry it on every structured log line. Moved up

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -83,8 +83,21 @@ fn idle_timeout() -> Duration {
 /// `AgentScope::User`; the synthesized root uses `Isolation::Process`),
 /// so we unwrap the spawn error into an `eprintln` rather than
 /// propagating.
-async fn build_agent_runtime(workspace_path: Option<&Path>) -> Option<AgentRuntime> {
-    let user_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+///
+/// `user_home_override` is the same test-isolation seam used by
+/// [`load_mcp_manager`]: when `Some`, the user-scope `~/.agents/` loader
+/// reads from this directory instead of `dirs::home_dir()`. Production
+/// callers pass `None`. Without this seam, a developer with personal
+/// agent defs in `~/.agents/` would see them merged into test fixtures
+/// and break length-sensitive assertions.
+async fn build_agent_runtime(
+    workspace_path: Option<&Path>,
+    user_home_override: Option<&Path>,
+) -> Option<AgentRuntime> {
+    let user_home = user_home_override
+        .map(Path::to_path_buf)
+        .or_else(dirs::home_dir)
+        .unwrap_or_else(|| PathBuf::from("/"));
     // Workspace-anchored load when we have one; fall back to user-only so
     // embedder-less sessions (tests, ephemeral CLI runs) still get agent
     // defs the user has authored.
@@ -990,7 +1003,8 @@ pub async fn serve_with_session_swappable<P: Provider + 'static>(
     // F-601: built before the dispatcher cache so the active agent's
     // `memory_enabled` flag can decide whether `memory.write` registers
     // and whether the memory body is appended to the system prompt.
-    let agent_runtime: Option<AgentRuntime> = build_agent_runtime(workspace_path.as_deref()).await;
+    let agent_runtime: Option<AgentRuntime> =
+        build_agent_runtime(workspace_path.as_deref(), user_home_override.as_deref()).await;
 
     // F-602: consult the user's `[memory.enabled.<agent>]` settings entry
     // before deciding whether memory is on. The Dashboard's Memory toggle

--- a/crates/forge-session/tests/fs_read_tool.rs
+++ b/crates/forge-session/tests/fs_read_tool.rs
@@ -97,6 +97,7 @@ async fn fs_read_tool_returns_content_bytes_sha256() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/handshake.rs
+++ b/crates/forge-session/tests/handshake.rs
@@ -142,6 +142,7 @@ async fn session_id_stable_across_handshakes() {
             Some(server_id),
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();
@@ -186,6 +187,7 @@ async fn workspace_reported_as_absolute_path() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/headless_session/basic.rs
+++ b/crates/forge-session/tests/headless_session/basic.rs
@@ -79,11 +79,20 @@ async fn full_headless_turn_emits_correct_event_sequence() {
 
     let sock_path = dir.path().join("session.sock");
 
+    // Isolate the daemon's user-scope `~/.mcp.json` loader from the
+    // developer's real home — without this, any host with entries in
+    // `~/.mcp.json` adds a leading `Event::McpState` to the captured
+    // event tape and the sequence assertion below fails. The override
+    // is honored by `forge-session::main` only in debug builds.
+    let user_home = dir.path().join("user_home");
+    std::fs::create_dir_all(&user_home).unwrap();
+
     let mut child = tokio::process::Command::new(FORGED)
         .arg("--auto-approve-unsafe")
         .env("FORGE_SESSION_ID", "headless-test-001")
         .env("FORGE_SOCKET_PATH", &sock_path)
         .env("FORGE_MOCK_SEQUENCE_FILE", &mock_path)
+        .env("FORGE_USER_HOME_FOR_TEST", &user_home)
         .stdout(Stdio::null())
         .stderr(Stdio::inherit())
         .spawn()

--- a/crates/forge-session/tests/interrupt_refine.rs
+++ b/crates/forge-session/tests/interrupt_refine.rs
@@ -112,6 +112,7 @@ async fn spawn_daemon(dir: &TempDir, scripts: Vec<String>) -> (std::path::PathBu
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/memory_injection.rs
+++ b/crates/forge-session/tests/memory_injection.rs
@@ -148,6 +148,7 @@ async fn serve_with_session_accepts_typed_active_agent_parameter() {
             // workspace — the rules in `resolve_session_memory` quietly
             // disable memory and the session continues normally.
             Some("scribe".to_string()),
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/orchestrator.rs
+++ b/crates/forge-session/tests/orchestrator.rs
@@ -97,6 +97,12 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
     let dir = TempDir::new().unwrap();
     let log_path = dir.path().join("events.jsonl");
     let sock_path = dir.path().join("test.sock");
+    // Isolate the daemon's user-scope `~/.mcp.json` loader from the
+    // developer's real home so a populated host `~/.mcp.json` does not
+    // prepend an `Event::McpState` to the captured event tape and break
+    // the sequence assertion below.
+    let user_home = dir.path().join("user_home");
+    std::fs::create_dir_all(&user_home).unwrap();
 
     let session = Arc::new(Session::create(log_path).await.unwrap());
     let provider = Arc::new(
@@ -110,6 +116,7 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
     let server_session = Arc::clone(&session);
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
+    let server_user_home = user_home.clone();
     tokio::spawn(async move {
         serve_with_session(
             &server_sock,
@@ -121,6 +128,7 @@ async fn full_turn_with_tool_call_emits_correct_event_sequence() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            Some(server_user_home),
         )
         .await
         .unwrap();
@@ -298,6 +306,7 @@ async fn approval_gate_fires_and_blocks_until_client_approves() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();
@@ -394,6 +403,7 @@ async fn auto_approve_skips_approval_gate_and_emits_auto_approved() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();
@@ -525,6 +535,7 @@ async fn tool_result_fed_back_to_provider_in_continuation() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();
@@ -647,6 +658,7 @@ async fn approval_with_this_tool_scope_is_recorded_faithfully() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();
@@ -734,6 +746,7 @@ async fn malformed_approval_scope_rejects_instead_of_silently_downgrading_to_onc
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();
@@ -839,6 +852,7 @@ async fn unexpected_post_handshake_frame_is_logged_not_silently_dropped() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/parallel_read_dispatch.rs
+++ b/crates/forge-session/tests/parallel_read_dispatch.rs
@@ -112,6 +112,7 @@ async fn two_real_fs_read_calls_dispatch_in_parallel_without_approval() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/pause_resume.rs
+++ b/crates/forge-session/tests/pause_resume.rs
@@ -83,9 +83,17 @@ fn extract_event(msg: &IpcMessage) -> Option<Event> {
 
 /// Spawn a `serve_with_session` daemon. Returns the socket path and the
 /// shared `Session` so tests can inspect `is_paused()` directly.
+///
+/// An empty user-home directory is wired through `user_home_override` so
+/// the daemon's `~/.mcp.json` loader does not see the developer's real
+/// home. Without this, a populated host `~/.mcp.json` prepends an
+/// `Event::McpState` to the event stream and the pause/resume sequence
+/// assertions below pick up the wrong "first event".
 async fn spawn_daemon(dir: &TempDir, scripts: Vec<String>) -> (std::path::PathBuf, Arc<Session>) {
     let log_path = dir.path().join("events.jsonl");
     let sock_path = dir.path().join("test.sock");
+    let user_home = dir.path().join("user_home");
+    std::fs::create_dir_all(&user_home).unwrap();
 
     let session = Arc::new(Session::create(log_path).await.unwrap());
     let provider = Arc::new(MockProvider::from_responses(scripts).unwrap());
@@ -93,6 +101,7 @@ async fn spawn_daemon(dir: &TempDir, scripts: Vec<String>) -> (std::path::PathBu
     let server_session = Arc::clone(&session);
     let server_provider = Arc::clone(&provider);
     let server_sock = sock_path.clone();
+    let server_user_home = user_home.clone();
     tokio::spawn(async move {
         serve_with_session(
             &server_sock,
@@ -104,6 +113,7 @@ async fn spawn_daemon(dir: &TempDir, scripts: Vec<String>) -> (std::path::PathBu
             None,
             None,
             None,
+            Some(server_user_home),
         )
         .await
         .unwrap();
@@ -400,6 +410,7 @@ async fn pause_during_tool_approval_does_not_kill_in_flight_tool() {
             server_provider,
             false, // auto_approve OFF — tool approval blocks
             false,
+            None,
             None,
             None,
             None,

--- a/crates/forge-session/tests/provider_swap.rs
+++ b/crates/forge-session/tests/provider_swap.rs
@@ -114,6 +114,7 @@ async fn next_turn_uses_new_provider_after_swap() {
             None,
             None, // F-587 keyless
             None, // F-601 active_agent: memory off
+            None,
         )
         .await
         .ok();
@@ -247,6 +248,7 @@ async fn switch_provider_frame_triggers_daemon_swap_path() {
             Some(server_swap),
             false,
             false,
+            None,
             None,
             None,
             None,

--- a/crates/forge-session/tests/rerun_branch.rs
+++ b/crates/forge-session/tests/rerun_branch.rs
@@ -98,6 +98,7 @@ async fn rerun_branch_keeps_both_variants_and_branch_selected_gates_display() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();
@@ -291,6 +292,7 @@ async fn select_branch_with_variant_zero_resolves_to_parent() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/rerun_fresh.rs
+++ b/crates/forge-session/tests/rerun_fresh.rs
@@ -129,6 +129,7 @@ async fn rerun_fresh_regenerates_from_user_message_root_and_supersedes_original(
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/rerun_replace.rs
+++ b/crates/forge-session/tests/rerun_replace.rs
@@ -95,6 +95,7 @@ async fn rerun_replace_supersedes_original_message_in_fresh_replay() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/step_events.rs
+++ b/crates/forge-session/tests/step_events.rs
@@ -109,6 +109,7 @@ async fn capture_turn_events(auto_approve: bool) -> Vec<Event> {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-session/tests/subscribe_replay.rs
+++ b/crates/forge-session/tests/subscribe_replay.rs
@@ -51,6 +51,11 @@ async fn subscribe_mid_stream_receives_historical_then_live_events() {
     let dir = TempDir::new().unwrap();
     let log_path = dir.path().join("events.jsonl");
     let sock_path = dir.path().join("test.sock");
+    // Isolate the daemon's user-scope `~/.mcp.json` loader from the
+    // developer's real home; otherwise a populated host `~/.mcp.json`
+    // adds an extra `Event::McpState` and `event_seq` reaches 4.
+    let user_home = dir.path().join("user_home");
+    std::fs::create_dir_all(&user_home).unwrap();
 
     // Create session and pre-write 3 events (seq 1, 2, 3)
     let session = Arc::new(Session::create(log_path).await.unwrap());
@@ -62,6 +67,7 @@ async fn subscribe_mid_stream_receives_historical_then_live_events() {
     let server_session = Arc::clone(&session);
     let server_sock = sock_path.clone();
     let provider = Arc::new(MockProvider::with_default_path());
+    let server_user_home = user_home.clone();
     tokio::spawn(async move {
         serve_with_session(
             &server_sock,
@@ -73,6 +79,7 @@ async fn subscribe_mid_stream_receives_historical_then_live_events() {
             None,
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            Some(server_user_home),
         )
         .await
         .unwrap();

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -2570,7 +2570,7 @@ async fn resolve_bg_session<R: Runtime>(
 
     // Lazy init — workspace root is the authoritative source for agent defs.
     let workspace_root = cached_workspace_root(state, session_id).await?;
-    let user_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    let user_home = resolve_user_home_dir(state);
 
     let defs = forge_agents::load_agents(&workspace_root, &user_home)
         .map_err(|e| format!("load agent defs: {e}"))?;

--- a/crates/forge-shell/src/ipc.rs
+++ b/crates/forge-shell/src/ipc.rs
@@ -3918,7 +3918,7 @@ pub async fn list_mcp_servers<R: Runtime>(
     } else {
         Some(resolve_workspace_root_for_command(webview.label(), &workspace_root, &state).await?)
     };
-    let user_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    let user_home = resolve_user_home_dir(&state);
     let entries = collect_mcp_servers(workspace_path.as_deref(), &user_home)?;
     Ok(entries.into_iter().filter(|e| e.matches(&scope)).collect())
 }
@@ -3949,7 +3949,7 @@ pub async fn list_agents<R: Runtime>(
     } else {
         Some(resolve_workspace_root_for_command(webview.label(), &workspace_root, &state).await?)
     };
-    let user_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    let user_home = resolve_user_home_dir(&state);
     let entries = collect_agents(workspace_path.as_deref(), &user_home)?;
     Ok(entries.into_iter().filter(|e| e.matches(&scope)).collect())
 }

--- a/crates/forge-shell/tests/bridge_e2e.rs
+++ b/crates/forge-shell/tests/bridge_e2e.rs
@@ -49,6 +49,7 @@ async fn spawn_daemon(path: &Path, session_id: &str) -> TempDir {
             Some(sid),
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-shell/tests/ipc_commands.rs
+++ b/crates/forge-shell/tests/ipc_commands.rs
@@ -66,6 +66,7 @@ async fn session_hello_command_round_trips_via_tauri_invoke() {
             Some("tauri-hello".to_string()),
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            None,
         )
         .await
         .unwrap();

--- a/crates/forge-shell/tests/ipc_mcp.rs
+++ b/crates/forge-shell/tests/ipc_mcp.rs
@@ -65,13 +65,23 @@ impl EventSink for ChannelSink {
 /// Spawn a `forge-session` daemon bound to `socket_path` with the given
 /// `workspace`. The workspace tempdir is returned so the caller's `.mcp.json`
 /// seeding drives the daemon's `load_mcp_manager` path.
+///
+/// An empty tempdir is wired through `serve_with_session`'s
+/// `user_home_override` so the daemon's user-scope `.mcp.json` loader does
+/// not see the developer's real `~/.mcp.json`. Without the override, any
+/// host with a populated user-tier MCP config inflates the daemon's server
+/// count and breaks length-sensitive assertions (CI passes only because
+/// `$HOME/.mcp.json` is absent there). The user-home tempdir is returned
+/// alongside the log dir so it outlives the spawned task.
 async fn spawn_daemon_with_workspace(
     socket_path: &Path,
     session_id: &str,
     workspace: std::path::PathBuf,
-) -> (Arc<Session>, TempDir) {
+) -> (Arc<Session>, TempDir, TempDir) {
     let log_dir = TempDir::new().unwrap();
     let log_path = log_dir.path().join("events.jsonl");
+    let user_home = TempDir::new().unwrap();
+    let user_home_path = user_home.path().to_path_buf();
     let session = Arc::new(Session::create(log_path).await.unwrap());
     let session_for_spawn = Arc::clone(&session);
     let provider = Arc::new(MockProvider::with_default_path());
@@ -88,6 +98,7 @@ async fn spawn_daemon_with_workspace(
             Some(sid),
             None, // F-587: keyless test wiring
             None, // F-601: no active agent — memory off in this test
+            Some(user_home_path),
         )
         .await
         .unwrap();
@@ -99,7 +110,7 @@ async fn spawn_daemon_with_workspace(
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
-    (session, log_dir)
+    (session, log_dir, user_home)
 }
 
 /// Write a `.mcp.json` declaring `name` as a stdio server pointing at
@@ -179,7 +190,7 @@ async fn session_list_mcp_servers_round_trips_against_daemon() {
     let workspace = TempDir::new().unwrap();
     seed_mcp_config(workspace.path(), "fixture", "/nonexistent/mcp-binary");
 
-    let (_session, _log) =
+    let (_session, _log, _home) =
         spawn_daemon_with_workspace(&sock, "list-session", workspace.path().to_path_buf()).await;
     let (bridge, _rx) = connect_bridge(&sock, "list-session").await;
 
@@ -203,7 +214,7 @@ async fn toggle_mcp_server_off_emits_disabled_state_event() {
     let workspace = TempDir::new().unwrap();
     seed_mcp_config(workspace.path(), "fixture", "/nonexistent/mcp-binary");
 
-    let (_session, _log) =
+    let (_session, _log, _home) =
         spawn_daemon_with_workspace(&sock, "toggle-session", workspace.path().to_path_buf()).await;
     let (bridge, mut rx) = connect_bridge(&sock, "toggle-session").await;
 
@@ -247,7 +258,7 @@ async fn toggle_mcp_server_on_restarts_disabled_server() {
     let workspace = TempDir::new().unwrap();
     seed_mcp_config(workspace.path(), "fixture", "/nonexistent/mcp-binary");
 
-    let (_session, _log) =
+    let (_session, _log, _home) =
         spawn_daemon_with_workspace(&sock, "restart-session", workspace.path().to_path_buf()).await;
     let (bridge, mut rx) = connect_bridge(&sock, "restart-session").await;
 
@@ -313,7 +324,7 @@ async fn toggle_mcp_server_unknown_name_reports_error() {
     let workspace = TempDir::new().unwrap();
     seed_mcp_config(workspace.path(), "fixture", "/nonexistent/mcp-binary");
 
-    let (_session, _log) =
+    let (_session, _log, _home) =
         spawn_daemon_with_workspace(&sock, "unknown-session", workspace.path().to_path_buf()).await;
     let (bridge, _rx) = connect_bridge(&sock, "unknown-session").await;
 
@@ -378,7 +389,7 @@ async fn running_session_toggle_disables_live_server() {
     let workspace = TempDir::new().unwrap();
     seed_mcp_config(workspace.path(), "mock", &mock_bin);
 
-    let (_session, _log) =
+    let (_session, _log, _home) =
         spawn_daemon_with_workspace(&sock, "running-session", workspace.path().to_path_buf()).await;
     let (bridge, mut rx) = connect_bridge(&sock, "running-session").await;
 
@@ -495,7 +506,7 @@ async fn import_mcp_config_dry_run_does_not_write_file() {
     )
     .unwrap();
 
-    let (_session, _log) =
+    let (_session, _log, _home) =
         spawn_daemon_with_workspace(&sock, "import-dry-session", workspace.path().to_path_buf())
             .await;
     let (bridge, _rx) = connect_bridge(&sock, "import-dry-session").await;
@@ -538,7 +549,7 @@ async fn import_mcp_config_apply_writes_merged_file() {
     )
     .unwrap();
 
-    let (_session, _log) = spawn_daemon_with_workspace(
+    let (_session, _log, _home) = spawn_daemon_with_workspace(
         &sock,
         "import-apply-session",
         workspace.path().to_path_buf(),
@@ -567,7 +578,7 @@ async fn import_mcp_config_unknown_source_reports_error() {
     let sock = sock_dir.path().join("import-bad.sock");
     let workspace = TempDir::new().unwrap();
 
-    let (_session, _log) =
+    let (_session, _log, _home) =
         spawn_daemon_with_workspace(&sock, "import-bad-session", workspace.path().to_path_buf())
             .await;
     let (bridge, _rx) = connect_bridge(&sock, "import-bad-session").await;


### PR DESCRIPTION
## Summary

`forge_session::server::load_mcp_manager` called `dirs::home_dir()` directly with no test override, so a developer's populated `~/.mcp.json` inflates the daemon's authoritative server count and prepends an extra `Event::McpState(...)` to event tapes captured by integration tests. CI passes because `$HOME` is clean there; local runs fail for anyone with a real user-tier MCP config.

This was the sibling leak flagged in the F-743 follow-up note (PR #896):

> `ipc_mcp::session_list_mcp_servers_round_trips_against_daemon` has the same pre-existing leak shape: `forge_session::server::load_mcp_manager` calls `dirs::home_dir()` directly with no test override, so a developer's `~/.mcp.json` inflates the server count.

## Approach

Mirror the F-743 `resolve_user_home_dir` pattern, but on the daemon side: thread an `Option<PathBuf> user_home_override` through `serve_with_session` and `serve_with_session_swappable`. `load_mcp_manager` consumes it and falls back to `dirs::home_dir()` only when `None`.

- **Production** (`forge-session::main`) passes `None` — `dirs::home_dir()` is the only resolver.
- **In-process daemon tests** (the many `tokio::spawn(serve_with_session(...))` integration tests in `forge-session/tests/` and `forge-shell/tests/`) pass `Some(<empty tempdir>)` where the sequence assertion would otherwise pick up a stray `McpState` event.
- **Subprocess tests** (the `forged` binary tests) set `FORGE_USER_HOME_FOR_TEST=<tempdir>`; the daemon reads this in `main.rs` under `cfg(debug_assertions)` so release builds never honor it.

While in the same module, also routed the F-591 shell-side `list_mcp_servers` and `list_agents` roster commands through the existing `resolve_user_home_dir(state)` helper — they were the last two callers in `forge-shell/src/ipc.rs` still calling `dirs::home_dir()` directly.

## Test plan

- [x] Reproducer: `cargo test -p forge-shell --features webview-test --test ipc_mcp session_list_mcp_servers_round_trips_against_daemon` — passes locally with a populated `~/.mcp.json`.
- [x] `cargo test -p forge-shell --features webview-test` — all pass.
- [x] `cargo test -p forge-session` — all pass.
- [x] `cargo clippy -p forge-shell -p forge-session --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --check -p forge-shell -p forge-session` — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p forge-shell -p forge-session --no-deps --all-features` — clean.