### PR TITLE
[F-749] Provider-error surfacing in ChatPane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,6 +1713,7 @@ dependencies = [
  "dirs 6.0.0",
  "forge-core",
  "futures",
+ "httpdate",
  "parking_lot",
  "reqwest 0.12.28",
  "secrecy",

--- a/crates/forge-core/src/event.rs
+++ b/crates/forge-core/src/event.rs
@@ -472,7 +472,86 @@ pub enum Event {
         target: String,
         message: String,
     },
+
+    /// F-749: typed provider-call failure surfaced inline in the chat
+    /// transcript.
+    ///
+    /// Emitted by `Orchestrator::run_turn` (and the rerun paths) when a real
+    /// provider call fails — HTTP non-2xx, transport / SSE / NDJSON error,
+    /// or a malformed stream payload — so the UI can render an error card
+    /// at the position where the assistant response would have appeared.
+    /// The card is durable across crash-restart because the event lives on
+    /// the session's event log alongside the originating `UserMessage`.
+    ///
+    /// `id` is the `MessageId` of the failing turn — the same id used by
+    /// the orchestrator for the (never-finalised) `AssistantMessage` and
+    /// the originating `UserMessage`, so subscribers can position the
+    /// card inline at the turn's slot.
+    ///
+    /// `kind` is the classified failure category the UI dispatches on
+    /// (`auth_error` → "Open provider settings" CTA, `rate_limit` →
+    /// disabled Retry + countdown, etc.). `message` is a human-readable
+    /// summary; `raw` (capped) carries the provider's verbatim error
+    /// text for the "Show details" disclosure. `retriable` is the
+    /// orchestrator's verdict on whether the same user message can be
+    /// re-sent productively — `false` for auth errors (the credential
+    /// must change first), `true` for transient classes.
+    TurnError {
+        id: MessageId,
+        at: DateTime<Utc>,
+        kind: TurnErrorKind,
+        message: String,
+        retriable: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        raw: Option<String>,
+    },
 }
+
+/// F-749: failure category the UI dispatches `TurnErrorCard` rendering on.
+///
+/// Wire shape is the standard internally-tagged form: each variant
+/// serializes as `{"kind": "<snake_case>"}` with any per-variant fields
+/// alongside (e.g. `{"kind":"rate_limit","retry_after_secs":42}`). The
+/// `Retry-After` value rides on the `RateLimit` variant so the UI can
+/// show a live countdown without re-parsing the message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TurnErrorKind {
+    /// HTTP 401 / 403 — credential rejected by the provider. The user
+    /// must change the active credential before retrying; the card hides
+    /// the Retry button and surfaces an "Open provider settings" CTA.
+    Auth,
+    /// HTTP 429 — provider rate limit hit. `retry_after_secs` carries the
+    /// parsed `Retry-After` response-header value when present so the UI
+    /// can render a live countdown; absent means "unknown — Retry is
+    /// disabled until the user re-engages."
+    RateLimit {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retry_after_secs: Option<u32>,
+    },
+    /// Transport-level failure: connection refused, DNS, TLS, idle /
+    /// wall-clock timeout, or generic SSE reader error. Retry is offered
+    /// immediately — the user is the best judge of whether the network
+    /// has recovered.
+    Network,
+    /// HTTP 5xx — provider-side server error. Retry is offered immediately.
+    Server,
+    /// Stream payload failed to parse or violated a framing invariant
+    /// (NDJSON decode error, oversized SSE line, malformed event shape).
+    /// Retry is offered immediately — the failure may be a transient
+    /// gateway glitch.
+    MalformedResponse,
+    /// Failure that did not match any of the above categories. Retry is
+    /// offered immediately; the "Show details" disclosure carries the
+    /// raw provider error so the user can self-diagnose.
+    Unknown,
+}
+
+/// F-749: max byte budget for the `raw` field on a `TurnError` event. Caps
+/// runaway provider error bodies so the on-disk event log cannot be inflated
+/// by a misbehaving upstream. Producers MUST truncate before constructing
+/// the event; consumers can rely on the field being within this bound.
+pub const TURN_ERROR_RAW_CAP_BYTES: usize = 4096;
 
 /// Severity bucket for [`Event::LogLine`]. Wire shape is the lowercase
 /// `tracing::Level` name so the TS adapter can drop it straight into a

--- a/crates/forge-core/src/lib.rs
+++ b/crates/forge-core/src/lib.rs
@@ -25,7 +25,10 @@ pub mod workspaces;
 pub use approvals::{ApprovalConfig, ApprovalEntry};
 pub use credentials::{Credentials, EnvFallbackStore, LayeredStore, MemoryStore};
 pub use error::{ForgeError, Result};
-pub use event::{ApprovalPreview, ApprovalSource, ContextRef, EndReason, Event, LogLineLevel};
+pub use event::{
+    ApprovalPreview, ApprovalSource, ContextRef, EndReason, Event, LogLineLevel, TurnErrorKind,
+    TURN_ERROR_RAW_CAP_BYTES,
+};
 pub use event_log::{read_since, EventLog, MAX_LINE_BYTES};
 pub use event_sink::EventSink;
 pub use ids::{

--- a/crates/forge-core/tests/event_wire_shape.rs
+++ b/crates/forge-core/tests/event_wire_shape.rs
@@ -562,6 +562,147 @@ fn background_agent_completed_wire_shape() {
 }
 
 #[test]
+fn turn_error_auth_wire_shape() {
+    // F-749: auth failure surfaces as a typed `TurnError` so the UI can
+    // render the "Open provider settings" CTA card.
+    assert_wire_eq(
+        Event::TurnError {
+            id: msg_id("mid-9"),
+            at: fixed_time(),
+            kind: forge_core::TurnErrorKind::Auth,
+            message: "Provider rejected the credential.".into(),
+            retriable: false,
+            raw: Some("HTTP 401: invalid api key".into()),
+        },
+        json!({
+            "type": "turn_error",
+            "id": "mid-9",
+            "at": "2026-04-18T10:00:00Z",
+            "kind": { "kind": "auth" },
+            "message": "Provider rejected the credential.",
+            "retriable": false,
+            "raw": "HTTP 401: invalid api key",
+        }),
+    );
+}
+
+#[test]
+fn turn_error_rate_limit_with_retry_after_wire_shape() {
+    // F-749: rate-limit carries the parsed `Retry-After` seconds so the
+    // card can render a live countdown next to a disabled Retry button.
+    assert_wire_eq(
+        Event::TurnError {
+            id: msg_id("mid-10"),
+            at: fixed_time(),
+            kind: forge_core::TurnErrorKind::RateLimit {
+                retry_after_secs: Some(42),
+            },
+            message: "Provider rate limit hit.".into(),
+            retriable: true,
+            raw: None,
+        },
+        json!({
+            "type": "turn_error",
+            "id": "mid-10",
+            "at": "2026-04-18T10:00:00Z",
+            "kind": { "kind": "rate_limit", "retry_after_secs": 42 },
+            "message": "Provider rate limit hit.",
+            "retriable": true,
+        }),
+    );
+}
+
+#[test]
+fn turn_error_network_omits_raw_when_none() {
+    // F-749: `raw` is `serde(skip_serializing_if = "Option::is_none")` so
+    // the field disappears from the wire when absent.
+    assert_wire_eq(
+        Event::TurnError {
+            id: msg_id("mid-11"),
+            at: fixed_time(),
+            kind: forge_core::TurnErrorKind::Network,
+            message: "Network error.".into(),
+            retriable: true,
+            raw: None,
+        },
+        json!({
+            "type": "turn_error",
+            "id": "mid-11",
+            "at": "2026-04-18T10:00:00Z",
+            "kind": { "kind": "network" },
+            "message": "Network error.",
+            "retriable": true,
+        }),
+    );
+}
+
+#[test]
+fn turn_error_server_wire_shape() {
+    assert_wire_eq(
+        Event::TurnError {
+            id: msg_id("mid-12"),
+            at: fixed_time(),
+            kind: forge_core::TurnErrorKind::Server,
+            message: "Provider 503.".into(),
+            retriable: true,
+            raw: None,
+        },
+        json!({
+            "type": "turn_error",
+            "id": "mid-12",
+            "at": "2026-04-18T10:00:00Z",
+            "kind": { "kind": "server" },
+            "message": "Provider 503.",
+            "retriable": true,
+        }),
+    );
+}
+
+#[test]
+fn turn_error_malformed_response_wire_shape() {
+    assert_wire_eq(
+        Event::TurnError {
+            id: msg_id("mid-13"),
+            at: fixed_time(),
+            kind: forge_core::TurnErrorKind::MalformedResponse,
+            message: "Provider stream parse error.".into(),
+            retriable: true,
+            raw: None,
+        },
+        json!({
+            "type": "turn_error",
+            "id": "mid-13",
+            "at": "2026-04-18T10:00:00Z",
+            "kind": { "kind": "malformed_response" },
+            "message": "Provider stream parse error.",
+            "retriable": true,
+        }),
+    );
+}
+
+#[test]
+fn turn_error_unknown_wire_shape() {
+    assert_wire_eq(
+        Event::TurnError {
+            id: msg_id("mid-14"),
+            at: fixed_time(),
+            kind: forge_core::TurnErrorKind::Unknown,
+            message: "Unknown provider failure.".into(),
+            retriable: true,
+            raw: None,
+        },
+        json!({
+            "type": "turn_error",
+            "id": "mid-14",
+            "at": "2026-04-18T10:00:00Z",
+            "kind": { "kind": "unknown" },
+            "message": "Unknown provider failure.",
+            "retriable": true,
+        }),
+    );
+}
+
+#[test]
 fn log_line_wire_shape() {
     // Dev-mode bridge from the daemon's `tracing` subscriber to the
     // webview console. `level` is the lowercase `tracing::Level` so the
@@ -1081,6 +1222,7 @@ fn variant_label(e: &Event) -> &'static str {
         Event::SessionResumed { .. } => "session_resumed",
         Event::SessionInterrupted { .. } => "session_interrupted",
         Event::LogLine { .. } => "log_line",
+        Event::TurnError { .. } => "turn_error",
     }
 }
 

--- a/crates/forge-providers/Cargo.toml
+++ b/crates/forge-providers/Cargo.toml
@@ -19,6 +19,10 @@ bytes = "1"
 dirs = "6.0.0"
 forge-core = { path = "../forge-core" }
 futures = "0.3"
+# F-749: parse the HTTP-date form of the `Retry-After` response header on 429
+# rate-limit replies. Already present transitively via reqwest's hyper
+# dependency tree; declared directly here for first-class use.
+httpdate = "1"
 # `parking_lot::Mutex` for `MockProvider` interior state — its guards are not
 # poisoned on holder-thread panic, so a panicking test does not cascade into
 # every subsequent `.lock()` call. Already present transitively via reqwest's

--- a/crates/forge-providers/src/anthropic/mod.rs
+++ b/crates/forge-providers/src/anthropic/mod.rs
@@ -14,10 +14,10 @@
 
 use crate::http_util::{self, HttpClientConfig};
 use crate::sse::{self, SseError, SseEvent};
-use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth};
+use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth, StreamErrorKind};
 use bytes::Bytes;
 use forge_core::Result;
-use futures::stream::{BoxStream, StreamExt};
+use futures::stream::{self, BoxStream, StreamExt};
 use secrecy::{ExposeSecret, SecretString};
 
 pub mod translate;
@@ -371,12 +371,22 @@ impl Provider for AnthropicProvider {
 
             let status = resp.status();
             if !status.is_success() {
+                // F-749: HTTP-level failure (401 / 429 / 5xx / …) is surfaced
+                // as a terminal `ChatChunk::Error` carrying the wire status
+                // code — not as a `Result::Err` — so the orchestrator sees a
+                // single uniform error pathway and the typed status threads
+                // straight to `TurnErrorKind` (auth / rate_limit / server).
+                let code = status.as_u16();
                 let body = resp.text().await.unwrap_or_default();
-                return Err(anyhow::anyhow!(
-                    "anthropic chat HTTP {status}: {}",
-                    http_util::truncate(&body, 500)
-                )
-                .into());
+                let preview = http_util::truncate(&body, 500);
+                let message = format!("anthropic chat HTTP {status}: {preview}");
+                return Ok(Box::pin(stream::once(async move {
+                    ChatChunk::Error {
+                        kind: StreamErrorKind::Transport,
+                        message,
+                        status: Some(code),
+                    }
+                })) as BoxStream<'static, ChatChunk>);
             }
 
             Ok(decode_anthropic_stream(resp.bytes_stream(), cfg))
@@ -433,6 +443,7 @@ where
             Err(e) => vec![ChatChunk::Error {
                 kind: http_util::map_sse_error(&e),
                 message: e.to_string(),
+                status: None,
             }],
         };
         futures::stream::iter(chunks)

--- a/crates/forge-providers/src/anthropic/mod.rs
+++ b/crates/forge-providers/src/anthropic/mod.rs
@@ -377,6 +377,17 @@ impl Provider for AnthropicProvider {
                 // single uniform error pathway and the typed status threads
                 // straight to `TurnErrorKind` (auth / rate_limit / server).
                 let code = status.as_u16();
+                // F-749: parse `Retry-After` for 429s so the UI's countdown
+                // fires against a real provider value. Header is read off the
+                // response *before* the body is consumed because `resp.text()`
+                // moves the response and headers along with it.
+                let retry_after_secs = if code == 429 {
+                    resp.headers()
+                        .get(reqwest::header::RETRY_AFTER)
+                        .and_then(http_util::parse_retry_after)
+                } else {
+                    None
+                };
                 let body = resp.text().await.unwrap_or_default();
                 let preview = http_util::truncate(&body, 500);
                 let message = format!("anthropic chat HTTP {status}: {preview}");
@@ -385,6 +396,7 @@ impl Provider for AnthropicProvider {
                         kind: StreamErrorKind::Transport,
                         message,
                         status: Some(code),
+                        retry_after_secs,
                     }
                 })) as BoxStream<'static, ChatChunk>);
             }
@@ -444,6 +456,7 @@ where
                 kind: http_util::map_sse_error(&e),
                 message: e.to_string(),
                 status: None,
+                retry_after_secs: None,
             }],
         };
         futures::stream::iter(chunks)

--- a/crates/forge-providers/src/http_util.rs
+++ b/crates/forge-providers/src/http_util.rs
@@ -26,7 +26,7 @@
 //!   the chain length, since user-supplied OpenAI-compatible gateways may
 //!   legitimately redirect.
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use crate::sse::SseError;
 use crate::StreamErrorKind;
@@ -88,6 +88,33 @@ pub(crate) fn map_sse_error(e: &SseError) -> StreamErrorKind {
     }
 }
 
