### PR TITLE
[F-744] Active credential injected into provider auth seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "chrono",
  "dirs 6.0.0",
  "forge-core",
  "futures",
@@ -1722,6 +1723,7 @@ dependencies = [
  "tokio-util",
  "toml 0.8.23",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "wiremock",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,7 +1397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1718,6 +1718,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "static_assertions",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -2774,7 +2775,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4158,7 +4159,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4597,7 +4598,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5166,6 +5167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5690,7 +5697,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6696,7 +6703,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/forge-providers/Cargo.toml
+++ b/crates/forge-providers/Cargo.toml
@@ -47,7 +47,18 @@ uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 
 [dev-dependencies]
+# F-744: leak-audit test needs `chrono` for constructing `Event` variants
+# carrying `DateTime<Utc>` fields without depending on the orchestrator.
+chrono = "0.4"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "time"] }
 futures = "0.3"
+# F-744: leak-audit test asserts `forge_core::Event` serialisation never
+# embeds a credential — constructed directly in the test to avoid pulling
+# the orchestrator's transitive deps into the provider test target.
+tracing = "0.1"
+# F-744: capture every `tracing` event emitted on the chat path so the
+# leak-audit test (`tests/auth_seam.rs`) can grep the buffer for the
+# sentinel credential.
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 wiremock = "0.6"

--- a/crates/forge-providers/Cargo.toml
+++ b/crates/forge-providers/Cargo.toml
@@ -50,6 +50,11 @@ tracing = "0.1"
 # F-744: leak-audit test needs `chrono` for constructing `Event` variants
 # carrying `DateTime<Utc>` fields without depending on the orchestrator.
 chrono = "0.4"
+# F-744: compile-time negative trait assertions — pin the no-`Display` /
+# no-`Serialize` posture of `ProviderAuth` so a future refactor that
+# accidentally derives either trait fails to build rather than silently
+# leaks the credential through string conversion or JSON.
+static_assertions = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "time"] }
 futures = "0.3"

--- a/crates/forge-providers/src/anthropic/mod.rs
+++ b/crates/forge-providers/src/anthropic/mod.rs
@@ -14,10 +14,11 @@
 
 use crate::http_util::{self, HttpClientConfig};
 use crate::sse::{self, SseError, SseEvent};
-use crate::{ChatChunk, ChatRequest, Provider};
+use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth};
 use bytes::Bytes;
 use forge_core::Result;
 use futures::stream::{BoxStream, StreamExt};
+use secrecy::ExposeSecret;
 
 pub mod translate;
 
@@ -35,7 +36,11 @@ pub const VERTEX_ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
 /// Anthropic API calls (`ApiKey`) and Google Vertex AI (`Vertex`). The
 /// Vertex variant retargets the base URL and replaces `x-api-key` with
 /// `Authorization: Bearer <gcloud-access-token>`.
-#[derive(Clone, Debug)]
+///
+/// `Debug` is hand-rolled (not derived) so the API key bytes never
+/// surface in trace / log output. The variant tag is preserved for
+/// diagnostic value; the credential is rendered as `"<redacted>"`.
+#[derive(Clone)]
 pub enum AuthMode {
     /// Direct Anthropic API: `x-api-key: <api_key>` against
     /// `https://api.anthropic.com/v1/messages`.
@@ -53,6 +58,22 @@ pub enum AuthMode {
     },
 }
 
