### PR TITLE
[F-746] Early credential validation at session_start

### DIFF
--- a/crates/forge-shell/src/session_spawn_ipc.rs
+++ b/crates/forge-shell/src/session_spawn_ipc.rs
@@ -41,6 +41,17 @@ pub const SESSION_START_ERROR: &str = "session_start: ";
 // convention so dashboard log filters and end-user messages stay consistent.
 pub const LIST_SESSIONS_ERROR: &str = "list_sessions: ";
 
+// F-746: reason suffix appended after `SESSION_START_ERROR` when the
+// pre-spawn credential check rejects. The dashboard's new-session dialog
+// substring-matches on this constant to render an actionable
+// "Configure provider" CTA pointing at `/providers#<id>`. Both the
+// missing-entry case (`store.has` returned `Ok(false)`) and the backend-
+// error case (`store.has` returned `Err`) collapse onto this single
+// reason — the user-visible recovery is identical (open the provider
+// settings; a locked keyring will surface a more specific message
+// there).
+pub const CREDENTIALS_MISSING_REASON: &str = "credentials_missing for provider ";
+
 /// F-727: wire-state value the picker treats as "attachable". The
 /// `dashboard_sessions` module emits `"stopped"` for active sessions whose
 /// UDS ping fails — those are the sessions the operator can re-attach by
@@ -105,6 +116,89 @@ pub fn provider_is_known(settings: &forge_core::settings::AppSettings, id: &str)
     crate::providers_ipc::is_known_provider_id(settings, id)
 }
 
+/// F-746: pure keyless classifier.
+///
+/// Returns `true` when `provider_id` requires no credential at the
+/// network boundary:
+///
+/// - The legacy bare slug `"ollama"` — kept for back-compat with callers
+///   that still pass the Phase-1 id before it was migrated to a
+///   `custom_openai:ollama` entry.
+/// - Any `custom_openai:<name>` whose section in
+///   `settings.providers.custom_openai[name].auth` is
+///   [`forge_core::settings::AuthShapeSettings::None`]. This is the
+///   production shape for the Ollama / local-vLLM / private-network
+///   gateway presets per F-730.
+///
+/// Built-in providers (`anthropic`, `openai`, named instances) are NOT
+/// keyless. Anthropic's Vertex sub-mode pulls a Google access token via
+/// `gcloud` rather than a keyring entry; F-746 deliberately keeps
+/// Vertex out of the keyless bucket because the absence of a usable
+/// token still wants surfacing — that's a follow-up enhancement, not
+/// this task.
+pub fn provider_is_keyless(
+    settings: &forge_core::settings::AppSettings,
+    provider_id: &str,
+) -> bool {
+    use forge_core::settings::AuthShapeSettings;
+
+    if provider_id == "ollama" {
+        return true;
+    }
+    if let Some(name) = provider_id.strip_prefix(crate::providers_ipc::CUSTOM_OPENAI_PREFIX) {
+        if let Some(entry) = settings.providers.custom_openai.get(name) {
+            return matches!(entry.auth, AuthShapeSettings::None);
+        }
+    }
+    false
+}
+
+/// F-746: pre-spawn credential check.
+///
+/// Called from `session_start` immediately after the unknown-provider
+/// gate and immediately before `spawn_forged_session`. The goal is to
+/// fail the new-session flow with an actionable error BEFORE any
+/// `forged` daemon is spawned or `/tmp/forge-*` socket is allocated;
+/// without this gate the first-turn `pull_active_credential` call
+/// (F-744) is where the user would first see the missing credential —
+/// by which point a stranded daemon is already running.
+///
+/// Returns:
+///
+/// - `Ok(())` when the provider is keyless (no credential is needed),
+///   or when the store reports the credential is present.
+/// - `Err(SESSION_START_ERROR + CREDENTIALS_MISSING_REASON + <id>)`
+///   when the store reports no entry OR when the store errors (keyring
+///   locked, Secret Service daemon down, etc.). Both shapes collapse
+///   to the same reason so the dashboard surfaces one CTA either way;
+///   the user-visible recovery (open `/providers#<id>`) is identical.
+pub async fn check_provider_credential(
+    store: &std::sync::Arc<dyn forge_core::credentials::Credentials>,
+    settings: &forge_core::settings::AppSettings,
+    provider_id: &str,
+) -> Result<(), String> {
+    if provider_is_keyless(settings, provider_id) {
+        return Ok(());
+    }
+    match store.has(provider_id).await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(format!(
+            "{SESSION_START_ERROR}{CREDENTIALS_MISSING_REASON}{provider_id}"
+        )),
+        Err(e) => {
+            tracing::warn!(
+                target: "forge_shell::session_start::credentials",
+                provider_id = %provider_id,
+                error = %e,
+                "credential presence probe failed",
+            );
+            Err(format!(
+                "{SESSION_START_ERROR}{CREDENTIALS_MISSING_REASON}{provider_id}"
+            ))
+        }
+    }
+}
+
 /// Pure agent check: `name` must match one of the loaded agent ids from
 /// the workspace + user-home roster. Exposed for unit tests.
 pub fn agent_is_known(
@@ -123,6 +217,7 @@ pub async fn session_start<R: Runtime>(
     input: SessionStartInput,
     webview: Webview<R>,
     state: State<'_, BridgeState>,
+    credentials: State<'_, crate::credentials_ipc::CredentialsState>,
 ) -> Result<SessionStartOutput, String> {
     crate::ipc::require_window_label(&webview, "dashboard", "session_start")?;
     validate_session_start_input(&input)?;
@@ -166,6 +261,17 @@ pub async fn session_start<R: Runtime>(
                 "{SESSION_START_ERROR}unknown provider: {provider_id}"
             ));
         }