+/// F-749: parse a `Retry-After` HTTP response header value into seconds-from-now.
+///
+/// RFC 9110 §10.2.3 allows two forms:
+///
+/// - **delta-seconds** — a non-negative integer count of seconds (`"120"`).
+/// - **HTTP-date** — an absolute timestamp (`"Wed, 21 Oct 2026 07:28:00 GMT"`).
+///
+/// The delta-seconds branch is tried first because it's the common case for
+/// 429 replies from Anthropic / OpenAI / Ollama. The HTTP-date branch falls
+/// back to [`httpdate::parse_http_date`] and converts the resulting
+/// [`SystemTime`] into a delta against `now`.
+///
+/// Returns `None` for missing headers, non-ASCII / non-UTF-8 byte sequences,
+/// negative deltas, deltas past `u32::MAX`, or HTTP-dates that are in the
+/// past. The caller is expected to be defensive: a malformed value collapses
+/// to "we don't know how long to wait", not an error.
+pub(crate) fn parse_retry_after(value: &reqwest::header::HeaderValue) -> Option<u32> {
+    let s = value.to_str().ok()?.trim();
+    if let Ok(secs) = s.parse::<u32>() {
+        return Some(secs);
+    }
+    let when = httpdate::parse_http_date(s).ok()?;
+    let now = SystemTime::now();
+    let dur = when.duration_since(now).ok()?;
+    u32::try_from(dur.as_secs()).ok()
+}
+
 /// UTF-8-safe prefix truncation for HTTP error-body logging. Walks character
 /// boundaries so a multi-byte codepoint is never split (a naive `&s[..max]`
 /// would panic on input like `"héllo"` when `max == 2`).
@@ -146,6 +173,59 @@ mod tests {
         let out = truncate("abcdefgh", 3);
         assert!(out.ends_with('…'));
         assert!(out.starts_with("abc"));
+    }
+
+    #[test]
+    fn parse_retry_after_delta_seconds() {
+        let h = reqwest::header::HeaderValue::from_static("120");
+        assert_eq!(parse_retry_after(&h), Some(120));
+    }
+
+    #[test]
+    fn parse_retry_after_delta_seconds_zero() {
+        let h = reqwest::header::HeaderValue::from_static("0");
+        assert_eq!(parse_retry_after(&h), Some(0));
+    }
+
+    #[test]
+    fn parse_retry_after_delta_seconds_with_whitespace() {
+        let h = reqwest::header::HeaderValue::from_static("  42  ");
+        assert_eq!(parse_retry_after(&h), Some(42));
+    }
+
+    #[test]
+    fn parse_retry_after_garbage_returns_none() {
+        let h = reqwest::header::HeaderValue::from_static("not-a-number-nor-a-date");
+        assert_eq!(parse_retry_after(&h), None);
+    }
+
+    #[test]
+    fn parse_retry_after_negative_returns_none() {
+        let h = reqwest::header::HeaderValue::from_static("-30");
+        // `u32::parse` rejects the leading sign and httpdate rejects the
+        // shape — defensively `None`.
+        assert_eq!(parse_retry_after(&h), None);
+    }
+
+    #[test]
+    fn parse_retry_after_past_http_date_returns_none() {
+        let h = reqwest::header::HeaderValue::from_static("Wed, 21 Oct 1970 07:28:00 GMT");
+        // The date is in the past, so `duration_since(now)` errors out.
+        assert_eq!(parse_retry_after(&h), None);
+    }
+
+    #[test]
+    fn parse_retry_after_future_http_date_yields_seconds_from_now() {
+        // Build a future timestamp by going +60s from now and formatting it.
+        let future = SystemTime::now() + Duration::from_secs(60);
+        let formatted = httpdate::fmt_http_date(future);
+        let h = reqwest::header::HeaderValue::from_str(&formatted).unwrap();
+        let secs = parse_retry_after(&h).expect("future http-date must parse");
+        // Allow a wide tolerance — system clock and the test's wall clock
+        // race by a few ms. The load-bearing claim is that the result is
+        // positive and within an order of magnitude of the input.
+        assert!(secs <= 60, "secs={secs} should be <= input window");
+        assert!(secs >= 55, "secs={secs} should be near 60");
     }
 
     #[test]

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -140,10 +140,19 @@ pub enum ChatChunk {
     /// the orchestrator so the UI's `TurnErrorKind` classifier can distinguish
     /// `Auth` (401) / `RateLimit` (429) / `Server` (5xx) from non-status
     /// failures without parsing the human-readable message text.
+    ///
+    /// `retry_after_secs` carries the parsed `Retry-After` HTTP response header
+    /// when the failure was a 429 rate-limit and the provider returned a
+    /// well-formed `Retry-After` value (either a delta-seconds integer or an
+    /// HTTP-date, both per RFC 9110 §10.2.3). `None` for every other failure
+    /// class, and `None` when the header was missing or malformed. The
+    /// orchestrator routes this onto `TurnErrorKind::RateLimit { retry_after_secs }`
+    /// so the UI's countdown can fire against a real provider value.
     Error {
         kind: StreamErrorKind,
         message: String,
         status: Option<u16>,
+        retry_after_secs: Option<u32>,
     },
 }
 

--- a/crates/forge-providers/src/lib.rs
+++ b/crates/forge-providers/src/lib.rs
@@ -132,9 +132,18 @@ pub enum ChatChunk {
     Done(String),
     /// Terminal, structured stream failure. The chunk stream closes after
     /// yielding this variant — callers should treat the current turn as aborted.
+    ///
+    /// F-749: `status` carries the HTTP response status code when the failure
+    /// originated from an HTTP-level non-2xx response (auth, rate-limit, 5xx,
+    /// etc.). `None` indicates the failure happened at the transport / SSE
+    /// adapter / parse layer rather than as an HTTP status. Surfaced through
+    /// the orchestrator so the UI's `TurnErrorKind` classifier can distinguish
+    /// `Auth` (401) / `RateLimit` (429) / `Server` (5xx) from non-status
+    /// failures without parsing the human-readable message text.
     Error {
         kind: StreamErrorKind,
         message: String,
+        status: Option<u16>,
     },
 }
 

--- a/crates/forge-providers/src/ollama/mod.rs
+++ b/crates/forge-providers/src/ollama/mod.rs
@@ -87,13 +87,19 @@ impl Provider for OllamaProvider {
                 .map_err(|e| anyhow::anyhow!("ollama chat request failed: {e}"))?;
 
             if !resp.status().is_success() {
+                // F-749: surface the HTTP status code on the error envelope
+                // so the orchestrator can classify Ollama 4xx/5xx into the
+                // matching `TurnErrorKind` (auth / rate_limit / server)
+                // without parsing the message string.
                 let status = resp.status();
+                let code = status.as_u16();
                 let body_text = resp.text().await.unwrap_or_default();
                 let preview = http_util::truncate(&body_text, 256);
                 return Ok(Box::pin(stream::once(async move {
                     ChatChunk::Error {
                         kind: StreamErrorKind::Transport,
                         message: format!("ollama HTTP {status}: {preview}"),
+                        status: Some(code),
                     }
                 })) as BoxStream<'static, ChatChunk>);
             }
@@ -110,11 +116,16 @@ impl Provider for OllamaProvider {
                         Err(e) => vec![ChatChunk::Error {
                             kind: StreamErrorKind::Transport,
                             message: format!("ollama NDJSON parse error: {e}"),
+                            // F-749: NDJSON decode failure has no HTTP status
+                            // attached; the orchestrator will classify on
+                            // `kind` instead and emit `MalformedResponse`.
+                            status: None,
                         }],
                     },
                     Err(e) => vec![ChatChunk::Error {
                         kind: StreamErrorKind::Transport,
                         message: format!("ollama stream read error: {e}"),
+                        status: None,
                     }],
                 };
                 stream::iter(chunks)

--- a/crates/forge-providers/src/ollama/mod.rs
+++ b/crates/forge-providers/src/ollama/mod.rs
@@ -93,6 +93,18 @@ impl Provider for OllamaProvider {
                 // without parsing the message string.
                 let status = resp.status();
                 let code = status.as_u16();
+                // F-749: Ollama is keyless and self-hosted, so 429 is rare —
+                // but a fronting reverse proxy may add rate-limiting and
+                // emit a standards-compliant `Retry-After`. Read it the same
+                // way the cloud providers do so the UI countdown lights up
+                // uniformly across all backends.
+                let retry_after_secs = if code == 429 {
+                    resp.headers()
+                        .get(reqwest::header::RETRY_AFTER)
+                        .and_then(http_util::parse_retry_after)
+                } else {
+                    None
+                };
                 let body_text = resp.text().await.unwrap_or_default();
                 let preview = http_util::truncate(&body_text, 256);
                 return Ok(Box::pin(stream::once(async move {
@@ -100,6 +112,7 @@ impl Provider for OllamaProvider {
                         kind: StreamErrorKind::Transport,
                         message: format!("ollama HTTP {status}: {preview}"),
                         status: Some(code),
+                        retry_after_secs,
                     }
                 })) as BoxStream<'static, ChatChunk>);
             }
@@ -120,12 +133,14 @@ impl Provider for OllamaProvider {
                             // attached; the orchestrator will classify on
                             // `kind` instead and emit `MalformedResponse`.
                             status: None,
+                            retry_after_secs: None,
                         }],
                     },
                     Err(e) => vec![ChatChunk::Error {
                         kind: StreamErrorKind::Transport,
                         message: format!("ollama stream read error: {e}"),
                         status: None,
+                        retry_after_secs: None,
                     }],
                 };
                 stream::iter(chunks)

--- a/crates/forge-providers/src/openai/mod.rs
+++ b/crates/forge-providers/src/openai/mod.rs
@@ -222,6 +222,18 @@ pub(crate) fn chat_request(
             // re-parsing the message text. See the matching branch on
             // `AnthropicProvider::chat_with_auth`.
             let code = status.as_u16();
+            // F-749: parse `Retry-After` for 429s. Both vanilla OpenAI and
+            // every OpenAI-compatible gateway routed through this helper
+            // (CustomOpenAi, Together, Anyscale, vLLM, LiteLLM, …) emit the
+            // header per RFC 9110 §10.2.3 — handling here covers all of them
+            // in one place rather than duplicating in each provider.
+            let retry_after_secs = if code == 429 {
+                resp.headers()
+                    .get(reqwest::header::RETRY_AFTER)
+                    .and_then(http_util::parse_retry_after)
+            } else {
+                None
+            };
             let body = resp.text().await.unwrap_or_default();
             let preview = http_util::truncate(&body, 500);
             let message = format!("openai chat HTTP {status}: {preview}");
@@ -230,6 +242,7 @@ pub(crate) fn chat_request(
                     kind: StreamErrorKind::Transport,
                     message,
                     status: Some(code),
+                    retry_after_secs,
                 }
             })) as BoxStream<'static, ChatChunk>);
         }
@@ -269,6 +282,7 @@ where
                 kind: http_util::map_sse_error(&e),
                 message: e.to_string(),
                 status: None,
+                retry_after_secs: None,
             }],
         };
         futures::stream::iter(chunks)

--- a/crates/forge-providers/src/openai/mod.rs
+++ b/crates/forge-providers/src/openai/mod.rs
@@ -15,10 +15,10 @@
 
 use crate::http_util::{self, HttpClientConfig};
 use crate::sse::{self, SseError, SseEvent};
-use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth};
+use crate::{ChatChunk, ChatRequest, Provider, ProviderAuth, StreamErrorKind};
 use bytes::Bytes;
 use forge_core::Result;
-use futures::stream::{BoxStream, StreamExt};
+use futures::stream::{self, BoxStream, StreamExt};
 use secrecy::{ExposeSecret, SecretString};
 
 pub mod custom;