+impl std::fmt::Debug for AuthMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthMode::ApiKey { .. } => f
+                .debug_struct("ApiKey")
+                .field("api_key", &"<redacted>")
+                .finish(),
+            AuthMode::Vertex { project, region } => f
+                .debug_struct("Vertex")
+                .field("project", project)
+                .field("region", region)
+                .finish(),
+        }
+    }
+}
+
 pub struct AnthropicProvider {
     base_url: String,
     auth: AuthMode,
@@ -60,6 +81,22 @@ pub struct AnthropicProvider {
     max_tokens: u32,
     stream_client: reqwest::Client,
     stream_cfg: sse::StreamConfig,
+}
+
+/// Hand-rolled `Debug` so the API key embedded in `auth` is never written
+/// to log output. Non-secret fields (`base_url`, `model`, `max_tokens`,
+/// `auth` variant tag with redacted credential) are surfaced for diagnostic
+/// value. Mirrors [`crate::openai::custom::CustomOpenAiProvider`]'s
+/// redaction posture (SEC-1).
+impl std::fmt::Debug for AnthropicProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnthropicProvider")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("max_tokens", &self.max_tokens)
+            .field("auth", &self.auth)
+            .finish_non_exhaustive()
+    }
 }
 
 impl AnthropicProvider {
@@ -150,6 +187,60 @@ pub fn fetch_vertex_access_token() -> anyhow::Result<String> {
     Ok(token)
 }
 
+/// Effective auth choice resolved for one outbound Anthropic request.
+///
+/// F-744: the seam supplies a per-turn credential through
+/// [`ProviderAuth`]; when the variant is `None` the provider falls back to
+/// its constructor-time [`AuthMode`]. This enum captures the resolved
+/// choice so the request-building code below is one match arm regardless
+/// of where the credential came from.
+enum ResolvedAuth<'a> {
+    /// `x-api-key` shape. The key is borrowed for the lifetime of the
+    /// request builder so we never copy the bytes into a longer-lived
+    /// allocation.
+    ApiKey(&'a str),
+    /// Vertex AI: same shape regardless of source (no seam path supplies
+    /// project/region — those are constructor-time configuration). The
+    /// seam's `ProviderAuth::Vertex` variant carries a pre-fetched token,
+    /// short-circuiting the gcloud shell-out.
+    Vertex {
+        project: &'a str,
+        region: &'a str,
+        prefetched_token: Option<&'a str>,
+    },
+}
+
+impl AnthropicProvider {
+    /// Resolve the effective auth for one outbound request, preferring the
+    /// per-turn `ProviderAuth` over the constructor-time `AuthMode`. Falls
+    /// back to the constructor value on `ProviderAuth::None`.
+    fn resolve_auth<'a>(&'a self, seam: &'a ProviderAuth) -> ResolvedAuth<'a> {
+        match (seam, &self.auth) {
+            (ProviderAuth::ApiKey(secret), _) => ResolvedAuth::ApiKey(secret.expose_secret()),
+            (ProviderAuth::Vertex(token), AuthMode::Vertex { project, region }) => {
+                ResolvedAuth::Vertex {
+                    project,
+                    region,
+                    prefetched_token: Some(token.expose_secret()),
+                }
+            }
+            // Seam `Vertex` against a non-Vertex constructor: fall back to
+            // constructor auth — calling Vertex against an API-key
+            // configuration is a configuration error the upstream layer
+            // (orchestrator + provider spec) must reject, not the provider.
+            (ProviderAuth::Vertex(_), AuthMode::ApiKey { api_key }) => {
+                ResolvedAuth::ApiKey(api_key)
+            }
+            (ProviderAuth::None, AuthMode::ApiKey { api_key }) => ResolvedAuth::ApiKey(api_key),
+            (ProviderAuth::None, AuthMode::Vertex { project, region }) => ResolvedAuth::Vertex {
+                project,
+                region,
+                prefetched_token: None,
+            },
+        }
+    }
+}
+
 impl Provider for AnthropicProvider {
     /// F-682: `#[instrument]` enables ops-level latency attribution for the
     /// per-turn chat path. `skip_all` keeps the request body (and any
@@ -167,7 +258,23 @@ impl Provider for AnthropicProvider {
         &self,
         req: ChatRequest,
     ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
-        let url = self.request_url();
+        // F-744: route the legacy `chat()` path through the auth seam so
+        // there's a single code path. `ProviderAuth::None` falls back to
+        // the constructor-time [`AuthMode`], preserving the pre-F-744
+        // behaviour exactly for callers that haven't wired the seam.
+        self.chat_with_auth(req, ProviderAuth::None)
+    }
+
+    #[tracing::instrument(
+        name = "provider.chat",
+        skip_all,
+        fields(provider = "anthropic", model = %self.model),
+    )]
+    fn chat_with_auth(
+        &self,
+        req: ChatRequest,
+        auth_in: ProviderAuth,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
         let body_result = translate::serialize_request(
             &req,
             &self.model,
@@ -176,27 +283,63 @@ impl Provider for AnthropicProvider {
         );
         let client = self.stream_client.clone();
         let cfg = self.stream_cfg;
-        let auth = self.auth.clone();
+
+        // Resolve auth eagerly (no `.await` involved): seam wins over
+        // constructor, then the resolved choice owns its strings so the
+        // async block doesn't borrow `self` across an `.await`.
+        let resolved_owned: ResolvedAuthOwned = match self.resolve_auth(&auth_in) {
+            ResolvedAuth::ApiKey(k) => ResolvedAuthOwned::ApiKey(k.to_string()),
+            ResolvedAuth::Vertex {
+                project,
+                region,
+                prefetched_token,
+            } => ResolvedAuthOwned::Vertex {
+                project: project.to_string(),
+                region: region.to_string(),
+                prefetched_token: prefetched_token.map(str::to_string),
+                model: self.model.clone(),
+            },
+        };
+        // Build the URL after resolution so Vertex can read project/region
+        // from the resolved form (handles the seam-overrides-constructor
+        // case, though no current call site exercises it).
+        let url = match &resolved_owned {
+            ResolvedAuthOwned::ApiKey(_) => {
+                format!("{}/v1/messages", self.base_url.trim_end_matches('/'))
+            }
+            ResolvedAuthOwned::Vertex {
+                project,
+                region,
+                model,
+                ..
+            } => format!(
+                "https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:streamRawPredict",
+            ),
+        };
 
         async move {
             let body = body_result
                 .map_err(|e| anyhow::anyhow!("anthropic chat body serialization failed: {e}"))?;
-            // Build auth-mode-specific request headers. Vertex shells
-            // out to gcloud for an ADC access token; failures here
-            // surface as the verbatim gcloud stderr so the user can act
-            // on them.
+            // Build auth-mode-specific request headers. Vertex without a
+            // pre-fetched token shells out to gcloud; failures surface as
+            // the verbatim gcloud stderr so the user can act on them.
             let mut builder = client.post(&url);
-            match &auth {
-                AuthMode::ApiKey { api_key } => {
+            match resolved_owned {
+                ResolvedAuthOwned::ApiKey(api_key) => {
                     builder = builder
                         .header("x-api-key", api_key.as_str())
                         .header("anthropic-version", ANTHROPIC_VERSION);
                 }
-                AuthMode::Vertex { .. } => {
-                    let token = tokio::task::spawn_blocking(fetch_vertex_access_token)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("vertex token join failed: {e}"))?
-                        .map_err(|e| anyhow::anyhow!("vertex auth: {e}"))?;
+                ResolvedAuthOwned::Vertex {
+                    prefetched_token, ..
+                } => {
+                    let token = match prefetched_token {
+                        Some(t) => t,
+                        None => tokio::task::spawn_blocking(fetch_vertex_access_token)
+                            .await
+                            .map_err(|e| anyhow::anyhow!("vertex token join failed: {e}"))?
+                            .map_err(|e| anyhow::anyhow!("vertex auth: {e}"))?,
+                    };
                     builder = builder
                         .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
                         .header("anthropic-version", VERTEX_ANTHROPIC_VERSION);
@@ -222,6 +365,18 @@ impl Provider for AnthropicProvider {
             Ok(decode_anthropic_stream(resp.bytes_stream(), cfg))
         }
     }
+}
+
+/// Owned form of [`ResolvedAuth`] suitable for moving into an `async move`
+/// block. Strings are short-lived and dropped with the request future.
+enum ResolvedAuthOwned {
+    ApiKey(String),
+    Vertex {
+        project: String,
+        region: String,
+        prefetched_token: Option<String>,
+        model: String,
+    },
 }
 
 /// Decode the raw `bytes` stream into a `ChatChunk` stream by piping through

--- a/crates/forge-providers/src/anthropic/mod.rs
+++ b/crates/forge-providers/src/anthropic/mod.rs
@@ -18,7 +18,7 @@ use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth};
 use bytes::Bytes;
 use forge_core::Result;
 use futures::stream::{BoxStream, StreamExt};
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 
 pub mod translate;
 
@@ -287,8 +287,16 @@ impl Provider for AnthropicProvider {
         // Resolve auth eagerly (no `.await` involved): seam wins over
         // constructor, then the resolved choice owns its strings so the
         // async block doesn't borrow `self` across an `.await`.
+        //
+        // F-744 zeroization contract: the secret bytes ride through the
+        // async block inside a `SecretString` (zeroizes on drop) — NEVER
+        // a plain `String` — so a panic mid-`.await` or the future being
+        // dropped before completion still scrubs the plaintext from the
+        // heap. `expose_secret()` is called only at the
+        // `builder.header(...)` boundary below and the exposed slice is
+        // dropped with the request future.
         let resolved_owned: ResolvedAuthOwned = match self.resolve_auth(&auth_in) {
-            ResolvedAuth::ApiKey(k) => ResolvedAuthOwned::ApiKey(k.to_string()),
+            ResolvedAuth::ApiKey(k) => ResolvedAuthOwned::ApiKey(SecretString::from(k.to_string())),
             ResolvedAuth::Vertex {
                 project,
                 region,
@@ -296,7 +304,7 @@ impl Provider for AnthropicProvider {
             } => ResolvedAuthOwned::Vertex {
                 project: project.to_string(),
                 region: region.to_string(),
-                prefetched_token: prefetched_token.map(str::to_string),
+                prefetched_token: prefetched_token.map(|t| SecretString::from(t.to_string())),
                 model: self.model.clone(),
             },
         };
@@ -326,22 +334,31 @@ impl Provider for AnthropicProvider {
             let mut builder = client.post(&url);
             match resolved_owned {
                 ResolvedAuthOwned::ApiKey(api_key) => {
+                    // F-744: `expose_secret()` borrows the inner bytes
+                    // for the lifetime of the header value. Once
+                    // `api_key` (the `SecretString`) drops at the end of
+                    // this match arm, the bytes are zeroized.
                     builder = builder
-                        .header("x-api-key", api_key.as_str())
+                        .header("x-api-key", api_key.expose_secret())
                         .header("anthropic-version", ANTHROPIC_VERSION);
                 }
                 ResolvedAuthOwned::Vertex {
                     prefetched_token, ..
                 } => {
-                    let token = match prefetched_token {
+                    let token: SecretString = match prefetched_token {
                         Some(t) => t,
-                        None => tokio::task::spawn_blocking(fetch_vertex_access_token)
-                            .await
-                            .map_err(|e| anyhow::anyhow!("vertex token join failed: {e}"))?
-                            .map_err(|e| anyhow::anyhow!("vertex auth: {e}"))?,
+                        None => SecretString::from(
+                            tokio::task::spawn_blocking(fetch_vertex_access_token)
+                                .await
+                                .map_err(|e| anyhow::anyhow!("vertex token join failed: {e}"))?
+                                .map_err(|e| anyhow::anyhow!("vertex auth: {e}"))?,
+                        ),
                     };
                     builder = builder
-                        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+                        .header(
+                            reqwest::header::AUTHORIZATION,
+                            format!("Bearer {}", token.expose_secret()),
+                        )
                         .header("anthropic-version", VERTEX_ANTHROPIC_VERSION);
                 }
             }
@@ -368,13 +385,20 @@ impl Provider for AnthropicProvider {
 }
 
 /// Owned form of [`ResolvedAuth`] suitable for moving into an `async move`
-/// block. Strings are short-lived and dropped with the request future.
+/// block.
+///
+/// F-744 zeroization contract: secret-bearing fields use
+/// [`secrecy::SecretString`] (not plain `String`) so the plaintext bytes are
+/// scrubbed on drop — including when the request future is cancelled
+/// mid-`.await`. Plaintext is exposed via [`ExposeSecret::expose_secret`]
+/// only at the `builder.header(...)` boundary, where the borrowed slice
+/// drops with the request future.
 enum ResolvedAuthOwned {
-    ApiKey(String),
+    ApiKey(SecretString),
     Vertex {
         project: String,
         region: String,
-        prefetched_token: Option<String>,
+        prefetched_token: Option<SecretString>,
         model: String,
     },
 }
@@ -448,6 +472,43 @@ mod tests {
     fn api_key_request_url_trims_trailing_slash() {
         let p = AnthropicProvider::new("https://api.anthropic.com/", "k", "claude-3", 4096);
         assert_eq!(p.request_url(), "https://api.anthropic.com/v1/messages");
+    }
+
+    /// F-744 zeroization contract regression. `ResolvedAuthOwned` is the
+    /// per-turn auth value that lives on the heap for the entire duration
+    /// of an outbound HTTP request future (across at least one `.await`).
+    /// Its secret-bearing fields MUST be `SecretString` (zeroizes on
+    /// drop), not plain `String` — otherwise the credential outlives the
+    /// `.await` without scrubbing. This test pins the storage type at
+    /// compile time: any future refactor that swaps `SecretString` back
+    /// for `String` will fail to type-check here.
+    #[test]
+    fn resolved_auth_owned_uses_secret_string_for_api_key() {
+        let owned = ResolvedAuthOwned::ApiKey(SecretString::from("sk-test".to_string()));
+        match &owned {
+            ResolvedAuthOwned::ApiKey(k) => {
+                let _: &SecretString = k;
+            }
+            ResolvedAuthOwned::Vertex { .. } => panic!("expected ApiKey arm"),
+        }
+    }
+
+    #[test]
+    fn resolved_auth_owned_vertex_prefetched_token_is_secret_string() {
+        let owned = ResolvedAuthOwned::Vertex {
+            project: "p".into(),
+            region: "r".into(),
+            prefetched_token: Some(SecretString::from("t".to_string())),
+            model: "m".into(),
+        };
+        match &owned {
+            ResolvedAuthOwned::Vertex {
+                prefetched_token, ..
+            } => {
+                let _: &Option<SecretString> = prefetched_token;
+            }
+            ResolvedAuthOwned::ApiKey(_) => panic!("expected Vertex arm"),
+        }
     }
 
     #[test]

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -9,6 +9,7 @@ use futures::stream::BoxStream;
 // `.lock()` in the same process. The `std::sync::Mutex` here used to require
 // `.lock().unwrap()` at every call site, turning one panic into N.
 use parking_lot::Mutex;
+use secrecy::SecretString;
 use serde::Deserialize;
 
 pub mod anthropic;
@@ -172,6 +173,69 @@ pub enum StreamErrorKind {
     Transport,
 }
 
+// ── Provider auth seam (F-744) ────────────────────────────────────────────────
+
+/// Per-request authentication value handed to [`Provider::chat_with_auth`].
+///
+/// F-744: the orchestrator pulls the active credential from the keyring at
+/// the start of every turn (see `forge_session::orchestrator::CredentialContext`)
+/// and threads it through this enum into the provider's outbound HTTP
+/// request, without storing the secret on the provider struct.
+///
+/// The variants describe *how* the credential is presented on the wire — not
+/// the storage mechanism. `ApiKey` covers both `Authorization: Bearer …`
+/// (OpenAI shape) and `x-api-key: …` (Anthropic shape); the provider impl
+/// decides which header to emit based on its own protocol. `Vertex` is
+/// distinct because the underlying token comes from gcloud ADC rather than
+/// the keyring, and the wire shape (`Authorization: Bearer <gcloud-token>`
+/// + an alternate `anthropic-version`) differs from the direct API.
+///
+/// `None` is the no-op variant: the provider falls back to whatever
+/// credential it was constructed with (if any), and keyless providers
+/// (Ollama) ignore the value entirely.
+///
+/// # Leak posture
+///
+/// - The inner secret is held in [`secrecy::SecretString`], whose `Debug`
+///   impl renders `"[REDACTED ...]"` and whose backing bytes are zeroized
+///   on drop.
+/// - `ProviderAuth` deliberately implements `Debug` (delegating to the
+///   variant tag + redacted secret) but **not** `Display` or `Serialize`.
+///   The plaintext bytes leave the enum only through a provider-private
+///   call site that builds an HTTP header value and drops it with the
+///   request future.
+#[derive(Clone)]
+pub enum ProviderAuth {
+    /// API key / bearer token. The provider chooses the wire header
+    /// (`Authorization: Bearer …` or `x-api-key: …`) based on its own
+    /// protocol.
+    ApiKey(SecretString),
+    /// Google Vertex AI access token obtained out-of-band (via
+    /// `gcloud auth application-default print-access-token`). Distinct
+    /// from `ApiKey` because the wire shape on Anthropic-on-Vertex
+    /// differs (different version pin, `Authorization: Bearer` header).
+    Vertex(SecretString),
+    /// No per-request credential supplied. Providers fall back to their
+    /// constructor-time credential (Anthropic / OpenAI today) or send
+    /// nothing (Ollama). `None` is also the variant tests use when
+    /// exercising the legacy `chat()` path through `chat_with_auth`.
+    None,
+}
+
+impl std::fmt::Debug for ProviderAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The wrapped `SecretString` already redacts on `Debug`; the
+        // variant tag is non-secret. We render the tag explicitly so the
+        // shape stays useful in trace output without ever surfacing the
+        // bytes.
+        match self {
+            ProviderAuth::ApiKey(_) => f.debug_tuple("ApiKey").field(&"[redacted]").finish(),
+            ProviderAuth::Vertex(_) => f.debug_tuple("Vertex").field(&"[redacted]").finish(),
+            ProviderAuth::None => f.write_str("None"),
+        }
+    }
+}
+
 // ── Provider trait ────────────────────────────────────────────────────────────
 
 /// Streaming chat provider.
@@ -199,6 +263,31 @@ pub trait Provider: Send + Sync {
         &self,
         req: ChatRequest,
     ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send;
+
+    /// F-744: authenticated chat entry point.
+    ///
+    /// The orchestrator calls this with the credential pulled from the
+    /// keyring for the active provider on every turn. Implementations:
+    ///
+    /// - **Anthropic / OpenAI / CustomOpenAI**: use the supplied
+    ///   [`ProviderAuth::ApiKey`] (or `Vertex`) to build the outbound
+    ///   request's auth header, falling back to their constructor-time
+    ///   credential when the seam passes `ProviderAuth::None` (preserves
+    ///   the legacy `chat()` path for tests and callers that haven't
+    ///   wired the seam yet).
+    /// - **Ollama**: ignore the credential entirely — Ollama is keyless.
+    ///
+    /// The default impl simply discards the credential and delegates to
+    /// [`Provider::chat`]. New providers added to the workspace get the
+    /// keyless no-op for free; provider impls that want per-request auth
+    /// override this method.
+    fn chat_with_auth(
+        &self,
+        req: ChatRequest,
+        _auth: ProviderAuth,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        self.chat(req)
+    }
 }
 
 // ── NDJSON deserialization ────────────────────────────────────────────────────
@@ -332,6 +421,19 @@ impl Provider for MockProvider {
                 futures::future::Either::Right(async move { result })
             }
         }
+    }
+
+    /// F-744: `MockProvider` ignores the seam credential — scripted
+    /// responses don't talk to a network. Tests that need to assert on
+    /// the value being threaded through the orchestrator should mount a
+    /// `wiremock` server against a real provider impl instead; the mock
+    /// path is for replay-only scenarios.
+    fn chat_with_auth(
+        &self,
+        req: ChatRequest,
+        _auth: ProviderAuth,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        self.chat(req)
     }
 }
 

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -264,7 +264,13 @@ pub trait Provider: Send + Sync {
         req: ChatRequest,
     ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send;
 
-    /// F-744: authenticated chat entry point.
+    /// F-744: authenticated chat entry point. **Preferred entry point for
+    /// credential-aware callers** — `chat()` is retained for compatibility
+    /// with callers that don't thread per-turn credentials (tests, the
+    /// `SwappableProvider` trampolines, the keyless `MockProvider`); new
+    /// code should call `chat_with_auth` so the seam is exercised end to
+    /// end. The trait keeps both methods because adding `#[deprecated]`
+    /// would noise up every `SwappableProvider::chat` trampoline.
     ///
     /// The orchestrator calls this with the credential pulled from the
     /// keyring for the active provider on every turn. Implementations:

--- a/crates/forge-providers/src/ollama/mod.rs
+++ b/crates/forge-providers/src/ollama/mod.rs
@@ -14,7 +14,10 @@
 use std::io;
 
 use crate::http_util::{self, HttpClientConfig};
-use crate::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider, StreamErrorKind};
+use crate::{
+    ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider, ProviderAuth,
+    StreamErrorKind,
+};
 use forge_core::Result;
 use futures::stream::{self, BoxStream, StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
@@ -48,6 +51,20 @@ impl OllamaProvider {
 }
 
 impl Provider for OllamaProvider {
+    /// F-744: explicit no-op override. Ollama is keyless, so the
+    /// per-turn credential from the orchestrator is dropped here without
+    /// reaching the network. The default trait impl would do the same
+    /// thing, but the explicit override documents the intent and pins
+    /// the contract so a future refactor can't silently start
+    /// authenticating against a local daemon.
+    fn chat_with_auth(
+        &self,
+        req: ChatRequest,
+        _auth: ProviderAuth,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        self.chat(req)
+    }
+
     #[tracing::instrument(
         name = "provider.chat",
         skip_all,

--- a/crates/forge-providers/src/openai/custom.rs
+++ b/crates/forge-providers/src/openai/custom.rs
@@ -41,7 +41,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::http_util::{self, HttpClientConfig};
 use crate::sse;
-use crate::{ChatChunk, ChatRequest, Provider};
+use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth};
 
 use super::{chat_request, translate};
 
@@ -243,7 +243,9 @@ impl CustomOpenAiProvider {
         )
     }
 
-    /// Build the auth-header list for one outbound chat request.
+    /// F-744: build the auth-header list for one outbound chat request,
+    /// preferring an `override_key` from the per-turn seam over the
+    /// constructor-time `api_key` when present.
     ///
     /// Both the `AuthShape::Header { name }` value and the
     /// `AuthShape::Bearer | Header → api_key` requirement are validated at
@@ -251,24 +253,24 @@ impl CustomOpenAiProvider {
     /// authenticated shapes (with a guaranteed-valid header name and key)
     /// or `None`. The `expect` is a structural assertion against the
     /// `new()` invariants — it cannot fire on a `Self` produced through
-    /// the public API.
-    fn auth_headers(&self) -> Vec<(reqwest::header::HeaderName, String)> {
-        match (&self.auth_shape, &self.api_key) {
+    /// the public API. `None` shape emits no headers regardless of
+    /// `override_key`.
+    fn auth_headers_with(
+        &self,
+        override_key: Option<&str>,
+    ) -> Vec<(reqwest::header::HeaderName, String)> {
+        let effective_key: Option<String> = override_key
+            .map(str::to_string)
+            .or_else(|| self.api_key.as_ref().map(|k| k.expose_secret().to_string()));
+        match (&self.auth_shape, effective_key) {
             (AuthShape::Bearer, Some(key)) => {
-                // `expose_secret()` returns a `&str` borrow into the
-                // `SecretString`; the only allocation that escapes the
-                // secret container is the header value below, which is
-                // consumed by the request future and dropped with it.
-                vec![(
-                    reqwest::header::AUTHORIZATION,
-                    format!("Bearer {}", key.expose_secret()),
-                )]
+                vec![(reqwest::header::AUTHORIZATION, format!("Bearer {key}"))]
             }
             (AuthShape::Header { name }, Some(key)) => {
                 let hname: reqwest::header::HeaderName = name
                     .parse()
                     .expect("auth.name validated at construction time");
-                vec![(hname, key.expose_secret().to_string())]
+                vec![(hname, key)]
             }
             _ => Vec::new(),
         }
@@ -333,8 +335,31 @@ impl Provider for CustomOpenAiProvider {
         &self,
         req: ChatRequest,
     ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        // F-744: route the legacy `chat()` path through the auth seam.
+        self.chat_with_auth(req, ProviderAuth::None)
+    }
+
+    #[tracing::instrument(
+        name = "provider.chat",
+        skip_all,
+        fields(provider = %self.name(), model = %self.model),
+    )]
+    fn chat_with_auth(
+        &self,
+        req: ChatRequest,
+        auth_in: ProviderAuth,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
         let body_result = translate::serialize_request(&req, &self.model, self.max_tokens);
-        let auth = self.auth_headers();
+        // F-744: prefer the per-turn credential from the seam over the
+        // constructor-time key. The wire shape (`Bearer` vs custom
+        // header) stays fixed — only the value rotates. `Vertex` is
+        // meaningless against an OpenAI-compatible endpoint and falls
+        // back to the constructor value.
+        let override_key: Option<String> = match &auth_in {
+            ProviderAuth::ApiKey(s) => Some(s.expose_secret().to_string()),
+            ProviderAuth::Vertex(_) | ProviderAuth::None => None,
+        };
+        let auth = self.auth_headers_with(override_key.as_deref());
         chat_request(
             self.stream_client.clone(),
             self.base_url.clone(),
@@ -546,7 +571,7 @@ mod tests {
             Some("sk-secret".into()),
         )
         .unwrap();
-        let h = p.auth_headers();
+        let h = p.auth_headers_with(None);
         assert_eq!(h.len(), 1);
         assert_eq!(h[0].0, reqwest::header::AUTHORIZATION);
         assert_eq!(h[0].1, "Bearer sk-secret");
@@ -565,7 +590,7 @@ mod tests {
             Some("sk-secret".into()),
         )
         .unwrap();
-        let h = p.auth_headers();
+        let h = p.auth_headers_with(None);
         assert_eq!(h.len(), 1);
         assert_eq!(h[0].0.as_str(), "x-api-key");
         assert_eq!(h[0].1, "sk-secret");
@@ -607,7 +632,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(p.auth_headers().is_empty());
+        assert!(p.auth_headers_with(None).is_empty());
     }
 
     #[test]

--- a/crates/forge-providers/src/openai/custom.rs
+++ b/crates/forge-providers/src/openai/custom.rs
@@ -36,14 +36,14 @@
 use forge_core::settings::{AuthShapeSettings, CustomOpenAiEntry};
 use forge_core::Result;
 use futures::stream::BoxStream;
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 
 use crate::http_util::{self, HttpClientConfig};
 use crate::sse;
 use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth};
 
-use super::{chat_request, translate};
+use super::{chat_request, translate, AuthHeaderValue};
 
 /// Cap on redirect hops the streaming client will follow. The redirect
 /// policy *also* re-validates each hop's URL via
@@ -85,8 +85,8 @@ pub enum AuthShape {
 /// plaintext bytes are zeroized on drop and never accidentally cloned as a
 /// plain `String`. The only place the plaintext leaves the secret container
 /// is the auth-header value built per request in the (private)
-/// `auth_headers` helper — created via [`ExposeSecret::expose_secret`] at
-/// the HTTP-header boundary and dropped with the outbound request future.
+/// `auth_headers` helper — created via [`secrecy::ExposeSecret::expose_secret`]
+/// at the HTTP-header boundary and dropped with the outbound request future.
 pub struct CustomOpenAiProvider {
     /// Stable identifier (e.g. `"vllm-local"`, `"together"`) — exposed to
     /// the settings UI and surfaced in error messages so a multi-entry
@@ -255,22 +255,27 @@ impl CustomOpenAiProvider {
     /// `new()` invariants — it cannot fire on a `Self` produced through
     /// the public API. `None` shape emits no headers regardless of
     /// `override_key`.
+    ///
+    /// F-744 zeroization contract: the returned values wrap a
+    /// [`SecretString`] (zeroizes on drop), not plain `String` — so the
+    /// header-value list can ride safely across the outbound `.await`
+    /// without leaving plaintext on the heap. Plaintext is materialized
+    /// only at the `builder.header(...)` boundary inside
+    /// [`super::chat_request`].
     fn auth_headers_with(
         &self,
-        override_key: Option<&str>,
-    ) -> Vec<(reqwest::header::HeaderName, String)> {
-        let effective_key: Option<String> = override_key
-            .map(str::to_string)
-            .or_else(|| self.api_key.as_ref().map(|k| k.expose_secret().to_string()));
+        override_key: Option<SecretString>,
+    ) -> Vec<(reqwest::header::HeaderName, AuthHeaderValue)> {
+        let effective_key: Option<SecretString> = override_key.or_else(|| self.api_key.clone());
         match (&self.auth_shape, effective_key) {
             (AuthShape::Bearer, Some(key)) => {
-                vec![(reqwest::header::AUTHORIZATION, format!("Bearer {key}"))]
+                vec![(reqwest::header::AUTHORIZATION, AuthHeaderValue::Bearer(key))]
             }
             (AuthShape::Header { name }, Some(key)) => {
                 let hname: reqwest::header::HeaderName = name
                     .parse()
                     .expect("auth.name validated at construction time");
-                vec![(hname, key)]
+                vec![(hname, AuthHeaderValue::Raw(key))]
             }
             _ => Vec::new(),
         }
@@ -355,11 +360,15 @@ impl Provider for CustomOpenAiProvider {
         // header) stays fixed — only the value rotates. `Vertex` is
         // meaningless against an OpenAI-compatible endpoint and falls
         // back to the constructor value.
-        let override_key: Option<String> = match &auth_in {
-            ProviderAuth::ApiKey(s) => Some(s.expose_secret().to_string()),
+        //
+        // The override is carried as `SecretString` (not plain `String`)
+        // so the seam credential is zeroized on drop end-to-end. See
+        // [`AuthHeaderValue`] for the wire-rendering boundary.
+        let override_key: Option<SecretString> = match &auth_in {
+            ProviderAuth::ApiKey(s) => Some(s.clone()),
             ProviderAuth::Vertex(_) | ProviderAuth::None => None,
         };
-        let auth = self.auth_headers_with(override_key.as_deref());
+        let auth = self.auth_headers_with(override_key);
         chat_request(
             self.stream_client.clone(),
             self.base_url.clone(),
@@ -574,7 +583,9 @@ mod tests {
         let h = p.auth_headers_with(None);
         assert_eq!(h.len(), 1);
         assert_eq!(h[0].0, reqwest::header::AUTHORIZATION);
-        assert_eq!(h[0].1, "Bearer sk-secret");
+        // F-744: header value materialized through the same `render()`
+        // boundary the production HTTP path uses.
+        assert_eq!(h[0].1.render(), "Bearer sk-secret");
     }
 
     #[test]
@@ -593,7 +604,7 @@ mod tests {
         let h = p.auth_headers_with(None);
         assert_eq!(h.len(), 1);
         assert_eq!(h[0].0.as_str(), "x-api-key");
-        assert_eq!(h[0].1, "sk-secret");
+        assert_eq!(h[0].1.render(), "sk-secret");
     }
 
     /// SEC-1 (#702): the api_key field is stored in a zeroize-on-drop

--- a/crates/forge-providers/src/openai/mod.rs
+++ b/crates/forge-providers/src/openai/mod.rs
@@ -15,10 +15,11 @@
 
 use crate::http_util::{self, HttpClientConfig};
 use crate::sse::{self, SseError, SseEvent};
-use crate::{ChatChunk, ChatRequest, Provider};
+use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth};
 use bytes::Bytes;
 use forge_core::Result;
 use futures::stream::{BoxStream, StreamExt};
+use secrecy::ExposeSecret;
 
 pub mod custom;
 pub mod translate;
@@ -36,6 +37,20 @@ pub struct OpenAiProvider {
     max_tokens: Option<u32>,
     stream_client: reqwest::Client,
     stream_cfg: sse::StreamConfig,
+}
+
+/// Hand-rolled `Debug` so the constructor-time API key never surfaces in
+/// trace / log output. Mirrors [`crate::anthropic::AnthropicProvider`] and
+/// [`crate::openai::custom::CustomOpenAiProvider`].
+impl std::fmt::Debug for OpenAiProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiProvider")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("max_tokens", &self.max_tokens)
+            .field("api_key", &"<redacted>")
+            .finish_non_exhaustive()
+    }
 }
 
 impl OpenAiProvider {
@@ -85,11 +100,34 @@ impl Provider for OpenAiProvider {
         &self,
         req: ChatRequest,
     ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        // F-744: route the legacy `chat()` path through the auth seam.
+        // `ProviderAuth::None` falls back to the constructor-time
+        // credential, preserving pre-F-744 behaviour for callers that
+        // haven't wired the seam yet.
+        self.chat_with_auth(req, ProviderAuth::None)
+    }
+
+    #[tracing::instrument(
+        name = "provider.chat",
+        skip_all,
+        fields(provider = "openai", model = %self.model),
+    )]
+    fn chat_with_auth(
+        &self,
+        req: ChatRequest,
+        auth_in: ProviderAuth,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
         let body_result = translate::serialize_request(&req, &self.model, self.max_tokens);
-        let auth = vec![(
-            reqwest::header::AUTHORIZATION,
-            format!("Bearer {}", self.api_key),
-        )];
+        // F-744: prefer the per-turn credential from the seam. Falls back
+        // to the constructor-time key on `ProviderAuth::None`. The
+        // OpenAI protocol uses the same `Authorization: Bearer …` shape
+        // regardless of source; `Vertex` is meaningless here and also
+        // falls back.
+        let bearer = match &auth_in {
+            ProviderAuth::ApiKey(s) => s.expose_secret().to_string(),
+            ProviderAuth::Vertex(_) | ProviderAuth::None => self.api_key.clone(),
+        };
+        let auth = vec![(reqwest::header::AUTHORIZATION, format!("Bearer {bearer}"))];
         chat_request(
             self.stream_client.clone(),
             self.base_url.clone(),

--- a/crates/forge-providers/src/openai/mod.rs
+++ b/crates/forge-providers/src/openai/mod.rs
@@ -19,7 +19,7 @@ use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth};
 use bytes::Bytes;
 use forge_core::Result;
 use futures::stream::{BoxStream, StreamExt};
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 
 pub mod custom;
 pub mod translate;
@@ -118,16 +118,24 @@ impl Provider for OpenAiProvider {
         auth_in: ProviderAuth,
     ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
         let body_result = translate::serialize_request(&req, &self.model, self.max_tokens);
-        // F-744: prefer the per-turn credential from the seam. Falls back
-        // to the constructor-time key on `ProviderAuth::None`. The
-        // OpenAI protocol uses the same `Authorization: Bearer …` shape
-        // regardless of source; `Vertex` is meaningless here and also
-        // falls back.
-        let bearer = match &auth_in {
-            ProviderAuth::ApiKey(s) => s.expose_secret().to_string(),
-            ProviderAuth::Vertex(_) | ProviderAuth::None => self.api_key.clone(),
+        // F-744 zeroization contract: hold the per-turn bearer in a
+        // `SecretString` (zeroizes on drop) for the lifetime of the
+        // request future, NOT a plain `String`. The seam-supplied
+        // `SecretString` is cloned only when fallback to the
+        // constructor-time plaintext `api_key` is required.
+        //
+        // `Vertex` is meaningless against an OpenAI Chat Completions
+        // endpoint and falls back to the constructor value.
+        let bearer: SecretString = match &auth_in {
+            ProviderAuth::ApiKey(s) => s.clone(),
+            ProviderAuth::Vertex(_) | ProviderAuth::None => {
+                SecretString::from(self.api_key.clone())
+            }
         };
-        let auth = vec![(reqwest::header::AUTHORIZATION, format!("Bearer {bearer}"))];
+        let auth = vec![(
+            reqwest::header::AUTHORIZATION,
+            AuthHeaderValue::Bearer(bearer),
+        )];
         chat_request(
             self.stream_client.clone(),
             self.base_url.clone(),
@@ -138,19 +146,51 @@ impl Provider for OpenAiProvider {
     }
 }
 
+/// F-744: secret-bearing header value carried into [`chat_request`].
+///
+/// The plaintext bytes never escape a [`secrecy::SecretString`] except
+/// through [`render`] at the `builder.header(...)` boundary; the rendered
+/// `String` is dropped with the per-iteration scope of the header loop.
+///
+/// `Raw` covers `CustomOpenAiProvider`'s `AuthShape::Header { name }` case
+/// where the wire value is the raw key (no `Bearer ` prefix).
+pub(crate) enum AuthHeaderValue {
+    Bearer(SecretString),
+    Raw(SecretString),
+}
+
+impl AuthHeaderValue {
+    /// Materialize the wire-format header-value string. The returned
+    /// `String` is intended to feed `reqwest::RequestBuilder::header` and
+    /// then drop immediately.
+    fn render(&self) -> String {
+        match self {
+            AuthHeaderValue::Bearer(s) => format!("Bearer {}", s.expose_secret()),
+            AuthHeaderValue::Raw(s) => s.expose_secret().to_string(),
+        }
+    }
+}
+
 /// Shared chat-request pipeline used by both [`OpenAiProvider`] and
 /// [`CustomOpenAiProvider`]. Lifted here so the two providers share a single
 /// implementation of the OpenAI Chat Completions wire protocol — only the
 /// auth-header construction differs between them.
 ///
-/// `auth_headers` is an `(HeaderName, header-value-string)` list rather than
-/// a fully-typed `HeaderMap` so call sites stay terse and the
+/// `auth_headers` is an `(HeaderName, AuthHeaderValue)` list rather than a
+/// fully-typed `HeaderMap` so call sites stay terse and the
 /// custom-provider's `AuthShape::None` variant maps to an empty `vec![]`
 /// without wrestling with `HeaderMap::new()`.
+///
+/// F-744: the value side is [`AuthHeaderValue`] (wrapping a
+/// [`secrecy::SecretString`]) rather than a plain `String`, so the
+/// plaintext credential bytes are scrubbed on drop even if the request
+/// future is cancelled. Plaintext is materialized only inside the
+/// per-iteration `value.render()` call below; the rendered string drops
+/// at the end of each loop iteration.
 pub(crate) fn chat_request(
     client: reqwest::Client,
     base_url: String,
-    auth_headers: Vec<(reqwest::header::HeaderName, String)>,
+    auth_headers: Vec<(reqwest::header::HeaderName, AuthHeaderValue)>,
     body_result: std::result::Result<Vec<u8>, serde_json::Error>,
     cfg: sse::StreamConfig,
 ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
@@ -163,7 +203,7 @@ pub(crate) fn chat_request(
             .post(&url)
             .header(reqwest::header::CONTENT_TYPE, "application/json");
         for (name, value) in auth_headers {
-            builder = builder.header(name, value);
+            builder = builder.header(name, value.render());
         }
         let resp = builder.body(body).send().await.map_err(|e| {
             // Preserve the source chain so a redirect-policy refusal

--- a/crates/forge-providers/src/runtime.rs
+++ b/crates/forge-providers/src/runtime.rs
@@ -28,7 +28,7 @@ use crate::openai::custom::CustomOpenAiProvider;
 use crate::openai::OpenAiProvider;
 #[cfg(any(test, feature = "testing"))]
 use crate::MockProvider;
-use crate::{ChatChunk, ChatRequest, Provider};
+use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth};
 
 /// Tagged-union of every concrete [`Provider`] implementation. Each chat
 /// call dispatches via `match` to the appropriate inner — no dynamic
@@ -88,6 +88,35 @@ impl Provider for RuntimeProvider {
                 RuntimeProvider::CustomOpenAi(p) => Box::pin(async move { p.chat(req).await }),
                 #[cfg(any(test, feature = "testing"))]
                 RuntimeProvider::Mock(p) => Box::pin(async move { p.chat(req).await }),
+            };
+            fut.await
+        }
+    }
+
+    /// F-744: dispatch the per-turn credential to the active inner provider.
+    /// The credential is moved into the boxed future for the active variant
+    /// only — sibling variants never see it.
+    fn chat_with_auth(
+        &self,
+        req: ChatRequest,
+        auth: ProviderAuth,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        let cloned = self.clone();
+        async move {
+            let fut: futures::future::BoxFuture<'static, _> = match cloned {
+                RuntimeProvider::Anthropic(p) => {
+                    Box::pin(async move { p.chat_with_auth(req, auth).await })
+                }
+                RuntimeProvider::OpenAi(p) => {
+                    Box::pin(async move { p.chat_with_auth(req, auth).await })
+                }
+                RuntimeProvider::CustomOpenAi(p) => {
+                    Box::pin(async move { p.chat_with_auth(req, auth).await })
+                }
+                #[cfg(any(test, feature = "testing"))]
+                RuntimeProvider::Mock(p) => {
+                    Box::pin(async move { p.chat_with_auth(req, auth).await })
+                }
             };
             fut.await
         }
@@ -164,6 +193,18 @@ impl Provider for SwappableProvider {
         //    yank the network connection out from under an active turn.
         let snapshot: RuntimeProvider = self.inner.read().clone();
         async move { snapshot.chat(req).await }
+    }
+
+    /// F-744: same snapshot semantics as [`Self::chat`]; the credential
+    /// moves into the snapshot's bound future so a mid-turn swap cannot
+    /// see or interfere with the in-flight credential.
+    fn chat_with_auth(
+        &self,
+        req: ChatRequest,
+        auth: ProviderAuth,
+    ) -> impl std::future::Future<Output = Result<BoxStream<'static, ChatChunk>>> + Send {
+        let snapshot: RuntimeProvider = self.inner.read().clone();
+        async move { snapshot.chat_with_auth(req, auth).await }
     }
 }
 

--- a/crates/forge-providers/tests/auth_seam.rs
+++ b/crates/forge-providers/tests/auth_seam.rs
@@ -1,0 +1,479 @@
+//! F-744: Active credential injected into provider auth seam.
+//!
+//! These tests pin the `Provider::chat_with_auth` contract:
+//!
+//! 1. The seam injects the supplied credential into outbound HTTP requests
+//!    (Anthropic `x-api-key`, OpenAI `Authorization: Bearer`,
+//!    CustomOpenAI per-`AuthShape`).
+//! 2. The seam is a no-op for keyless providers (Ollama).
+//! 3. The credential is never observable through `Debug`, `Display`, or
+//!    `serde` on `forge_core::Event`s or on provider state.
+//! 4. `tracing` logs emitted on the chat path never contain the credential.
+
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+use forge_providers::anthropic::{AnthropicProvider, ANTHROPIC_VERSION};
+use forge_providers::ollama::OllamaProvider;
+use forge_providers::openai::{custom::CustomOpenAiProvider, AuthShape, OpenAiProvider};
+use forge_providers::{ChatBlock, ChatMessage, ChatRequest, ChatRole, Provider, ProviderAuth};
+use futures::StreamExt;
+use secrecy::SecretString;
+use tracing_subscriber::fmt::MakeWriter;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const SENTINEL: &str = "SECRET-12345-DO-NOT-LEAK";
+
+const ANTHROPIC_FIXTURE: &str = include_str!("fixtures/anthropic_text_and_tool_use.sse");
+const OPENAI_FIXTURE: &str = include_str!("fixtures/openai_text_and_tool_use.sse");
+const OLLAMA_FIXTURE: &str = include_str!("fixtures/ollama_text_only.ndjson");
+
+fn user_msg(text: &str) -> ChatMessage {
+    ChatMessage {
+        role: ChatRole::User,
+        content: vec![ChatBlock::Text(text.into())],
+    }
+}
+
+fn req() -> ChatRequest {
+    ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    }
+}
+
+fn auth_api_key(value: &str) -> ProviderAuth {
+    ProviderAuth::ApiKey(SecretString::from(value.to_string()))
+}
+
+// ── Injection: Anthropic ──────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn anthropic_chat_with_auth_injects_x_api_key_from_seam() {
+    let server = MockServer::start().await;
+
+    // Pin: the request must carry the seam-supplied `SENTINEL`, NOT any
+    // constructor-time key.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("x-api-key", SENTINEL))
+        .and(header("anthropic-version", ANTHROPIC_VERSION))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(ANTHROPIC_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    // Constructor takes a placeholder key — the seam must override it.
+    let p = AnthropicProvider::new(server.uri(), "ctor-key-ignored", "claude-3-5-sonnet", 4096);
+
+    let mut stream = p
+        .chat_with_auth(req(), auth_api_key(SENTINEL))
+        .await
+        .expect("chat_with_auth ok");
+    while let Some(_c) = stream.next().await {}
+}
+
+// ── Injection: OpenAI ─────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn openai_chat_with_auth_injects_bearer_from_seam() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {SENTINEL}").as_str(),
+        ))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(OPENAI_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let p = OpenAiProvider::new(server.uri(), "ctor-key-ignored", "gpt-4o");
+
+    let mut stream = p
+        .chat_with_auth(req(), auth_api_key(SENTINEL))
+        .await
+        .expect("chat_with_auth ok");
+    while let Some(_c) = stream.next().await {}
+}
+
+// ── Injection: CustomOpenAI (bearer) ──────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_openai_chat_with_auth_injects_bearer_from_seam() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {SENTINEL}").as_str(),
+        ))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(OPENAI_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let p = CustomOpenAiProvider::new(
+        "vllm",
+        server.uri(),
+        "gpt-4o",
+        vec!["gpt-4o".into()],
+        AuthShape::Bearer,
+        Some("ctor-key-ignored".into()),
+    )
+    .expect("construct");
+
+    let mut stream = p
+        .chat_with_auth(req(), auth_api_key(SENTINEL))
+        .await
+        .expect("chat_with_auth ok");
+    while let Some(_c) = stream.next().await {}
+}
+
+// ── Injection: CustomOpenAI (header shape) ────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_openai_chat_with_auth_injects_custom_header_from_seam() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header("x-api-key", SENTINEL))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(OPENAI_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let p = CustomOpenAiProvider::new(
+        "gw",
+        server.uri(),
+        "gpt-4o",
+        vec!["gpt-4o".into()],
+        AuthShape::Header {
+            name: "X-API-Key".into(),
+        },
+        Some("ctor-key-ignored".into()),
+    )
+    .expect("construct");
+
+    let mut stream = p
+        .chat_with_auth(req(), auth_api_key(SENTINEL))
+        .await
+        .expect("chat_with_auth ok");
+    while let Some(_c) = stream.next().await {}
+}
+
+// ── No-op: Ollama ─────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ollama_chat_with_auth_does_not_send_auth_header() {
+    let server = MockServer::start().await;
+
+    // The mock must match on the absence of any auth header. wiremock's
+    // matcher set has no "absent" assertion, so we install a strict matcher
+    // that requires the request to have NO Authorization or X-API-Key header
+    // by mounting a single mock that responds 200 and then asserting after
+    // the call that the captured request carries neither.
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/x-ndjson")
+                .set_body_string(OLLAMA_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let p = OllamaProvider::new(server.uri(), "llama3.2");
+    let mut stream = p
+        .chat_with_auth(req(), auth_api_key(SENTINEL))
+        .await
+        .expect("chat_with_auth ok");
+    while let Some(_c) = stream.next().await {}
+
+    // Inspect the captured wiremock request log. None of the recorded
+    // requests should carry an auth-shaped header containing the sentinel.
+    let recorded = server.received_requests().await.expect("requests recorded");
+    assert!(
+        !recorded.is_empty(),
+        "ollama provider must have fired at least one request"
+    );
+    for r in recorded {
+        for (name, value) in r.headers.iter() {
+            let n = name.as_str().to_ascii_lowercase();
+            let v = std::str::from_utf8(value.as_bytes()).unwrap_or("");
+            assert!(
+                !(n == "authorization" || n == "x-api-key"),
+                "ollama must not send {n}: header (got {v:?})"
+            );
+            assert!(
+                !v.contains(SENTINEL),
+                "no header should ever contain the credential sentinel (got {n}: {v:?})"
+            );
+        }
+    }
+}
+
+// ── Leak audit: Debug ─────────────────────────────────────────────────────────
+
+#[test]
+fn provider_auth_debug_redacts_sentinel() {
+    let auth = auth_api_key(SENTINEL);
+    let dbg = format!("{auth:?}");
+    assert!(
+        !dbg.contains(SENTINEL),
+        "ProviderAuth Debug leaked the credential: {dbg}"
+    );
+}
+
+#[test]
+fn provider_auth_display_redacts_sentinel() {
+    // `ProviderAuth` deliberately does NOT implement `Display`; the value
+    // must only leave the enum through `expose_secret()` at the network
+    // boundary. We assert that no implicit string conversion path leaks
+    // the bytes. (This is a compile-time guarantee: if a `Display` impl
+    // ever lands, the next assertion must be updated to assert redaction.)
+    let auth = auth_api_key(SENTINEL);
+    // Negative compile-time check via a function pointer would be ideal
+    // but is hard to express portably; the runtime path that exercises
+    // every reasonable formatter is `Debug`, asserted above.
+    let _ = auth;
+}
+
+#[test]
+fn anthropic_provider_debug_does_not_contain_sentinel() {
+    let p = AnthropicProvider::new("https://x", SENTINEL, "claude-3", 4096);
+    let dbg = format!("{p:?}");
+    assert!(
+        !dbg.contains(SENTINEL),
+        "AnthropicProvider Debug leaked the credential: {dbg}"
+    );
+}
+
+#[test]
+fn openai_provider_debug_does_not_contain_sentinel() {
+    let p = OpenAiProvider::new("https://x", SENTINEL, "gpt-4o");
+    let dbg = format!("{p:?}");
+    assert!(
+        !dbg.contains(SENTINEL),
+        "OpenAiProvider Debug leaked the credential: {dbg}"
+    );
+}
+
+#[test]
+fn custom_openai_provider_debug_does_not_contain_sentinel() {
+    let p = CustomOpenAiProvider::new(
+        "x",
+        "https://api.example.com",
+        "gpt-4o",
+        vec![],
+        AuthShape::Bearer,
+        Some(SENTINEL.into()),
+    )
+    .unwrap();
+    let dbg = format!("{p:?}");
+    assert!(
+        !dbg.contains(SENTINEL),
+        "CustomOpenAiProvider Debug leaked the credential: {dbg}"
+    );
+}
+
+// ── Leak audit: Event serialization ───────────────────────────────────────────
+
+#[test]
+fn forge_core_event_serialization_never_contains_provider_auth_payload() {
+    // The seam contract is that `ProviderAuth` lives at the request-time
+    // boundary; nothing on the `forge_core::Event` enum carries provider
+    // credentials. Serialize a representative cross-section of events
+    // (every variant we can construct cheaply) and assert the sentinel
+    // never appears. If a future refactor smuggles a credential into an
+    // event field, this test will fail.
+    use chrono::Utc;
+    use forge_core::ids::{MessageId, ProviderId, StepId};
+    use forge_core::{Event, StepKind};
+    use std::sync::Arc;
+
+    // Construct events that touch provider/auth-adjacent fields.
+    let events: Vec<Event> = vec![
+        Event::UserMessage {
+            id: MessageId::new(),
+            at: Utc::now(),
+            text: Arc::from(SENTINEL), // attacker tries to smuggle via text
+            context: vec![],
+            branch_parent: None,
+        },
+        Event::AssistantMessage {
+            id: MessageId::new(),
+            provider: ProviderId::new(),
+            model: "claude-3".to_string(),
+            at: Utc::now(),
+            stream_finalised: true,
+            text: Arc::from(""),
+            branch_parent: None,
+            branch_variant_index: 0,
+        },
+        Event::StepStarted {
+            step_id: StepId::new(),
+            instance_id: None,
+            kind: StepKind::Model,
+            started_at: Utc::now(),
+            index: 1,
+            total: None,
+        },
+    ];
+
+    for ev in &events {
+        let json = serde_json::to_string(ev).expect("event must serialize");
+        // The UserMessage variant intentionally seeds SENTINEL into the
+        // user-typed text field — that's a user-supplied string and
+        // serializes faithfully. Skip that one variant; for every other
+        // event variant, the sentinel must not appear.
+        if matches!(ev, Event::UserMessage { .. }) {
+            continue;
+        }
+        assert!(
+            !json.contains(SENTINEL),
+            "Event serialization leaked credential: {json}"
+        );
+    }
+}
+
+// ── Leak audit: tracing logs ──────────────────────────────────────────────────
+
+/// `MakeWriter` that appends every emitted span/event body into a shared
+/// `Vec<u8>` so the test can grep the captured log buffer for the sentinel.
+#[derive(Clone, Default)]
+struct CapturingWriter {
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for CapturingWriter {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        self.buf.lock().unwrap().extend_from_slice(data);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CapturingWriter {
+    type Writer = CapturingWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tracing_logs_emitted_on_chat_path_do_not_contain_credential() {
+    // Capture every `tracing` event emitted during the chat call. The
+    // `#[instrument]` span on each provider's `chat` runs through this
+    // subscriber as a default-guard scope.
+    let writer = CapturingWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(writer.clone())
+        .with_max_level(tracing::Level::TRACE)
+        .with_ansi(false)
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(ANTHROPIC_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let p = AnthropicProvider::new(server.uri(), "ctor-key", "claude-3-5-sonnet", 4096);
+    let mut stream = p
+        .chat_with_auth(req(), auth_api_key(SENTINEL))
+        .await
+        .expect("chat_with_auth ok");
+    while let Some(_c) = stream.next().await {}
+
+    let captured = writer.buf.lock().unwrap();
+    let captured_str = String::from_utf8_lossy(&captured);
+    assert!(
+        !captured_str.contains(SENTINEL),
+        "tracing logs leaked credential: {captured_str}"
+    );
+}
+
+// ── Default impl: chat() unchanged ────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn provider_chat_default_path_unchanged_for_anthropic_constructor_key() {
+    // The legacy `chat()` entry must keep using the constructor-time
+    // credential — F-744 must not regress callers that still go through
+    // `Provider::chat`.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("x-api-key", "sk-legacy"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(ANTHROPIC_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let p = AnthropicProvider::new(server.uri(), "sk-legacy", "claude-3-5-sonnet", 4096);
+    let mut stream = p.chat(req()).await.expect("chat ok");
+    while let Some(_c) = stream.next().await {}
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn provider_auth_none_falls_back_to_constructor_credential_for_anthropic() {
+    // When the seam is invoked with `ProviderAuth::None`, the legacy
+    // constructor-time credential must still be sent — this preserves the
+    // call shape for callers that opt out of per-turn injection (e.g.
+    // tests, or providers that don't support per-turn credentials).
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("x-api-key", "sk-legacy"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(ANTHROPIC_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let p = AnthropicProvider::new(server.uri(), "sk-legacy", "claude-3-5-sonnet", 4096);
+    let mut stream = p
+        .chat_with_auth(req(), ProviderAuth::None)
+        .await
+        .expect("chat_with_auth ok");
+    while let Some(_c) = stream.next().await {}
+}
+
+// Compile-time guarantee: ensure `ProviderAuth` is `Send + Sync` so it can
+// be threaded through the orchestrator's per-turn binding without further
+// wrapping.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<ProviderAuth>();
+};

--- a/crates/forge-providers/tests/auth_seam.rs
+++ b/crates/forge-providers/tests/auth_seam.rs
@@ -243,19 +243,17 @@ fn provider_auth_debug_redacts_sentinel() {
     );
 }
 
-#[test]
-fn provider_auth_display_redacts_sentinel() {
-    // `ProviderAuth` deliberately does NOT implement `Display`; the value
-    // must only leave the enum through `expose_secret()` at the network
-    // boundary. We assert that no implicit string conversion path leaks
-    // the bytes. (This is a compile-time guarantee: if a `Display` impl
-    // ever lands, the next assertion must be updated to assert redaction.)
-    let auth = auth_api_key(SENTINEL);
-    // Negative compile-time check via a function pointer would be ideal
-    // but is hard to express portably; the runtime path that exercises
-    // every reasonable formatter is `Debug`, asserted above.
-    let _ = auth;
-}
+// F-744: compile-time guarantee that `ProviderAuth` does NOT implement
+// `Display` or `serde::Serialize`. Either trait would expose a path to
+// stringify or serialize the secret bytes without going through
+// `expose_secret()` at the network boundary. Any future code that
+// accidentally derives or hand-rolls either impl will fail to build,
+// rather than silently leaking the credential through `format!("{}", auth)`
+// or `serde_json::to_string(&auth)`.
+static_assertions::assert_not_impl_any!(
+    forge_providers::ProviderAuth: std::fmt::Display,
+    serde::Serialize,
+);
 
 #[test]
 fn anthropic_provider_debug_does_not_contain_sentinel() {
@@ -477,3 +475,31 @@ const _: fn() = || {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<ProviderAuth>();
 };
+
+/// F-744 zeroization contract: the per-turn credential held inside
+/// `ProviderAuth::ApiKey` (and `Vertex`) is a `secrecy::SecretString`,
+/// which `Zeroize`s on drop. A plain `String` would leave the plaintext
+/// bytes on the heap after the request future is dropped — defeating the
+/// core security claim of F-744. This compile-time check pins the inner
+/// type so a refactor that swaps it back to a non-zeroizing container
+/// fails to build.
+#[test]
+fn provider_auth_api_key_inner_is_secret_string() {
+    // Pattern-bind the inner field and assert its type via let-binding —
+    // a `&String` would fail to coerce to `&SecretString`.
+    let auth = auth_api_key(SENTINEL);
+    match &auth {
+        ProviderAuth::ApiKey(s) => {
+            let _: &SecretString = s;
+        }
+        _ => panic!("expected ApiKey variant"),
+    }
+
+    let v = ProviderAuth::Vertex(SecretString::from("t".to_string()));
+    match &v {
+        ProviderAuth::Vertex(s) => {
+            let _: &SecretString = s;
+        }
+        _ => panic!("expected Vertex variant"),
+    }
+}

--- a/crates/forge-session/src/compaction.rs
+++ b/crates/forge-session/src/compaction.rs
@@ -298,6 +298,7 @@ impl Drop for ReleaseCompactingOnDrop {
 /// call without intervening writes selects the same turns again — callers
 /// (typically the orchestrator's auto-trigger) gate on
 /// `summarizing_in_flight` to avoid that.
+#[allow(clippy::too_many_arguments)]
 pub async fn compact<P: Provider>(
     session: Arc<Session>,
     provider: Arc<P>,
@@ -306,6 +307,12 @@ pub async fn compact<P: Provider>(
     fraction: f64,
     pinned: &HashSet<MessageId>,
     trigger: CompactTrigger,
+    // F-744: auth seam threaded from the orchestrator so the privileged
+    // summary call uses the same per-turn credential as the live turn.
+    // `ProviderAuth::None` preserves the pre-F-744 behaviour for keyless
+    // providers (Ollama) and for callers that don't wire the seam
+    // (existing unit tests, embedders).
+    auth: forge_providers::ProviderAuth,
 ) -> Result<CompactionResult> {
     // Refuse to recurse: the privileged summary call below could in
     // principle drive the byte budget further, but auto-triggering must
@@ -365,7 +372,9 @@ pub async fn compact<P: Provider>(
     // the unfiltered post-cap total — used to tell the caller how much was
     // discarded via the [`Event::CompactionTruncated`] marker emitted below.
     let req = build_summary_request(&excerpt);
-    let mut stream = provider.chat(req).await?;
+    // F-744: route through the auth seam so the privileged summary call
+    // uses the per-turn credential supplied by the orchestrator.
+    let mut stream = provider.chat_with_auth(req, auth).await?;
     let mut summary_text = String::new();
     let mut truncated = false;
     let mut accumulated_bytes: u64 = 0;
@@ -748,6 +757,7 @@ mod tests {
             DEFAULT_COMPACT_FRACTION,
             &HashSet::new(),
             CompactTrigger::AutoAt98Pct,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .unwrap();
@@ -823,6 +833,7 @@ mod tests {
             DEFAULT_COMPACT_FRACTION,
             &pinned,
             CompactTrigger::UserRequested,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .unwrap_err();
@@ -874,6 +885,7 @@ mod tests {
             DEFAULT_COMPACT_FRACTION,
             &HashSet::new(),
             CompactTrigger::AutoAt98Pct,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .unwrap();
@@ -971,6 +983,7 @@ mod tests {
             DEFAULT_COMPACT_FRACTION,
             &HashSet::new(),
             CompactTrigger::AutoAt98Pct,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .unwrap();
@@ -1013,6 +1026,7 @@ mod tests {
             DEFAULT_COMPACT_FRACTION,
             &HashSet::new(),
             CompactTrigger::UserRequested,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .unwrap_err();

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -12,7 +12,9 @@ use forge_core::{
     StepOutcome,
 };
 use forge_ipc::sidecar::{SecretBytes, SidecarCredentials, SidecarMessage};
-use forge_providers::{ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider};
+use forge_providers::{
+    ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider, ProviderAuth,
+};
 use futures::StreamExt;
 use secrecy::ExposeSecret;
 use tokio::sync::{mpsc, oneshot, Mutex};
@@ -93,78 +95,102 @@ impl std::fmt::Debug for CredentialContext {
     }
 }
 
-/// F-587: pull the active provider's credential, exactly once, before a
-/// turn or rerun's request loop opens.
+/// F-587 / F-744: pull the active provider's credential, exactly once,
+/// before a turn or rerun's request loop opens.
 ///
 /// Shared between `run_turn`, `Orchestrator::rerun_replace`,
 /// `Orchestrator::rerun_branch`, and `Orchestrator::rerun_fresh` so the
-/// pull contract is identical on every turn-shaped path. The pulled value
-/// is dropped immediately on this Phase-1 keyless build; when Phase-3
-/// providers consume `CredentialContext`, the value is handed into
-/// per-request auth shape via `secrecy::ExposeSecret::expose_secret` at
-/// the network boundary, never logged or stringified.
+/// pull contract is identical on every turn-shaped path. F-744 wires the
+/// pulled value through into the provider's [`Provider::chat_with_auth`]
+/// at the network boundary — the secret never leaves this module except
+/// as a [`SecretString`] handed straight to the provider seam, which is
+/// responsible for `ExposeSecret`-ing it onto the outgoing request.
 ///
 /// Backend errors propagate. A misconfigured Secret Service daemon or a
 /// locked Keychain is more useful as a turn-level failure than a silent
 /// fall-through to "no auth" that the provider would later 401 on.
-async fn pull_active_credential(ctx: &Option<CredentialContext>) -> Result<()> {
-    if let Some(ctx) = ctx.as_ref() {
-        let pulled = ctx.store.get(&ctx.provider_id).await?;
-        tracing::trace!(
-            target: "forge_session::orchestrator::credentials",
-            provider_id = %ctx.provider_id,
-            hit = pulled.is_some(),
-            "credential pull",
-        );
+async fn pull_active_credential(
+    ctx: &Option<CredentialContext>,
+) -> Result<Option<secrecy::SecretString>> {
+    let Some(ctx) = ctx.as_ref() else {
+        return Ok(None);
+    };
+    let pulled = ctx.store.get(&ctx.provider_id).await?;
+    tracing::trace!(
+        target: "forge_session::orchestrator::credentials",
+        provider_id = %ctx.provider_id,
+        hit = pulled.is_some(),
+        "credential pull",
+    );
 
-        // F-608 step 6: when a sidecar push hook is wired AND the
-        // credential pull hit, frame the value as a `Credentials` IPC
-        // message and forward it to the per-instance sidecar before the
-        // orchestrator's caller emits `RunTurn`. The provider's
-        // per-request auth shape on the sidecar side then has the value
-        // staged. We deliberately do NOT push on the miss path —
-        // staging an empty credential would teach the sidecar a bogus
-        // "I have a key" signal for a provider that's actually keyless.
-        //
-        // Security: `expose_secret()` is the only call site that
-        // touches the cleartext bytes; the result is moved straight
-        // into `SecretBytes` (whose `Debug`/`Display` redact) and never
-        // bound to a `&str` we could accidentally log. The trace
-        // emission below carries `provider_id` + `instance_id` only —
-        // never the byte count, never the value.
-        if let (Some(secret), Some(push)) = (pulled.as_ref(), ctx.sidecar_push.as_ref()) {
-            let frame = SidecarMessage::Credentials(SidecarCredentials {
-                provider_id: ProviderId::from_string(ctx.provider_id.clone()),
-                secret: SecretBytes::new(secret.expose_secret().as_bytes().to_vec()),
-            });
-            match push.command_tx.send(frame).await {
-                Ok(()) => {
-                    tracing::trace!(
-                        target: "forge_session::orchestrator::credentials",
-                        provider_id = %ctx.provider_id,
-                        instance_id = %push.instance_id,
-                        "pushed credential",
-                    );
-                }
-                Err(_) => {
-                    // Closed channel = supervisor has wound the sidecar
-                    // down. The pending `RunTurn` will land on the same
-                    // closed channel; surface here as a warn rather than
-                    // failing the turn pre-emptively so the caller's own
-                    // error path (if any) drives the lifecycle.
-                    tracing::warn!(
-                        target: "forge_session::orchestrator::credentials",
-                        provider_id = %ctx.provider_id,
-                        instance_id = %push.instance_id,
-                        "sidecar credential push: channel closed",
-                    );
-                }
+    // F-608 step 6: when a sidecar push hook is wired AND the
+    // credential pull hit, frame the value as a `Credentials` IPC
+    // message and forward it to the per-instance sidecar before the
+    // orchestrator's caller emits `RunTurn`. The provider's
+    // per-request auth shape on the sidecar side then has the value
+    // staged. We deliberately do NOT push on the miss path —
+    // staging an empty credential would teach the sidecar a bogus
+    // "I have a key" signal for a provider that's actually keyless.
+    //
+    // Security: `expose_secret()` is the only call site that
+    // touches the cleartext bytes; the result is moved straight
+    // into `SecretBytes` (whose `Debug`/`Display` redact) and never
+    // bound to a `&str` we could accidentally log. The trace
+    // emission below carries `provider_id` + `instance_id` only —
+    // never the byte count, never the value.
+    if let (Some(secret), Some(push)) = (pulled.as_ref(), ctx.sidecar_push.as_ref()) {
+        let frame = SidecarMessage::Credentials(SidecarCredentials {
+            provider_id: ProviderId::from_string(ctx.provider_id.clone()),
+            secret: SecretBytes::new(secret.expose_secret().as_bytes().to_vec()),
+        });
+        match push.command_tx.send(frame).await {
+            Ok(()) => {
+                tracing::trace!(
+                    target: "forge_session::orchestrator::credentials",
+                    provider_id = %ctx.provider_id,
+                    instance_id = %push.instance_id,
+                    "pushed credential",
+                );
+            }
+            Err(_) => {
+                // Closed channel = supervisor has wound the sidecar
+                // down. The pending `RunTurn` will land on the same
+                // closed channel; surface here as a warn rather than
+                // failing the turn pre-emptively so the caller's own
+                // error path (if any) drives the lifecycle.
+                tracing::warn!(
+                    target: "forge_session::orchestrator::credentials",
+                    provider_id = %ctx.provider_id,
+                    instance_id = %push.instance_id,
+                    "sidecar credential push: channel closed",
+                );
             }
         }
-
-        drop(pulled);
     }
-    Ok(())
+
+    Ok(pulled)
+}
+
+/// F-744: build a [`ProviderAuth`] for the active provider from the
+/// per-turn pulled credential. Keyless providers (Ollama) map to
+/// `ProviderAuth::None` regardless of whether a credential was pulled —
+/// the seam at the provider end will drop the value either way, but
+/// emitting `None` makes the keyless contract explicit at the call site.
+fn build_provider_auth(provider_id: &str, pulled: Option<secrecy::SecretString>) -> ProviderAuth {
+    // Ollama is keyless. Any other provider id that lands here (anthropic,
+    // openai, custom_openai, anthropic-vertex) uses the `ApiKey` shape;
+    // Anthropic's Vertex sub-mode is currently driven entirely through
+    // the constructor-time `AuthMode` (gcloud token fetched at request
+    // time) and does not flow through the keyring, so the seam variant
+    // here stays `ApiKey` for now and the provider falls back to
+    // `AuthMode::Vertex` when the seam is `None`.
+    if provider_id == "ollama" {
+        return ProviderAuth::None;
+    }
+    match pulled {
+        Some(s) => ProviderAuth::ApiKey(s),
+        None => ProviderAuth::None,
+    }
 }
 
 use crate::byte_budget::ByteBudget;
@@ -289,13 +315,25 @@ pub async fn run_turn<P: Provider>(
     // keyless. See [`CredentialContext`] for the seam contract.
     credentials: Option<CredentialContext>,
 ) -> Result<()> {
-    // F-587: pull the credential for the active provider before any
+    // F-587 / F-744: pull the credential for the active provider before any
     // model-side work begins. Shared with the rerun paths via
     // `pull_active_credential` so every turn-shaped entry point honors the
     // same pull-once contract. A credential-pull failure fails the turn
     // before compaction runs — that's the right ordering: we won't burn a
     // privileged summary call on a turn that was going to fail anyway.
-    pull_active_credential(&credentials).await?;
+    //
+    // F-744: the pulled `SecretString` is mapped into a `ProviderAuth`
+    // tagged with the active provider's id and threaded into
+    // `run_request_loop` (and into `compact()` below) so the provider's
+    // `chat_with_auth` seam can build the auth header per request.
+    let pulled_secret = pull_active_credential(&credentials).await?;
+    let provider_auth = build_provider_auth(
+        credentials
+            .as_ref()
+            .map(|c| c.provider_id.as_str())
+            .unwrap_or(""),
+        pulled_secret,
+    );
 
     // F-598: auto-trigger context compaction at byte-budget >= 98%. Runs
     // BEFORE the new turn's UserMessage is logged so the summary marker
@@ -320,6 +358,11 @@ pub async fn run_turn<P: Provider>(
             && !session.is_compacting()
         {
             let pinned = std::collections::HashSet::new();
+            // F-744: auto-compaction uses the same per-turn credential — it
+            // runs *before* the actual chat request below, so the seam
+            // value is identical for both calls. Clone is a refcount bump
+            // on the inner `SecretString` (zeroized on drop with the
+            // request future).
             if let Err(e) = compact(
                 Arc::clone(&session),
                 Arc::clone(&provider),
@@ -328,6 +371,7 @@ pub async fn run_turn<P: Provider>(
                 DEFAULT_COMPACT_FRACTION,
                 &pinned,
                 forge_core::CompactTrigger::AutoAt98Pct,
+                provider_auth.clone(),
             )
             .await
             {
@@ -443,6 +487,7 @@ pub async fn run_turn<P: Provider>(
         &ctx,
         auto_approve,
         instance_id,
+        provider_auth,
     )
     .await
 }
@@ -527,6 +572,13 @@ pub(crate) async fn run_request_loop<P: Provider>(
     // parent id. `None` preserves the pre-F-140 behaviour for embedders
     // that don't have an agent runtime wired up.
     instance_id: Option<forge_core::ids::AgentInstanceId>,
+    // F-744: per-turn credential bound at the orchestrator entry point and
+    // handed to `Provider::chat_with_auth` on each model step within the
+    // loop. Cloned per iteration so the original outlives the inner box;
+    // every clone (and the original) zeroizes on drop. `ProviderAuth::None`
+    // is the keyless contract for Ollama and the no-credential fallback for
+    // tests that exercise the legacy `chat()` path.
+    auth: ProviderAuth,
 ) -> Result<()> {
     // Fixed provider/model identifiers for the mock provider.
     let provider_id = ProviderId::new();
@@ -605,7 +657,14 @@ pub(crate) async fn run_request_loop<P: Provider>(
             })
             .await?;
 
-        let mut stream = provider.chat(req.clone()).await?;
+        // F-744: route through the auth seam so the per-turn credential
+        // (resolved at `run_turn` / `rerun_*` entry, propagated here as
+        // `auth`) is injected into the outbound request's auth header on
+        // every model step. `auth.clone()` is a deep clone of the inner
+        // `SecretString` — required because the loop can re-enter with a
+        // tool-result continuation that needs the same credential — but
+        // the cloned secret zeroizes on drop with the request future.
+        let mut stream = provider.chat_with_auth(req.clone(), auth.clone()).await?;
         let mut assistant_text = String::new();
         // F-599: buffer every `ChatChunk::ToolCall` emitted in this stream
         // pass and dispatch the buffered set as one batch after the stream
@@ -1600,9 +1659,17 @@ impl Orchestrator {
         // F-587: see `rerun_message`.
         credentials: Option<CredentialContext>,
     ) -> Result<MessageId> {
-        // F-587: pull the active provider's credential before regeneration
-        // begins, identical to `run_turn`. Backend errors fail the rerun.
-        pull_active_credential(&credentials).await?;
+        // F-587 / F-744: pull the active provider's credential before
+        // regeneration begins, identical to `run_turn`. Backend errors
+        // fail the rerun.
+        let pulled_secret = pull_active_credential(&credentials).await?;
+        let provider_auth = build_provider_auth(
+            credentials
+                .as_ref()
+                .map(|c| c.provider_id.as_str())
+                .unwrap_or(""),
+            pulled_secret,
+        );
 
         // Read the log up to the current tip; filter prior supersede markers
         // so a second rerun doesn't rebuild context from already-hidden
@@ -1689,6 +1756,7 @@ impl Orchestrator {
             &ctx,
             auto_approve,
             instance_id,
+            provider_auth,
         )
         .await?;
 
@@ -1742,8 +1810,15 @@ impl Orchestrator {
         // F-587: see `rerun_message`.
         credentials: Option<CredentialContext>,
     ) -> Result<MessageId> {
-        // F-587: same pull-once contract as `run_turn` / `rerun_replace`.
-        pull_active_credential(&credentials).await?;
+        // F-587 / F-744: same pull-once contract as `run_turn` / `rerun_replace`.
+        let pulled_secret = pull_active_credential(&credentials).await?;
+        let provider_auth = build_provider_auth(
+            credentials
+                .as_ref()
+                .map(|c| c.provider_id.as_str())
+                .unwrap_or(""),
+            pulled_secret,
+        );
 
         let history = read_since(&session.log_path, 0)
             .await
@@ -1822,6 +1897,7 @@ impl Orchestrator {
             &ctx,
             auto_approve,
             instance_id,
+            provider_auth,
         )
         .await?;
 
@@ -1868,8 +1944,15 @@ impl Orchestrator {
         // F-587: see `rerun_message`.
         credentials: Option<CredentialContext>,
     ) -> Result<MessageId> {
-        // F-587: same pull-once contract as `run_turn` / `rerun_replace`.
-        pull_active_credential(&credentials).await?;
+        // F-587 / F-744: same pull-once contract as `run_turn` / `rerun_replace`.
+        let pulled_secret = pull_active_credential(&credentials).await?;
+        let provider_auth = build_provider_auth(
+            credentials
+                .as_ref()
+                .map(|c| c.provider_id.as_str())
+                .unwrap_or(""),
+            pulled_secret,
+        );
 
         let history = read_since(&session.log_path, 0)
             .await
@@ -1940,6 +2023,7 @@ impl Orchestrator {
             &ctx,
             auto_approve,
             instance_id,
+            provider_auth,
         )
         .await?;
 
@@ -2903,6 +2987,7 @@ mod tests {
                 &ctx,
                 true,
                 None,
+                forge_providers::ProviderAuth::None,
             )
             .await
             .expect("turn completes");
@@ -2998,6 +3083,7 @@ mod tests {
             &ctx,
             true,
             None,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .expect("turn completes");
@@ -3114,6 +3200,7 @@ mod tests {
             &ctx,
             true,
             None,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .expect("turn completes");
@@ -3196,6 +3283,7 @@ mod tests {
             &ctx,
             true, // auto-approve so write.x doesn't block on a prompt
             None,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .expect("turn completes");
@@ -3296,6 +3384,7 @@ mod tests {
             &ctx,
             true,
             None,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .expect("turn completes");
@@ -3415,6 +3504,7 @@ mod tests {
             &ctx,
             true,
             None,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .expect("first turn completes");
@@ -3452,6 +3542,7 @@ mod tests {
             &ctx,
             true,
             None,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .expect("follow-up turn completes");
@@ -3566,6 +3657,7 @@ mod tests {
             &ctx,
             true,
             None,
+            forge_providers::ProviderAuth::None,
         )
         .await
         .expect("turn completes despite tool panic");

--- a/crates/forge-session/src/server.rs
+++ b/crates/forge-session/src/server.rs
@@ -1596,8 +1596,24 @@ async fn handle_connection<P: Provider + 'static>(
                         let session = Arc::clone(&session);
                         let provider = Arc::clone(&provider);
                         let session_id_for_compact = Arc::clone(&session_id);
+                        // F-744: pull the per-call credential snapshot for
+                        // the manual compaction here, off-loop, so the
+                        // privileged summary call routes through the same
+                        // auth seam as a live turn. Keyless / unwired sessions
+                        // pass `ProviderAuth::None` and the provider's
+                        // constructor-time credential (if any) takes over.
+                        let compact_creds = credentials.clone();
                         tokio::spawn(async move {
                             let pinned = std::collections::HashSet::new();
+                            let auth = match compact_creds.as_ref() {
+                                Some(ctx) => match ctx.store.get(&ctx.provider_id).await {
+                                    Ok(Some(secret)) if ctx.provider_id != "ollama" => {
+                                        forge_providers::ProviderAuth::ApiKey(secret)
+                                    }
+                                    _ => forge_providers::ProviderAuth::None,
+                                },
+                                None => forge_providers::ProviderAuth::None,
+                            };
                             if let Err(e) = crate::compaction::compact(
                                 session,
                                 provider,
@@ -1606,6 +1622,7 @@ async fn handle_connection<P: Provider + 'static>(
                                 crate::compaction::DEFAULT_COMPACT_FRACTION,
                                 &pinned,
                                 forge_core::CompactTrigger::UserRequested,
+                                auth,
                             )
                             .await
                             {


### PR DESCRIPTION
Closes forge-ide/forge#888

## Summary
- Added `Provider::chat_with_auth(req, ProviderAuth)` so the orchestrator threads the per-turn credential from the keyring into the outbound HTTP request, without storing the secret on the provider struct.
- `ProviderAuth` wraps `secrecy::SecretString` with redacting `Debug` and no `Display`/`Serialize`; variants `ApiKey`, `Vertex`, `None`.
- Anthropic / OpenAI / CustomOpenAI override `chat_with_auth` to inject the seam credential, falling back to constructor-time auth on `ProviderAuth::None`. Each provider gains a hand-rolled `Debug` that redacts its stored credential.
- Ollama: explicit no-op override pins the keyless contract.
- `RuntimeProvider` / `SwappableProvider` dispatch the seam to the active inner; the snapshot-then-await pattern preserves swap-during-stream isolation.
- Orchestrator (`run_turn`, `rerun_*`) and `compaction::compact` pull the credential once per turn entry and pass `ProviderAuth` to `chat_with_auth`. The server-side manual-compact path pulls inline (off-loop).
- New leak-audit test `tests/auth_seam.rs` (14 cases) asserts the sentinel credential never appears in provider/auth `Debug`, `forge_core::Event` serialization output, or any captured `tracing` event. wiremock pins the wire header for each authenticated provider and confirms Ollama sends no auth header.

## Test plan
- `cargo test --workspace` passes (the single failing `full_headless_turn_emits_correct_event_sequence` test is pre-existing — fails identically on `upstream/main`).
- `cargo clippy --workspace --all-targets -- -D warnings` passes.
- `cargo fmt --check` passes.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p forge-providers -p forge-session --no-deps` passes for the touched crates. (Pre-existing `forge-term` rustdoc errors are unrelated.)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)