### PR TITLE
[F-754] Move focus to error CTA when session_start surfaces an actionable error

### DIFF
--- a/web/packages/app/src/components/NewSessionDialog.test.tsx
+++ b/web/packages/app/src/components/NewSessionDialog.test.tsx
@@ -386,10 +386,44 @@ describe('NewSessionDialog spawn-failed state', () => {
     expect(cta).toBeInTheDocument();
     expect(cta.getAttribute('href')).toBe('/providers#anthropic');
 
+    // F-754: focus migrates to the CTA after the alert region has rendered.
+    // The move is scheduled through a microtask boundary so the `role="alert"`
+    // announcement fires before focus shifts. Waiting on the focus assertion
+    // gives the scheduled task a chance to run.
+    await waitFor(() => expect(document.activeElement).toBe(cta));
+
     // Clicking the CTA closes the dialog so navigation can replace the
     // dashboard route without the modal lingering on top of it.
     fireEvent.click(cta);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  // F-754: non-credential errors must NOT pull focus off the submit button —
+  // retry stays one keypress away.
+  it('keeps focus on submit for non-credential errors', async () => {
+    installInvokeStub({
+      sessionStart: async () => {
+        throw new Error(
+          'session_start: workspace not accessible: No such file or directory (os error 2)',
+        );
+      },
+    });
+    setActiveWorkspaceRoot('/work/repo');
+    const { getByTestId } = renderDialog();
+    await waitFor(() => expect(getByTestId('provider-select')).toBeInTheDocument());
+
+    const submit = getByTestId('new-session-submit') as HTMLButtonElement;
+    submit.focus();
+    expect(document.activeElement).toBe(submit);
+
+    fireEvent.click(submit);
+    await waitFor(() => expect(getByTestId('new-session-error')).toBeInTheDocument());
+
+    // Give any scheduled microtask a chance to run; focus must remain on the
+    // submit button because there is no CTA to migrate to.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(document.activeElement).toBe(submit);
   });
 
   // Non-credential errors must NOT render the CTA — only the verbatim

--- a/web/packages/app/src/components/NewSessionDialog.test.tsx
+++ b/web/packages/app/src/components/NewSessionDialog.test.tsx
@@ -419,10 +419,11 @@ describe('NewSessionDialog spawn-failed state', () => {
     fireEvent.click(submit);
     await waitFor(() => expect(getByTestId('new-session-error')).toBeInTheDocument());
 
-    // Give any scheduled microtask a chance to run; focus must remain on the
-    // submit button because there is no CTA to migrate to.
-    await Promise.resolve();
-    await Promise.resolve();
+    // Yield a full task so every queued microtask drains; focus must remain
+    // on the submit button because there is no CTA to migrate to. A
+    // `setTimeout(0)` is more resilient than chained `Promise.resolve()` —
+    // any future async hop in the impl would still be flushed here.
+    await new Promise((r) => setTimeout(r, 0));
     expect(document.activeElement).toBe(submit);
   });
 

--- a/web/packages/app/src/components/NewSessionDialog.tsx
+++ b/web/packages/app/src/components/NewSessionDialog.tsx
@@ -252,6 +252,23 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
     extractMissingCredentialProviderId(error()),
   );
 
+  // F-754: when the error path renders an actionable CTA, migrate focus
+  // off the (now-disabled) submit button onto the CTA so screen-reader
+  // users don't have to tab to it. Defer through `queueMicrotask` so the
+  // `role="alert"` announcement fires first — moving focus synchronously
+  // in the same tick would pre-empt assistive tech reading the alert.
+  // Non-credential errors leave focus alone so retry stays one keypress
+  // away on the submit button.
+  createEffect(() => {
+    if (missingCredentialProvider() === null) return;
+    queueMicrotask(() => {
+      const cta = dialogRef?.querySelector<HTMLElement>(
+        '[data-testid="new-session-error-cta"]',
+      );
+      cta?.focus();
+    });
+  });
+
   // Focus-trap. Spec §Trigger calls for the workspace field to receive
   // focus on open — the field is the first interactive element either way.
   let dialogRef: HTMLDivElement | undefined;

--- a/web/packages/app/src/components/NewSessionDialog.tsx
+++ b/web/packages/app/src/components/NewSessionDialog.tsx
@@ -252,6 +252,17 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
     extractMissingCredentialProviderId(error()),
   );
 
+  // Focus-trap. Spec §Trigger calls for the workspace field to receive
+  // focus on open — the field is the first interactive element either way.
+  // Declared above the F-754 focus-migration effect so the effect closes
+  // over an in-scope binding rather than relying on initializer order.
+  let dialogRef: HTMLDivElement | undefined;
+  useFocusTrap(() => dialogRef, {
+    initialFocus: () =>
+      dialogRef?.querySelector<HTMLElement>('[data-testid="workspace-input"]') ??
+      undefined,
+  });
+
   // F-754: when the error path renders an actionable CTA, migrate focus
   // off the (now-disabled) submit button onto the CTA so screen-reader
   // users don't have to tab to it. Defer through `queueMicrotask` so the
@@ -267,15 +278,6 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
       );
       cta?.focus();
     });
-  });
-
-  // Focus-trap. Spec §Trigger calls for the workspace field to receive
-  // focus on open — the field is the first interactive element either way.
-  let dialogRef: HTMLDivElement | undefined;
-  useFocusTrap(() => dialogRef, {
-    initialFocus: () =>
-      dialogRef?.querySelector<HTMLElement>('[data-testid="workspace-input"]') ??
-      undefined,
   });
 
   const onSubmit = async (e: Event): Promise<void> => {


### PR DESCRIPTION
Closes forge-ide/forge#903

## Summary
- When `session_start` rejects with `credentials_missing for provider <id>`, the New session dialog now migrates focus to `[data-testid="new-session-error-cta"]` so screen-reader users do not have to tab off the disabled submit button.
- Focus move is scheduled through `queueMicrotask` so the `role="alert"` announcement fires before the focus shift.
- Non-credential errors (e.g. workspace not accessible) leave focus on the submit button so retry stays one keypress away.

## Implementation
- `NewSessionDialog.tsx`: added a `createEffect` that watches `missingCredentialProvider()` and, when non-null, queues a microtask to `focus()` the CTA. The effect short-circuits on null so non-credential errors are untouched.
- `NewSessionDialog.test.tsx`: extended the existing `renders a Configure provider CTA on credentials_missing error` test with a `document.activeElement` assertion, plus a new `keeps focus on submit for non-credential errors` case as a regression guard.

## Test plan
- `pnpm --filter app test NewSessionDialog` — 27/27 pass
- `just check-web` — typecheck, token, raw-button lints all green
- `cargo fmt --check && cargo check --workspace && cargo test --workspace && cargo clippy --all-targets -- -D warnings` — all green
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean (CI parity)

## Verification status
PR is open; DoD and code-review gates are pending in the parent context (per the forge-finish-task handoff protocol).