### PR TITLE
[F-745] Anthropic + OpenAI chat_stream end-to-end

### DIFF
--- a/crates/forge-providers/tests/anthropic.rs
+++ b/crates/forge-providers/tests/anthropic.rs
@@ -292,6 +292,103 @@ async fn chat_line_too_long_yields_typed_error_and_terminates() {
     );
 }
 
+/// F-745 DoD #3: a continuation turn that carries a prior assistant
+/// `ChatBlock::ToolCall` plus a user `ChatBlock::ToolResult` must serialize
+/// onto the wire as Anthropic's `tool_use` block (inside the assistant
+/// message) and a paired user-role `tool_result` block referencing the
+/// original `tool_use_id`. Asserts on the actual HTTP request body the
+/// mock server received — not the in-memory translate output — so a
+/// future refactor that breaks the wire shape surfaces here.
+#[tokio::test(flavor = "multi_thread")]
+async fn tool_call_and_result_round_trip_through_request_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(TEXT_AND_TOOL_USE_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(server.uri(), "sk-test", "claude-3-5-sonnet", 4096);
+    let req = ChatRequest {
+        system: None,
+        messages: vec![
+            ChatMessage {
+                role: ChatRole::User,
+                content: vec![ChatBlock::Text("what is the weather in sf".into())],
+            },
+            ChatMessage {
+                role: ChatRole::Assistant,
+                content: vec![
+                    ChatBlock::Text("checking".into()),
+                    ChatBlock::ToolCall {
+                        id: "toolu_round_trip".into(),
+                        name: "get_weather".into(),
+                        args: serde_json::json!({"city": "sf"}),
+                    },
+                ],
+            },
+            ChatMessage {
+                role: ChatRole::User,
+                content: vec![ChatBlock::ToolResult {
+                    id: "toolu_round_trip".into(),
+                    result: serde_json::json!({"temp": 60}),
+                }],
+            },
+        ],
+        parallel_tool_calls_allowed: false,
+    };
+    let mut stream = provider.chat(req).await.expect("chat ok");
+    while stream.next().await.is_some() {}
+
+    let received = server.received_requests().await.expect("received");
+    assert_eq!(received.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&received[0].body).expect("json body");
+
+    let messages = body["messages"].as_array().expect("messages array");
+    // The assistant turn must carry a `tool_use` block referencing the id.
+    let assistant_msg = messages
+        .iter()
+        .find(|m| m["role"] == "assistant")
+        .expect("assistant message must be present");
+    let content = assistant_msg["content"]
+        .as_array()
+        .expect("assistant content array");
+    let tool_use = content
+        .iter()
+        .find(|b| b["type"] == "tool_use")
+        .expect("tool_use block must be present on the assistant message");
+    assert_eq!(tool_use["id"], "toolu_round_trip");
+    assert_eq!(tool_use["name"], "get_weather");
+    assert_eq!(tool_use["input"], serde_json::json!({"city": "sf"}));
+
+    // The follow-up user-role tool_result must reference the same id.
+    // Anthropic carries the result as a string-encoded JSON payload.
+    let tool_result_msg = messages
+        .iter()
+        .find(|m| {
+            m["role"] == "user"
+                && m["content"]
+                    .as_array()
+                    .map(|c| c.iter().any(|b| b["type"] == "tool_result"))
+                    .unwrap_or(false)
+        })
+        .expect("user-role tool_result message expected");
+    let result_block = tool_result_msg["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|b| b["type"] == "tool_result")
+        .unwrap();
+    assert_eq!(result_block["tool_use_id"], "toolu_round_trip");
+    let payload = result_block["content"].as_str().expect("content string");
+    let parsed: serde_json::Value = serde_json::from_str(payload).expect("nested json");
+    assert_eq!(parsed, serde_json::json!({"temp": 60}));
+}
+
 // F-647: Anthropic provider must not follow HTTP redirects. A misconfigured
 // proxy or network-layer attacker can inject `302 Location: 169.254.169.254`
 // and the default reqwest client would follow blindly to IMDS or another
@@ -324,4 +421,66 @@ async fn chat_does_not_follow_redirects() {
         msg.contains("302"),
         "error must reflect the upstream 302 status: {msg}"
     );
+}
+
+/// Manual smoke test against the real Anthropic API.
+///
+/// Skipped by default. To run:
+///
+/// ```bash
+/// FORGE_ANTHROPIC_SMOKE_API_KEY=sk-ant-... \
+///   cargo test -p forge-providers --test anthropic \
+///   -- --ignored chat_against_real_anthropic
+/// ```
+///
+/// Verifies the full request → stream → typed chunks path against the
+/// production Anthropic endpoint. CI never runs this — it depends on a
+/// live API key and is documented as evidence for F-745 DoD #5 ("smoke
+/// test against each provider").
+///
+/// Mirrors the F-743 `chat_against_local_ollama` pattern: env-gated,
+/// terse system prompt, asserts a non-empty assistant reply plus a
+/// terminal `Done`.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn chat_against_real_anthropic() {
+    let api_key = std::env::var("FORGE_ANTHROPIC_SMOKE_API_KEY")
+        .expect("set FORGE_ANTHROPIC_SMOKE_API_KEY to a valid Anthropic API key");
+    let base_url = std::env::var("FORGE_ANTHROPIC_SMOKE_URL")
+        .unwrap_or_else(|_| "https://api.anthropic.com".to_string());
+    // `claude-3-5-haiku-latest` is the cheapest current-line Claude model and is
+    // sufficient for a five-word reply. Override with FORGE_ANTHROPIC_SMOKE_MODEL.
+    let model = std::env::var("FORGE_ANTHROPIC_SMOKE_MODEL")
+        .unwrap_or_else(|_| "claude-3-5-haiku-latest".to_string());
+
+    let provider = AnthropicProvider::new(&base_url, &api_key, &model, 256);
+    let req = ChatRequest {
+        system: Some(std::sync::Arc::from(
+            "You are a terse assistant. Reply with one short sentence.",
+        )),
+        messages: vec![user_msg("Say hello in five words or fewer.")],
+        parallel_tool_calls_allowed: false,
+    };
+
+    let mut stream = provider.chat(req).await.expect("chat call succeeds");
+    let mut accumulated = String::new();
+    let mut saw_done = false;
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            ChatChunk::TextDelta(delta) => accumulated.push_str(&delta),
+            ChatChunk::Done(_) => saw_done = true,
+            ChatChunk::ToolCall { .. } => {
+                // unexpected for this prompt — model shouldn't request a tool
+            }
+            ChatChunk::Error { kind, message } => {
+                panic!("anthropic returned error: kind={kind:?}, message={message}")
+            }
+        }
+    }
+    assert!(saw_done, "expected a final Done chunk");
+    assert!(
+        !accumulated.trim().is_empty(),
+        "expected non-empty assistant text"
+    );
+    eprintln!("anthropic replied: {accumulated}");
 }