@@ -216,12 +216,22 @@ pub(crate) fn chat_request(
 
         let status = resp.status();
         if !status.is_success() {
+            // F-749: HTTP-level failure surfaces as a terminal `ChatChunk::Error`
+            // carrying the wire status code so the orchestrator can route it
+            // onto `TurnErrorKind::Auth` / `RateLimit` / `Server` without
+            // re-parsing the message text. See the matching branch on
+            // `AnthropicProvider::chat_with_auth`.
+            let code = status.as_u16();
             let body = resp.text().await.unwrap_or_default();
-            return Err(anyhow::anyhow!(
-                "openai chat HTTP {status}: {}",
-                http_util::truncate(&body, 500)
-            )
-            .into());
+            let preview = http_util::truncate(&body, 500);
+            let message = format!("openai chat HTTP {status}: {preview}");
+            return Ok(Box::pin(stream::once(async move {
+                ChatChunk::Error {
+                    kind: StreamErrorKind::Transport,
+                    message,
+                    status: Some(code),
+                }
+            })) as BoxStream<'static, ChatChunk>);
         }
 
         Ok(decode_openai_stream(resp.bytes_stream(), cfg))
@@ -258,6 +268,7 @@ where
             Err(e) => vec![ChatChunk::Error {
                 kind: http_util::map_sse_error(&e),
                 message: e.to_string(),
+                status: None,
             }],
         };
         futures::stream::iter(chunks)

--- a/crates/forge-providers/tests/anthropic.rs
+++ b/crates/forge-providers/tests/anthropic.rs
@@ -124,17 +124,37 @@ async fn chat_maps_http_errors() {
         parallel_tool_calls_allowed: false,
     };
 
-    let err = provider
-        .chat(req)
-        .await
-        .err()
-        .expect("HTTP 401 must map to Err");
-    let msg = format!("{err}");
-    assert!(msg.contains("401"), "error should mention status: {msg}");
-    assert!(
-        msg.contains("invalid api key"),
-        "error should include body: {msg}"
+    // F-749: HTTP non-2xx surfaces as a terminal `ChatChunk::Error` carrying
+    // the wire status code rather than collapsing into an opaque `Err`. The
+    // orchestrator's classifier reads `status` to route 401 → `Auth`.
+    let mut stream = provider.chat(req).await.expect("chat returns Ok stream");
+    let chunks: Vec<ChatChunk> = {
+        let mut v = Vec::new();
+        while let Some(c) = stream.next().await {
+            v.push(c);
+        }
+        v
+    };
+    assert_eq!(
+        chunks.len(),
+        1,
+        "expected exactly one error chunk: {chunks:?}"
     );
+    match &chunks[0] {
+        ChatChunk::Error {
+            kind,
+            message,
+            status,
+        } => {
+            assert_eq!(*status, Some(401), "status must carry the wire code");
+            assert!(matches!(kind, StreamErrorKind::Transport));
+            assert!(
+                message.contains("401") && message.contains("invalid api key"),
+                "message should carry the body: {message}"
+            );
+        }
+        other => panic!("expected ChatChunk::Error, got {other:?}"),
+    }
 }
 
 /// A peer that opens a 200 response with valid SSE prelude, emits one event,
@@ -315,13 +335,25 @@ async fn chat_does_not_follow_redirects() {
         messages: vec![user_msg("hi")],
         parallel_tool_calls_allowed: false,
     };
-    let err = match provider.chat(req).await {
-        Ok(_) => panic!("redirect must surface as an error, not be followed"),
-        Err(e) => e,
+    // F-749: redirect surfaces as a terminal `ChatChunk::Error` (not a
+    // followed redirect, not an opaque `Err`). The 302 status rides on
+    // `ChatChunk::Error.status` so the orchestrator can classify it.
+    let mut stream = provider.chat(req).await.expect("chat returns Ok stream");
+    let chunks: Vec<ChatChunk> = {
+        let mut v = Vec::new();
+        while let Some(c) = stream.next().await {
+            v.push(c);
+        }
+        v
     };
-    let msg = format!("{err}");
-    assert!(
-        msg.contains("302"),
-        "error must reflect the upstream 302 status: {msg}"
-    );
+    let last = chunks.last().expect("at least one chunk");
+    match last {
+        ChatChunk::Error {
+            message, status, ..
+        } => {
+            assert_eq!(*status, Some(302), "status must reflect the wire 302");
+            assert!(message.contains("302"), "message echoes status: {message}");
+        }
+        other => panic!("expected ChatChunk::Error, got {other:?}"),
+    }
 }

--- a/crates/forge-providers/tests/anthropic.rs
+++ b/crates/forge-providers/tests/anthropic.rs
@@ -636,7 +636,7 @@ async fn chat_against_real_anthropic() {
             ChatChunk::ToolCall { .. } => {
                 // unexpected for this prompt — model shouldn't request a tool
             }
-            ChatChunk::Error { kind, message } => {
+            ChatChunk::Error { kind, message, .. } => {
                 panic!("anthropic returned error: kind={kind:?}, message={message}")
             }
         }

--- a/crates/forge-providers/tests/anthropic.rs
+++ b/crates/forge-providers/tests/anthropic.rs
@@ -145,6 +145,7 @@ async fn chat_maps_http_errors() {
             kind,
             message,
             status,
+            retry_after_secs,
         } => {
             assert_eq!(*status, Some(401), "status must carry the wire code");
             assert!(matches!(kind, StreamErrorKind::Transport));
@@ -152,6 +153,10 @@ async fn chat_maps_http_errors() {
                 message.contains("401") && message.contains("invalid api key"),
                 "message should carry the body: {message}"
             );
+            // F-749: 401 isn't a rate-limit, so the parser doesn't run and the
+            // field stays `None`. Pinned here so a future refactor that
+            // accidentally populates it on non-429 trips this assertion.
+            assert_eq!(*retry_after_secs, None);
         }
         other => panic!("expected ChatChunk::Error, got {other:?}"),
     }
@@ -353,6 +358,133 @@ async fn chat_does_not_follow_redirects() {
         } => {
             assert_eq!(*status, Some(302), "status must reflect the wire 302");
             assert!(message.contains("302"), "message echoes status: {message}");
+        }
+        other => panic!("expected ChatChunk::Error, got {other:?}"),
+    }
+}
+
+/// F-749: a 429 response with a delta-seconds `Retry-After` header must
+/// surface that value on `ChatChunk::Error.retry_after_secs` so the
+/// orchestrator can thread it onto `TurnErrorKind::RateLimit` and the UI
+/// countdown lights up against a real provider value.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_429_with_retry_after_delta_seconds_threads_value_onto_chunk() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "30")
+                .set_body_string("rate limited"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(server.uri(), "sk-test", "claude-3-5-sonnet", 4096);
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+    let mut stream = provider.chat(req).await.expect("chat returns Ok stream");
+    let chunk = stream.next().await.expect("at least one chunk");
+    match chunk {
+        ChatChunk::Error {
+            status,
+            retry_after_secs,
+            ..
+        } => {
+            assert_eq!(status, Some(429));
+            assert_eq!(
+                retry_after_secs,
+                Some(30),
+                "delta-seconds value must round-trip onto the error chunk"
+            );
+        }
+        other => panic!("expected ChatChunk::Error, got {other:?}"),
+    }
+}
+
+/// F-749: a 429 with an HTTP-date `Retry-After` is parsed via
+/// `httpdate::parse_http_date` and converted into seconds-from-now.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_429_with_retry_after_http_date_threads_value_onto_chunk() {
+    let server = MockServer::start().await;
+    // Build a "60 seconds from now" HTTP-date so the parsed value is
+    // approximately 60 (we allow a wide tolerance below for the wall-clock
+    // race between mock-server-setup and provider call).
+    let future = std::time::SystemTime::now() + Duration::from_secs(60);
+    let http_date = httpdate::fmt_http_date(future);
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", http_date.as_str())
+                .set_body_string("rate limited"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(server.uri(), "sk-test", "claude-3-5-sonnet", 4096);
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+    let mut stream = provider.chat(req).await.expect("chat returns Ok stream");
+    let chunk = stream.next().await.expect("at least one chunk");
+    match chunk {
+        ChatChunk::Error {
+            status,
+            retry_after_secs,
+            ..
+        } => {
+            assert_eq!(status, Some(429));
+            let secs = retry_after_secs.expect("http-date Retry-After must parse");
+            assert!(
+                (40..=60).contains(&secs),
+                "expected ~60s, got {secs}s — allow a wide tolerance for wall-clock race"
+            );
+        }
+        other => panic!("expected ChatChunk::Error, got {other:?}"),
+    }
+}
+
+/// F-749: a malformed `Retry-After` collapses to `None` rather than failing
+/// the request. The orchestrator's UI still surfaces the rate-limit error
+/// — it just doesn't show a countdown.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_429_with_malformed_retry_after_yields_none() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "not-a-number-or-a-date")
+                .set_body_string("rate limited"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(server.uri(), "sk-test", "claude-3-5-sonnet", 4096);
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+    let mut stream = provider.chat(req).await.expect("chat returns Ok stream");
+    let chunk = stream.next().await.expect("at least one chunk");
+    match chunk {
+        ChatChunk::Error {
+            status,
+            retry_after_secs,
+            ..
+        } => {
+            assert_eq!(status, Some(429));
+            assert_eq!(
+                retry_after_secs, None,
+                "malformed Retry-After must defensively collapse to None"
+            );
         }
         other => panic!("expected ChatChunk::Error, got {other:?}"),
     }

--- a/crates/forge-providers/tests/ollama.rs
+++ b/crates/forge-providers/tests/ollama.rs
@@ -272,8 +272,12 @@ async fn chat_against_local_ollama() {
             ChatChunk::ToolCall { .. } => {
                 // unexpected for this prompt — model shouldn't request a tool
             }
-            ChatChunk::Error { kind, message } => {
-                panic!("ollama returned error: kind={kind:?}, message={message}")
+            ChatChunk::Error {
+                kind,
+                message,
+                status,
+            } => {
+                panic!("ollama returned error: kind={kind:?}, status={status:?}, message={message}")
             }
         }
     }
@@ -306,8 +310,13 @@ async fn chat_maps_http_error_to_typed_chunk() {
 
     let first = stream.next().await.expect("first chunk");
     match first {
-        ChatChunk::Error { kind, message } => {
+        ChatChunk::Error {
+            kind,
+            message,
+            status,
+        } => {
             assert!(matches!(kind, forge_providers::StreamErrorKind::Transport));
+            assert_eq!(status, Some(500), "status must carry the wire code");
             assert!(
                 message.contains("500"),
                 "message should mention status: {message}"

--- a/crates/forge-providers/tests/ollama.rs
+++ b/crates/forge-providers/tests/ollama.rs
@@ -276,6 +276,7 @@ async fn chat_against_local_ollama() {
                 kind,
                 message,
                 status,
+                retry_after_secs: _,
             } => {
                 panic!("ollama returned error: kind={kind:?}, status={status:?}, message={message}")
             }
@@ -314,6 +315,7 @@ async fn chat_maps_http_error_to_typed_chunk() {
             kind,
             message,
             status,
+            retry_after_secs,
         } => {
             assert!(matches!(kind, forge_providers::StreamErrorKind::Transport));
             assert_eq!(status, Some(500), "status must carry the wire code");
@@ -321,6 +323,8 @@ async fn chat_maps_http_error_to_typed_chunk() {
                 message.contains("500"),
                 "message should mention status: {message}"
             );
+            // F-749: 500 isn't a rate-limit, so the parser doesn't run.
+            assert_eq!(retry_after_secs, None);
         }
         other => panic!("expected Error chunk, got {other:?}"),
     }

--- a/crates/forge-providers/tests/openai.rs
+++ b/crates/forge-providers/tests/openai.rs
@@ -124,17 +124,36 @@ async fn chat_maps_http_errors() {
         parallel_tool_calls_allowed: false,
     };
 
-    let err = provider
-        .chat(req)
-        .await
-        .err()
-        .expect("HTTP 401 must map to Err");
-    let msg = format!("{err}");
-    assert!(msg.contains("401"), "error should mention status: {msg}");
-    assert!(
-        msg.contains("invalid api key"),
-        "error should include body: {msg}"
+    // F-749: HTTP non-2xx surfaces as a terminal `ChatChunk::Error` carrying
+    // the wire status code rather than collapsing into an opaque `Err`.
+    let mut stream = provider.chat(req).await.expect("chat returns Ok stream");
+    let chunks: Vec<ChatChunk> = {
+        let mut v = Vec::new();
+        while let Some(c) = stream.next().await {
+            v.push(c);
+        }
+        v
+    };
+    assert_eq!(
+        chunks.len(),
+        1,
+        "expected exactly one error chunk: {chunks:?}"
     );
+    match &chunks[0] {
+        ChatChunk::Error {
+            kind,
+            message,
+            status,
+        } => {
+            assert_eq!(*status, Some(401), "status must carry the wire code");
+            assert!(matches!(kind, StreamErrorKind::Transport));
+            assert!(
+                message.contains("401") && message.contains("invalid api key"),
+                "message should carry the body: {message}"
+            );
+        }
+        other => panic!("expected ChatChunk::Error, got {other:?}"),
+    }
 }
 
 /// A peer that opens a 200 response with valid SSE prelude, emits one event,
@@ -309,13 +328,24 @@ async fn chat_does_not_follow_redirects() {
         messages: vec![user_msg("hi")],
         parallel_tool_calls_allowed: false,
     };
-    let err = match provider.chat(req).await {
-        Ok(_) => panic!("redirect must surface as an error, not be followed"),
-        Err(e) => e,
+    // F-749: redirect surfaces as a terminal `ChatChunk::Error` (not a
+    // followed redirect, not an opaque `Err`).
+    let mut stream = provider.chat(req).await.expect("chat returns Ok stream");
+    let chunks: Vec<ChatChunk> = {
+        let mut v = Vec::new();
+        while let Some(c) = stream.next().await {
+            v.push(c);
+        }
+        v
     };
-    let msg = format!("{err}");
-    assert!(
-        msg.contains("302"),
-        "error must reflect the upstream 302 status: {msg}"
-    );
+    let last = chunks.last().expect("at least one chunk");
+    match last {
+        ChatChunk::Error {
+            message, status, ..
+        } => {
+            assert_eq!(*status, Some(302), "status must reflect the wire 302");
+            assert!(message.contains("302"), "message echoes status: {message}");
+        }
+        other => panic!("expected ChatChunk::Error, got {other:?}"),
+    }
 }

--- a/crates/forge-providers/tests/openai.rs
+++ b/crates/forge-providers/tests/openai.rs
@@ -529,7 +529,7 @@ async fn chat_against_real_openai() {
             ChatChunk::ToolCall { .. } => {
                 // unexpected for this prompt — model shouldn't request a tool
             }
-            ChatChunk::Error { kind, message } => {
+            ChatChunk::Error { kind, message, .. } => {
                 panic!("openai returned error: kind={kind:?}, message={message}")
             }
         }

--- a/crates/forge-providers/tests/openai.rs
+++ b/crates/forge-providers/tests/openai.rs
@@ -144,6 +144,7 @@ async fn chat_maps_http_errors() {
             kind,
             message,
             status,
+            retry_after_secs,
         } => {
             assert_eq!(*status, Some(401), "status must carry the wire code");
             assert!(matches!(kind, StreamErrorKind::Transport));
@@ -151,6 +152,9 @@ async fn chat_maps_http_errors() {
                 message.contains("401") && message.contains("invalid api key"),
                 "message should carry the body: {message}"
             );
+            // F-749: 401 isn't a rate-limit, so the parser doesn't run and the
+            // field stays `None`.
+            assert_eq!(*retry_after_secs, None);
         }
         other => panic!("expected ChatChunk::Error, got {other:?}"),
     }
@@ -345,6 +349,48 @@ async fn chat_does_not_follow_redirects() {
         } => {
             assert_eq!(*status, Some(302), "status must reflect the wire 302");
             assert!(message.contains("302"), "message echoes status: {message}");
+        }
+        other => panic!("expected ChatChunk::Error, got {other:?}"),
+    }
+}
+
+/// F-749: a 429 response with a delta-seconds `Retry-After` header must
+/// surface that value on `ChatChunk::Error.retry_after_secs` so the
+/// orchestrator can thread it onto `TurnErrorKind::RateLimit` and the UI
+/// countdown lights up against a real provider value.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_429_with_retry_after_delta_seconds_threads_value_onto_chunk() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "45")
+                .set_body_string("rate limited"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = OpenAiProvider::new(server.uri(), "sk-test", "gpt-4o");
+    let req = ChatRequest {
+        system: None,
+        messages: vec![user_msg("hi")],
+        parallel_tool_calls_allowed: false,
+    };
+    let mut stream = provider.chat(req).await.expect("chat returns Ok stream");
+    let chunk = stream.next().await.expect("at least one chunk");
+    match chunk {
+        ChatChunk::Error {
+            status,
+            retry_after_secs,
+            ..
+        } => {
+            assert_eq!(status, Some(429));
+            assert_eq!(
+                retry_after_secs,
+                Some(45),
+                "delta-seconds value must round-trip onto the error chunk"
+            );
         }
         other => panic!("expected ChatChunk::Error, got {other:?}"),
     }

--- a/crates/forge-providers/tests/openai_custom.rs
+++ b/crates/forge-providers/tests/openai_custom.rs
@@ -263,15 +263,35 @@ async fn http_error_propagates_with_status_and_body() {
     )
     .expect("provider construction");
 
-    let err = provider
-        .chat(req())
-        .await
-        .err()
-        .expect("HTTP 401 must map to Err");
-    let msg = format!("{err}");
-    assert!(msg.contains("401"), "error should mention status: {msg}");
-    assert!(
-        msg.contains("invalid api key"),
-        "error should include body: {msg}"
+    // F-749: HTTP non-2xx surfaces as a terminal `ChatChunk::Error` carrying
+    // the wire status code so the orchestrator's classifier can route it
+    // onto `TurnErrorKind::Auth` without re-parsing the message text.
+    let mut stream = provider.chat(req()).await.expect("chat returns Ok stream");
+    let chunks: Vec<ChatChunk> = {
+        let mut v = Vec::new();
+        while let Some(c) = stream.next().await {
+            v.push(c);
+        }
+        v
+    };
+    assert_eq!(
+        chunks.len(),
+        1,
+        "expected exactly one error chunk: {chunks:?}"
     );
+    match &chunks[0] {
+        ChatChunk::Error {
+            kind,
+            message,
+            status,
+        } => {
+            assert_eq!(*status, Some(401), "status must carry the wire code");
+            assert!(matches!(kind, forge_providers::StreamErrorKind::Transport));
+            assert!(
+                message.contains("401") && message.contains("invalid api key"),
+                "message should carry the body: {message}"
+            );
+        }
+        other => panic!("expected ChatChunk::Error, got {other:?}"),
+    }
 }

--- a/crates/forge-providers/tests/openai_custom.rs
+++ b/crates/forge-providers/tests/openai_custom.rs
@@ -284,6 +284,7 @@ async fn http_error_propagates_with_status_and_body() {
             kind,
             message,
             status,
+            retry_after_secs,
         } => {
             assert_eq!(*status, Some(401), "status must carry the wire code");
             assert!(matches!(kind, forge_providers::StreamErrorKind::Transport));
@@ -291,6 +292,8 @@ async fn http_error_propagates_with_status_and_body() {
                 message.contains("401") && message.contains("invalid api key"),
                 "message should carry the body: {message}"
             );
+            // F-749: 401 isn't a rate-limit, so the parser doesn't run.
+            assert_eq!(*retry_after_secs, None);
         }
         other => panic!("expected ChatChunk::Error, got {other:?}"),
     }

--- a/crates/forge-session/src/compaction.rs
+++ b/crates/forge-session/src/compaction.rs
@@ -408,12 +408,14 @@ pub async fn compact<P: Provider>(
                 kind,
                 message,
                 status,
+                retry_after_secs,
             } => {
-                // F-749: status is informational here — compaction is a
-                // privileged background path that already collapses every
-                // failure into one Err; the orchestrator's TurnError path
-                // doesn't route through this call.
+                // F-749: status and retry_after_secs are informational here —
+                // compaction is a privileged background path that already
+                // collapses every failure into one Err; the orchestrator's
+                // TurnError path doesn't route through this call.
                 let _ = status;
+                let _ = retry_after_secs;
                 return Err(anyhow!(
                     "compact: provider stream aborted ({kind:?}): {message}"
                 ));

--- a/crates/forge-session/src/compaction.rs
+++ b/crates/forge-session/src/compaction.rs
@@ -404,7 +404,16 @@ pub async fn compact<P: Provider>(
             ChatChunk::ToolCall { .. } => {
                 // Privileged summary call must not invoke tools — ignore.
             }
-            ChatChunk::Error { kind, message } => {
+            ChatChunk::Error {
+                kind,
+                message,
+                status,
+            } => {
+                // F-749: status is informational here — compaction is a
+                // privileged background path that already collapses every
+                // failure into one Err; the orchestrator's TurnError path
+                // doesn't route through this call.
+                let _ = status;
                 return Err(anyhow!(
                     "compact: provider stream aborted ({kind:?}): {message}"
                 ));

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -9,11 +9,12 @@ use forge_core::{
     credentials::Credentials,
     ids::{AgentInstanceId, MessageId, ProviderId, StepId, ToolCallId},
     read_since, ApprovalScope, ApprovalSource, Event, EventSink, RerunVariant, StepKind,
-    StepOutcome,
+    StepOutcome, TurnErrorKind, TURN_ERROR_RAW_CAP_BYTES,
 };
 use forge_ipc::sidecar::{SecretBytes, SidecarCredentials, SidecarMessage};
 use forge_providers::{
     ChatBlock, ChatChunk, ChatMessage, ChatRequest, ChatRole, Provider, ProviderAuth,
+    StreamErrorKind,
 };
 use futures::StreamExt;
 use secrecy::ExposeSecret;
@@ -191,6 +192,57 @@ fn build_provider_auth(provider_id: &str, pulled: Option<secrecy::SecretString>)
         Some(s) => ProviderAuth::ApiKey(s),
         None => ProviderAuth::None,
     }
+}
+
+/// F-749: classify a terminal `ChatChunk::Error` into the typed
+/// [`TurnErrorKind`] the UI dispatches on. HTTP status — when present —
+/// is authoritative (`401`/`403` → Auth, `429` → RateLimit, `5xx` → Server);
+/// otherwise the SSE / NDJSON kind decides (`LineTooLong` and stream parse
+/// failures → MalformedResponse, timeouts / transport → Network).
+///
+/// `retriable` mirrors the spec: false for auth (the credential must change
+/// first) and true for everything else. The UI gates the Retry button
+/// directly on this verdict so the classification stays in one place.
+fn classify_chunk_error(kind: StreamErrorKind, status: Option<u16>) -> (TurnErrorKind, bool) {
+    if let Some(code) = status {
+        return match code {
+            401 | 403 => (TurnErrorKind::Auth, false),
+            429 => (
+                TurnErrorKind::RateLimit {
+                    retry_after_secs: None,
+                },
+                true,
+            ),
+            500..=599 => (TurnErrorKind::Server, true),
+            _ => (TurnErrorKind::Unknown, true),
+        };
+    }
+    match kind {
+        StreamErrorKind::LineTooLong => (TurnErrorKind::MalformedResponse, true),
+        StreamErrorKind::IdleTimeout
+        | StreamErrorKind::WallClockTimeout
+        | StreamErrorKind::Transport => (TurnErrorKind::Network, true),
+    }
+}
+
+/// F-749: byte-cap the raw provider error before it lands on the event log.
+/// Drops to `None` for empty input so the wire shape omits the field
+/// (matches `serde(skip_serializing_if = "Option::is_none")`). UTF-8-safe —
+/// walks character boundaries so a multi-byte codepoint is never split.
+fn truncate_raw_error(s: &str) -> Option<String> {
+    if s.is_empty() {
+        return None;
+    }
+    if s.len() <= TURN_ERROR_RAW_CAP_BYTES {
+        return Some(s.to_string());
+    }
+    let cut = s
+        .char_indices()
+        .take_while(|(i, _)| *i < TURN_ERROR_RAW_CAP_BYTES)
+        .last()
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(0);
+    Some(format!("{}…", &s[..cut]))
 }
 
 use crate::byte_budget::ByteBudget;
@@ -725,12 +777,44 @@ pub(crate) async fn run_request_loop<P: Provider>(
                     break;
                 }
 
-                ChatChunk::Error { kind, message } => {
-                    // Stream aborted under a provider-layer bound (line cap,
-                    // idle timeout, wall-clock timeout, transport error).
-                    // Drop any buffered tool calls — they never reached
-                    // the dispatcher and emitting partial Tool* events
-                    // would leave a half-bracketed step window.
+                ChatChunk::Error {
+                    kind,
+                    message,
+                    status,
+                } => {
+                    // Stream aborted under a provider-layer bound (HTTP non-2xx,
+                    // line cap, idle timeout, wall-clock timeout, transport
+                    // error). Drop any buffered tool calls — they never reached
+                    // the dispatcher and emitting partial Tool* events would
+                    // leave a half-bracketed step window.
+                    //
+                    // F-749: emit the typed `TurnError` so the UI can render
+                    // the failure as an inline error card at the turn's slot.
+                    // The classifier maps HTTP status (when present) onto
+                    // `Auth` / `RateLimit` / `Server` and falls back on the
+                    // stream-error kind for transport / SSE classes.
+                    let (error_kind, retriable) = classify_chunk_error(kind, status);
+                    let raw = truncate_raw_error(&message);
+                    let user_facing = match &error_kind {
+                        TurnErrorKind::Auth => {
+                            "Provider rejected the credential. Open provider settings to update it.".to_string()
+                        }
+                        TurnErrorKind::RateLimit { .. } => {
+                            "Provider rate limit hit. Retry will become available shortly.".to_string()
+                        }
+                        TurnErrorKind::Network => {
+                            "Network error talking to the provider. Check your connection and retry.".to_string()
+                        }
+                        TurnErrorKind::Server => {
+                            "Provider returned a server error. Retry to see if the issue cleared.".to_string()
+                        }
+                        TurnErrorKind::MalformedResponse => {
+                            "Provider response could not be parsed. Retry to see if it recovers.".to_string()
+                        }
+                        TurnErrorKind::Unknown => {
+                            "Provider call failed. See details to diagnose.".to_string()
+                        }
+                    };
                     events
                         .emit(Event::AssistantMessage {
                             id: msg_id.clone(),
@@ -742,6 +826,16 @@ pub(crate) async fn run_request_loop<P: Provider>(
                             text: Arc::from(assistant_text.as_str()),
                             branch_parent: branch_parent.clone(),
                             branch_variant_index,
+                        })
+                        .await?;
+                    events
+                        .emit(Event::TurnError {
+                            id: msg_id.clone(),
+                            at: Utc::now(),
+                            kind: error_kind,
+                            message: user_facing,
+                            retriable,
+                            raw,
                         })
                         .await?;
                     // F-139: close the Model step with an Error outcome

--- a/crates/forge-session/src/orchestrator.rs
+++ b/crates/forge-session/src/orchestrator.rs
@@ -203,16 +203,20 @@ fn build_provider_auth(provider_id: &str, pulled: Option<secrecy::SecretString>)
 /// `retriable` mirrors the spec: false for auth (the credential must change
 /// first) and true for everything else. The UI gates the Retry button
 /// directly on this verdict so the classification stays in one place.
-fn classify_chunk_error(kind: StreamErrorKind, status: Option<u16>) -> (TurnErrorKind, bool) {
+///
+/// `retry_after_secs` is the parsed `Retry-After` header value from the
+/// provider — populated by the provider-layer 429 branch — and is forwarded
+/// onto [`TurnErrorKind::RateLimit`]. Ignored for every other status / kind
+/// because the wire shape only carries it on `RateLimit`.
+fn classify_chunk_error(
+    kind: StreamErrorKind,
+    status: Option<u16>,
+    retry_after_secs: Option<u32>,
+) -> (TurnErrorKind, bool) {
     if let Some(code) = status {
         return match code {
             401 | 403 => (TurnErrorKind::Auth, false),
-            429 => (
-                TurnErrorKind::RateLimit {
-                    retry_after_secs: None,
-                },
-                true,
-            ),
+            429 => (TurnErrorKind::RateLimit { retry_after_secs }, true),
             500..=599 => (TurnErrorKind::Server, true),
             _ => (TurnErrorKind::Unknown, true),
         };
@@ -781,6 +785,7 @@ pub(crate) async fn run_request_loop<P: Provider>(
                     kind,
                     message,
                     status,
+                    retry_after_secs,
                 } => {
                     // Stream aborted under a provider-layer bound (HTTP non-2xx,
                     // line cap, idle timeout, wall-clock timeout, transport
@@ -792,8 +797,12 @@ pub(crate) async fn run_request_loop<P: Provider>(
                     // the failure as an inline error card at the turn's slot.
                     // The classifier maps HTTP status (when present) onto
                     // `Auth` / `RateLimit` / `Server` and falls back on the
-                    // stream-error kind for transport / SSE classes.
-                    let (error_kind, retriable) = classify_chunk_error(kind, status);
+                    // stream-error kind for transport / SSE classes; the
+                    // provider-parsed `Retry-After` value rides through onto
+                    // `TurnErrorKind::RateLimit.retry_after_secs` so the UI's
+                    // countdown fires against a real value.
+                    let (error_kind, retriable) =
+                        classify_chunk_error(kind, status, retry_after_secs);
                     let raw = truncate_raw_error(&message);
                     let user_facing = match &error_kind {
                         TurnErrorKind::Auth => {

--- a/crates/forge-session/tests/turn_error_emission.rs
+++ b/crates/forge-session/tests/turn_error_emission.rs
@@ -27,6 +27,7 @@ struct ErrorProvider {
     kind: StreamErrorKind,
     message: String,
     status: Option<u16>,
+    retry_after_secs: Option<u32>,
 }
 
 impl Provider for ErrorProvider {
@@ -38,11 +39,13 @@ impl Provider for ErrorProvider {
         let kind = self.kind;
         let message = self.message.clone();
         let status = self.status;
+        let retry_after_secs = self.retry_after_secs;
         async move {
             let chunk = ChatChunk::Error {
                 kind,
                 message,
                 status,
+                retry_after_secs,
             };
             Ok(Box::pin(stream::iter(vec![chunk])) as BoxStream<'static, ChatChunk>)
         }
@@ -110,6 +113,7 @@ async fn http_401_maps_to_auth_kind_with_retriable_false() {
             kind: StreamErrorKind::Transport,
             message: "anthropic chat HTTP 401: invalid api key".into(),
             status: Some(401),
+            retry_after_secs: None,
         },
     )
     .await;
@@ -145,6 +149,7 @@ async fn http_403_also_maps_to_auth_kind() {
             kind: StreamErrorKind::Transport,
             message: "openai chat HTTP 403: forbidden".into(),
             status: Some(403),
+            retry_after_secs: None,
         },
     )
     .await;
@@ -170,6 +175,7 @@ async fn http_429_maps_to_rate_limit_kind() {
             kind: StreamErrorKind::Transport,
             message: "anthropic chat HTTP 429: rate limited".into(),
             status: Some(429),
+            retry_after_secs: None,
         },
     )
     .await;
@@ -193,6 +199,99 @@ async fn http_429_maps_to_rate_limit_kind() {
 }
 
 #[tokio::test]
+async fn http_429_retry_after_secs_flows_through_to_turn_error() {
+    // F-749: when the provider parses `Retry-After: 30` into `Some(30)` on
+    // the `ChatChunk::Error` envelope, the orchestrator must thread that
+    // onto `TurnErrorKind::RateLimit.retry_after_secs` so the UI's
+    // countdown lights up against a real value.
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "anthropic chat HTTP 429: rate limited".into(),
+            status: Some(429),
+            retry_after_secs: Some(30),
+        },
+    )
+    .await;
+
+    let err = first_turn_error(&events);
+    let Event::TurnError { kind, .. } = err else {
+        unreachable!()
+    };
+    assert_eq!(
+        *kind,
+        TurnErrorKind::RateLimit {
+            retry_after_secs: Some(30)
+        },
+        "retry_after_secs must flow from ChatChunk::Error through to TurnErrorKind::RateLimit"
+    );
+}
+
+#[tokio::test]
+async fn http_429_without_retry_after_yields_none_on_turn_error() {
+    // When the provider returns no `Retry-After` header (or a malformed one),
+    // the value stays `None` and the UI falls back to an immediately-available
+    // Retry button rather than an indefinite countdown.
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "anthropic chat HTTP 429: rate limited".into(),
+            status: Some(429),
+            retry_after_secs: None,
+        },
+    )
+    .await;
+
+    let err = first_turn_error(&events);
+    let Event::TurnError { kind, .. } = err else {
+        unreachable!()
+    };
+    assert_eq!(
+        *kind,
+        TurnErrorKind::RateLimit {
+            retry_after_secs: None
+        }
+    );
+}
+
+#[tokio::test]
+async fn wall_clock_timeout_maps_to_network() {
+    // F-749: parity with the IdleTimeout case. Wall-clock timeouts share the
+    // same UI affordance (retry available immediately, generic network copy)
+    // because both are best-modeled as "transient connectivity issue".
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::WallClockTimeout,
+            message: "stream exceeded wall-clock budget".into(),
+            status: None,
+            retry_after_secs: None,
+        },
+    )
+    .await;
+    let err = first_turn_error(&events);
+    let Event::TurnError {
+        kind, retriable, ..
+    } = err
+    else {
+        unreachable!()
+    };
+    assert_eq!(*kind, TurnErrorKind::Network);
+    assert!(*retriable);
+}
+
+#[tokio::test]
 async fn http_500_maps_to_server_kind() {
     let dir = TempDir::new().unwrap();
     let log = dir.path().join("events.jsonl");
@@ -203,6 +302,7 @@ async fn http_500_maps_to_server_kind() {
             kind: StreamErrorKind::Transport,
             message: "openai chat HTTP 500: internal server error".into(),
             status: Some(500),
+            retry_after_secs: None,
         },
     )
     .await;
@@ -228,6 +328,7 @@ async fn http_503_maps_to_server_kind() {
             kind: StreamErrorKind::Transport,
             message: "anthropic chat HTTP 503: service unavailable".into(),
             status: Some(503),
+            retry_after_secs: None,
         },
     )
     .await;
@@ -249,6 +350,7 @@ async fn transport_without_status_maps_to_network() {
             kind: StreamErrorKind::Transport,
             message: "connection refused".into(),
             status: None,
+            retry_after_secs: None,
         },
     )
     .await;
@@ -274,6 +376,7 @@ async fn idle_timeout_maps_to_network() {
             kind: StreamErrorKind::IdleTimeout,
             message: "stream idle".into(),
             status: None,
+            retry_after_secs: None,
         },
     )
     .await;
@@ -295,6 +398,7 @@ async fn line_too_long_maps_to_malformed_response() {
             kind: StreamErrorKind::LineTooLong,
             message: "sse line exceeded cap".into(),
             status: None,
+            retry_after_secs: None,
         },
     )
     .await;
@@ -320,6 +424,7 @@ async fn unrecognized_status_maps_to_unknown() {
             kind: StreamErrorKind::Transport,
             message: "anthropic chat HTTP 418: i am a teapot".into(),
             status: Some(418),
+            retry_after_secs: None,
         },
     )
     .await;
@@ -345,6 +450,7 @@ async fn turn_error_id_matches_originating_user_message() {
             kind: StreamErrorKind::Transport,
             message: "HTTP 500".into(),
             status: Some(500),
+            retry_after_secs: None,
         },
     )
     .await;
@@ -377,6 +483,7 @@ async fn turn_error_raw_is_capped_at_4kib() {
             kind: StreamErrorKind::Transport,
             message: big.clone(),
             status: Some(500),
+            retry_after_secs: None,
         },
     )
     .await;

--- a/crates/forge-session/tests/turn_error_emission.rs
+++ b/crates/forge-session/tests/turn_error_emission.rs
@@ -1,0 +1,402 @@
+//! F-749: orchestrator-level coverage that provider failures land on the
+//! session log as typed `Event::TurnError` events.
+//!
+//! Each test drives `run_turn` with a minimal in-process provider that
+//! yields a single `ChatChunk::Error { status, kind, message }` — covering
+//! every HTTP class the spec calls out (401 → Auth, 429 → RateLimit,
+//! 5xx → Server) plus the non-status SSE / transport / parse classes
+//! (Network, MalformedResponse). The assertions read straight off the
+//! durable event log so a regression in classification or wire-shape
+//! surfaces in the same place the UI will read it from.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use forge_core::{read_since, Event, TurnErrorKind};
+use forge_providers::{ChatChunk, ChatRequest, Provider, ProviderAuth, StreamErrorKind};
+use forge_session::orchestrator::run_turn;
+use forge_session::session::Session;
+use futures::stream::{self, BoxStream};
+use tempfile::TempDir;
+
+/// In-process provider that yields exactly one `ChatChunk::Error` and ends.
+/// Sidesteps `MockProvider` because the NDJSON scripted path can't construct
+/// a typed error envelope today — we want the orchestrator's classifier
+/// exercised end-to-end with the same shape a real provider emits.
+struct ErrorProvider {
+    kind: StreamErrorKind,
+    message: String,
+    status: Option<u16>,
+}
+
+impl Provider for ErrorProvider {
+    fn chat(
+        &self,
+        _req: ChatRequest,
+    ) -> impl std::future::Future<Output = forge_core::Result<BoxStream<'static, ChatChunk>>> + Send
+    {
+        let kind = self.kind;
+        let message = self.message.clone();
+        let status = self.status;
+        async move {
+            let chunk = ChatChunk::Error {
+                kind,
+                message,
+                status,
+            };
+            Ok(Box::pin(stream::iter(vec![chunk])) as BoxStream<'static, ChatChunk>)
+        }
+    }
+
+    fn chat_with_auth(
+        &self,
+        req: ChatRequest,
+        _auth: ProviderAuth,
+    ) -> impl std::future::Future<Output = forge_core::Result<BoxStream<'static, ChatChunk>>> + Send
+    {
+        self.chat(req)
+    }
+}
+
+async fn run_failing_turn(log_path: PathBuf, provider: ErrorProvider) -> Vec<Event> {
+    let session = Arc::new(
+        Session::create(log_path.clone())
+            .await
+            .expect("session create"),
+    );
+    let approvals = Default::default();
+    let _ = run_turn(
+        Arc::clone(&session),
+        session.as_ref(),
+        Arc::new(provider),
+        "hello".to_string(),
+        approvals,
+        vec![],
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    read_since(&log_path, 0)
+        .await
+        .expect("read event log")
+        .into_iter()
+        .map(|(_, ev)| ev)
+        .collect()
+}
+
+fn first_turn_error(events: &[Event]) -> &Event {
+    events
+        .iter()
+        .find(|e| matches!(e, Event::TurnError { .. }))
+        .expect("TurnError event landed on the log")
+}
+
+#[tokio::test]
+async fn http_401_maps_to_auth_kind_with_retriable_false() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "anthropic chat HTTP 401: invalid api key".into(),
+            status: Some(401),
+        },
+    )
+    .await;
+
+    let err = first_turn_error(&events);
+    let Event::TurnError {
+        kind,
+        retriable,
+        raw,
+        ..
+    } = err
+    else {
+        unreachable!()
+    };
+    assert_eq!(*kind, TurnErrorKind::Auth);
+    assert!(!*retriable, "auth errors are not retriable");
+    assert!(
+        raw.as_deref()
+            .map(|s| s.contains("401") && s.contains("invalid api key"))
+            .unwrap_or(false),
+        "raw should preserve the provider error verbatim: {raw:?}"
+    );
+}
+
+#[tokio::test]
+async fn http_403_also_maps_to_auth_kind() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "openai chat HTTP 403: forbidden".into(),
+            status: Some(403),
+        },
+    )
+    .await;
+    let err = first_turn_error(&events);
+    let Event::TurnError {
+        kind, retriable, ..
+    } = err
+    else {
+        unreachable!()
+    };
+    assert_eq!(*kind, TurnErrorKind::Auth);
+    assert!(!*retriable);
+}
+
+#[tokio::test]
+async fn http_429_maps_to_rate_limit_kind() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "anthropic chat HTTP 429: rate limited".into(),
+            status: Some(429),
+        },
+    )
+    .await;
+    let err = first_turn_error(&events);
+    let Event::TurnError {
+        kind, retriable, ..
+    } = err
+    else {
+        unreachable!()
+    };
+    assert!(
+        matches!(
+            kind,
+            TurnErrorKind::RateLimit {
+                retry_after_secs: _
+            }
+        ),
+        "expected RateLimit, got {kind:?}"
+    );
+    assert!(*retriable, "rate-limit failures are retriable");
+}
+
+#[tokio::test]
+async fn http_500_maps_to_server_kind() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "openai chat HTTP 500: internal server error".into(),
+            status: Some(500),
+        },
+    )
+    .await;
+    let err = first_turn_error(&events);
+    let Event::TurnError {
+        kind, retriable, ..
+    } = err
+    else {
+        unreachable!()
+    };
+    assert_eq!(*kind, TurnErrorKind::Server);
+    assert!(*retriable);
+}
+
+#[tokio::test]
+async fn http_503_maps_to_server_kind() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "anthropic chat HTTP 503: service unavailable".into(),
+            status: Some(503),
+        },
+    )
+    .await;
+    let err = first_turn_error(&events);
+    let Event::TurnError { kind, .. } = err else {
+        unreachable!()
+    };
+    assert_eq!(*kind, TurnErrorKind::Server);
+}
+
+#[tokio::test]
+async fn transport_without_status_maps_to_network() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "connection refused".into(),
+            status: None,
+        },
+    )
+    .await;
+    let err = first_turn_error(&events);
+    let Event::TurnError {
+        kind, retriable, ..
+    } = err
+    else {
+        unreachable!()
+    };
+    assert_eq!(*kind, TurnErrorKind::Network);
+    assert!(*retriable);
+}
+
+#[tokio::test]
+async fn idle_timeout_maps_to_network() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::IdleTimeout,
+            message: "stream idle".into(),
+            status: None,
+        },
+    )
+    .await;
+    let err = first_turn_error(&events);
+    let Event::TurnError { kind, .. } = err else {
+        unreachable!()
+    };
+    assert_eq!(*kind, TurnErrorKind::Network);
+}
+
+#[tokio::test]
+async fn line_too_long_maps_to_malformed_response() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::LineTooLong,
+            message: "sse line exceeded cap".into(),
+            status: None,
+        },
+    )
+    .await;
+    let err = first_turn_error(&events);
+    let Event::TurnError {
+        kind, retriable, ..
+    } = err
+    else {
+        unreachable!()
+    };
+    assert_eq!(*kind, TurnErrorKind::MalformedResponse);
+    assert!(*retriable);
+}
+
+#[tokio::test]
+async fn unrecognized_status_maps_to_unknown() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "anthropic chat HTTP 418: i am a teapot".into(),
+            status: Some(418),
+        },
+    )
+    .await;
+    let err = first_turn_error(&events);
+    let Event::TurnError {
+        kind, retriable, ..
+    } = err
+    else {
+        unreachable!()
+    };
+    assert_eq!(*kind, TurnErrorKind::Unknown);
+    assert!(*retriable);
+}
+
+#[tokio::test]
+async fn turn_error_id_matches_originating_user_message() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: "HTTP 500".into(),
+            status: Some(500),
+        },
+    )
+    .await;
+
+    let user_id = events
+        .iter()
+        .find_map(|e| match e {
+            Event::UserMessage { id, .. } => Some(id.clone()),
+            _ => None,
+        })
+        .expect("UserMessage on log");
+    let Event::TurnError { id, .. } = first_turn_error(&events) else {
+        unreachable!()
+    };
+    assert_eq!(
+        id, &user_id,
+        "TurnError.id ties the failure to its originating user message slot"
+    );
+}
+
+#[tokio::test]
+async fn turn_error_raw_is_capped_at_4kib() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("events.jsonl");
+
+    let big = "x".repeat(8 * 1024);
+    let events = run_failing_turn(
+        log,
+        ErrorProvider {
+            kind: StreamErrorKind::Transport,
+            message: big.clone(),
+            status: Some(500),
+        },
+    )
+    .await;
+    let Event::TurnError { raw, .. } = first_turn_error(&events) else {
+        unreachable!()
+    };
+    let raw = raw
+        .as_deref()
+        .expect("raw should be populated for non-empty message");
+    // The cap is 4 KiB + one trailing ellipsis codepoint when truncation
+    // fires. Asserting the raw is strictly shorter than the input is the
+    // load-bearing guarantee.
+    assert!(
+        raw.len() < big.len(),
+        "raw must be truncated below input: raw={} input={}",
+        raw.len(),
+        big.len()
+    );
+    assert!(
+        raw.ends_with('…'),
+        "truncation should append an ellipsis marker"
+    );
+}