+
+        // F-746: pre-spawn credential validation. Keyless providers
+        // (`ollama`, `custom_openai:<name>` with `auth.shape = "none"`)
+        // skip this check entirely; every other provider must have a
+        // reachable credential in the store, or `session_start` fails
+        // BEFORE `spawn_forged_session` allocates a daemon + UDS. A
+        // missing entry and a backend error both collapse to the same
+        // `credentials_missing` reason so the dashboard renders one
+        // actionable CTA either way.
+        let store = credentials.store();
+        check_provider_credential(&store, &settings, provider_id).await?;
     }
 
     let user_home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"));
@@ -236,7 +342,12 @@ pub async fn list_sessions<R: Runtime>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use forge_core::settings::AppSettings;
+    use forge_core::credentials::{Credentials, MemoryStore};
+    use forge_core::settings::{
+        AppSettings, AuthShapeSettings, CustomOpenAiEntry, ProvidersSettings,
+    };
+    use secrecy::SecretString;
+    use std::sync::Arc;
 
     fn input(
         workspace_root: &str,
@@ -423,5 +534,166 @@ mod tests {
     #[test]
     fn attachable_wire_state_is_stopped() {
         assert_eq!(ATTACHABLE_WIRE_STATE, "stopped");
+    }
+
+    // -----------------------------------------------------------------
+    // F-746: pre-spawn credential validation
+    // -----------------------------------------------------------------
+
+    /// Backend wired to fail every `get` / `has` call — exercises the
+    /// keyring-locked / Secret-Service-unreachable error path. Holds no
+    /// secrets and is not constructible from outside the test module.
+    struct FailingStore;
+
+    #[async_trait::async_trait]
+    impl Credentials for FailingStore {
+        async fn get(
+            &self,
+            _provider_id: &str,
+        ) -> Result<Option<SecretString>, forge_core::ForgeError> {
+            Err(anyhow::anyhow!("keyring backend unavailable").into())
+        }
+        async fn set(
+            &self,
+            _provider_id: &str,
+            _value: SecretString,
+        ) -> Result<(), forge_core::ForgeError> {
+            Err(anyhow::anyhow!("read-only test stub").into())
+        }
+        async fn remove(&self, _provider_id: &str) -> Result<(), forge_core::ForgeError> {
+            Err(anyhow::anyhow!("read-only test stub").into())
+        }
+        async fn has(&self, _provider_id: &str) -> Result<bool, forge_core::ForgeError> {
+            Err(anyhow::anyhow!("keyring backend unavailable").into())
+        }
+    }
+
+    fn settings_with_custom_openai(name: &str, auth: AuthShapeSettings) -> AppSettings {
+        let mut providers = ProvidersSettings::default();
+        providers.custom_openai.insert(
+            name.to_string(),
+            CustomOpenAiEntry {
+                base_url: "http://127.0.0.1:11434".into(),
+                model: "qwen2.5".into(),
+                model_list: vec![],
+                auth,
+                api_key: None,
+            },
+        );
+        AppSettings {
+            providers,
+            ..AppSettings::default()
+        }
+    }
+
+    /// Pin the F-746 error suffix so the dashboard's CTA mapper has a
+    /// stable substring to key on.
+    #[test]
+    fn credentials_missing_error_suffix_is_stable() {
+        assert_eq!(
+            CREDENTIALS_MISSING_REASON,
+            "credentials_missing for provider "
+        );
+    }
+
+    /// Built-in providers (anthropic, openai) are NOT keyless — both
+    /// require an API key in the credential store.
+    #[test]
+    fn builtins_are_not_keyless() {
+        let settings = AppSettings::default();
+        assert!(!provider_is_keyless(&settings, "anthropic"));
+        assert!(!provider_is_keyless(&settings, "openai"));
+    }
+
+    /// The legacy bare `ollama` id is keyless — covers callers that still
+    /// pass the historical Phase-1 slug before it was migrated to
+    /// `custom_openai:ollama`.
+    #[test]
+    fn legacy_ollama_id_is_keyless() {
+        let settings = AppSettings::default();
+        assert!(provider_is_keyless(&settings, "ollama"));
+    }
+
+    /// A `custom_openai:<name>` entry whose section declares
+    /// `auth = { shape = "none" }` is keyless. This is the production shape
+    /// for Ollama via the custom_openai preset (F-743).
+    #[test]
+    fn custom_openai_with_auth_none_is_keyless() {
+        let settings = settings_with_custom_openai("ollama", AuthShapeSettings::None);
+        assert!(provider_is_keyless(&settings, "custom_openai:ollama"));
+    }
+
+    /// A `custom_openai:<name>` with the default bearer auth shape is NOT
+    /// keyless — its credential must be present in the store.
+    #[test]
+    fn custom_openai_with_bearer_is_not_keyless() {
+        let settings = settings_with_custom_openai("together", AuthShapeSettings::Bearer);
+        assert!(!provider_is_keyless(&settings, "custom_openai:together"));
+    }
+
+    /// Keyless check: an unconfigured `custom_openai:<name>` (no section
+    /// in settings) is NOT keyless. The unknown-provider gate upstream
+    /// rejects this case first; the credential check stays conservative.
+    #[test]
+    fn custom_openai_without_section_is_not_keyless() {
+        let settings = AppSettings::default();
+        assert!(!provider_is_keyless(&settings, "custom_openai:ghost"));
+    }
+
+    /// Keyless skip: when the provider is keyless, the check returns
+    /// `Ok(())` without consulting the store. We use `FailingStore` to
+    /// prove no `get` / `has` call is made.
+    #[tokio::test]
+    async fn check_credential_skips_keyless_provider() {
+        let store: Arc<dyn Credentials> = Arc::new(FailingStore);
+        let settings = settings_with_custom_openai("ollama", AuthShapeSettings::None);
+        check_provider_credential(&store, &settings, "custom_openai:ollama")
+            .await
+            .expect("keyless skip must not touch the store");
+    }
+
+    /// Happy path: keyed provider with a stored credential passes the
+    /// check.
+    #[tokio::test]
+    async fn check_credential_accepts_present_credential() {
+        let mem = MemoryStore::new();
+        mem.set("anthropic", SecretString::from("sk-test-1"))
+            .await
+            .unwrap();
+        let store: Arc<dyn Credentials> = Arc::new(mem);
+        let settings = AppSettings::default();
+        check_provider_credential(&store, &settings, "anthropic")
+            .await
+            .expect("present credential must pass");
+    }
+
+    /// Missing-entry rejection: the store reports `Ok(false)`. Error
+    /// carries the canonical prefix + reason + provider id.
+    #[tokio::test]
+    async fn check_credential_rejects_missing_entry() {
+        let store: Arc<dyn Credentials> = Arc::new(MemoryStore::new());
+        let settings = AppSettings::default();
+        let err = check_provider_credential(&store, &settings, "anthropic")
+            .await
+            .expect_err("absent credential must reject");
+        assert!(err.starts_with(SESSION_START_ERROR), "prefix: {err}");
+        assert!(err.contains(CREDENTIALS_MISSING_REASON), "reason: {err}");
+        assert!(err.ends_with("anthropic"), "provider id suffix: {err}");
+    }
+
+    /// Keyring-locked rejection: the store errors on `has`. The check
+    /// collapses both shapes (missing entry, backend error) onto the
+    /// same `credentials_missing` umbrella so the dashboard renders one
+    /// CTA either way.
+    #[tokio::test]
+    async fn check_credential_rejects_backend_error() {
+        let store: Arc<dyn Credentials> = Arc::new(FailingStore);
+        let settings = AppSettings::default();
+        let err = check_provider_credential(&store, &settings, "openai")
+            .await
+            .expect_err("keyring backend error must reject");
+        assert!(err.starts_with(SESSION_START_ERROR), "prefix: {err}");
+        assert!(err.contains(CREDENTIALS_MISSING_REASON), "reason: {err}");
+        assert!(err.ends_with("openai"), "provider id suffix: {err}");
     }
 }

--- a/crates/forge-shell/src/session_spawn_ipc.rs
+++ b/crates/forge-shell/src/session_spawn_ipc.rs
@@ -163,7 +163,25 @@ pub fn provider_is_keyless(
 /// (F-744) is where the user would first see the missing credential —
 /// by which point a stranded daemon is already running.
 ///
-/// Returns:
+/// # Keyring key shape
+///
+/// `store.has(provider_id)` is called with the **full `provider_id`
+/// string verbatim** — including any `<vendor>:<name>` suffix for
+/// named built-in instances (`anthropic:work`, `openai:personal`) and
+/// `custom_openai:<name>` rows. Every [`Credentials`] implementor
+/// (memory, env-fallback, keyring) keys its entries on that same raw
+/// slug per the trait contract in
+/// [`forge_core::credentials`] (point 2 of the trait doc): the
+/// `provider_id` the caller hands in is the source of truth.
+///
+/// On the keyring backend the slug lands in the platform-specific
+/// "account" field; the service namespace (`"forge"` by default) is
+/// applied by [`forge_core::credentials::KeyringStore`] and is
+/// transparent to callers here. The F-587 audit pins this convention.
+///
+/// [`Credentials`]: forge_core::credentials::Credentials
+///
+/// # Returns
 ///
 /// - `Ok(())` when the provider is keyless (no credential is needed),
 ///   or when the store reports the credential is present.
@@ -695,5 +713,39 @@ mod tests {
         assert!(err.starts_with(SESSION_START_ERROR), "prefix: {err}");
         assert!(err.contains(CREDENTIALS_MISSING_REASON), "reason: {err}");
         assert!(err.ends_with("openai"), "provider id suffix: {err}");
+    }
+
+    /// Named-instance happy path: a built-in with a `<vendor>:<name>`
+    /// suffix (`anthropic:work`) and a keyring entry seeded under the
+    /// exact same key passes the credential check. Pins the contract
+    /// documented above `check_provider_credential`: the store is
+    /// consulted with the full `provider_id` verbatim, no
+    /// normalization or vendor-prefix stripping.
+    #[tokio::test]
+    async fn check_credential_accepts_named_builtin_with_keyring_entry() {
+        let mem = MemoryStore::new();
+        mem.set("anthropic:work", SecretString::from("sk-work-1"))
+            .await
+            .unwrap();
+        let store: Arc<dyn Credentials> = Arc::new(mem);
+        let settings = AppSettings::default();
+        check_provider_credential(&store, &settings, "anthropic:work")
+            .await
+            .expect("named-instance credential must pass");
+    }
+
+    /// A `custom_openai:<name>` row whose `auth.shape = "header"` (the
+    /// X-Api-Key / custom-header preset) is NOT keyless — only
+    /// `AuthShapeSettings::None` is. Guards against a future refactor
+    /// silently widening the keyless bucket.
+    #[test]
+    fn custom_openai_with_header_auth_is_not_keyless() {
+        let settings = settings_with_custom_openai(
+            "local",
+            AuthShapeSettings::Header {
+                name: "X-Api-Key".into(),
+            },
+        );
+        assert!(!provider_is_keyless(&settings, "custom_openai:local"));
     }
 }

--- a/web/packages/app/src/components/NewSessionDialog.css
+++ b/web/packages/app/src/components/NewSessionDialog.css
@@ -158,6 +158,20 @@
   word-break: break-word;
 }
 