--- a/crates/forge-providers/tests/openai.rs
+++ b/crates/forge-providers/tests/openai.rs
@@ -286,6 +286,94 @@ async fn chat_line_too_long_yields_typed_error_and_terminates() {
     );
 }
 
+/// F-745 DoD #3: a continuation turn that carries a prior assistant
+/// `ChatBlock::ToolCall` plus a user `ChatBlock::ToolResult` must serialize
+/// onto the wire as OpenAI's `tool_calls` array (inside the assistant
+/// message) and a paired `role: "tool"` message keyed by `tool_call_id`.
+/// Asserts on the actual HTTP request body the mock server received — so
+/// a future refactor that breaks the wire shape surfaces here.
+#[tokio::test(flavor = "multi_thread")]
+async fn tool_call_and_result_round_trip_through_request_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(TEXT_AND_TOOL_USE_FIXTURE),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = OpenAiProvider::new(server.uri(), "sk-test", "gpt-4o");
+    let req = ChatRequest {
+        system: None,
+        messages: vec![
+            ChatMessage {
+                role: ChatRole::User,
+                content: vec![ChatBlock::Text("what is the weather in sf".into())],
+            },
+            ChatMessage {
+                role: ChatRole::Assistant,
+                content: vec![
+                    ChatBlock::Text("checking".into()),
+                    ChatBlock::ToolCall {
+                        id: "call_round_trip".into(),
+                        name: "get_weather".into(),
+                        args: serde_json::json!({"city": "sf"}),
+                    },
+                ],
+            },
+            ChatMessage {
+                role: ChatRole::User,
+                content: vec![ChatBlock::ToolResult {
+                    id: "call_round_trip".into(),
+                    result: serde_json::json!({"temp": 60}),
+                }],
+            },
+        ],
+        parallel_tool_calls_allowed: false,
+    };
+    let mut stream = provider.chat(req).await.expect("chat ok");
+    while stream.next().await.is_some() {}
+
+    let received = server.received_requests().await.expect("received");
+    assert_eq!(received.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&received[0].body).expect("json body");
+    let messages = body["messages"].as_array().expect("messages array");
+
+    // Assistant message must carry a sibling `tool_calls` array.
+    let assistant_msg = messages
+        .iter()
+        .find(|m| m["role"] == "assistant")
+        .expect("assistant message must be present");
+    let tcs = assistant_msg["tool_calls"]
+        .as_array()
+        .expect("assistant message must carry a structured tool_calls array");
+    assert_eq!(tcs.len(), 1, "expected exactly one tool_call");
+    assert_eq!(tcs[0]["id"], "call_round_trip");
+    assert_eq!(tcs[0]["type"], "function");
+    assert_eq!(tcs[0]["function"]["name"], "get_weather");
+    // OpenAI carries arguments as a JSON-encoded string — round-trip through
+    // `from_str` to verify the encoded value.
+    let args_str = tcs[0]["function"]["arguments"]
+        .as_str()
+        .expect("arguments is a JSON string per OpenAI's wire shape");
+    let parsed_args: serde_json::Value = serde_json::from_str(args_str).expect("nested args json");
+    assert_eq!(parsed_args, serde_json::json!({"city": "sf"}));
+
+    // The follow-up tool result becomes a dedicated `role: "tool"` message
+    // keyed by `tool_call_id`.
+    let tool_msg = messages
+        .iter()
+        .find(|m| m["role"] == "tool")
+        .expect("dedicated tool role message expected");
+    assert_eq!(tool_msg["tool_call_id"], "call_round_trip");
+    let payload = tool_msg["content"].as_str().expect("content string");
+    let parsed: serde_json::Value = serde_json::from_str(payload).expect("nested json");
+    assert_eq!(parsed, serde_json::json!({"temp": 60}));
+}
+
 // F-647: OpenAI provider must not follow HTTP redirects. A misconfigured
 // proxy or network-layer attacker can inject `302 Location: 169.254.169.254`
 // and the default reqwest client would follow blindly to IMDS or another