--- a/web/packages/app/src/ipc/events.test.ts
+++ b/web/packages/app/src/ipc/events.test.ts
@@ -690,3 +690,160 @@ describe('fromRustEvent — context_compacted (F-598)', () => {
     ).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// F-749 — turn_error
+// ---------------------------------------------------------------------------
+
+describe('fromRustEvent — turn_error', () => {
+  it('maps auth wire shape onto TurnError with retriable=false', () => {
+    expect(
+      fromRustEvent({
+        type: 'turn_error',
+        id: 'mid-9',
+        at: '2026-04-18T10:00:00Z',
+        kind: { kind: 'auth' },
+        message: 'Provider rejected the credential.',
+        retriable: false,
+        raw: 'HTTP 401: invalid api key',
+      }),
+    ).toEqual({
+      kind: 'TurnError',
+      message_id: 'mid-9',
+      error_kind: 'auth',
+      message: 'Provider rejected the credential.',
+      retriable: false,
+      raw: 'HTTP 401: invalid api key',
+    });
+  });
+
+  it('maps rate_limit with retry_after_secs onto TurnError', () => {
+    expect(
+      fromRustEvent({
+        type: 'turn_error',
+        id: 'mid-10',
+        at: '2026-04-18T10:00:00Z',
+        kind: { kind: 'rate_limit', retry_after_secs: 42 },
+        message: 'Provider rate limit hit.',
+        retriable: true,
+      }),
+    ).toEqual({
+      kind: 'TurnError',
+      message_id: 'mid-10',
+      error_kind: 'rate_limit',
+      message: 'Provider rate limit hit.',
+      retriable: true,
+      retry_after_secs: 42,
+    });
+  });
+
+  it('omits retry_after_secs when absent', () => {
+    expect(
+      fromRustEvent({
+        type: 'turn_error',
+        id: 'mid-11',
+        at: '2026-04-18T10:00:00Z',
+        kind: { kind: 'rate_limit' },
+        message: 'Provider rate limit hit.',
+        retriable: true,
+      }),
+    ).toEqual({
+      kind: 'TurnError',
+      message_id: 'mid-11',
+      error_kind: 'rate_limit',
+      message: 'Provider rate limit hit.',
+      retriable: true,
+    });
+  });
+
+  it('maps network / server / malformed_response / unknown variants', () => {
+    const cases: Array<{
+      variant: string;
+      expected:
+        | 'network'
+        | 'server'
+        | 'malformed_response'
+        | 'unknown';
+    }> = [
+      { variant: 'network', expected: 'network' },
+      { variant: 'server', expected: 'server' },
+      { variant: 'malformed_response', expected: 'malformed_response' },
+      { variant: 'unknown', expected: 'unknown' },
+    ];
+    for (const c of cases) {
+      const out = fromRustEvent({
+        type: 'turn_error',
+        id: `mid-${c.variant}`,
+        at: '2026-04-18T10:00:00Z',
+        kind: { kind: c.variant },
+        message: 'fail',
+        retriable: true,
+      });
+      expect(out).toMatchObject({
+        kind: 'TurnError',
+        error_kind: c.expected,
+        retriable: true,
+      });
+    }
+  });
+
+  it('falls back to `unknown` when the wire kind is unrecognised', () => {
+    expect(
+      fromRustEvent({
+        type: 'turn_error',
+        id: 'mid-x',
+        at: '2026-04-18T10:00:00Z',
+        kind: { kind: 'not_a_real_kind' },
+        message: 'fail',
+        retriable: true,
+      }),
+    ).toMatchObject({
+      kind: 'TurnError',
+      error_kind: 'unknown',
+    });
+  });
+
+  it('drops malformed payloads (missing id / message / retriable / kind)', () => {
+    // missing id
+    expect(
+      fromRustEvent({
+        type: 'turn_error',
+        at: '2026-04-18T10:00:00Z',
+        kind: { kind: 'auth' },
+        message: 'm',
+        retriable: false,
+      }),
+    ).toBeNull();
+    // missing message
+    expect(
+      fromRustEvent({
+        type: 'turn_error',
+        id: 'mid',
+        at: '2026-04-18T10:00:00Z',
+        kind: { kind: 'auth' },
+        retriable: false,
+      }),
+    ).toBeNull();
+    // missing retriable
+    expect(
+      fromRustEvent({
+        type: 'turn_error',
+        id: 'mid',
+        at: '2026-04-18T10:00:00Z',
+        kind: { kind: 'auth' },
+        message: 'm',
+      }),
+    ).toBeNull();
+    // missing kind tag
+    expect(
+      fromRustEvent({
+        type: 'turn_error',
+        id: 'mid',
+        at: '2026-04-18T10:00:00Z',
+        kind: {},
+        message: 'm',
+        retriable: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/web/packages/app/src/ipc/events.ts
+++ b/web/packages/app/src/ipc/events.ts
@@ -368,6 +368,77 @@ export function fromRustEvent(rustEvent: unknown): SessionEvent | null {
     };
   }
 
+  // F-749: provider-error surfacing — maps the Rust `turn_error` event to
+  // the store's `TurnError` shape so `ChatPane` can render an inline error
+  // card at the failing turn's slot.
+  //
+  // Wire shape pinned by `crates/forge-core/tests/event_wire_shape.rs`:
+  //   { "type": "turn_error", "id": "<MessageId>", "at": "<RFC3339>",
+  //     "kind": { "kind": "auth" | "rate_limit" | ..., ... },
+  //     "message": "<string>", "retriable": <bool>, "raw"?: "<string>" }
+  //
+  // `kind` is an internally-tagged enum; the inner discriminator key (also
+  // called `kind`) drives the card's render variant. `retry_after_secs`
+  // rides on the `rate_limit` arm only.
+  if (type === 'turn_error') {
+    const id = ev['id'];
+    const message = ev['message'];
+    const retriable = ev['retriable'];
+    const kindRaw = ev['kind'];
+    if (!isString(id)) {
+      warnDrop('turn_error', 'id missing or not a string');
+      return null;
+    }
+    if (!isString(message)) {
+      warnDrop('turn_error', 'message missing or not a string');
+      return null;
+    }
+    if (typeof retriable !== 'boolean') {
+      warnDrop('turn_error', 'retriable missing or not a boolean');
+      return null;
+    }
+    if (!isObjectWith(kindRaw, 'kind') || !isString(kindRaw.kind)) {
+      warnDrop('turn_error', 'kind missing or not a tagged variant');
+      return null;
+    }
+    const variant = kindRaw.kind;
+    const knownKinds = [
+      'auth',
+      'rate_limit',
+      'network',
+      'server',
+      'malformed_response',
+      'unknown',
+    ];
+    const errorKind = knownKinds.includes(variant)
+      ? (variant as
+          | 'auth'
+          | 'rate_limit'
+          | 'network'
+          | 'server'
+          | 'malformed_response'
+          | 'unknown')
+      : 'unknown';
+    const out: SessionEvent = {
+      kind: 'TurnError',
+      message_id: id,
+      error_kind: errorKind,
+      message,
+      retriable,
+    };
+    if (errorKind === 'rate_limit') {
+      const retryAfter = (kindRaw as Record<string, unknown>)['retry_after_secs'];
+      if (typeof retryAfter === 'number' && Number.isFinite(retryAfter)) {
+        out.retry_after_secs = retryAfter;
+      }
+    }
+    const raw = ev['raw'];
+    if (isString(raw)) {
+      out.raw = raw;
+    }
+    return out;
+  }
+
   // F-145: branch deletion — tombstones a variant.
   if (type === 'branch_deleted') {
     const parent = ev['parent'];

--- a/web/packages/app/src/routes/Session/ChatPane.css
+++ b/web/packages/app/src/routes/Session/ChatPane.css
@@ -168,6 +168,83 @@
   border-radius: var(--r-sm);
 }
 
+/* F-749: provider-error card. Renders inline in the transcript at the
+   failing turn's slot. Warning/danger surface tint; no provider/model
+   avatar (reserved for real assistant messages). Action treatment is
+   keyed by `data-error-kind` in the component layer; the surface
+   doesn't change tint by kind today — kind drives the action chrome,
+   not the card shell. */
+.turn-error-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  border-radius: var(--r-sm);
+}
+
+.turn-error-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.turn-error-card__icon {
+  font-family: var(--font-mono);
+  font-size: var(--type-mono-sm);
+  color: var(--color-error);
+}
+
+.turn-error-card__kind {
+  font-family: var(--font-mono);
+  font-size: var(--type-mono-sm);
+  color: var(--color-accent-danger);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}
+
+.turn-error-card__message {
+  margin: 0;
+  font-size: var(--type-body-sm);
+  color: var(--color-text-primary);
+  word-break: break-word;
+}
+
+.turn-error-card__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.turn-error-card__details-toggle {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--type-mono-sm);
+  cursor: pointer;
+  padding: var(--sp-1) var(--sp-2);
+}
+
+.turn-error-card__details-toggle:hover {
+  color: var(--color-text-primary);
+}
+
+.turn-error-card__raw,
+.turn-error-card__raw-empty {
+  margin: 0;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-surface-1, rgba(0, 0, 0, 0.2));
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: var(--type-mono-sm);
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
 .turn__error-icon {
   flex: 0 0 auto;
   font-family: var(--font-mono);

--- a/web/packages/app/src/routes/Session/ChatPane.test.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.test.tsx
@@ -2437,3 +2437,72 @@ describe('ToolCallCard Phase 3 — CSS drift fixture (F-447)', () => {
     );
   });
 });
+
+describe('ChatPane retry flow (F-749)', () => {
+  it('drops the failed user turn and error card on retry and re-sends the original text', async () => {
+    invokeMock.mockResolvedValue(undefined);
+    // Stage a failed exchange: prior good turn pair + a failing user turn
+    // followed by a `TurnError`. Mirrors the orchestrator's wire ordering
+    // (UserMessage → AssistantMessage(empty, finalised) → TurnError).
+    pushEvent(SID, { kind: 'UserMessage', text: 'hello', message_id: 'msg-good' });
+    pushEvent(SID, { kind: 'AssistantMessage', text: 'hi back', message_id: 'msg-good' });
+    pushEvent(SID, { kind: 'UserMessage', text: 'please fail', message_id: 'msg-fail' });
+    pushEvent(SID, { kind: 'AssistantMessage', text: '', message_id: 'msg-fail' });
+    pushEvent(SID, {
+      kind: 'TurnError',
+      message_id: 'msg-fail',
+      error_kind: 'network',
+      message: 'transport error',
+      retriable: true,
+    });
+
+    const { getByTestId, queryByTestId } = render(() => <ChatPane />);
+    // Sanity: the error card is rendered before retry.
+    expect(getByTestId('turn-error-card-msg-fail')).toBeTruthy();
+
+    // Click Retry. The handler must (a) remove the error card AND the
+    // originating user turn from the transcript, (b) invoke
+    // session_send_message with the original failed-turn text.
+    fireEvent.click(getByTestId('turn-error-retry-msg-fail'));
+
+    // Error card is gone.
+    expect(queryByTestId('turn-error-card-msg-fail')).toBeNull();
+    // The prior good exchange survives; the failing user turn is gone too.
+    // Bubble-text assertions are coarse-grained — Composer + assistant
+    // bubbles share data-testids, so we go through the store directly.
+    const turns = (await import('../../stores/messages')).getMessagesState(SID).turns;
+    // After retry: [user "hello", assistant "hi back"] — the failing
+    // pair was spliced.
+    const userTexts = turns
+      .filter((t) => t.type === 'user')
+      .map((t) => (t as { text: string }).text);
+    expect(userTexts).toEqual(['hello']);
+
+    // session_send_message fired with the original failed-turn text.
+    expect(invokeMock).toHaveBeenCalledWith('session_send_message', {
+      sessionId: SID,
+      text: 'please fail',
+    });
+  });
+
+  it('does not call session_send_message when there is no preceding user turn', () => {
+    // Defensive: the orchestrator's protocol guarantees a UserMessage
+    // precedes every TurnError, but a corrupt replay could theoretically
+    // land a TurnError as the very first turn. The handler must no-op
+    // rather than firing a send with empty text.
+    pushEvent(SID, {
+      kind: 'TurnError',
+      message_id: 'msg-orphan',
+      error_kind: 'network',
+      message: 'transport error',
+      retriable: true,
+    });
+
+    const { getByTestId } = render(() => <ChatPane />);
+    fireEvent.click(getByTestId('turn-error-retry-msg-orphan'));
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      'session_send_message',
+      expect.anything(),
+    );
+  });
+});

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -53,6 +53,7 @@ import {
 import { ApprovalPrompt } from '../../components/ApprovalPrompt/ApprovalPrompt';
 import { WhitelistedPill } from '../../components/ApprovalPrompt/WhitelistedPill';
 import { CompactButton } from './CompactButton';
+import { TurnErrorCard } from './TurnErrorCard';
 import {
   ContextPicker,
   detectAtTrigger,
@@ -1604,6 +1605,36 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
                 // the banner's `children` prop when they arrive with a
                 // matching `instance_id`; today the list is empty.
                 return <SubAgentBanner turn={turn} />;
+              case 'turn_error': {
+                // F-749: retry re-sends the originating user message as a
+                // new turn. The orchestrator's protocol guarantees the
+                // failing turn's `message_id` ties to the **immediately
+                // preceding** UserMessage event, so walking back through
+                // the transcript to find the nearest user turn before the
+                // error is sufficient. No new IPC primitive needed — the
+                // existing `sessionSendMessage` is the right call site.
+                const turns = state().turns;
+                const errorIdx = turns.findIndex(
+                  (t) => t.type === 'turn_error' && t.message_id === turn.message_id,
+                );
+                const priorUser = (() => {
+                  for (let i = errorIdx - 1; i >= 0; i--) {
+                    const t = turns[i];
+                    if (t && t.type === 'user') return t;
+                  }
+                  return null;
+                })();
+                const onRetry = (): void => {
+                  const id = sessionId();
+                  if (!id || !priorUser) return;
+                  setAwaitingResponse(id, true);
+                  setUserScrolledUp(false);
+                  sessionSendMessage(id, priorUser.text).catch((err) =>
+                    reportInvokeError(id, 'session_send_message', err),
+                  );
+                };
+                return <TurnErrorCard turn={turn} onRetry={onRetry} />;
+              }
               case 'context_compacted':
                 // F-598: inline summary marker. Anchors the user's eye to
                 // the boundary between summarized history (now collapsed

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -16,6 +16,7 @@ import {
   activeVariantPosition,
   liveVariantCount,
   neighbourVariantId,
+  removeFailedTurnPair,
   type ChatTurn,
   type BranchGroup,
   type ToolCallStatus,
@@ -1613,6 +1614,14 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
                 // the transcript to find the nearest user turn before the
                 // error is sufficient. No new IPC primitive needed — the
                 // existing `sessionSendMessage` is the right call site.
+                //
+                // We also strip the failed exchange (user turn + error card)
+                // from the local transcript *before* dispatching the new
+                // send, so the user sees a single fresh attempt rather than
+                // a duplicate user bubble stacked above the new turn. See
+                // `removeFailedTurnPair` for the rationale on doing this
+                // store-side rather than via a new `MessageSuperseded`
+                // event.
                 const turns = state().turns;
                 const errorIdx = turns.findIndex(
                   (t) => t.type === 'turn_error' && t.message_id === turn.message_id,
@@ -1626,10 +1635,15 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
                 })();
                 const onRetry = (): void => {
                   const id = sessionId();
-                  if (!id || !priorUser) return;
+                  if (!id || !priorUser || errorIdx < 0) return;
+                  // Capture the text BEFORE we splice — the priorUser
+                  // reference survives because `splice` mutates in place
+                  // but the captured `.text` string is a value copy.
+                  const text = priorUser.text;
+                  removeFailedTurnPair(id, errorIdx);
                   setAwaitingResponse(id, true);
                   setUserScrolledUp(false);
-                  sessionSendMessage(id, priorUser.text).catch((err) =>
+                  sessionSendMessage(id, text).catch((err) =>
                     reportInvokeError(id, 'session_send_message', err),
                   );
                 };

--- a/web/packages/app/src/routes/Session/ChatPane.tsx
+++ b/web/packages/app/src/routes/Session/ChatPane.tsx
@@ -6,6 +6,7 @@ import {
   Show,
   createMemo,
 } from 'solid-js';
+import { useNavigate } from '@solidjs/router';
 import { Button } from '@forge/design';
 import { activeSessionId, activeWorkspaceRoot } from '../../stores/session';
 import {
@@ -1352,6 +1353,26 @@ export interface ChatPaneProps {
 
 export const ChatPane: Component<ChatPaneProps> = (props) => {
   const sessionId = () => activeSessionId();
+  // F-749: route navigator captured here so `<TurnErrorCard>` can stay a
+  // pure presentation component without its own router-context dependency.
+  // The production app always mounts ChatPane inside `<Router>`, but the
+  // `ChatPane.test.tsx` suite renders it bare for fast iteration —
+  // calling `useNavigate()` without a router throws "<A> and 'use'
+  // router primitives can be only used inside a Route." The try/catch
+  // collapses that into a `null` navigator; the auth CTA becomes a no-op
+  // in non-router renders, which matches the test fixtures' expectations
+  // (they assert via injected stub on `<TurnErrorCard onOpenProviderSettings>`).
+  // The try/catch lives at the boundary that owns the navigation intent
+  // (ChatPane) rather than leaking into every leaf that wants to navigate.
+  let navigate: ((to: string) => void) | null = null;
+  try {
+    navigate = useNavigate();
+  } catch {
+    navigate = null;
+  }
+  const openProviderSettings = (): void => {
+    navigate?.('/providers');
+  };
   const state = createMemo(() => {
     const id = sessionId();
     if (!id) return { turns: [], awaitingResponse: false, streamingMessageId: null, branchGroups: {} };
@@ -1647,7 +1668,13 @@ export const ChatPane: Component<ChatPaneProps> = (props) => {
                     reportInvokeError(id, 'session_send_message', err),
                   );
                 };
-                return <TurnErrorCard turn={turn} onRetry={onRetry} />;
+                return (
+                  <TurnErrorCard
+                    turn={turn}
+                    onRetry={onRetry}
+                    onOpenProviderSettings={openProviderSettings}
+                  />
+                );
               }
               case 'context_compacted':
                 // F-598: inline summary marker. Anchors the user's eye to

--- a/web/packages/app/src/routes/Session/TurnErrorCard.test.tsx
+++ b/web/packages/app/src/routes/Session/TurnErrorCard.test.tsx
@@ -1,0 +1,211 @@
+// F-749: rendering + action behaviour for `<TurnErrorCard>`. Covers each
+// `TurnErrorKind` arm — auth shows "Open provider settings" and hides
+// Retry; rate_limit shows a countdown when seconds are known; the other
+// kinds show Retry immediately. The "Show details" disclosure flips the
+// raw section in/out. Tests inject `onOpenProviderSettings` to avoid the
+// solid-router context dependency.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, fireEvent, render } from '@solidjs/testing-library';
+import type { ChatTurn } from '../../stores/messages';
+import { TurnErrorCard } from './TurnErrorCard';
+
+type TurnErrorTurn = Extract<ChatTurn, { type: 'turn_error' }>;
+
+function fixture(overrides: Partial<TurnErrorTurn> = {}): TurnErrorTurn {
+  return {
+    type: 'turn_error',
+    message_id: 'mid-failed',
+    error_kind: 'unknown',
+    message: 'something broke',
+    retriable: true,
+    ...overrides,
+  } as TurnErrorTurn;
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TurnErrorCard — auth kind', () => {
+  it('renders "Open provider settings" CTA and hides Retry', () => {
+    const turn = fixture({ error_kind: 'auth', retriable: false });
+    const onOpen = vi.fn();
+    const { getByTestId, queryByTestId } = render(() => (
+      <TurnErrorCard turn={turn} onOpenProviderSettings={onOpen} />
+    ));
+
+    expect(getByTestId(`turn-error-open-providers-${turn.message_id}`)).toBeTruthy();
+    expect(queryByTestId(`turn-error-retry-${turn.message_id}`)).toBeNull();
+  });
+
+  it('invokes the navigation callback when the CTA is clicked', () => {
+    const turn = fixture({ error_kind: 'auth', retriable: false });
+    const onOpen = vi.fn();
+    const { getByTestId } = render(() => (
+      <TurnErrorCard turn={turn} onOpenProviderSettings={onOpen} />
+    ));
+
+    fireEvent.click(getByTestId(`turn-error-open-providers-${turn.message_id}`));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('renders the `auth_error` monospace label', () => {
+    const turn = fixture({ error_kind: 'auth', retriable: false });
+    const { getByTestId } = render(() => (
+      <TurnErrorCard turn={turn} onOpenProviderSettings={vi.fn()} />
+    ));
+
+    expect(getByTestId(`turn-error-kind-${turn.message_id}`).textContent).toBe(
+      'auth_error',
+    );
+  });
+});
+
+describe('TurnErrorCard — rate_limit kind', () => {
+  it('renders Retry disabled with a countdown when retry_after_secs is known', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
+    const turn = fixture({
+      error_kind: 'rate_limit',
+      retriable: true,
+      retry_after_secs: 5,
+    });
+    const onRetry = vi.fn();
+    const { getByTestId } = render(() => (
+      <TurnErrorCard turn={turn} onRetry={onRetry} />
+    ));
+    const btn = getByTestId(
+      `turn-error-retry-${turn.message_id}`,
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toContain('RETRY IN 5');
+    // Clicking a disabled Retry must not fire the callback.
+    fireEvent.click(btn);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('flips Retry to enabled once the countdown elapses', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
+    const turn = fixture({
+      error_kind: 'rate_limit',
+      retriable: true,
+      retry_after_secs: 2,
+    });
+    const onRetry = vi.fn();
+    const { getByTestId } = render(() => (
+      <TurnErrorCard turn={turn} onRetry={onRetry} />
+    ));
+    const btn = getByTestId(
+      `turn-error-retry-${turn.message_id}`,
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+
+    vi.advanceTimersByTime(3000);
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent).toContain('RETRY');
+    fireEvent.click(btn);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('shows Retry available immediately when retry_after_secs is unknown', () => {
+    const turn = fixture({
+      error_kind: 'rate_limit',
+      retriable: true,
+    });
+    const onRetry = vi.fn();
+    const { getByTestId } = render(() => (
+      <TurnErrorCard turn={turn} onRetry={onRetry} />
+    ));
+    const btn = getByTestId(
+      `turn-error-retry-${turn.message_id}`,
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    fireEvent.click(btn);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});
+
+describe('TurnErrorCard — retriable kinds (network / server / malformed / unknown)', () => {
+  const cases: Array<TurnErrorTurn['error_kind']> = [
+    'network',
+    'server',
+    'malformed_response',
+    'unknown',
+  ];
+
+  it.each(cases)(
+    'renders Retry available immediately for %s',
+    (kind) => {
+      const turn = fixture({ error_kind: kind, retriable: true });
+      const onRetry = vi.fn();
+      const { getByTestId, queryByTestId } = render(() => (
+        <TurnErrorCard turn={turn} onRetry={onRetry} />
+      ));
+      const btn = getByTestId(
+        `turn-error-retry-${turn.message_id}`,
+      ) as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+      // The auth CTA must not appear for any retriable kind.
+      expect(
+        queryByTestId(`turn-error-open-providers-${turn.message_id}`),
+      ).toBeNull();
+      fireEvent.click(btn);
+      expect(onRetry).toHaveBeenCalledOnce();
+    },
+  );
+});
+
+describe('TurnErrorCard — Show details disclosure', () => {
+  it('hides `raw` by default and reveals on click', () => {
+    const turn = fixture({
+      error_kind: 'server',
+      retriable: true,
+      raw: 'HTTP 503: service unavailable',
+    });
+    const { getByTestId, queryByTestId } = render(() => (
+      <TurnErrorCard turn={turn} onRetry={vi.fn()} />
+    ));
+
+    expect(queryByTestId(`turn-error-raw-${turn.message_id}`)).toBeNull();
+    fireEvent.click(getByTestId(`turn-error-details-toggle-${turn.message_id}`));
+    expect(
+      getByTestId(`turn-error-raw-${turn.message_id}`).textContent,
+    ).toContain('HTTP 503');
+  });
+
+  it('shows a placeholder when raw is absent', () => {
+    const turn = fixture({ error_kind: 'network', retriable: true });
+    const { getByTestId } = render(() => (
+      <TurnErrorCard turn={turn} onRetry={vi.fn()} />
+    ));
+    fireEvent.click(getByTestId(`turn-error-details-toggle-${turn.message_id}`));
+    expect(
+      getByTestId(`turn-error-raw-empty-${turn.message_id}`).textContent,
+    ).toMatch(/No additional provider detail/);
+  });
+});
+
+describe('TurnErrorCard — non-retriable verdict respected', () => {
+  it('disables Retry when the orchestrator marked the error non-retriable', () => {
+    // Defensive: even for a non-auth kind, `retriable: false` on the wire
+    // wins. The card MUST never offer a Retry the daemon told us is
+    // counterproductive.
+    const turn = fixture({ error_kind: 'unknown', retriable: false });
+    const onRetry = vi.fn();
+    const { getByTestId } = render(() => (
+      <TurnErrorCard turn={turn} onRetry={onRetry} />
+    ));
+    const btn = getByTestId(
+      `turn-error-retry-${turn.message_id}`,
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    fireEvent.click(btn);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/app/src/routes/Session/TurnErrorCard.tsx
+++ b/web/packages/app/src/routes/Session/TurnErrorCard.tsx
@@ -23,7 +23,6 @@ import {
   createMemo,
   onCleanup,
 } from 'solid-js';
-import { useNavigate } from '@solidjs/router';
 import { Button } from '@forge/design';
 import type { ChatTurn } from '../../stores/messages';
 
@@ -60,25 +59,16 @@ export interface TurnErrorCardProps {
    */
   onRetry?: () => void;
   /**
-   * Navigation callback for the auth CTA. When omitted the component falls
-   * back to `useNavigate('/providers')`. Tests inject a stub to assert the
-   * click path without booting the router.
+   * Navigation callback for the auth CTA. Required for `auth` errors —
+   * the parent (`ChatPane`) creates a `useNavigate('/providers')` closure
+   * and passes it through. Decoupling the router dep from this component
+   * keeps it pure presentation and lets tests mount it without booting
+   * the router context.
    */
   onOpenProviderSettings?: () => void;
 }
 
 export const TurnErrorCard: Component<TurnErrorCardProps> = (props) => {
-  // Try to read solid-router's navigator. Tests that mount the card outside
-  // a `<Router>` rely on the injected `onOpenProviderSettings` prop and
-  // never hit `useNavigate` — guard the call so the component doesn't
-  // throw during a non-router render.
-  let routerNavigate: ((to: string) => void) | null = null;
-  try {
-    routerNavigate = useNavigate();
-  } catch {
-    routerNavigate = null;
-  }
-
   const [detailsOpen, setDetailsOpen] = createSignal(false);
 
   // Countdown only matters when retry_after_secs is known. Re-derives once
@@ -118,13 +108,7 @@ export const TurnErrorCard: Component<TurnErrorCardProps> = (props) => {
   };
 
   const handleOpenProviderSettings = (): void => {
-    if (props.onOpenProviderSettings) {
-      props.onOpenProviderSettings();
-      return;
-    }
-    if (routerNavigate) {
-      routerNavigate('/providers');
-    }
+    props.onOpenProviderSettings?.();
   };
 
   return (

--- a/web/packages/app/src/routes/Session/TurnErrorCard.tsx
+++ b/web/packages/app/src/routes/Session/TurnErrorCard.tsx
@@ -1,0 +1,212 @@
+// F-749: inline error card surfaced when a provider call fails mid-turn.
+//
+// Rendered by ChatPane at the transcript slot where the assistant response
+// would have appeared. Visually distinct from assistant messages — no
+// provider/model avatar, warning/danger surface tint, monospace error-type
+// label — so it cannot be confused with model output.
+//
+// Action treatment is keyed off `error_kind`:
+//
+// | kind                 | action                                              |
+// |----------------------|-----------------------------------------------------|
+// | `auth`               | "Open provider settings" CTA (navigates to /providers) |
+// | `rate_limit`         | Retry, disabled with countdown when retry_after_secs known |
+// | `network` / `server` / `malformed_response` / `unknown` | Retry, available immediately |
+//
+// "Show details" disclosure reveals the verbatim `raw` provider error;
+// collapsed by default. Raw is never shown in the main copy.
+
+import {
+  type Component,
+  Show,
+  createSignal,
+  createMemo,
+  onCleanup,
+} from 'solid-js';
+import { useNavigate } from '@solidjs/router';
+import { Button } from '@forge/design';
+import type { ChatTurn } from '../../stores/messages';
+
+type TurnErrorTurn = Extract<ChatTurn, { type: 'turn_error' }>;
+type ErrorKind = TurnErrorTurn['error_kind'];
+
+/**
+ * Human-readable label rendered as the monospace error-type chip. Mirrors
+ * the Rust `TurnErrorKind` wire tag so a triage chat against the daemon's
+ * event log lines up 1:1 with what the user saw.
+ */
+function errorKindLabel(kind: ErrorKind): string {
+  switch (kind) {
+    case 'auth':
+      return 'auth_error';
+    case 'rate_limit':
+      return 'rate_limit';
+    case 'network':
+      return 'network_error';
+    case 'server':
+      return 'server_error';
+    case 'malformed_response':
+      return 'malformed_response';
+    case 'unknown':
+      return 'unknown';
+  }
+}
+
+export interface TurnErrorCardProps {
+  turn: TurnErrorTurn;
+  /**
+   * Retry callback. Owner (`ChatPane`) re-sends the originating user
+   * message text as a new turn. Hidden entirely for `auth` errors.
+   */
+  onRetry?: () => void;
+  /**
+   * Navigation callback for the auth CTA. When omitted the component falls
+   * back to `useNavigate('/providers')`. Tests inject a stub to assert the
+   * click path without booting the router.
+   */
+  onOpenProviderSettings?: () => void;
+}
+
+export const TurnErrorCard: Component<TurnErrorCardProps> = (props) => {
+  // Try to read solid-router's navigator. Tests that mount the card outside
+  // a `<Router>` rely on the injected `onOpenProviderSettings` prop and
+  // never hit `useNavigate` — guard the call so the component doesn't
+  // throw during a non-router render.
+  let routerNavigate: ((to: string) => void) | null = null;
+  try {
+    routerNavigate = useNavigate();
+  } catch {
+    routerNavigate = null;
+  }
+
+  const [detailsOpen, setDetailsOpen] = createSignal(false);
+
+  // Countdown only matters when retry_after_secs is known. Re-derives once
+  // per second; cleared on unmount via `onCleanup`. When the countdown hits
+  // 0 the Retry button becomes active (parity with the network/server
+  // branches).
+  const [now, setNow] = createSignal(Date.now());
+  const mountedAt = Date.now();
+  const intervalId =
+    props.turn.error_kind === 'rate_limit' &&
+    props.turn.retry_after_secs !== undefined
+      ? setInterval(() => setNow(Date.now()), 1000)
+      : null;
+  onCleanup(() => {
+    if (intervalId !== null) clearInterval(intervalId);
+  });
+
+  const remainingSecs = createMemo<number | null>(() => {
+    if (props.turn.error_kind !== 'rate_limit') return null;
+    if (props.turn.retry_after_secs === undefined) return null;
+    const elapsed = Math.floor((now() - mountedAt) / 1000);
+    const remain = props.turn.retry_after_secs - elapsed;
+    return remain > 0 ? remain : 0;
+  });
+
+  const isAuth = (): boolean => props.turn.error_kind === 'auth';
+  const retryDisabled = createMemo<boolean>(() => {
+    if (isAuth()) return true;
+    if (!props.turn.retriable) return true;
+    const r = remainingSecs();
+    return r !== null && r > 0;
+  });
+
+  const handleRetry = (): void => {
+    if (retryDisabled()) return;
+    props.onRetry?.();
+  };
+
+  const handleOpenProviderSettings = (): void => {
+    if (props.onOpenProviderSettings) {
+      props.onOpenProviderSettings();
+      return;
+    }
+    if (routerNavigate) {
+      routerNavigate('/providers');
+    }
+  };
+
+  return (
+    <div
+      class="turn-error-card"
+      data-testid={`turn-error-card-${props.turn.message_id}`}
+      data-error-kind={props.turn.error_kind}
+      role="alert"
+    >
+      <header class="turn-error-card__header">
+        <span class="turn-error-card__icon" aria-hidden="true">
+          !
+        </span>
+        <span
+          class="turn-error-card__kind"
+          data-testid={`turn-error-kind-${props.turn.message_id}`}
+        >
+          {errorKindLabel(props.turn.error_kind)}
+        </span>
+      </header>
+      <p
+        class="turn-error-card__message"
+        data-testid={`turn-error-message-${props.turn.message_id}`}
+      >
+        {props.turn.message}
+      </p>
+
+      <div class="turn-error-card__actions">
+        <Show when={isAuth()}>
+          <Button
+            variant="primary"
+            class="turn-error-card__cta"
+            data-testid={`turn-error-open-providers-${props.turn.message_id}`}
+            onClick={handleOpenProviderSettings}
+          >
+            OPEN PROVIDER SETTINGS
+          </Button>
+        </Show>
+        <Show when={!isAuth()}>
+          <Button
+            variant="primary"
+            class="turn-error-card__retry"
+            data-testid={`turn-error-retry-${props.turn.message_id}`}
+            disabled={retryDisabled()}
+            onClick={handleRetry}
+          >
+            <Show
+              when={remainingSecs() !== null && remainingSecs()! > 0}
+              fallback={<>RETRY</>}
+            >
+              RETRY IN {remainingSecs()}s
+            </Show>
+          </Button>
+        </Show>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="turn-error-card__details-toggle"
+          data-testid={`turn-error-details-toggle-${props.turn.message_id}`}
+          aria-expanded={detailsOpen()}
+          onClick={() => setDetailsOpen((v) => !v)}
+        >
+          {detailsOpen() ? 'Hide details' : 'Show details'}
+        </Button>
+      </div>
+
+      <Show when={detailsOpen() && props.turn.raw !== undefined}>
+        <pre
+          class="turn-error-card__raw"
+          data-testid={`turn-error-raw-${props.turn.message_id}`}
+        >
+          {props.turn.raw}
+        </pre>
+      </Show>
+      <Show when={detailsOpen() && props.turn.raw === undefined}>
+        <p
+          class="turn-error-card__raw-empty"
+          data-testid={`turn-error-raw-empty-${props.turn.message_id}`}
+        >
+          No additional provider detail captured.
+        </p>
+      </Show>
+    </div>
+  );
+};

--- a/web/packages/app/src/stores/messages.test.ts
+++ b/web/packages/app/src/stores/messages.test.ts
@@ -4,6 +4,7 @@ import {
   setAwaitingResponse,
   getMessagesState,
   resetMessagesStore,
+  removeFailedTurnPair,
   liveVariantCount,
   activeVariantPosition,
   neighbourVariantId,
@@ -640,6 +641,53 @@ describe('messages store', () => {
       if (turn.type !== 'turn_error') throw new Error('expected turn_error');
       expect(turn.retry_after_secs).toBe(17);
       expect(turn.raw).toBe('HTTP 429: too many requests');
+    });
+  });
+
+  describe('removeFailedTurnPair (F-749 retry)', () => {
+    it('removes the error card and the immediately preceding user turn', () => {
+      pushEvent(SID, { kind: 'UserMessage', text: 'a', message_id: 'msg-a' });
+      pushEvent(SID, { kind: 'AssistantMessage', text: 'A', message_id: 'msg-a-r' });
+      pushEvent(SID, { kind: 'UserMessage', text: 'b', message_id: 'msg-b' });
+      pushEvent(SID, {
+        kind: 'TurnError',
+        message_id: 'msg-b',
+        error_kind: 'network',
+        message: 'transport',
+        retriable: true,
+      });
+
+      const before = getMessagesState(SID).turns;
+      // Expected: [user a, assistant A, user b, turn_error]
+      expect(before.map((t) => t.type)).toEqual([
+        'user',
+        'assistant',
+        'user',
+        'turn_error',
+      ]);
+
+      // Strip the failed pair (indices 2..3) — leaves the prior exchange intact.
+      removeFailedTurnPair(SID, 3);
+      const after = getMessagesState(SID).turns;
+      expect(after.map((t) => t.type)).toEqual(['user', 'assistant']);
+      expect((after[0]! as { text: string }).text).toBe('a');
+    });
+
+    it('is a no-op when index is out of range', () => {
+      pushEvent(SID, { kind: 'UserMessage', text: 'a', message_id: 'msg-a' });
+      pushEvent(SID, {
+        kind: 'TurnError',
+        message_id: 'msg-a',
+        error_kind: 'network',
+        message: 'transport',
+        retriable: true,
+      });
+      const lenBefore = getMessagesState(SID).turns.length;
+      // index 99 is past the end; defensive guard must return without mutation
+      removeFailedTurnPair(SID, 99);
+      // index 0 would underflow (`errorIdx - 1 == -1`); also a no-op
+      removeFailedTurnPair(SID, 0);
+      expect(getMessagesState(SID).turns).toHaveLength(lenBefore);
     });
   });
 });

--- a/web/packages/app/src/stores/messages.test.ts
+++ b/web/packages/app/src/stores/messages.test.ts
@@ -588,4 +588,58 @@ describe('messages store', () => {
       expect(turn.tool_count).toBeUndefined();
     });
   });
+
+  describe('TurnError events (F-749)', () => {
+    it('replaces an empty streaming assistant turn at the same message_id', () => {
+      // Mirror the orchestrator's protocol: it emits a finalised empty
+      // assistant turn immediately before the TurnError so the slot exists.
+      pushEvent(SID, { kind: 'UserMessage', text: 'hi', message_id: 'msg-1' });
+      pushEvent(SID, { kind: 'AssistantMessage', text: '', message_id: 'msg-1' });
+      pushEvent(SID, {
+        kind: 'TurnError',
+        message_id: 'msg-1',
+        error_kind: 'auth',
+        message: 'rejected',
+        retriable: false,
+      });
+      const state = getMessagesState(SID);
+      // The transcript ends up as [user, turn_error] — no dangling empty bubble.
+      expect(state.turns.map((t) => t.type)).toEqual(['user', 'turn_error']);
+      const err = state.turns[1]!;
+      if (err.type !== 'turn_error') throw new Error('expected turn_error');
+      expect(err.error_kind).toBe('auth');
+      expect(err.retriable).toBe(false);
+      expect(state.awaitingResponse).toBe(false);
+      expect(state.streamingMessageId).toBeNull();
+    });
+
+    it('appends a turn_error when no assistant placeholder exists', () => {
+      pushEvent(SID, { kind: 'UserMessage', text: 'hi', message_id: 'msg-1' });
+      pushEvent(SID, {
+        kind: 'TurnError',
+        message_id: 'msg-99',
+        error_kind: 'network',
+        message: 'transport error',
+        retriable: true,
+      });
+      const state = getMessagesState(SID);
+      expect(state.turns.map((t) => t.type)).toEqual(['user', 'turn_error']);
+    });
+
+    it('preserves retry_after_secs and raw onto the turn', () => {
+      pushEvent(SID, {
+        kind: 'TurnError',
+        message_id: 'msg-1',
+        error_kind: 'rate_limit',
+        message: 'rate limit',
+        retriable: true,
+        retry_after_secs: 17,
+        raw: 'HTTP 429: too many requests',
+      });
+      const turn = getMessagesState(SID).turns[0]!;
+      if (turn.type !== 'turn_error') throw new Error('expected turn_error');
+      expect(turn.retry_after_secs).toBe(17);
+      expect(turn.raw).toBe('HTTP 429: too many requests');
+    });
+  });
 });

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -105,6 +105,27 @@ export type SessionEvent =
       summary_msg_id: string;
       summarized_turns: number;
       trigger: 'AutoAt98Pct' | 'UserRequested';
+    }
+  // F-749: typed provider-call failure surfaced inline in the transcript.
+  // ChatPane renders a `<TurnErrorCard>` for each turn that hits this state
+  // at the position where the assistant response would have appeared. The
+  // store discards any partial assistant turn at `message_id` because the
+  // orchestrator's protocol guarantees no `AssistantDelta` lands after a
+  // `TurnError` — the empty bubble would otherwise dangle.
+  | {
+      kind: 'TurnError';
+      message_id: string;
+      error_kind:
+        | 'auth'
+        | 'rate_limit'
+        | 'network'
+        | 'server'
+        | 'malformed_response'
+        | 'unknown';
+      message: string;
+      retriable: boolean;
+      retry_after_secs?: number;
+      raw?: string;
     };
 
 // ---------------------------------------------------------------------------
@@ -187,6 +208,23 @@ export type ChatTurn =
       summary_msg_id: string;
       summarized_turns: number;
       trigger: 'AutoAt98Pct' | 'UserRequested';
+    }
+  // F-749: failed-turn marker. ChatPane renders the `<TurnErrorCard>` at
+  // this turn's position with action buttons keyed off `error_kind`.
+  | {
+      type: 'turn_error';
+      message_id: string;
+      error_kind:
+        | 'auth'
+        | 'rate_limit'
+        | 'network'
+        | 'server'
+        | 'malformed_response'
+        | 'unknown';
+      message: string;
+      retriable: boolean;
+      retry_after_secs?: number;
+      raw?: string;
     };
 
 // ---------------------------------------------------------------------------
@@ -703,6 +741,43 @@ export function pushEvent(sessionId: SessionId, event: SessionEvent): void {
             summarized_turns: event.summarized_turns,
             trigger: event.trigger,
           });
+        }),
+      );
+      break;
+    }
+
+    // F-749: failed turn — replace the empty/streaming assistant placeholder
+    // (the orchestrator emits an `AssistantMessage(stream_finalised=true,
+    // text="")` immediately before the `TurnError`) with the typed error
+    // turn so the card lands at the exact transcript slot the user
+    // expects. The originating user turn stays untouched.
+    case 'TurnError': {
+      setMessagesStore(
+        produce((s) => {
+          const state = s[sessionId]!;
+          const idx = state.turns.findIndex(
+            (t) => t.type === 'assistant' && t.message_id === event.message_id,
+          );
+          const next: Extract<ChatTurn, { type: 'turn_error' }> = {
+            type: 'turn_error',
+            message_id: event.message_id,
+            error_kind: event.error_kind,
+            message: event.message,
+            retriable: event.retriable,
+          };
+          if (event.retry_after_secs !== undefined) {
+            next.retry_after_secs = event.retry_after_secs;
+          }
+          if (event.raw !== undefined) {
+            next.raw = event.raw;
+          }
+          if (idx >= 0) {
+            state.turns[idx] = next;
+          } else {
+            state.turns.push(next);
+          }
+          state.streamingMessageId = null;
+          state.awaitingResponse = false;
         }),
       );
       break;

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -307,6 +307,47 @@ export function cancelStream(sessionId: SessionId): void {
   setMessagesStore(sessionId, 'streamingMessageId', null);
 }
 
+/**
+ * F-749: locally drop the failed exchange (the originating user turn + the
+ * error card) before retrying. The orchestrator's protocol pairs each
+ * `TurnError` with the immediately preceding `UserMessage` event, so the
+ * range we splice is exactly `[errorIdx - 1, errorIdx]`.
+ *
+ * Why store-side and not orchestrator-side (`MessageSuperseded`):
+ *
+ * The orchestrator-side path would emit a new `MessageSuperseded { old_id }`
+ * event from a new `rerun_user_message` IPC primitive, and the existing
+ * `MessageSuperseded` handler would filter the old turns visually. That's
+ * architecturally cleaner — it keeps the log authoritative and the UI a
+ * pure projection — but it's a much larger change: new IPC method, new
+ * event variant, new orchestrator code path, plus the new event has to
+ * survive replay across daemon restart. For F-749 the failed exchange is
+ * known-bad and the user is explicitly asking to discard it; the store-side
+ * splice produces an identical user-visible transcript without the IPC
+ * surface-area expansion. If we later need cross-replay durability for
+ * "this turn was retried", we can lift this into `MessageSuperseded` then.
+ *
+ * The local-only nature of the splice is also why this isn't a SessionEvent
+ * — there's no wire payload to dispatch, just a UI-state mutation.
+ */
+export function removeFailedTurnPair(
+  sessionId: SessionId,
+  errorTurnIndex: number,
+): void {
+  ensureSession(sessionId);
+  setMessagesStore(
+    sessionId,
+    produce((state: MessagesState) => {
+      // Defensive bounds — `errorTurnIndex` should always be >= 1 (there's
+      // always a `UserMessage` immediately before a `TurnError` per the
+      // orchestrator's protocol), but a stale index from a re-render race
+      // would otherwise splice off the start of the array silently.
+      if (errorTurnIndex < 1 || errorTurnIndex >= state.turns.length) return;
+      state.turns.splice(errorTurnIndex - 1, 2);
+    }),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // F-145 — branch-group helpers
 // ---------------------------------------------------------------------------

--- a/web/packages/app/src/stores/messages.ts
+++ b/web/packages/app/src/stores/messages.ts
@@ -792,6 +792,18 @@ export function pushEvent(sessionId: SessionId, event: SessionEvent): void {
     // text="")` immediately before the `TurnError`) with the typed error
     // turn so the card lands at the exact transcript slot the user
     // expects. The originating user turn stays untouched.
+    //
+    // Event-ordering assumption: the orchestrator emits the finalised
+    // (empty) `AssistantMessage` BEFORE the `TurnError` on every error
+    // path — see `orchestrator.rs` `ChatChunk::Error` arm. That ordering
+    // is what lets us "replace" the assistant slot via the `idx >= 0`
+    // branch. The fallback `idx < 0` branch covers out-of-order delivery
+    // (replay glitches, log truncation between AssistantMessage and
+    // TurnError, or a future orchestrator path that emits TurnError
+    // standalone): we append the error card as a fresh turn rather than
+    // dropping the failure on the floor, and we still clear
+    // `streamingMessageId` + `awaitingResponse` so the composer unlocks
+    // regardless of which arm fires.
     case 'TurnError': {
       setMessagesStore(
         produce((s) => {


### PR DESCRIPTION
Closes forge-ide/forge#893

## Summary
- New `forge_core::Event::TurnError` variant + `TurnErrorKind` enum covering `Auth`, `RateLimit { retry_after_secs }`, `Network`, `Server`, `MalformedResponse`, `Unknown`. Wire shape pinned by `event_wire_shape.rs`.
- `ChatChunk::Error` extended with `status: Option<u16>`; Anthropic, OpenAI, Custom-OpenAI, and Ollama all surface HTTP failures as terminal `Error` chunks carrying the wire status code instead of bubbling `Err`.
- Orchestrator `classify_chunk_error` maps status → `TurnErrorKind` (status wins, `StreamErrorKind` falls back) and emits `Event::TurnError` between the empty `AssistantMessage(finalised)` and `StepFinished(Error)`. `raw` is byte-capped at 4 KiB via `truncate_raw_error`.
- New `<TurnErrorCard>` (`web/packages/app/src/routes/Session/TurnErrorCard.tsx`) renders inline in the transcript: auth shows "Open provider settings" CTA (no Retry); rate_limit shows Retry disabled with a live countdown when `retry_after_secs` is known; network/server/malformed_response/unknown show Retry immediately. "Show details" disclosure reveals `raw`.
- Retry re-sends the originating user message text via `sessionSendMessage` — no new IPC primitive needed.

## Test plan
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` all pass.
- `pnpm --filter app typecheck && pnpm --filter app test` — 1538 tests pass (22 new).
- 6 new `event_wire_shape.rs` cases cover each `TurnErrorKind` JSON shape.
- 11 new orchestrator integration tests in `crates/forge-session/tests/turn_error_emission.rs` cover 401/403/429/500/503/418/transport/idle/line-too-long classification, retriable verdict, raw cap, and id↔UserMessage linkage.
- 13 new component tests in `TurnErrorCard.test.tsx` cover each kind's render + action behavior including the rate-limit countdown.
- 6 new adapter tests + 3 new store tests verify the TS wire path end-to-end.

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)