+/* F-746: inline "Configure provider" CTA appended to the error region
+ * when `session_start` rejects with `credentials_missing for provider
+ * <id>`. Routes to `/providers#<id>` so the deep-link scrolls the
+ * Providers page to the offending row. */
+.new-session-dialog__error-cta {
+  color: var(--color-ember-400);
+  text-decoration: underline;
+}
+
+.new-session-dialog__error-cta:hover,
+.new-session-dialog__error-cta:focus-visible {
+  color: var(--color-ember-300);
+}
+
 .new-session-dialog__actions {
   display: flex;
   justify-content: flex-end;

--- a/web/packages/app/src/components/NewSessionDialog.test.tsx
+++ b/web/packages/app/src/components/NewSessionDialog.test.tsx
@@ -8,6 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, waitFor } from '@solidjs/testing-library';
+import { MemoryRouter, Route } from '@solidjs/router';
 
 // Mock the dialog plugin before importing the SUT — the real plugin throws
 // outside a Tauri runtime. The mock is reset per-test via `mockOpenDialog`.
@@ -343,6 +344,73 @@ describe('NewSessionDialog spawn-failed state', () => {
     // Retry — error clears once submit fires again.
     fireEvent.click(getByTestId('new-session-submit'));
     await waitFor(() => expect(attempts).toBe(2));
+  });
+
+  // F-746: pre-spawn credential validation surfaces a typed error from
+  // session_start with the reason `credentials_missing for provider <id>`.
+  // The dialog parses the provider id out of the message and renders an
+  // inline CTA that deep-links to `/providers#<id>` so the user can
+  // configure the missing credential without leaving the new-session
+  // flow blind. The CTA uses `@solidjs/router`'s `<A>` element, so this
+  // test renders the dialog inside a `MemoryRouter`.
+  it('renders a Configure provider CTA on credentials_missing error', async () => {
+    const errMsg = 'session_start: credentials_missing for provider anthropic';
+    installInvokeStub({
+      sessionStart: async () => {
+        throw new Error(errMsg);
+      },
+    });
+    setActiveWorkspaceRoot('/work/repo');
+    const onClose = vi.fn();
+    const onSpawned = vi.fn();
+    const { getByTestId } = render(() => (
+      <MemoryRouter>
+        <Route
+          path="/"
+          component={() => (
+            <NewSessionDialog open={true} onClose={onClose} onSpawned={onSpawned} />
+          )}
+        />
+      </MemoryRouter>
+    ));
+
+    await waitFor(() => expect(getByTestId('provider-select')).toBeInTheDocument());
+
+    fireEvent.click(getByTestId('new-session-submit'));
+
+    await waitFor(() => expect(getByTestId('new-session-error')).toBeInTheDocument());
+    const alert = getByTestId('new-session-error');
+    expect(alert).toHaveTextContent(errMsg);
+
+    const cta = getByTestId('new-session-error-cta');
+    expect(cta).toBeInTheDocument();
+    expect(cta.getAttribute('href')).toBe('/providers#anthropic');
+
+    // Clicking the CTA closes the dialog so navigation can replace the
+    // dashboard route without the modal lingering on top of it.
+    fireEvent.click(cta);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  // Non-credential errors must NOT render the CTA — only the verbatim
+  // daemon message. Guards against an over-eager substring match catching
+  // legitimate errors that happen to mention "credentials".
+  it('does not render the CTA for unrelated session_start errors', async () => {
+    installInvokeStub({
+      sessionStart: async () => {
+        throw new Error(
+          'session_start: workspace not accessible: No such file or directory (os error 2)',
+        );
+      },
+    });
+    setActiveWorkspaceRoot('/work/repo');
+    const { getByTestId, queryByTestId } = renderDialog();
+    await waitFor(() => expect(getByTestId('provider-select')).toBeInTheDocument());
+
+    fireEvent.click(getByTestId('new-session-submit'));
+    await waitFor(() => expect(getByTestId('new-session-error')).toBeInTheDocument());
+
+    expect(queryByTestId('new-session-error-cta')).toBeNull();
   });
 
   it('surfaces a client-side error when workspace is whitespace-only', async () => {

--- a/web/packages/app/src/components/NewSessionDialog.tsx
+++ b/web/packages/app/src/components/NewSessionDialog.tsx
@@ -36,6 +36,7 @@ import {
   Show,
 } from 'solid-js';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import { A } from '@solidjs/router';
 import { Button } from '@forge/design';
 import type {
   RosterTier,
@@ -96,6 +97,28 @@ function toProviderOptions(entries: ProviderEntry[]): ProviderOption[] {
         enabled: !blocked && p.model_available,
       };
     });
+}
+
+/**
+ * F-746: stable wire-error suffix the daemon emits when
+ * `session_start`'s pre-spawn credential check rejects. The full error
+ * shape is
+ * `session_start: credentials_missing for provider <provider_id>` —
+ * extracting `<provider_id>` lets the dialog deep-link the recovery
+ * CTA to `/providers#<id>`. Both the "no entry stored" and the
+ * "keyring backend unreachable" branches collapse onto this single
+ * reason on the daemon side; the Providers page surfaces the more
+ * specific message after the user lands there.
+ */
+const CREDENTIALS_MISSING_REASON = 'credentials_missing for provider ';
+
+/** Return the provider id when `msg` is a `credentials_missing` rejection. */
+function extractMissingCredentialProviderId(msg: string | null): string | null {
+  if (msg === null) return null;
+  const idx = msg.indexOf(CREDENTIALS_MISSING_REASON);
+  if (idx === -1) return null;
+  const id = msg.slice(idx + CREDENTIALS_MISSING_REASON.length).trim();
+  return id.length > 0 ? id : null;
 }
 
 /** Pick the default provider id per spec §Fields. */
@@ -432,6 +455,17 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
                 data-testid="new-session-error"
               >
                 {error()}
+                <Show when={extractMissingCredentialProviderId(error()) !== null}>
+                  {' '}
+                  <A
+                    class="new-session-dialog__error-cta"
+                    data-testid="new-session-error-cta"
+                    href={`/providers#${extractMissingCredentialProviderId(error()) ?? ''}`}
+                    onClick={() => props.onClose()}
+                  >
+                    Configure provider
+                  </A>
+                </Show>
               </div>
             </Show>
 

--- a/web/packages/app/src/components/NewSessionDialog.tsx
+++ b/web/packages/app/src/components/NewSessionDialog.tsx
@@ -241,6 +241,17 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
     }
   });
 