@@ -318,4 +406,62 @@ async fn chat_does_not_follow_redirects() {
         msg.contains("302"),
         "error must reflect the upstream 302 status: {msg}"
     );
+}
+
+/// Manual smoke test against the real OpenAI API.
+///
+/// Skipped by default. To run:
+///
+/// ```bash
+/// FORGE_OPENAI_SMOKE_API_KEY=sk-... \
+///   cargo test -p forge-providers --test openai \
+///   -- --ignored chat_against_real_openai
+/// ```
+///
+/// Verifies the full request → stream → typed chunks path against the
+/// production OpenAI endpoint. CI never runs this — it depends on a
+/// live API key and is documented as evidence for F-745 DoD #5 ("smoke
+/// test against each provider").
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn chat_against_real_openai() {
+    let api_key = std::env::var("FORGE_OPENAI_SMOKE_API_KEY")
+        .expect("set FORGE_OPENAI_SMOKE_API_KEY to a valid OpenAI API key");
+    let base_url = std::env::var("FORGE_OPENAI_SMOKE_URL")
+        .unwrap_or_else(|_| "https://api.openai.com".to_string());
+    // `gpt-4o-mini` is the cheapest stable GPT-4-family model. Override with
+    // FORGE_OPENAI_SMOKE_MODEL.
+    let model =
+        std::env::var("FORGE_OPENAI_SMOKE_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_string());
+
+    let provider = OpenAiProvider::new(&base_url, &api_key, &model);
+    let req = ChatRequest {
+        system: Some(std::sync::Arc::from(
+            "You are a terse assistant. Reply with one short sentence.",
+        )),
+        messages: vec![user_msg("Say hello in five words or fewer.")],
+        parallel_tool_calls_allowed: false,
+    };
+
+    let mut stream = provider.chat(req).await.expect("chat call succeeds");
+    let mut accumulated = String::new();
+    let mut saw_done = false;
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            ChatChunk::TextDelta(delta) => accumulated.push_str(&delta),
+            ChatChunk::Done(_) => saw_done = true,
+            ChatChunk::ToolCall { .. } => {
+                // unexpected for this prompt — model shouldn't request a tool
+            }
+            ChatChunk::Error { kind, message } => {
+                panic!("openai returned error: kind={kind:?}, message={message}")
+            }
+        }
+    }
+    assert!(saw_done, "expected a final Done chunk");
+    assert!(
+        !accumulated.trim().is_empty(),
+        "expected non-empty assistant text"
+    );
+    eprintln!("openai replied: {accumulated}");
 }

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -266,6 +266,9 @@ async fn main() -> Result<()> {
 /// today; the cfg gates all three desktop OSes), fall back to the
 /// env-only store.
 fn build_credential_context(provider_id: &'static str) -> Option<CredentialContext> {
+    // `EnvFallbackStore::default()` reads `ANTHROPIC_API_KEY` for the
+    // `anthropic` provider and `OPENAI_API_KEY` for `openai` when the
+    // keyring has no entry — the canonical vendor env vars.
     let store: Arc<dyn Credentials> = {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         {

--- a/crates/forge-session/src/main.rs
+++ b/crates/forge-session/src/main.rs
@@ -1,7 +1,13 @@
 use anyhow::Result;
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+use forge_core::credentials::KeyringStore;
+use forge_core::credentials::{Credentials, EnvFallbackStore, LayeredStore};
 use forge_core::Event;
+use forge_providers::anthropic::{AnthropicProvider, DEFAULT_MAX_TOKENS};
 use forge_providers::ollama::OllamaProvider;
+use forge_providers::openai::OpenAiProvider;
 use forge_providers::MockProvider;
+use forge_session::orchestrator::CredentialContext;
 use forge_session::{
     log_bridge,
     pid_file::OwnedPidFile,
@@ -200,7 +206,84 @@ async fn main() -> Result<()> {
             )
             .await
         }
+        // F-745: Anthropic direct API. Constructor `api_key` is the empty
+        // string — the F-744 seam injects the real key per-turn from the
+        // credential store. The orchestrator pulls under `provider_id =
+        // "anthropic"`; with no keyring entry the layered store falls through
+        // to `ANTHROPIC_API_KEY` env. F-746 will add early-fail credential
+        // validation; until then a missing key surfaces as an upstream 401
+        // mapped to `ChatChunk::Error` by the provider.
+        ProviderKind::Anthropic { base_url, model } => {
+            let provider = Arc::new(AnthropicProvider::new(
+                base_url,
+                String::new(),
+                model,
+                DEFAULT_MAX_TOKENS,
+            ));
+            let credentials = build_credential_context("anthropic");
+            serve_with_session(
+                &socket_path,
+                session,
+                provider,
+                auto_approve,
+                ephemeral,
+                workspace,
+                Some(session_id),
+                credentials,
+                active_agent,
+                user_home_override,
+            )
+            .await
+        }
+        // F-745: OpenAI direct API. Same constructor-vs-seam posture as
+        // Anthropic; provider id is `"openai"`, env fallback is
+        // `OPENAI_API_KEY`.
+        ProviderKind::OpenAi { base_url, model } => {
+            let provider = Arc::new(OpenAiProvider::new(base_url, String::new(), model));
+            let credentials = build_credential_context("openai");
+            serve_with_session(
+                &socket_path,
+                session,
+                provider,
+                auto_approve,
+                ephemeral,
+                workspace,
+                Some(session_id),
+                credentials,
+                active_agent,
+                user_home_override,
+            )
+            .await
+        }
     }
+}
+
+/// F-745: build a [`CredentialContext`] for a keyed provider.
+///
+/// Production wiring per the credentials module docs:
+/// `LayeredStore::new(KeyringStore, EnvFallbackStore::default())` — keyring
+/// primary, env fallback. On targets without a platform keyring (none
+/// today; the cfg gates all three desktop OSes), fall back to the
+/// env-only store.
+fn build_credential_context(provider_id: &'static str) -> Option<CredentialContext> {
+    let store: Arc<dyn Credentials> = {
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        {
+            Arc::new(LayeredStore::new(
+                KeyringStore::new(),
+                EnvFallbackStore::default(),
+            ))
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+        {
+            Arc::new(EnvFallbackStore::default())
+        }
+    };
+    Some(CredentialContext {
+        store,
+        provider_id: provider_id.to_string(),
+        sidecar_push: None,
+    })
 }
 
 /// Parse `--flag value` from a flat argv. Returns None if the flag isn't

--- a/crates/forge-session/src/provider_spec.rs
+++ b/crates/forge-session/src/provider_spec.rs
@@ -321,6 +321,13 @@ mod tests {
         assert!(parse_provider_spec("anthropic:claude-3-5-sonnet@").is_err());
     }
 
+    #[test]
+    fn rejects_anthropic_with_empty_rest() {
+        // Mirror of `rejects_ollama_with_empty_model`: a bare colon after the
+        // kind implies an empty model — `parse_model_at_url` errors here.
+        assert!(parse_provider_spec("anthropic:").is_err());
+    }
+
     // F-745: OpenAI provider spec parsing.
 
     #[test]
@@ -367,6 +374,13 @@ mod tests {
     #[test]
     fn rejects_openai_with_empty_url() {
         assert!(parse_provider_spec("openai:gpt-4o-mini@").is_err());
+    }
+
+    #[test]
+    fn rejects_openai_with_empty_rest() {
+        // Mirror of `rejects_ollama_with_empty_model`: a bare colon after the
+        // kind implies an empty model — `parse_model_at_url` errors here.
+        assert!(parse_provider_spec("openai:").is_err());
     }
 
     // F-745: the resolver returns the correct kind for both new providers.

--- a/crates/forge-session/src/provider_spec.rs
+++ b/crates/forge-session/src/provider_spec.rs
@@ -8,16 +8,53 @@
 //! - `ollama`                              — defaults (localhost:11434, llama3.2)
 //! - `ollama:<model>`                      — custom model, default base_url
 //! - `ollama:<model>@<base_url>`           — both custom
+//! - `anthropic`                           — defaults (api.anthropic.com, claude-sonnet-4-6)
+//! - `anthropic:<model>`                   — custom model, default base_url
+//! - `anthropic:<model>@<base_url>`        — both custom
+//! - `openai`                              — defaults (api.openai.com, gpt-4o-mini)
+//! - `openai:<model>`                      — custom model, default base_url
+//! - `openai:<model>@<base_url>`           — both custom
 
 use anyhow::{anyhow, Result};
 
 pub const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434";
 pub const DEFAULT_OLLAMA_MODEL: &str = "llama3.2";
 
+/// Default base URL for the Anthropic Messages API.
+pub const DEFAULT_ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com";
+/// Default Claude model. Pinned to the current Sonnet line (4.6, dateless
+/// pinned snapshot) per Anthropic's 2026 model catalog. Users override via
+/// `--provider anthropic:<model>`.
+pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-6";
+
+/// Default base URL for the OpenAI Chat Completions API.
+pub const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com";
+/// Default OpenAI model. `gpt-4o-mini` is the cheapest stable
+/// GPT-4-family model and is sufficient for the F-745 smoke-test surface;
+/// users override via `--provider openai:<model>`.
+pub const DEFAULT_OPENAI_MODEL: &str = "gpt-4o-mini";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProviderKind {
     Mock,
-    Ollama { base_url: String, model: String },
+    Ollama {
+        base_url: String,
+        model: String,
+    },
+    /// F-745: direct Anthropic Messages API. The constructor-time `api_key`
+    /// is supplied by `forged` from an env / keyring lookup at startup; the
+    /// orchestrator's F-744 seam overrides it per-turn with the active
+    /// credential.
+    Anthropic {
+        base_url: String,
+        model: String,
+    },
+    /// F-745: direct OpenAI Chat Completions API. Same constructor-vs-seam
+    /// posture as Anthropic.
+    OpenAi {
+        base_url: String,
+        model: String,
+    },
 }
 
 pub fn parse_provider_spec(spec: &str) -> Result<ProviderKind> {
@@ -31,8 +68,10 @@ pub fn parse_provider_spec(spec: &str) -> Result<ProviderKind> {
     match kind {
         "mock" => Ok(ProviderKind::Mock),
         "ollama" => parse_ollama_rest(rest),
+        "anthropic" => parse_anthropic_rest(rest),
+        "openai" => parse_openai_rest(rest),
         other => Err(anyhow!(
-            "unknown provider kind: {other:?} (supported: mock, ollama)"
+            "unknown provider kind: {other:?} (supported: mock, ollama, anthropic, openai)"
         )),
     }
 }
@@ -54,30 +93,67 @@ pub fn resolve_provider_kind(spec: Option<&str>) -> Result<ProviderKind> {
 }
 
 fn parse_ollama_rest(rest: Option<&str>) -> Result<ProviderKind> {
-    let (model, base_url) = match rest {
-        None => (
-            DEFAULT_OLLAMA_MODEL.to_string(),
-            DEFAULT_OLLAMA_BASE_URL.to_string(),
-        ),
+    let (model, base_url) = parse_model_at_url(
+        rest,
+        "ollama",
+        DEFAULT_OLLAMA_MODEL,
+        DEFAULT_OLLAMA_BASE_URL,
+    )?;
+    Ok(ProviderKind::Ollama { base_url, model })
+}
+
+fn parse_anthropic_rest(rest: Option<&str>) -> Result<ProviderKind> {
+    let (model, base_url) = parse_model_at_url(
+        rest,
+        "anthropic",
+        DEFAULT_ANTHROPIC_MODEL,
+        DEFAULT_ANTHROPIC_BASE_URL,
+    )?;
+    Ok(ProviderKind::Anthropic { base_url, model })
+}
+
+fn parse_openai_rest(rest: Option<&str>) -> Result<ProviderKind> {
+    let (model, base_url) = parse_model_at_url(
+        rest,
+        "openai",
+        DEFAULT_OPENAI_MODEL,
+        DEFAULT_OPENAI_BASE_URL,
+    )?;
+    Ok(ProviderKind::OpenAi { base_url, model })
+}
+
+/// Shared `<model>@<base_url>` grammar used by every keyed-provider spec.
+///
+/// - `None` → both defaults.
+/// - `Some("")` → empty after the `:` separator: error (model cannot be empty).
+/// - `Some("model")` → custom model, default URL.
+/// - `Some("model@url")` → both custom; either side empty errors explicitly.
+fn parse_model_at_url(
+    rest: Option<&str>,
+    kind: &str,
+    default_model: &str,
+    default_url: &str,
+) -> Result<(String, String)> {
+    match rest {
+        None => Ok((default_model.to_string(), default_url.to_string())),
         Some(rest) => match rest.split_once('@') {
             Some((m, u)) => {
                 if m.is_empty() {
-                    return Err(anyhow!("ollama spec: model cannot be empty"));
+                    return Err(anyhow!("{kind} spec: model cannot be empty"));
                 }
                 if u.is_empty() {
-                    return Err(anyhow!("ollama spec: base_url cannot be empty"));
+                    return Err(anyhow!("{kind} spec: base_url cannot be empty"));
                 }
-                (m.to_string(), u.to_string())
+                Ok((m.to_string(), u.to_string()))
             }
             None => {
                 if rest.is_empty() {
-                    return Err(anyhow!("ollama spec: model cannot be empty"));
+                    return Err(anyhow!("{kind} spec: model cannot be empty"));
                 }
-                (rest.to_string(), DEFAULT_OLLAMA_BASE_URL.to_string())
+                Ok((rest.to_string(), default_url.to_string()))
             }
         },
-    };
-    Ok(ProviderKind::Ollama { base_url, model })
+    }
 }
 
 #[cfg(test)]
@@ -96,7 +172,7 @@ mod tests {
 
     #[test]
     fn rejects_unknown_kind() {
-        let err = parse_provider_spec("anthropic:claude").unwrap_err();
+        let err = parse_provider_spec("not-a-real-provider:something").unwrap_err();
         assert!(err.to_string().contains("unknown"));
     }
 
@@ -189,5 +265,121 @@ mod tests {
             msg.contains("provider_spec_required"),
             "expected provider_spec_required, got: {msg}"
         );
+    }
+
+    // F-745: Anthropic provider spec parsing.
+    //
+    // Grammar:
+    //   anthropic                         → defaults (api.anthropic.com, claude-sonnet-4-6)
+    //   anthropic:<model>                 → custom model, default URL
+    //   anthropic:<model>@<base_url>      → both custom
+
+    #[test]
+    fn parses_bare_anthropic_with_defaults() {
+        let kind = parse_provider_spec("anthropic").unwrap();
+        assert_eq!(
+            kind,
+            ProviderKind::Anthropic {
+                base_url: DEFAULT_ANTHROPIC_BASE_URL.into(),
+                model: DEFAULT_ANTHROPIC_MODEL.into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_anthropic_with_explicit_model() {
+        let kind = parse_provider_spec("anthropic:claude-3-5-sonnet").unwrap();
+        assert_eq!(
+            kind,
+            ProviderKind::Anthropic {
+                base_url: DEFAULT_ANTHROPIC_BASE_URL.into(),
+                model: "claude-3-5-sonnet".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_anthropic_with_model_at_url() {
+        let kind = parse_provider_spec("anthropic:claude-3-5-sonnet@https://anthropic.example.com")
+            .unwrap();
+        assert_eq!(
+            kind,
+            ProviderKind::Anthropic {
+                base_url: "https://anthropic.example.com".into(),
+                model: "claude-3-5-sonnet".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_anthropic_with_empty_model() {
+        assert!(parse_provider_spec("anthropic:@https://host").is_err());
+    }
+
+    #[test]
+    fn rejects_anthropic_with_empty_url() {
+        assert!(parse_provider_spec("anthropic:claude-3-5-sonnet@").is_err());
+    }
+
+    // F-745: OpenAI provider spec parsing.
+
+    #[test]
+    fn parses_bare_openai_with_defaults() {
+        let kind = parse_provider_spec("openai").unwrap();
+        assert_eq!(
+            kind,
+            ProviderKind::OpenAi {
+                base_url: DEFAULT_OPENAI_BASE_URL.into(),
+                model: DEFAULT_OPENAI_MODEL.into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_openai_with_explicit_model() {
+        let kind = parse_provider_spec("openai:gpt-4.1-nano").unwrap();
+        assert_eq!(
+            kind,
+            ProviderKind::OpenAi {
+                base_url: DEFAULT_OPENAI_BASE_URL.into(),
+                model: "gpt-4.1-nano".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_openai_with_model_at_url() {
+        let kind = parse_provider_spec("openai:gpt-4o-mini@https://openai.example.com").unwrap();
+        assert_eq!(
+            kind,
+            ProviderKind::OpenAi {
+                base_url: "https://openai.example.com".into(),
+                model: "gpt-4o-mini".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_openai_with_empty_model() {
+        assert!(parse_provider_spec("openai:@https://host").is_err());
+    }
+
+    #[test]
+    fn rejects_openai_with_empty_url() {
+        assert!(parse_provider_spec("openai:gpt-4o-mini@").is_err());
+    }
+
+    // F-745: the resolver returns the correct kind for both new providers.
+
+    #[test]
+    fn resolve_provider_kind_with_anthropic_spec_returns_anthropic() {
+        let kind = resolve_provider_kind(Some("anthropic")).unwrap();
+        assert!(matches!(kind, ProviderKind::Anthropic { .. }));
+    }
+
+    #[test]
+    fn resolve_provider_kind_with_openai_spec_returns_openai() {
+        let kind = resolve_provider_kind(Some("openai")).unwrap();
+        assert!(matches!(kind, ProviderKind::OpenAi { .. }));
     }
 }


### PR DESCRIPTION
Closes forge-ide/forge#889

## Summary

Wires the Anthropic and OpenAI provider implementations into `forged`'s
spawn path so a session can stream against either provider in production.
The chat_stream SSE parsers, tool-call envelopes, and credential auth
seam already landed in F-743 / F-744; this task extends the `--provider`
grammar, instantiates the providers in the daemon's `main`, plumbs the
F-744 `CredentialContext` for each, and pins the wire-level tool-call
round-trip plus per-provider smoke-test affordances.

- `provider_spec` grammar adds `anthropic[:<model>[@<base_url>]]` and
  `openai[:<model>[@<base_url>]]`, mirroring the Ollama shape. Defaults
  pin to `claude-sonnet-4-6` and `gpt-4o-mini`. A shared
  `parse_model_at_url` collapses the three keyed parsers into one
  implementation.
- `forged` main: new `ProviderKind::Anthropic` / `OpenAi` match arms
  build the provider with an empty constructor key and a
  `CredentialContext` over `LayeredStore(KeyringStore, EnvFallbackStore)`
  so the orchestrator's per-turn F-744 pull reads from the keyring or
  `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` env.
- Wiremock regression: `tool_call_and_result_round_trip_through_request_body`
  for both providers asserts the outgoing request body carries the
  assistant `tool_use` / `tool_calls` block keyed by the provider id and
  the follow-up `tool_result` / `role: "tool"` message references the same
  id. Asserts on the actual mock-server-recorded body, not the in-memory
  translator output.
- Smoke tests: `chat_against_real_anthropic` and `chat_against_real_openai`
  gated by `FORGE_{ANTHROPIC,OPENAI}_SMOKE_API_KEY`, mirroring the F-743
  Ollama smoke-test pattern; `#[ignore]`'d so CI never runs them.

## Test plan

- `cargo fmt --check` passes
- `cargo test --workspace` passes (no failures across the workspace)
- `cargo clippy --all-targets -- -D warnings` passes
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` passes
- DoD #5 smoke tests run manually with a valid key — paste output below
  to evidence:
  - `FORGE_ANTHROPIC_SMOKE_API_KEY=... cargo test -p forge-providers --test anthropic -- --ignored chat_against_real_anthropic`
  - `FORGE_OPENAI_SMOKE_API_KEY=... cargo test -p forge-providers --test openai -- --ignored chat_against_real_openai`

## Verification status

PR is open; DoD and code-review gates are pending in the parent context
(per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)