+  // Memoize the credentials-missing parse so the `<Show>` guard and the
+  // child `href` share a single evaluation per render. Solid evaluates
+  // `when` and the child render expression independently, so calling
+  // `extractMissingCredentialProviderId(error())` in both places would
+  // re-parse the same string twice — a `createMemo` is the idiomatic
+  // fix and also lets the child callback receive the non-null id
+  // directly (no `?? ''` fallback).
+  const missingCredentialProvider = createMemo(() =>
+    extractMissingCredentialProviderId(error()),
+  );
+
   // Focus-trap. Spec §Trigger calls for the workspace field to receive
   // focus on open — the field is the first interactive element either way.
   let dialogRef: HTMLDivElement | undefined;
@@ -455,16 +466,20 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
                 data-testid="new-session-error"
               >
                 {error()}
-                <Show when={extractMissingCredentialProviderId(error()) !== null}>
-                  {' '}
-                  <A
-                    class="new-session-dialog__error-cta"
-                    data-testid="new-session-error-cta"
-                    href={`/providers#${extractMissingCredentialProviderId(error()) ?? ''}`}
-                    onClick={() => props.onClose()}
-                  >
-                    Configure provider
-                  </A>
+                <Show when={missingCredentialProvider()}>
+                  {(id) => (
+                    <>
+                      {' '}
+                      <A
+                        class="new-session-dialog__error-cta"
+                        data-testid="new-session-error-cta"
+                        href={`/providers#${id()}`}
+                        onClick={() => props.onClose()}
+                      >
+                        Configure provider
+                      </A>
+                    </>
+                  )}
                 </Show>
               </div>
             </Show>


### PR DESCRIPTION
Closes forge-ide/forge#890

## Summary

- `session_start` IPC now consults `forge-credentials` for the chosen provider before calling `forge_cli::spawn::spawn_forged_session`. Keyless providers (legacy `ollama` id and any `custom_openai:<name>` with `auth.shape = "none"`) skip the check.
- A missing or unreachable credential surfaces as `Err("session_start: credentials_missing for provider <id>")` BEFORE any daemon spawn or `/tmp/forge-*` socket allocation. Missing-entry and keyring-backend-error paths collapse onto the same reason so the dashboard renders one CTA either way.
- The new-session dialog substring-matches the `credentials_missing` reason and renders an inline "Configure provider" CTA that deep-links to `/providers#<id>`, giving the user a one-click recovery without leaving the new-session flow blind.

## Test plan

- `cargo test --workspace` passes (273 tests in `forge-shell`, full suite green)
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo fmt --check` passes
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` passes
- Web: `pnpm test` in `web/` passes (1518/1518), including new `NewSessionDialog` cases:
  - `renders a Configure provider CTA on credentials_missing error`
  - `does not render the CTA for unrelated session_start errors`
- New Rust unit tests in `session_spawn_ipc.rs`:
  - `legacy_ollama_id_is_keyless`
  - `custom_openai_with_auth_none_is_keyless`
  - `custom_openai_with_bearer_is_not_keyless`
  - `custom_openai_without_section_is_not_keyless`
  - `builtins_are_not_keyless`
  - `check_credential_skips_keyless_provider` (proves keyless path never touches the store via `FailingStore`)
  - `check_credential_accepts_present_credential`
  - `check_credential_rejects_missing_entry`
  - `check_credential_rejects_backend_error`
  - `credentials_missing_error_suffix_is_stable` (pins the wire-reason constant the dashboard depends on)

## Verification status

PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)